### PR TITLE
refine `useInfiniteQuery()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ import { createReactQueryHooks, createTRPCClient } from '@trpc/react';
 import { QueryClient } from 'react-query';
 // Type-only import:
 // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export
-import type { AppRouter, Context } from '../pages/api/trpc/[...trpc]';
+import type { AppRouter } from '../pages/api/trpc/[...trpc]';
 
 export const client = createTRPCClient<AppRouter>({
   url: '/api/trpc',

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ export const client = createTRPCClient<AppRouter>({
   url: '/api/trpc',
 });
 
-export const trpc = createReactQueryHooks<AppRouter, Context>({
+export const trpc = createReactQueryHooks({
   client,
   queryClient: new QueryClient(),
 });

--- a/examples/next-hello-world/package.json
+++ b/examples/next-hello-world/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/hello-world",
-  "version": "2.1.0-alpha.1",
+  "version": "2.1.0-alpha.2",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -11,8 +11,8 @@
     "test-start": "start-server-and-test start http://localhost:3000 test"
   },
   "dependencies": {
-    "@trpc/client": "^2.1.0-alpha.1",
-    "@trpc/react": "^2.1.0-alpha.1",
+    "@trpc/client": "^2.1.0-alpha.2",
+    "@trpc/react": "^2.1.0-alpha.2",
     "@trpc/server": "^2.1.0-alpha.1",
     "next": "10.0.4",
     "react": "17.0.1",

--- a/examples/next-hello-world/package.json
+++ b/examples/next-hello-world/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/hello-world",
-  "version": "2.1.0-alpha.0",
+  "version": "2.1.0-alpha.1",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -11,9 +11,9 @@
     "test-start": "start-server-and-test start http://localhost:3000 test"
   },
   "dependencies": {
-    "@trpc/client": "^2.1.0-alpha.0",
-    "@trpc/react": "^2.1.0-alpha.0",
-    "@trpc/server": "^2.1.0-alpha.0",
+    "@trpc/client": "^2.1.0-alpha.1",
+    "@trpc/react": "^2.1.0-alpha.1",
+    "@trpc/server": "^2.1.0-alpha.1",
     "next": "10.0.4",
     "react": "17.0.1",
     "react-dom": "17.0.1",

--- a/examples/next-hello-world/utils/trpc.ts
+++ b/examples/next-hello-world/utils/trpc.ts
@@ -2,7 +2,7 @@ import { createReactQueryHooks, createTRPCClient } from '@trpc/react';
 import { QueryClient } from 'react-query';
 // Type-only import:
 // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export
-import type { AppRouter, Context } from '../pages/api/trpc/[...trpc]';
+import type { AppRouter } from '../pages/api/trpc/[...trpc]';
 
 // create helper methods for queries, mutations, and subscriptionos
 export const client = createTRPCClient<AppRouter>({
@@ -10,7 +10,7 @@ export const client = createTRPCClient<AppRouter>({
 });
 
 // create react query hooks for trpc
-export const trpc = createReactQueryHooks<AppRouter, Context>({
+export const trpc = createReactQueryHooks({
   client,
   queryClient: new QueryClient(),
 });

--- a/examples/next-hello-world/utils/trpc.ts
+++ b/examples/next-hello-world/utils/trpc.ts
@@ -2,7 +2,7 @@ import { createReactQueryHooks, createTRPCClient } from '@trpc/react';
 import { QueryClient } from 'react-query';
 // Type-only import:
 // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export
-import type { AppRouter } from '../pages/api/trpc/[...trpc]';
+import type { AppRouter, Context } from '../pages/api/trpc/[...trpc]';
 
 // create helper methods for queries, mutations, and subscriptionos
 export const client = createTRPCClient<AppRouter>({
@@ -10,7 +10,7 @@ export const client = createTRPCClient<AppRouter>({
 });
 
 // create react query hooks for trpc
-export const trpc = createReactQueryHooks({
+export const trpc = createReactQueryHooks<AppRouter, Context>({
   client,
   queryClient: new QueryClient(),
 });

--- a/examples/next-ssg-chat/package.json
+++ b/examples/next-ssg-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/chat",
-  "version": "2.1.0-alpha.1",
+  "version": "2.1.0-alpha.2",
   "private": true,
   "scripts": {
     "dx:next": "prisma generate && next dev",
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@prisma/client": "^2.16.0",
-    "@trpc/client": "^2.1.0-alpha.1",
-    "@trpc/react": "^2.1.0-alpha.1",
+    "@trpc/client": "^2.1.0-alpha.2",
+    "@trpc/react": "^2.1.0-alpha.2",
     "@trpc/server": "^2.1.0-alpha.1",
     "jest": "^26.6.3",
     "jest-playwright": "^0.0.1",

--- a/examples/next-ssg-chat/package.json
+++ b/examples/next-ssg-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/chat",
-  "version": "2.1.0-alpha.0",
+  "version": "2.1.0-alpha.1",
   "private": true,
   "scripts": {
     "dx:next": "prisma generate && next dev",
@@ -18,9 +18,9 @@
   },
   "dependencies": {
     "@prisma/client": "^2.16.0",
-    "@trpc/client": "^2.1.0-alpha.0",
-    "@trpc/react": "^2.1.0-alpha.0",
-    "@trpc/server": "^2.1.0-alpha.0",
+    "@trpc/client": "^2.1.0-alpha.1",
+    "@trpc/react": "^2.1.0-alpha.1",
+    "@trpc/server": "^2.1.0-alpha.1",
     "jest": "^26.6.3",
     "jest-playwright": "^0.0.1",
     "jest-playwright-preset": "^1.4.5",

--- a/examples/next-ssg-chat/pages/index.tsx
+++ b/examples/next-ssg-chat/pages/index.tsx
@@ -30,7 +30,7 @@ export default function Home() {
     isFetchingPreviousPage,
     fetchPreviousPage,
   } = trpc.useInfiniteQuery(['messages.list', {}], {
-    getPreviousPageParam: (d) => (d as any).prevCursor,
+    getPreviousPageParam: (d) => d.prevCursor,
   });
   const [msgs, setMessages] = useState(
     () => data?.pages.map((p) => p.items).flat() ?? [],

--- a/examples/next-ssg-chat/utils/trpc.ts
+++ b/examples/next-ssg-chat/utils/trpc.ts
@@ -2,10 +2,9 @@ import { createReactQueryHooks, createTRPCClient } from '@trpc/react';
 import type { inferRouteOutput } from '@trpc/server';
 import { QueryClient } from 'react-query';
 import superjson from 'superjson';
-
 // ℹ️ Type-only import:
 // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export
-import type { AppRouter, Context } from '../pages/api/trpc/[...trpc]';
+import type { AppRouter } from '../pages/api/trpc/[...trpc]';
 
 // create helper methods for queries, mutations, and subscriptionos
 export const client = createTRPCClient<AppRouter>({
@@ -14,7 +13,7 @@ export const client = createTRPCClient<AppRouter>({
 });
 
 // create react query hooks for trpc
-export const trpc = createReactQueryHooks<AppRouter, Context>({
+export const trpc = createReactQueryHooks({
   client,
   queryClient: new QueryClient(),
 });

--- a/examples/next-ssg-chat/utils/trpc.ts
+++ b/examples/next-ssg-chat/utils/trpc.ts
@@ -4,7 +4,7 @@ import { QueryClient } from 'react-query';
 import superjson from 'superjson';
 // ℹ️ Type-only import:
 // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export
-import type { AppRouter } from '../pages/api/trpc/[...trpc]';
+import type { AppRouter, Context } from '../pages/api/trpc/[...trpc]';
 
 // create helper methods for queries, mutations, and subscriptionos
 export const client = createTRPCClient<AppRouter>({
@@ -13,7 +13,7 @@ export const client = createTRPCClient<AppRouter>({
 });
 
 // create react query hooks for trpc
-export const trpc = createReactQueryHooks({
+export const trpc = createReactQueryHooks<AppRouter, Context>({
   client,
   queryClient: new QueryClient(),
 });

--- a/examples/next-ssg-chat/utils/trpc.ts
+++ b/examples/next-ssg-chat/utils/trpc.ts
@@ -4,7 +4,7 @@ import { QueryClient } from 'react-query';
 import superjson from 'superjson';
 // ℹ️ Type-only import:
 // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export
-import type { AppRouter, Context } from '../pages/api/trpc/[...trpc]';
+import type { AppRouter } from '../pages/api/trpc/[...trpc]';
 
 // create helper methods for queries, mutations, and subscriptionos
 export const client = createTRPCClient<AppRouter>({
@@ -13,7 +13,7 @@ export const client = createTRPCClient<AppRouter>({
 });
 
 // create react query hooks for trpc
-export const trpc = createReactQueryHooks<AppRouter, Context>({
+export const trpc = createReactQueryHooks({
   client,
   queryClient: new QueryClient(),
 });

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/playground",
-  "version": "2.1.0-alpha.1",
+  "version": "2.1.0-alpha.2",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server.ts",
@@ -8,8 +8,8 @@
     "dev": "run-p dev:* --print-label"
   },
   "dependencies": {
-    "@trpc/client": "^2.1.0-alpha.1",
-    "@trpc/react": "^2.1.0-alpha.1",
+    "@trpc/client": "^2.1.0-alpha.2",
+    "@trpc/react": "^2.1.0-alpha.2",
     "@trpc/server": "^2.1.0-alpha.1",
     "@types/node-fetch": "^2.5.8",
     "abort-controller": "^3.0.0",

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/playground",
-  "version": "2.1.0-alpha.0",
+  "version": "2.1.0-alpha.1",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server.ts",
@@ -8,9 +8,9 @@
     "dev": "run-p dev:* --print-label"
   },
   "dependencies": {
-    "@trpc/client": "^2.1.0-alpha.0",
-    "@trpc/react": "^2.1.0-alpha.0",
-    "@trpc/server": "^2.1.0-alpha.0",
+    "@trpc/client": "^2.1.0-alpha.1",
+    "@trpc/react": "^2.1.0-alpha.1",
+    "@trpc/server": "^2.1.0-alpha.1",
     "@types/node-fetch": "^2.5.8",
     "abort-controller": "^3.0.0",
     "body-parser": "^1.19.0",

--- a/examples/standalone-server/package.json
+++ b/examples/standalone-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/standalone-server",
-  "version": "2.1.0-alpha.1",
+  "version": "2.1.0-alpha.2",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server.ts",
@@ -8,8 +8,8 @@
     "dev": "run-p dev:* --print-label"
   },
   "dependencies": {
-    "@trpc/client": "^2.1.0-alpha.1",
-    "@trpc/react": "^2.1.0-alpha.1",
+    "@trpc/client": "^2.1.0-alpha.2",
+    "@trpc/react": "^2.1.0-alpha.2",
     "@trpc/server": "^2.1.0-alpha.1",
     "@types/node-fetch": "^2.5.8",
     "abort-controller": "^3.0.0",

--- a/examples/standalone-server/package.json
+++ b/examples/standalone-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/standalone-server",
-  "version": "2.1.0-alpha.0",
+  "version": "2.1.0-alpha.1",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server.ts",
@@ -8,9 +8,9 @@
     "dev": "run-p dev:* --print-label"
   },
   "dependencies": {
-    "@trpc/client": "^2.1.0-alpha.0",
-    "@trpc/react": "^2.1.0-alpha.0",
-    "@trpc/server": "^2.1.0-alpha.0",
+    "@trpc/client": "^2.1.0-alpha.1",
+    "@trpc/react": "^2.1.0-alpha.1",
+    "@trpc/server": "^2.1.0-alpha.1",
     "@types/node-fetch": "^2.5.8",
     "abort-controller": "^3.0.0",
     "node-fetch": "^2.6.1",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.0-alpha.1",
+  "version": "2.1.0-alpha.2",
   "registry": "https://registry.npmjs.org/",
   "publishConfig": {
     "access": "public"

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.0-alpha.0",
+  "version": "2.1.0-alpha.1",
   "registry": "https://registry.npmjs.org/",
   "publishConfig": {
     "access": "public"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/client",
-  "version": "2.1.0-alpha.0",
+  "version": "2.1.0-alpha.1",
   "description": "TRPC Client lib",
   "author": "KATT",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@trpc/server": "^2.1.0-alpha.0"
+    "@trpc/server": "^2.1.0-alpha.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/client",
-  "version": "2.1.0-alpha.1",
+  "version": "2.1.0-alpha.2",
   "description": "TRPC Client lib",
   "author": "KATT",
   "license": "MIT",

--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -9,7 +9,6 @@ import type {
   inferRouteOutput,
   inferSubscriptionOutput,
   Maybe,
-  Router,
 } from '@trpc/server';
 
 type CancelFn = () => void;

--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -295,7 +295,7 @@ export class TRPCClient<TRouter extends AnyRouter> {
 
   public subscription<
     TSubscriptions extends TRouter['_def']['subscriptions'],
-    TPath extends string & TSubscriptions,
+    TPath extends string & keyof TSubscriptions,
     TOutput extends inferSubscriptionOutput<TRouter, TPath>,
     TInput extends inferRouteInput<TSubscriptions[TPath]>
   >(

--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -110,7 +110,8 @@ export class TRPCClient<TRouter extends AnyRouter> {
   constructor(opts: CreateTRPCClientOptions) {
     const { fetchOpts } = opts;
     this.opts = opts;
-    this.fetch = getFetch(fetchOpts?.fetch);
+    const _fetch = getFetch(fetchOpts?.fetch);
+    this.fetch = (...args) => _fetch(...args);
     this.AC = getAbortController(fetchOpts?.AbortController);
     this.transformer = opts.transformer ?? {
       serialize: (data) => data,

--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -5,7 +5,9 @@ import type {
   HTTPResponseEnvelope,
   HTTPSuccessResponseEnvelope,
   inferHandlerFn,
+  inferHandlerInput,
   inferRouteInput,
+  inferRouteOutput,
   inferSubscriptionOutput,
   Maybe,
 } from '@trpc/server';
@@ -98,6 +100,244 @@ export interface CreateTRPCClientOptions {
   onError?: (error: TRPCClientError) => void;
   transformer?: DataTransformer;
 }
+type TRPCType = 'subscription' | 'query' | 'mutation';
+
+export class TRPCClient2<TRouter extends AnyRouter<TContext>> {
+  private fetch: typeof fetch;
+  private AC: ReturnType<typeof getAbortController>;
+  private transformer: DataTransformer;
+  private opts: CreateTRPCClientOptions;
+
+  constructor(opts: CreateTRPCClientOptions) {
+    const { fetchOpts } = opts;
+    this.opts = opts;
+    this.fetch = getFetch(fetchOpts?.fetch);
+    this.AC = getAbortController(fetchOpts?.AbortController);
+    this.transformer = opts.transformer ?? {
+      serialize: (data) => data,
+      deserialize: (data) => data,
+    };
+  }
+
+  private serializeInput(input: unknown) {
+    return typeof input !== 'undefined'
+      ? this.transformer.serialize(input)
+      : input;
+  }
+  private async handleResponse(promise: Promise<Response>) {
+    let res: Maybe<Response> = null;
+    let json: Maybe<HTTPResponseEnvelope<unknown>> = null;
+    try {
+      res = await promise;
+      const rawJson = await res.json();
+      json = this.transformer.deserialize(
+        rawJson,
+      ) as HTTPResponseEnvelope<unknown>;
+
+      if (json.ok) {
+        this.opts.onSuccess && this.opts.onSuccess(json);
+        return json.data as any;
+      }
+      throw new TRPCClientError(json.error.message, { json, res });
+    } catch (originalError) {
+      let err: TRPCClientError = originalError;
+      if (!(err instanceof TRPCClientError)) {
+        err = new TRPCClientError(originalError.message, {
+          originalError,
+          res,
+          json,
+        });
+      }
+      this.opts.onError && this.opts.onError(err);
+      throw err;
+    }
+  }
+  private getHeaders() {
+    return {
+      'content-type': 'application/json',
+      ...(this.opts.getHeaders ? this.opts.getHeaders() : {}),
+    };
+  }
+
+  public request({
+    type,
+    input,
+    path,
+  }: {
+    type: TRPCType;
+    input: unknown;
+    path: string;
+  }) {
+    type ReqOpts = {
+      method: string;
+      body?: string;
+      url: string;
+    };
+    const { url } = this.opts;
+    const reqOptsMap: Record<TRPCType, () => ReqOpts> = {
+      subscription: () => ({
+        method: 'PATCH',
+        body: JSON.stringify({ input: this.serializeInput(input) }),
+        url: `${url}/${path}`,
+      }),
+      mutation: () => ({
+        method: 'POST',
+        body: JSON.stringify({ input: this.serializeInput(input) }),
+        url: `${url}/${path}`,
+      }),
+      query: () => ({
+        method: 'GET',
+        url:
+          `${url}/${path}` +
+          (input != null
+            ? `?input=${encodeURIComponent(
+                JSON.stringify(this.serializeInput(input)),
+              )}`
+            : ''),
+      }),
+    };
+
+    const reqOptsFn = reqOptsMap[type];
+    if (!reqOptsFn) {
+      throw new Error(`Unhandled type "${type}"`);
+    }
+    const ac = this.AC ? new this.AC() : null;
+
+    const { url: reqUrl, ...rest } = reqOptsFn();
+    const reqOpts = {
+      ...rest,
+      signal: ac?.signal,
+      headers: this.getHeaders(),
+    };
+    // console.log('reqOpts', {reqUrl, reqOpts, type, input})
+    const promise: CancellablePromise<any> & {
+      cancel(): void;
+    } = this.handleResponse(this.fetch(reqUrl, reqOpts)) as any;
+    promise.cancel = () => {
+      ac?.abort();
+    };
+
+    return promise;
+  }
+  public query<
+    TQueries extends TRouter['_def']['queries'],
+    TPath extends string & TQueries
+  >(
+    path: TPath,
+    ...args: inferHandlerInput<TQueries, TPath>
+  ): CancellablePromise<inferRouteOutput<TQueries[TPath]>> {
+    return this.request({
+      type: 'query',
+      path,
+      input: args[0],
+    });
+  }
+
+  public mutation<
+    TMutations extends TRouter['_def']['mutations'],
+    TPath extends string & TMutations
+  >(
+    path: TPath,
+    ...args: inferHandlerInput<TMutations, TPath>
+  ): CancellablePromise<inferRouteOutput<TMutations[TPath]>> {
+    return this.request({
+      type: 'mutation',
+      path,
+      input: args[0],
+    });
+  }
+
+  public subscriptionOnce<
+    TSubscriptions extends TRouter['_def']['subscriptions'],
+    TPath extends string & TSubscriptions,
+    TOutput extends inferSubscriptionOutput<TRouter, TPath>
+  >(
+    path: TPath,
+    ...args: inferHandlerInput<TSubscriptions, TPath>
+  ): CancellablePromise<TOutput[]> {
+    const [input] = args;
+    let stopped = false;
+    let nextTry: any; // setting as `NodeJS.Timeout` causes compat issues, can probably be solved
+    let currentRequest: CancellablePromise<TOutput[]> | null = null;
+
+    const promise = new Promise<TOutput[]>((resolve, reject) => {
+      const exec = async () => {
+        if (stopped) {
+          return;
+        }
+        try {
+          currentRequest = this.request({
+            type: 'subscription',
+            input,
+            path,
+          });
+          const data = await currentRequest;
+          // console.log('response', { path, input, data });
+          resolve(data);
+        } catch (_err) {
+          const err: TRPCClientError = _err;
+
+          if (err.json?.statusCode === 408) {
+            // server told us to reconnect
+            exec();
+          } else {
+            reject(err);
+          }
+        }
+      };
+      exec();
+    }) as CancellablePromise<TOutput[]>;
+    promise.cancel = () => {
+      stopped = true;
+      clearTimeout(nextTry);
+      currentRequest?.cancel && currentRequest.cancel();
+    };
+
+    return (promise as any) as CancellablePromise<TOutput[]>;
+  }
+}
+// export type TRPCClient2<
+//   TRouter extends Router<TContext, TQueries, TMutations, TSubscriptions>,
+//   TContext,
+//   TQueries extends TRouter['_def']['queries'] = TRouter['_def']['queries'],
+//   TMutations extends TRouter['_def']['mutations'] = TRouter['_def']['mutations'],
+//   TSubscriptions extends TRouter['_def']['subscriptions'] = TRouter['_def']['subscriptions']
+// > = (
+//   opts: CreateTRPCClientOptions,
+// ) => {
+//   request: (opts: {
+//     type: TRPCType;
+//     input: unknown;
+//     path: string;
+//   }) => CancellablePromise<any>;
+//   mutation: inferHandlerFn<TMutations>;
+//   query: inferHandlerFn<TMutations>;
+//   subscriptionOnce<
+//     TPath extends keyof TSubscriptions & string,
+//     TInput extends inferRouteInput<TSubscriptions[TPath]>,
+//     TOutput extends inferSubscriptionOutput<TRouter, TPath>
+//   >(
+//     path: TPath,
+//     input: TInput,
+//   ): CancellablePromise<TOutput[]>;
+//   subscription: <
+//     TPath extends keyof TSubscriptions & string,
+//     TInput extends inferRouteInput<TSubscriptions[TPath]>,
+//     TOutput extends inferSubscriptionOutput<TRouter, TPath>
+//   >(
+//     path: TPath,
+//     opts: {
+//       initialInput: TInput;
+//       onError?: (err: NextInputError | TRPCClientError) => void;
+//       onData?: (data: TOutput[]) => void;
+//       /**
+//        * Input cursor for next call to subscription endpoint
+//        */
+//       nextInput: (data: TOutput[]) => TInput;
+//     },
+//   ) => CancelFn;
+//   transformer: DataTransformer;
+// };
 
 export function createTRPCClient<TRouter extends AnyRouter>(
   opts: CreateTRPCClientOptions,
@@ -150,7 +390,7 @@ export function createTRPCClient<TRouter extends AnyRouter>(
       ...(opts.getHeaders ? opts.getHeaders() : {}),
     };
   }
-  type TRPCType = 'subscription' | 'query' | 'mutation';
+
   function request({
     type,
     input,

--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -9,6 +9,7 @@ import type {
   inferRouteOutput,
   inferSubscriptionOutput,
   Maybe,
+  Router,
 } from '@trpc/server';
 
 type CancelFn = () => void;
@@ -104,7 +105,7 @@ type TRPCType = 'subscription' | 'query' | 'mutation';
 export class TRPCClient<TRouter extends AnyRouter> {
   private fetch: typeof fetch;
   private AC: ReturnType<typeof getAbortController>;
-  private transformer: DataTransformer;
+  public readonly transformer: DataTransformer;
   private opts: CreateTRPCClientOptions;
 
   constructor(opts: CreateTRPCClientOptions) {
@@ -220,10 +221,10 @@ export class TRPCClient<TRouter extends AnyRouter> {
   }
   public query<
     TQueries extends TRouter['_def']['queries'],
-    TPath extends string & TQueries
+    TPath extends string & keyof TQueries
   >(
     path: TPath,
-    ...args: inferHandlerInput<TQueries, TPath>
+    ...args: inferHandlerInput<TQueries[TPath]>
   ): CancellablePromise<inferRouteOutput<TQueries[TPath]>> {
     return this.request({
       type: 'query',
@@ -234,10 +235,10 @@ export class TRPCClient<TRouter extends AnyRouter> {
 
   public mutation<
     TMutations extends TRouter['_def']['mutations'],
-    TPath extends string & TMutations
+    TPath extends string & keyof TMutations
   >(
     path: TPath,
-    ...args: inferHandlerInput<TMutations, TPath>
+    ...args: inferHandlerInput<TMutations[TPath]>
   ): CancellablePromise<inferRouteOutput<TMutations[TPath]>> {
     return this.request({
       type: 'mutation',
@@ -248,7 +249,7 @@ export class TRPCClient<TRouter extends AnyRouter> {
 
   public subscriptionOnce<
     TSubscriptions extends TRouter['_def']['subscriptions'],
-    TPath extends string & TSubscriptions,
+    TPath extends string & keyof TSubscriptions,
     TOutput extends inferSubscriptionOutput<TRouter, TPath>,
     TInput extends inferRouteInput<TSubscriptions[TPath]>
   >(path: TPath, input: TInput): CancellablePromise<TOutput[]> {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/react",
-  "version": "2.1.0-alpha.1",
+  "version": "2.1.0-alpha.2",
   "description": "TRPC React lib",
   "author": "KATT",
   "license": "MIT",
@@ -33,7 +33,7 @@
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@trpc/client": "^2.1.0-alpha.1",
+    "@trpc/client": "^2.1.0-alpha.2",
     "@trpc/server": "^2.1.0-alpha.1",
     "@types/express": "^4.17.11",
     "body-parser": "^1.19.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,6 +23,11 @@
     "README.md",
     "dist"
   ],
+  "eslintConfig": {
+    "rules": {
+      "react-hooks/exhaustive-deps": "error"
+    }
+  },
   "peerDependencies": {
     "@trpc/client": "^1.4.1",
     "react": ">=16.8.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/react",
-  "version": "2.1.0-alpha.0",
+  "version": "2.1.0-alpha.1",
   "description": "TRPC React lib",
   "author": "KATT",
   "license": "MIT",
@@ -33,8 +33,8 @@
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@trpc/client": "^2.1.0-alpha.0",
-    "@trpc/server": "^2.1.0-alpha.0",
+    "@trpc/client": "^2.1.0-alpha.1",
+    "@trpc/server": "^2.1.0-alpha.1",
     "@types/express": "^4.17.11",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",

--- a/packages/react/src/createReactQueryHooks.ts
+++ b/packages/react/src/createReactQueryHooks.ts
@@ -179,9 +179,10 @@ export function createReactQueryHooks<
     const [path, userInput] = pathAndArgs;
 
     const currentCursor = useRef<any>(null);
+    const cacheKey = [CACHE_PREFIX_LIVE_QUERY, path, userInput];
 
     const hook = useQuery<TInput, TRPCClientError, TOutput>(
-      [CACHE_PREFIX_LIVE_QUERY, path, userInput],
+      cacheKey,
       () =>
         (client.subscriptionOnce as any)(path, {
           ...userInput,

--- a/packages/react/src/createReactQueryHooks.ts
+++ b/packages/react/src/createReactQueryHooks.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { TRPCClient, TRPCClientError } from '@trpc/client';
 import type {
+  AnyRouter,
   inferRouteInput,
   inferRouteOutput,
   inferSubscriptionOutput,
-  Router,
   RouteWithInput,
 } from '@trpc/server';
 import { useEffect, useMemo, useRef } from 'react';
@@ -32,10 +32,15 @@ export type OutputWithCursor<TData, TCursor extends any = any> = {
   data: TData;
 };
 export function createReactQueryHooks<
-  TRouter extends Router<TContext, any, any, any>,
-  TContext,
-  TClient extends TRPCClient = TRPCClient
->({ client, queryClient }: { client: TClient; queryClient: QueryClient }) {
+  TRouter extends AnyRouter<TContext>,
+  TContext
+>({
+  client,
+  queryClient,
+}: {
+  client: TRPCClient<TRouter>;
+  queryClient: QueryClient;
+}) {
   type TQueries = TRouter['_def']['queries'];
   type TMutations = TRouter['_def']['mutations'];
   type TSubscriptions = TRouter['_def']['subscriptions'];
@@ -173,7 +178,7 @@ export function createReactQueryHooks<
     const hook = useQuery<TInput, TRPCClientError, TOutput>(
       pathAndArgs,
       () =>
-        client.subscriptionOnce(path, {
+        (client.subscriptionOnce as any)(path, {
           ...userInput,
           cursor: currentCursor.current,
         }) as any,
@@ -303,7 +308,7 @@ export function createReactQueryHooks<
       pathAndArgs,
       ({ pageParam }) => {
         const actualInput = { ...input, cursor: pageParam };
-        return client.query(path, actualInput);
+        return (client.query as any)(path, actualInput);
       },
       opts,
     );

--- a/packages/react/src/createReactQueryHooks.ts
+++ b/packages/react/src/createReactQueryHooks.ts
@@ -157,7 +157,8 @@ export function createReactQueryHooks<
         stopped = true;
         promise.cancel();
       };
-    }, [queryKey]);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [queryKey, enabled]);
   }
 
   /**
@@ -203,6 +204,7 @@ export function createReactQueryHooks<
     useEffect(() => {
       currentCursor.current = lastCursor;
       hook.refetch();
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [lastCursor]);
 
     return { ...hook, data };

--- a/packages/react/src/createReactQueryHooks.ts
+++ b/packages/react/src/createReactQueryHooks.ts
@@ -250,7 +250,7 @@ export function createReactQueryHooks<
   ): Promise<void> => {
     const input = opts.input ?? null;
     const { path, ctx } = opts;
-    const cacheKey = [path, input];
+    const cacheKey = [CACHE_PREFIX_INFINITE_QUERIES, path, input];
 
     await queryClient.prefetchInfiniteQuery(cacheKey, async () => {
       const data = await router.invoke({

--- a/packages/react/src/createReactQueryHooks.ts
+++ b/packages/react/src/createReactQueryHooks.ts
@@ -10,17 +10,16 @@ import type {
 import { useEffect, useMemo, useRef } from 'react';
 import {
   FetchQueryOptions,
+  hashQueryKey,
   QueryClient,
+  useInfiniteQuery,
+  UseInfiniteQueryOptions,
   useMutation,
   UseMutationOptions,
   UseMutationResult,
   useQuery,
   UseQueryOptions,
   UseQueryResult,
-  useInfiniteQuery,
-  UseInfiniteQueryOptions,
-  UseInfiniteQueryResult,
-  hashQueryKey,
 } from 'react-query';
 import {
   dehydrate,
@@ -34,8 +33,9 @@ export type OutputWithCursor<TData, TCursor extends any = any> = {
 };
 export function createReactQueryHooks<
   TRouter extends Router<TContext, any, any, any>,
-  TContext
->({ client, queryClient }: { client: TRPCClient; queryClient: QueryClient }) {
+  TContext,
+  TClient extends TRPCClient = TRPCClient
+>({ client, queryClient }: { client: TClient; queryClient: QueryClient }) {
   type TQueries = TRouter['_def']['queries'];
   type TMutations = TRouter['_def']['mutations'];
   type TSubscriptions = TRouter['_def']['subscriptions'];
@@ -296,10 +296,10 @@ export function createReactQueryHooks<
     TOutput extends inferRouteOutput<TQueries[TPath]>
   >(
     pathAndArgs: [TPath, Omit<TInput, 'cursor'>],
-    opts?: UseInfiniteQueryOptions<TInput, TRPCClientError, TOutput>,
-  ): UseInfiniteQueryResult<TOutput, TRPCClientError> {
+    opts?: UseInfiniteQueryOptions<TOutput, TRPCClientError, TInput>,
+  ) {
     const [path, input] = pathAndArgs;
-    return useInfiniteQuery<TInput, TRPCClientError, TOutput>(
+    return useInfiniteQuery<TOutput, TRPCClientError, TInput>(
       pathAndArgs,
       ({ pageParam }) => {
         const actualInput = { ...input, cursor: pageParam };

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/server",
-  "version": "2.1.0-alpha.0",
+  "version": "2.1.0-alpha.1",
   "description": "TRPC Server",
   "author": "KATT",
   "license": "MIT",

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -77,17 +77,19 @@ export type inferSubscriptionOutput<
 >;
 
 export type inferHandlerInput<
-  TRoutes extends RouteRecord<any, any, any>,
-  TPath extends keyof TRoutes & string
-> = TRoutes[TPath] extends RouteWithInput<any, any, any>
-  ? [inferRouteInput<TRoutes[TPath]>]
+  TRoute extends Route
+> = TRoute extends RouteWithInput<any, any, any>
+  ? [inferRouteInput<TRoute>]
   : [undefined?];
 
 export type inferHandlerFn<TRoutes extends RouteRecord<any, any, any>> = <
+  TRoute extends TRoutes[TPath],
   TPath extends keyof TRoutes & string
 >(
   path: TPath,
-  ...args: inferHandlerInput<TRoutes, TPath>
+  ...args: TRoute extends RouteWithInput<any, any, any>
+    ? [inferRouteInput<TRoute>]
+    : [undefined?]
 ) => Promise<inferRouteOutput<TRoutes[TPath]>>;
 
 export type AnyRouter<TContext = any> = Router<TContext, any, any, any>;

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -76,14 +76,18 @@ export type inferSubscriptionOutput<
   >['output']
 >;
 
+export type inferHandlerInput<
+  TRoutes extends RouteRecord<any, any, any>,
+  TPath extends keyof TRoutes & string
+> = TRoutes[TPath] extends RouteWithInput<any, any, any>
+  ? [inferRouteInput<TRoutes[TPath]>]
+  : [undefined?];
+
 export type inferHandlerFn<TRoutes extends RouteRecord<any, any, any>> = <
-  TPath extends keyof TRoutes & string,
-  TRoute extends TRoutes[TPath]
+  TPath extends keyof TRoutes & string
 >(
   path: TPath,
-  ...args: TRoute extends RouteWithInput<any, any, any>
-    ? [inferRouteInput<TRoute>]
-    : [undefined?]
+  ...args: inferHandlerInput<TRoutes, TPath>
 ) => Promise<inferRouteOutput<TRoutes[TPath]>>;
 
 export type AnyRouter<TContext = any> = Router<TContext, any, any, any>;

--- a/packages/server/src/subscription.ts
+++ b/packages/server/src/subscription.ts
@@ -81,6 +81,7 @@ export class Subscription<TOutput = unknown> {
 
   /**
    * This method is just here to help with `inferSubscriptionOutput` which I can't get working without it
+   * @deprecated
    */
   protected output(): TOutput {
     throw new Error('Legacy');

--- a/packages/server/test/react.test.tsx
+++ b/packages/server/test/react.test.tsx
@@ -6,7 +6,7 @@ import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { expectTypeOf } from 'expect-type';
 import hash from 'hash-sum';
-import React, { useEffect, useState } from 'react';
+import React, { Fragment, useEffect, useState } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import * as z from 'zod';
 import { createReactQueryHooks, OutputWithCursor } from '../../react/src';
@@ -145,7 +145,7 @@ afterEach(() => {
 test('basic query', async () => {
   const { hooks } = factory;
   function MyComponent() {
-    const allPostsQuery = hooks.useQuery('allPosts');
+    const allPostsQuery = hooks.useQuery(['allPosts']);
     expectTypeOf(allPostsQuery.data!).toMatchTypeOf<Post[]>();
 
     return <pre>{JSON.stringify(allPostsQuery.data ?? 'n/a', null, 4)}</pre>;
@@ -326,12 +326,7 @@ test('useInfiniteQuery()', async () => {
   const { hooks } = factory;
 
   function MyComponent() {
-    const {
-      data,
-      hasNextPage,
-      isFetchingNextPage,
-      fetchNextPage,
-    } = hooks.useInfiniteQuery(
+    const q = hooks.useInfiniteQuery(
       [
         'paginatedPosts',
         {
@@ -342,21 +337,56 @@ test('useInfiniteQuery()', async () => {
         getNextPageParam: (lastPage) => lastPage.nextCursor,
       },
     );
+    expectTypeOf(q.data?.pages[0].items).toMatchTypeOf<undefined | Post[]>();
 
-    return (
+    // const ra = useInfiniteQuery(
+    //   [
+    //     'paginatedPosts',
+    //     {
+    //       limit: 1,
+    //     },
+    //   ],
+    //   ({ pageParam = undefined }) =>
+    //     hooks.client.query('paginatedPosts', {
+    //       limit: 1,
+    //       cursor: pageParam,
+    //     }),
+    //   {
+    //     getNextPageParam: (lastPage) => lastPage.nextCursor,
+    //   },
+    // );
+
+    return q.status === 'loading' ? (
+      <p>Loading...</p>
+    ) : q.status === 'error' ? (
+      <p>Error: {q.error.message}</p>
+    ) : (
       <>
-        <button
-          data-testid="loadMore"
-          onClick={() => fetchNextPage()}
-          disabled={!hasNextPage || isFetchingNextPage}
-        >
-          {isFetchingNextPage
-            ? 'Loading more...'
-            : hasNextPage
-            ? 'Load More'
-            : 'Nothing more to load'}
-        </button>
-        {JSON.stringify(data ?? null)}
+        {q.data?.pages.map((group, i) => (
+          <Fragment key={i}>
+            {group.items.map((msg) => (
+              <Fragment key={msg.id}>
+                <div>{msg.title}</div>
+              </Fragment>
+            ))}
+          </Fragment>
+        ))}
+        <div>
+          <button
+            onClick={() => q.fetchNextPage()}
+            disabled={!q.hasNextPage || q.isFetchingNextPage}
+            data-testid="loadMore"
+          >
+            {q.isFetchingNextPage
+              ? 'Loading more...'
+              : q.hasNextPage
+              ? 'Load More'
+              : 'Nothing more to load'}
+          </button>
+        </div>
+        <div>
+          {q.isFetching && !q.isFetchingNextPage ? 'Fetching...' : null}
+        </div>
       </>
     );
   }
@@ -374,6 +404,7 @@ test('useInfiniteQuery()', async () => {
   });
   await waitFor(() => {
     expect(utils.container).toHaveTextContent('first post');
+    expect(utils.container).not.toHaveTextContent('second post');
     expect(utils.container).toHaveTextContent('Load More');
   });
   userEvent.click(utils.getByTestId('loadMore'));
@@ -386,9 +417,25 @@ test('useInfiniteQuery()', async () => {
     expect(utils.container).toHaveTextContent('Nothing more to load');
   });
 
-  expect(utils.container.innerHTML).toMatchInlineSnapshot(
-    `"<button data-testid=\\"loadMore\\" disabled=\\"\\">Nothing more to load</button>{\\"pages\\":[{\\"items\\":[{\\"id\\":\\"1\\",\\"title\\":\\"first post\\",\\"createdAt\\":0}],\\"nextCursor\\":1},{\\"items\\":[{\\"id\\":\\"2\\",\\"title\\":\\"second post\\",\\"createdAt\\":1}]}],\\"pageParams\\":[null,1]}"`,
-  );
+  expect(utils.container).toMatchInlineSnapshot(`
+    <div>
+      <div>
+        first post
+      </div>
+      <div>
+        second post
+      </div>
+      <div>
+        <button
+          data-testid="loadMore"
+          disabled=""
+        >
+          Nothing more to load
+        </button>
+      </div>
+      <div />
+    </div>
+  `);
 });
 
 test('useInfiniteQueryOnServer()', async () => {

--- a/packages/server/test/react.test.tsx
+++ b/packages/server/test/react.test.tsx
@@ -3,19 +3,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import '@testing-library/jest-dom';
 import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { expectTypeOf } from 'expect-type';
 import hash from 'hash-sum';
 import React, { useEffect, useState } from 'react';
-import {
-  QueryClient,
-  QueryClientProvider,
-  useInfiniteQuery,
-} from 'react-query';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import * as z from 'zod';
 import { createReactQueryHooks, OutputWithCursor } from '../../react/src';
 import * as trpc from '../src';
 import { routerToServerAndClient } from './_testHelpers';
-import userEvent from '@testing-library/user-event';
 
 type Context = {};
 type Post = {

--- a/packages/server/test/react.test.tsx
+++ b/packages/server/test/react.test.tsx
@@ -121,12 +121,10 @@ function createAppRouter() {
 
   const { client, close } = routerToServerAndClient(appRouter);
   const queryClient = new QueryClient();
-  const hooks = createReactQueryHooks<typeof appRouter, Context, typeof client>(
-    {
-      client,
-      queryClient,
-    },
-  );
+  const hooks = createReactQueryHooks({
+    client,
+    queryClient,
+  });
 
   return {
     appRouter,

--- a/packages/server/test/react.test.tsx
+++ b/packages/server/test/react.test.tsx
@@ -6,7 +6,11 @@ import { render, waitFor } from '@testing-library/react';
 import { expectTypeOf } from 'expect-type';
 import hash from 'hash-sum';
 import React, { useEffect, useState } from 'react';
-import { QueryClient, QueryClientProvider } from 'react-query';
+import {
+  QueryClient,
+  QueryClientProvider,
+  useInfiniteQuery,
+} from 'react-query';
 import * as z from 'zod';
 import { createReactQueryHooks, OutputWithCursor } from '../../react/src';
 import * as trpc from '../src';
@@ -120,12 +124,13 @@ function createAppRouter() {
     });
 
   const { client, close } = routerToServerAndClient(appRouter);
-
   const queryClient = new QueryClient();
-  const hooks = createReactQueryHooks<typeof appRouter, Context>({
-    client: client,
-    queryClient,
-  });
+  const hooks = createReactQueryHooks<typeof appRouter, Context, typeof client>(
+    {
+      client,
+      queryClient,
+    },
+  );
 
   return {
     appRouter,
@@ -325,6 +330,7 @@ test('prefetchQuery', async () => {
 
 test('useInfiniteQuery()', async () => {
   const { hooks } = factory;
+
   function MyComponent() {
     const {
       data,
@@ -339,7 +345,7 @@ test('useInfiniteQuery()', async () => {
         },
       ],
       {
-        getNextPageParam: (lastPage) => (lastPage as any).nextCursor,
+        getNextPageParam: (lastPage) => lastPage.nextCursor,
       },
     );
 


### PR DESCRIPTION
- Fix types for `useInfiniteQuery`
- Refactor trpc client into a class (reluctantly)
- Prefix cache keys for live query and infinite query so you can query same endpoints without getting unexpected cache cache hits