### PR TITLE
Add middleware support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ TRPC is a framework for building strongly typed RPC APIs with TypeScript. Altern
   - [Getting started with Next.js](#getting-started-with-nextjs)
   - [Defining routes](#defining-routes)
   - [Merging routers](#merging-routers)
+  - [Router middlewares, `preHook()`](#router-middlewares-prehook)
   - [Data transformers](#data-transformers)
   - [Server-side rendering (SSR / SSG)](#server-side-rendering-ssr--ssg)
 - [Further reading](#further-reading)
@@ -288,6 +289,7 @@ export type AppRouter = typeof appRouter;
 
 </details>
 
+
 ## Merging routers
 
 Writing all API-code in your code in the same file is a bad idea. It's easy to merge routes with other routes. Thanks to TypeScript 4.1 template literal types we can also prefix the routes without breaking type safety.
@@ -331,6 +333,45 @@ const appRouter = createRouter()
 ```
 
 </details>
+
+## Router middlewares, `preHook()`
+
+You can are able to add middleware to a whole router with the `preHook()` method. The prehook(s) will be run before any of the routes defined after are invoked.
+
+Example, from [the tests](./packages/server/test/preHook.test.ts):
+<details><summary>Code</summary>
+
+```ts
+trpc
+  .router<Context>()
+  .query('foo', {
+    resolve() {
+      return 'bar';
+    },
+  })
+  .merge(
+    'admin.',
+    trpc
+      .router<Context>()
+      .preHook(async ({ ctx }) => {
+        if (!ctx.user?.isAdmin) {
+          throw httpError.unauthorized();
+        }
+      })
+      .query('secretPlace', {
+        resolve() {
+          resolverMock();
+
+          return 'a key';
+        },
+      }),
+  )
+```
+</details>
+
+In the example above any call to `admin.*` will ensure that the user is an "admin" before executing any query or mutation.
+
+
 
 ## Data transformers
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ TRPC is a framework for building strongly typed RPC APIs with TypeScript. Altern
   - [Getting started with Next.js](#getting-started-with-nextjs)
   - [Defining routes](#defining-routes)
   - [Merging routers](#merging-routers)
-  - [Router middlewares, `preHook()`](#router-middlewares-prehook)
+  - [Router middlewares](#router-middlewares)
   - [Data transformers](#data-transformers)
   - [Server-side rendering (SSR / SSG)](#server-side-rendering-ssr--ssg)
 - [Further reading](#further-reading)
@@ -334,11 +334,11 @@ const appRouter = createRouter()
 
 </details>
 
-## Router middlewares, `preHook()`
+## Router middlewares
 
-You can are able to add middleware to a whole router with the `preHook()` method. The prehook(s) will be run before any of the routes defined after are invoked.
+You can are able to add middlewares to a whole router with the `middleware()` method. The middleware(s) will be run before any of the routes defined after are invoked & can be async or sync.
 
-Example, from [the tests](./packages/server/test/preHook.test.ts):
+Example, from [the tests](./packages/server/test/middleware.test.ts):
 <details><summary>Code</summary>
 
 ```ts
@@ -353,7 +353,7 @@ trpc
     'admin.',
     trpc
       .router<Context>()
-      .preHook(async ({ ctx }) => {
+      .middleware(async ({ ctx }) => {
         if (!ctx.user?.isAdmin) {
           throw httpError.unauthorized();
         }

--- a/packages/server/src/adapters/express.ts
+++ b/packages/server/src/adapters/express.ts
@@ -6,7 +6,7 @@ import {
   CreateContextFnOptions,
   requestHandler,
 } from '../http';
-import { Router } from '../router';
+import { AnyRouter } from '../router';
 
 export type CreateExpressContextOptions = CreateContextFnOptions<
   express.Request,
@@ -21,7 +21,7 @@ export type CreateExpressContextFn<TContext> = CreateContextFn<
 
 export function createExpressMiddleware<
   TContext,
-  TRouter extends Router<TContext, any, any, any>
+  TRouter extends AnyRouter<TContext>
 >(
   opts: {
     router: TRouter;

--- a/packages/server/src/adapters/next.ts
+++ b/packages/server/src/adapters/next.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
-
 import {
   BaseOptions,
   CreateContextFn,
@@ -9,7 +8,7 @@ import {
   getErrorResponseEnvelope,
   requestHandler,
 } from '../http';
-import { Router } from '../router';
+import { AnyRouter } from '../router';
 
 export type CreateNextContextOptions = CreateContextFnOptions<
   NextApiRequest,
@@ -23,7 +22,7 @@ export type CreateNextContextFn<TContext> = CreateContextFn<
 >;
 export function createNextApiHandler<
   TContext,
-  TRouter extends Router<TContext, any, any, any>
+  TRouter extends AnyRouter<TContext>
 >(
   opts: {
     router: TRouter;

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -4,7 +4,7 @@ import qs from 'qs';
 import url from 'url';
 import { assertNotBrowser } from './assertNotBrowser';
 import { InputValidationError, RouteNotFoundError } from './errors';
-import { Router } from './router';
+import { AnyRouter } from './router';
 import { Subscription } from './subscription';
 import { DataTransformer } from './transformer';
 assertNotBrowser();
@@ -162,7 +162,7 @@ async function getPostBody({
 
 export async function requestHandler<
   TContext,
-  TRouter extends Router<TContext, any, any, any>,
+  TRouter extends AnyRouter<TContext>,
   TCreateContextFn extends CreateContextFn<TContext, TRequest, TResponse>,
   TRequest extends BaseRequest,
   TResponse extends BaseResponse

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -161,11 +161,11 @@ async function getPostBody({
 }
 
 export async function requestHandler<
+  TContext,
   TRouter extends AnyRouter<TContext>,
   TCreateContextFn extends CreateContextFn<TContext, TRequest, TResponse>,
   TRequest extends BaseRequest,
-  TResponse extends BaseResponse,
-  TContext = any
+  TResponse extends BaseResponse
 >({
   req,
   res,

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -161,11 +161,11 @@ async function getPostBody({
 }
 
 export async function requestHandler<
-  TContext,
   TRouter extends AnyRouter<TContext>,
   TCreateContextFn extends CreateContextFn<TContext, TRequest, TResponse>,
   TRequest extends BaseRequest,
-  TResponse extends BaseResponse
+  TResponse extends BaseResponse,
+  TContext = any
 >({
   req,
   res,

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -283,34 +283,42 @@ export class Router<
       throw new Error(`Duplicate endpoint(s): ${duplicates.join(', ')}`);
     }
 
-    const addPreHooks = <TRoutes extends RouteRecord>(routes: TRoutes) => {
-      const newRoutes = {} as TRoutes;
-      for (const key in routes) {
-        const route = routes[key];
-        newRoutes[key] = {
-          ...route,
-          _preHooks: [...(route._preHooks ?? []), ...this._def.preHooks],
-        };
-      }
-      return newRoutes;
-    };
     return new Router<TContext, any, any, any>({
       queries: {
         ...this._def.queries,
-        ...addPreHooks(Router.prefixRoutes(router._def.queries, prefix)),
+        ...this.inhertPreHooks(
+          Router.prefixRoutes(router._def.queries, prefix),
+        ),
       },
       mutations: {
         ...this._def.mutations,
-        ...addPreHooks(Router.prefixRoutes(router._def.mutations, prefix)),
+        ...this.inhertPreHooks(
+          Router.prefixRoutes(router._def.mutations, prefix),
+        ),
       },
       subscriptions: {
         ...this._def.subscriptions,
-        ...addPreHooks(Router.prefixRoutes(router._def.subscriptions, prefix)),
+        ...this.inhertPreHooks(
+          Router.prefixRoutes(router._def.subscriptions, prefix),
+        ),
       },
       preHooks: this._def.preHooks,
     });
   }
 
+  private inhertPreHooks<TRoutes extends RouteRecord<TCtx>, TCtx>(
+    routes: TRoutes,
+  ): TRoutes {
+    const newRoutes = {} as TRoutes;
+    for (const key in routes) {
+      const route = routes[key];
+      newRoutes[key] = {
+        ...route,
+        _preHooks: [...(route._preHooks ?? []), ...this._def.preHooks],
+      };
+    }
+    return newRoutes;
+  }
   private static getInput<TRoute extends Route<any, any, any>>(
     route: TRoute,
     rawInput: unknown,
@@ -363,7 +371,6 @@ export class Router<
     return !!this._def[what][path];
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   /**
    * Function to be called before any route is invoked
    * Can be async or not async

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -36,7 +36,6 @@ export type RouteWithInput<
 > = {
   input: RouteInputParser<TInput>;
   resolve: RouteResolver<TContext, TInput, TOutput>;
-  _preHooks?: PreHookFunction<TContext>[];
 };
 
 export type RouteWithoutInput<
@@ -47,11 +46,12 @@ export type RouteWithoutInput<
   input?: undefined | null;
   resolve: RouteResolver<TContext, TInput, TOutput>;
 };
-export type Route<TContext = unknown, TInput = unknown, TOutput = unknown> =
+export type Route<TContext = unknown, TInput = unknown, TOutput = unknown> = (
   | RouteWithInput<TContext, TInput, TOutput>
-  | (RouteWithoutInput<TContext, TInput, TOutput> & {
-      _preHooks?: PreHookFunction<TContext>[];
-    });
+  | RouteWithoutInput<TContext, TInput, TOutput>
+) & {
+  _preHooks?: PreHookFunction<TContext>[];
+};
 
 export type RouteRecord<
   TContext = unknown,

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -23,15 +23,11 @@ export type RouteInputParser<TInput = unknown> =
   | RouteInputParserYupEsque<TInput>
   | RouteInputParserCustomValidatorEsque<TInput>;
 
-type RouteResolverOpts<TContext = unknown, TInput = unknown> = {
-  ctx: TContext;
-  input: TInput;
-};
 export type RouteResolver<
   TContext = unknown,
   TInput = unknown,
   TOutput = unknown
-> = (opts: RouteResolverOpts<TContext, TInput>) => Promise<TOutput> | TOutput;
+> = (opts: { ctx: TContext; input: TInput }) => Promise<TOutput> | TOutput;
 
 export type RouteWithInput<
   TContext = unknown,

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -97,7 +97,7 @@ export type inferHandlerFn<TRoutes extends RouteRecord<any, any, any>> = <
 
 export type AnyRouter<TContext = any> = Router<TContext, any, any, any>;
 
-export type PreHookFunction<TContext = unknown> = (opts: {
+export type PreHookFunction<TContext> = (opts: {
   ctx: TContext;
 }) => Promise<void> | void;
 export class Router<
@@ -265,14 +265,14 @@ export class Router<
     }
 
     const duplicateQueries = Object.keys(router._def.queries).filter((key) =>
-      this.has('queries', key),
+      this.has('queries', prefix + key),
     );
     const duplicateMutations = Object.keys(
       router._def.mutations,
-    ).filter((key) => this.has('mutations', key));
+    ).filter((key) => this.has('mutations', prefix + key));
     const duplicateSubscriptions = Object.keys(
       router._def.subscriptions,
-    ).filter((key) => this.has('subscriptions', key));
+    ).filter((key) => this.has('subscriptions', prefix + key));
 
     const duplicates = [
       ...duplicateQueries,
@@ -314,7 +314,11 @@ export class Router<
       const route = routes[key];
       newRoutes[key] = {
         ...route,
-        _preHooks: [...(route._preHooks ?? []), ...this._def.preHooks],
+        _preHooks: [
+          //
+          ...this._def.preHooks,
+          ...(route._preHooks ?? []),
+        ],
       };
     }
     return newRoutes;

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -384,7 +384,7 @@ export class Router<
 
   /**
    * Function to be called before any route is invoked
-   * Can be async or not async
+   * Can be async or sync
    */
   preHook(fn: TPreHook) {
     this._def.preHooks.push(fn);

--- a/packages/server/test/preHook.test.ts
+++ b/packages/server/test/preHook.test.ts
@@ -1,0 +1,153 @@
+import { routerToServerAndClient } from './_testHelpers';
+import * as trpc from '../src';
+import { httpError } from '../src';
+
+test('does not crash', async () => {
+  const { client, close } = routerToServerAndClient(
+    trpc
+      .router()
+      .query('foo', {
+        resolve() {
+          return 'bar';
+        },
+      })
+      .preHook(() => {}),
+  );
+
+  expect(await client.query('foo')).toBe('bar');
+
+  close();
+});
+test('is called if def first', async () => {
+  const preHook = jest.fn();
+  const { client, close } = routerToServerAndClient(
+    trpc
+      .router()
+      .preHook(preHook)
+      .query('foo1', {
+        resolve() {
+          return 'bar1';
+        },
+      })
+      .query('foo2', {
+        resolve() {
+          return 'bar2';
+        },
+      }),
+  );
+
+  expect(await client.query('foo1')).toBe('bar1');
+  expect(await client.query('foo2')).toBe('bar2');
+  expect(preHook).toHaveBeenCalledTimes(2);
+  close();
+});
+
+test('is not called if def last', async () => {
+  const preHook = jest.fn();
+  const { client, close } = routerToServerAndClient(
+    trpc
+      .router()
+      .query('foo', {
+        resolve() {
+          return 'bar';
+        },
+      })
+      .preHook(preHook),
+  );
+
+  expect(await client.query('foo')).toBe('bar');
+  expect(preHook).toHaveBeenCalledTimes(0);
+  close();
+});
+
+test('affects child routers', async () => {
+  const preHook = jest.fn();
+  const { client, close } = routerToServerAndClient(
+    trpc
+      .router()
+      .preHook(preHook)
+      .query('foo1', {
+        resolve() {
+          return 'bar1';
+        },
+      })
+      .merge(
+        'child.',
+        trpc.router().query('foo2', {
+          resolve() {
+            return 'bar2';
+          },
+        }),
+      ),
+  );
+
+  expect(await client.query('foo1')).toBe('bar1');
+  expect(await client.query('child.foo2')).toBe('bar2');
+  expect(preHook).toHaveBeenCalledTimes(2);
+  close();
+});
+
+test('allows you to throw an error (e.g. auth)', async () => {
+  type Context = {
+    user?: {
+      id: number;
+      name: string;
+      isAdmin: boolean;
+    };
+  };
+  const resolverMock = jest.fn();
+
+  const headers: Record<string, string | undefined> = {};
+
+  const { client, close } = routerToServerAndClient(
+    trpc
+      .router<Context>()
+      .query('foo', {
+        resolve() {
+          return 'bar';
+        },
+      })
+      .merge(
+        'admin.',
+        trpc
+          .router<Context>()
+          .preHook(({ ctx }) => {
+            if (!ctx.user?.isAdmin) {
+              throw httpError.unauthorized();
+            }
+          })
+          .query('secretPlace', {
+            resolve() {
+              resolverMock();
+
+              return 'a key';
+            },
+          }),
+      ),
+    {
+      createContext({ req }) {
+        if (req.headers.authorization === 'meow') {
+          return {
+            user: {
+              id: 1,
+              name: 'KATT',
+              isAdmin: true,
+            },
+          };
+        }
+        return {};
+      },
+      getHeaders: () => headers,
+    },
+  );
+
+  expect(await client.query('foo')).toBe('bar');
+  await expect(client.query('admin.secretPlace')).rejects.toMatchObject({
+    res: { status: 401 },
+  });
+  expect(resolverMock).toHaveBeenCalledTimes(0);
+  headers.authorization = 'meow';
+  expect(await client.query('admin.secretPlace')).toBe('a key');
+  expect(resolverMock).toHaveBeenCalledTimes(1);
+  close();
+});

--- a/packages/server/test/preHook.test.ts
+++ b/packages/server/test/preHook.test.ts
@@ -2,22 +2,6 @@ import { routerToServerAndClient } from './_testHelpers';
 import * as trpc from '../src';
 import { httpError } from '../src';
 
-test('does not crash', async () => {
-  const { client, close } = routerToServerAndClient(
-    trpc
-      .router()
-      .query('foo', {
-        resolve() {
-          return 'bar';
-        },
-      })
-      .preHook(() => {}),
-  );
-
-  expect(await client.query('foo')).toBe('bar');
-
-  close();
-});
 test('is called if def first', async () => {
   const preHook = jest.fn();
   const { client, close } = routerToServerAndClient(


### PR DESCRIPTION
- allows you to create a middleware-esque thing on a router that cascades down on all routes added after
- I don't love the name `preHook` - would love some input.
- (started on a proper "middleware"-thing in #88, but it's a bit complicated as it might require async iterables, so might do that later or never)
- see the tests for usage, here's an example of an admin "sub-router"   https://github.com/trpc/trpc/blob/5f96526432bd8d5454e145e62e3df9eba3f9785c/packages/server/test/preHook.test.ts#L67-L84
