### PR TITLE
skip importing prisma model on chat example

### DIFF
--- a/examples/next-ssg-chat/pages/index.tsx
+++ b/examples/next-ssg-chat/pages/index.tsx
@@ -1,9 +1,11 @@
-import { Message } from '@prisma/client';
 import Head from 'next/head';
 import { useEffect, useMemo, useState } from 'react';
 import { dehydrate } from 'react-query/hydration';
-import { trpc } from '../utils/trpc';
+import { inferQueryOutput, trpc } from '../utils/trpc';
 import { appRouter } from './api/trpc/[...trpc]';
+
+type MessagesOutput = inferQueryOutput<'messages.list'>;
+type Message = MessagesOutput['items'][number];
 
 function maxDate(dates: Date[]) {
   let max = dates[0];

--- a/examples/next-ssg-chat/utils/trpc.ts
+++ b/examples/next-ssg-chat/utils/trpc.ts
@@ -20,8 +20,7 @@ export const trpc = createReactQueryHooks<AppRouter, Context>({
 
 /**
  * This is a helper method to infer the output of a query resolver
- * @example
- * `type HelloOutput = inferQueryOutput<'hello'>`
+ * @example type HelloOutput = inferQueryOutput<'hello'>
  */
 export type inferQueryOutput<
   TRouteKey extends keyof AppRouter['_def']['queries']

--- a/examples/next-ssg-chat/utils/trpc.ts
+++ b/examples/next-ssg-chat/utils/trpc.ts
@@ -4,6 +4,7 @@ import { QueryClient } from 'react-query';
 // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export
 import type { AppRouter, Context } from '../pages/api/trpc/[...trpc]';
 import superjson from 'superjson';
+import type { inferRouteInput, inferRouteOutput } from '@trpc/server';
 
 // create helper methods for queries, mutations, and subscriptionos
 export const client = createTRPCClient<AppRouter>({
@@ -16,3 +17,12 @@ export const trpc = createReactQueryHooks<AppRouter, Context>({
   queryClient: new QueryClient(),
   transformer: superjson,
 });
+
+/**
+ * This is a helper method to infer the output of a query resolver
+ * @example
+ * `type HelloOutput = inferQueryOutput<'hello'>`
+ */
+export type inferQueryOutput<
+  TRouteKey extends keyof AppRouter['_def']['queries']
+> = inferRouteOutput<AppRouter['_def']['queries'][TRouteKey]>;


### PR DESCRIPTION
showcase that you can [quite easily] infer output of the resolvers