### PR TITLE
rename route to procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ TRPC is a framework for building strongly typed RPC APIs with TypeScript. Altern
 - [Usage](#usage)
   - [Example apps](#example-apps)
   - [Getting started with Next.js](#getting-started-with-nextjs)
-  - [Defining routes](#defining-routes)
+  - [Defining procedures](#defining-procedures)
   - [Merging routers](#merging-routers)
   - [Router middlewares](#router-middlewares)
   - [Data transformers](#data-transformers)
@@ -74,7 +74,7 @@ The code here is taken from [`./examples/next-hello-world`](./examples/next-hell
 yarn add @trpc/client @trpc/server @trpc/react zod react-query
 ```
 
-- tRPC wraps a tiny layer of sugar around [react-query](https://react-query.tanstack.com/overview) when using React which gives you type safety and auto completion of your routes
+- tRPC wraps a tiny layer of sugar around [react-query](https://react-query.tanstack.com/overview) when using React which gives you type safety and auto completion of your procedures
 - Zod is a great validation lib that works well, but tRPC also works out-of-the-box with yup/myzod/ts-json-validator/[..] - [see test suite](./packages/server/test/validators.test.ts)
 
 </details>
@@ -103,7 +103,7 @@ function createRouter() {
 }
 // Important: only use this export with SSR/SSG
 export const appRouter = createRouter()
-  // Create route at path 'hello'
+  // Create procedure at path 'hello'
   .query('hello', {
     // using zod schema to validate and infer input values
     input: z
@@ -182,7 +182,7 @@ import Head from 'next/head';
 import { trpc } from '../utils/trpc';
 
 export default function Home() {
-  // try typing here to see that you get autocompletioon & type safety on the route name
+  // try typing here to see that you get autocompletion & type safety on the procedure's name
   const helloNoArgs = trpc.useQuery(['hello']);
   const helloWithArgs = trpc.useQuery(['hello', { text: 'client' }]);
 
@@ -216,9 +216,9 @@ export default function Home() {
 </details>
 
 
-## Defining routes
+## Defining procedures
 
-Defining routes is the same for queries, mutations, and subscription with the exception that subscriptions needs to return a `Subscription`-instance.
+Defining procedures is the same for queries, mutations, and subscription with the exception that subscriptions needs to return a `Subscription`-instance.
 
 <details><summary>Example query without input argument</summary>
 
@@ -226,7 +226,7 @@ Defining routes is the same for queries, mutations, and subscription with the ex
 import * as trpc from '@trpc/server';
 
 export const appRouter = trpc.router()
-  // Create route at path 'hello'
+  // Create procedure at path 'hello'
   .query('hello', {
     resolve({ ctx }) {
       return {
@@ -292,7 +292,7 @@ export type AppRouter = typeof appRouter;
 
 ## Merging routers
 
-Writing all API-code in your code in the same file is a bad idea. It's easy to merge routes with other routes. Thanks to TypeScript 4.1 template literal types we can also prefix the routes without breaking type safety.
+Writing all API-code in your code in the same file is a bad idea. It's easy to merge procedures with other procedures. Thanks to TypeScript 4.1 template literal types we can also prefix the procedures without breaking type safety.
 
 <details><summary>Example code</summary>
 
@@ -327,8 +327,8 @@ const users = createRouter()
 
 
 const appRouter = createRouter()
-  .merge('users.', users) // prefix user routes with "users."
-  .merge('posts.', posts) // prefix poosts routes with "posts."
+  .merge('users.', users) // prefix user procedures with "users."
+  .merge('posts.', posts) // prefix poosts procedures with "posts."
   ;
 ```
 
@@ -336,7 +336,7 @@ const appRouter = createRouter()
 
 ## Router middlewares
 
-You can are able to add middlewares to a whole router with the `middleware()` method. The middleware(s) will be run before any of the routes defined after are invoked & can be async or sync.
+You can are able to add middlewares to a whole router with the `middleware()` method. The middleware(s) will be run before any of the procedures defined after are invoked & can be async or sync.
 
 Example, from [the tests](./packages/server/test/middleware.test.ts):
 <details><summary>Code</summary>

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ export default function Home() {
 
 ## Defining procedures (_endpoints / routes_)
 
-> - A procedure can be seen as the REST-equivalent of an endpoint.
+> - A procedure can be viewed as the equivalent of a REST-endpoint.
 > - There's no internal difference between queries and mutations apart from semantics.
 
 Defining procedures is the same for queries, mutations, and subscription with the exception that subscriptions need to return a `Subscription`-instance.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ TRPC is a framework for building strongly typed RPC APIs with TypeScript. Altern
 - [Usage](#usage)
   - [Example apps](#example-apps)
   - [Getting started with Next.js](#getting-started-with-nextjs)
-  - [Defining procedures](#defining-procedures)
+  - [Defining procedures (_endpoints / routes_)](#defining-procedures-endpoints--routes)
   - [Merging routers](#merging-routers)
   - [Router middlewares](#router-middlewares)
   - [Data transformers](#data-transformers)
@@ -216,9 +216,14 @@ export default function Home() {
 </details>
 
 
-## Defining procedures
+## Defining procedures (_endpoints / routes_)
 
-Defining procedures is the same for queries, mutations, and subscription with the exception that subscriptions needs to return a `Subscription`-instance.
+> - A procedure can be seen as the REST-equivalent of an endpoint.
+> - There's no internal difference between queries and mutations apart from semantics.
+
+Defining procedures is the same for queries, mutations, and subscription with the exception that subscriptions need to return a `Subscription`-instance.
+
+
 
 <details><summary>Example query without input argument</summary>
 

--- a/examples/next-hello-world/package.json
+++ b/examples/next-hello-world/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/hello-world",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0-alpha.2",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -11,9 +11,9 @@
     "test-start": "start-server-and-test start 3000 test"
   },
   "dependencies": {
-    "@trpc/client": "^3.0.0-alpha.0",
-    "@trpc/react": "^3.0.0-alpha.0",
-    "@trpc/server": "^3.0.0-alpha.0",
+    "@trpc/client": "^3.0.0-alpha.2",
+    "@trpc/react": "^3.0.0-alpha.2",
+    "@trpc/server": "^3.0.0-alpha.2",
     "next": "10.0.4",
     "react": "17.0.1",
     "react-dom": "17.0.1",

--- a/examples/next-hello-world/package.json
+++ b/examples/next-hello-world/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/hello-world",
-  "version": "2.2.0",
+  "version": "3.0.0-alpha.0",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -11,9 +11,9 @@
     "test-start": "start-server-and-test start 3000 test"
   },
   "dependencies": {
-    "@trpc/client": "^2.2.0",
-    "@trpc/react": "^2.2.0",
-    "@trpc/server": "^2.2.0",
+    "@trpc/client": "^3.0.0-alpha.0",
+    "@trpc/react": "^3.0.0-alpha.0",
+    "@trpc/server": "^3.0.0-alpha.0",
     "next": "10.0.4",
     "react": "17.0.1",
     "react-dom": "17.0.1",

--- a/examples/next-hello-world/pages/api/trpc/[...trpc].ts
+++ b/examples/next-hello-world/pages/api/trpc/[...trpc].ts
@@ -16,7 +16,7 @@ function createRouter() {
 }
 // Important: only use this export with SSR/SSG
 export const appRouter = createRouter()
-  // Create route at path 'hello'
+  // Create procedure at path 'hello'
   .query('hello', {
     // using zod schema to validate and infer input values
     input: z

--- a/examples/next-hello-world/pages/index.tsx
+++ b/examples/next-hello-world/pages/index.tsx
@@ -2,7 +2,7 @@ import Head from 'next/head';
 import { trpc } from '../utils/trpc';
 
 export default function Home() {
-  // try typing here to see that you get autocompletioon & type safety on the route name
+  // try typing here to see that you get autocompletion & type safety on the procedure's name
   const helloNoArgs = trpc.useQuery(['hello']);
   const helloWithArgs = trpc.useQuery(['hello', { text: 'client' }]);
 

--- a/examples/next-ssg-chat/package.json
+++ b/examples/next-ssg-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/chat",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0-alpha.2",
   "private": true,
   "scripts": {
     "dx:next": "prisma generate && next dev",
@@ -18,9 +18,9 @@
   },
   "dependencies": {
     "@prisma/client": "^2.16.0",
-    "@trpc/client": "^3.0.0-alpha.0",
-    "@trpc/react": "^3.0.0-alpha.0",
-    "@trpc/server": "^3.0.0-alpha.0",
+    "@trpc/client": "^3.0.0-alpha.2",
+    "@trpc/react": "^3.0.0-alpha.2",
+    "@trpc/server": "^3.0.0-alpha.2",
     "jest": "^26.6.3",
     "jest-playwright": "^0.0.1",
     "jest-playwright-preset": "^1.4.5",

--- a/examples/next-ssg-chat/package.json
+++ b/examples/next-ssg-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/chat",
-  "version": "2.2.0",
+  "version": "3.0.0-alpha.0",
   "private": true,
   "scripts": {
     "dx:next": "prisma generate && next dev",
@@ -18,9 +18,9 @@
   },
   "dependencies": {
     "@prisma/client": "^2.16.0",
-    "@trpc/client": "^2.2.0",
-    "@trpc/react": "^2.2.0",
-    "@trpc/server": "^2.2.0",
+    "@trpc/client": "^3.0.0-alpha.0",
+    "@trpc/react": "^3.0.0-alpha.0",
+    "@trpc/server": "^3.0.0-alpha.0",
     "jest": "^26.6.3",
     "jest-playwright": "^0.0.1",
     "jest-playwright-preset": "^1.4.5",

--- a/examples/next-ssg-chat/utils/trpc.ts
+++ b/examples/next-ssg-chat/utils/trpc.ts
@@ -1,5 +1,5 @@
 import { createReactQueryHooks, createTRPCClient } from '@trpc/react';
-import type { inferRouteOutput } from '@trpc/server';
+import type { inferProcedureOutput } from '@trpc/server';
 import { QueryClient } from 'react-query';
 import superjson from 'superjson';
 // ℹ️ Type-only import:
@@ -24,4 +24,4 @@ export const trpc = createReactQueryHooks({
  */
 export type inferQueryOutput<
   TRouteKey extends keyof AppRouter['_def']['queries']
-> = inferRouteOutput<AppRouter['_def']['queries'][TRouteKey]>;
+> = inferProcedureOutput<AppRouter['_def']['queries'][TRouteKey]>;

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/playground",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0-alpha.2",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server.ts",
@@ -12,9 +12,9 @@
     "test-start": "start-server-and-test 'node dist/server' 2021 'node dist/client'"
   },
   "dependencies": {
-    "@trpc/client": "^3.0.0-alpha.0",
-    "@trpc/react": "^3.0.0-alpha.0",
-    "@trpc/server": "^3.0.0-alpha.0",
+    "@trpc/client": "^3.0.0-alpha.2",
+    "@trpc/react": "^3.0.0-alpha.2",
+    "@trpc/server": "^3.0.0-alpha.2",
     "@types/node-fetch": "^2.5.8",
     "abort-controller": "^3.0.0",
     "body-parser": "^1.19.0",

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/playground",
-  "version": "2.2.0",
+  "version": "3.0.0-alpha.0",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server.ts",
@@ -12,9 +12,9 @@
     "test-start": "start-server-and-test 'node dist/server' 2021 'node dist/client'"
   },
   "dependencies": {
-    "@trpc/client": "^2.2.0",
-    "@trpc/react": "^2.2.0",
-    "@trpc/server": "^2.2.0",
+    "@trpc/client": "^3.0.0-alpha.0",
+    "@trpc/react": "^3.0.0-alpha.0",
+    "@trpc/server": "^3.0.0-alpha.0",
     "@types/node-fetch": "^2.5.8",
     "abort-controller": "^3.0.0",
     "body-parser": "^1.19.0",

--- a/examples/playground/src/server.ts
+++ b/examples/playground/src/server.ts
@@ -30,7 +30,7 @@ function createRouter() {
   return trpc.router<Context>();
 }
 
-// --------- create routes etc
+// --------- create procedures etc
 
 let id = 0;
 
@@ -165,7 +165,7 @@ async function main() {
       },
     }),
   );
-  app.get('/', (_req, res) => res.send('hello'))
+  app.get('/', (_req, res) => res.send('hello'));
   app.listen(2021, () => {
     console.log('listening on port 2021');
   });

--- a/examples/standalone-server/package.json
+++ b/examples/standalone-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/standalone-server",
-  "version": "2.2.0",
+  "version": "3.0.0-alpha.0",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server.ts",
@@ -11,9 +11,9 @@
     "test-start": "start-server-and-test 'node dist/server' 2022 'node dist/client'"
   },
   "dependencies": {
-    "@trpc/client": "^2.2.0",
-    "@trpc/react": "^2.2.0",
-    "@trpc/server": "^2.2.0",
+    "@trpc/client": "^3.0.0-alpha.0",
+    "@trpc/react": "^3.0.0-alpha.0",
+    "@trpc/server": "^3.0.0-alpha.0",
     "@types/node-fetch": "^2.5.8",
     "abort-controller": "^3.0.0",
     "node-fetch": "^2.6.1",

--- a/examples/standalone-server/package.json
+++ b/examples/standalone-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/standalone-server",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0-alpha.2",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server.ts",
@@ -11,9 +11,9 @@
     "test-start": "start-server-and-test 'node dist/server' 2022 'node dist/client'"
   },
   "dependencies": {
-    "@trpc/client": "^3.0.0-alpha.0",
-    "@trpc/react": "^3.0.0-alpha.0",
-    "@trpc/server": "^3.0.0-alpha.0",
+    "@trpc/client": "^3.0.0-alpha.2",
+    "@trpc/react": "^3.0.0-alpha.2",
+    "@trpc/server": "^3.0.0-alpha.2",
     "@types/node-fetch": "^2.5.8",
     "abort-controller": "^3.0.0",
     "node-fetch": "^2.6.1",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.0",
+  "version": "3.0.0-alpha.0",
   "registry": "https://registry.npmjs.org/",
   "publishConfig": {
     "access": "public"

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0-alpha.2",
   "registry": "https://registry.npmjs.org/",
   "publishConfig": {
     "access": "public"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/client",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0-alpha.2",
   "description": "TRPC Client lib",
   "author": "KATT",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@trpc/server": "^3.0.0-alpha.0"
+    "@trpc/server": "^3.0.0-alpha.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/client",
-  "version": "2.2.0",
+  "version": "3.0.0-alpha.0",
   "description": "TRPC Client lib",
   "author": "KATT",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@trpc/server": "^2.2.0"
+    "@trpc/server": "^3.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -5,8 +5,8 @@ import type {
   HTTPResponseEnvelope,
   HTTPSuccessResponseEnvelope,
   inferHandlerInput,
-  inferRouteInput,
-  inferRouteOutput,
+  inferProcedureInput,
+  inferProcedureOutput,
   inferSubscriptionOutput,
   Maybe,
 } from '@trpc/server';
@@ -225,7 +225,7 @@ export class TRPCClient<TRouter extends AnyRouter> {
   >(
     path: TPath,
     ...args: inferHandlerInput<TQueries[TPath]>
-  ): CancellablePromise<inferRouteOutput<TQueries[TPath]>> {
+  ): CancellablePromise<inferProcedureOutput<TQueries[TPath]>> {
     return this.request({
       type: 'query',
       path,
@@ -239,7 +239,7 @@ export class TRPCClient<TRouter extends AnyRouter> {
   >(
     path: TPath,
     ...args: inferHandlerInput<TMutations[TPath]>
-  ): CancellablePromise<inferRouteOutput<TMutations[TPath]>> {
+  ): CancellablePromise<inferProcedureOutput<TMutations[TPath]>> {
     return this.request({
       type: 'mutation',
       path,
@@ -251,7 +251,7 @@ export class TRPCClient<TRouter extends AnyRouter> {
     TSubscriptions extends TRouter['_def']['subscriptions'],
     TPath extends string & keyof TSubscriptions,
     TOutput extends inferSubscriptionOutput<TRouter, TPath>,
-    TInput extends inferRouteInput<TSubscriptions[TPath]>
+    TInput extends inferProcedureInput<TSubscriptions[TPath]>
   >(path: TPath, input: TInput): CancellablePromise<TOutput[]> {
     let stopped = false;
     let nextTry: any; // setting as `NodeJS.Timeout` causes compat issues, can probably be solved
@@ -297,7 +297,7 @@ export class TRPCClient<TRouter extends AnyRouter> {
     TSubscriptions extends TRouter['_def']['subscriptions'],
     TPath extends string & keyof TSubscriptions,
     TOutput extends inferSubscriptionOutput<TRouter, TPath>,
-    TInput extends inferRouteInput<TSubscriptions[TPath]>
+    TInput extends inferProcedureInput<TSubscriptions[TPath]>
   >(
     path: TPath,
     opts: {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/react",
-  "version": "2.2.0",
+  "version": "3.0.0-alpha.0",
   "description": "TRPC React lib",
   "author": "KATT",
   "license": "MIT",
@@ -38,8 +38,8 @@
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@trpc/client": "^2.2.0",
-    "@trpc/server": "^2.2.0",
+    "@trpc/client": "^3.0.0-alpha.0",
+    "@trpc/server": "^3.0.0-alpha.0",
     "@types/express": "^4.17.11",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/react",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0-alpha.2",
   "description": "TRPC React lib",
   "author": "KATT",
   "license": "MIT",
@@ -38,8 +38,8 @@
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@trpc/client": "^3.0.0-alpha.0",
-    "@trpc/server": "^3.0.0-alpha.0",
+    "@trpc/client": "^3.0.0-alpha.2",
+    "@trpc/server": "^3.0.0-alpha.2",
     "@types/express": "^4.17.11",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",

--- a/packages/react/src/createReactQueryHooks.ts
+++ b/packages/react/src/createReactQueryHooks.ts
@@ -2,10 +2,10 @@
 import { TRPCClient, TRPCClientError } from '@trpc/client';
 import type {
   AnyRouter,
-  inferRouteInput,
-  inferRouteOutput,
+  inferProcedureInput,
+  inferProcedureOutput,
   inferSubscriptionOutput,
-  RouteWithInput,
+  ProcedureWithInput,
 } from '@trpc/server';
 import { useEffect, useMemo, useRef } from 'react';
 import {
@@ -52,24 +52,24 @@ export function createReactQueryHooks<
   // function _useQuery<
   //   // TODO exclude all with mandatory input from TPath
   //   TPath extends keyof TQueries & string,
-  //   TOutput extends inferRouteOutput<TQueries[TPath]>
+  //   TOutput extends inferProcedureOutput<TQueries[TPath]>
   // >(
   //   path: TPath,
   //   opts?: UseQueryOptions<unknown, TRPCClientError, TOutput>,
   // ): UseQueryResult<TOutput, TRPCClientError>;
   function _useQuery<
     TPath extends keyof TQueries,
-    TRoute extends TQueries[TPath],
-    TOutput extends inferRouteOutput<TRoute>
+    TProcedure extends TQueries[TPath],
+    TOutput extends inferProcedureOutput<TProcedure>
   >(
     pathAndArgs: [
       path: TPath,
-      ...args: TRoute extends RouteWithInput<any, any, any>
-        ? [inferRouteInput<TRoute>]
+      ...args: TProcedure extends ProcedureWithInput<any, any, any>
+        ? [inferProcedureInput<TProcedure>]
         : [undefined?]
     ],
     opts?: UseQueryOptions<
-      inferRouteInput<TQueries[TPath]>,
+      inferProcedureInput<TQueries[TPath]>,
       TRPCClientError,
       TOutput
     >,
@@ -94,8 +94,8 @@ export function createReactQueryHooks<
 
   function _useMutation<
     TPath extends keyof TMutations & string,
-    TInput extends inferRouteInput<TMutations[TPath]>,
-    TOutput extends inferRouteOutput<TMutations[TPath]>
+    TInput extends inferProcedureInput<TMutations[TPath]>,
+    TOutput extends inferProcedureOutput<TMutations[TPath]>
   >(
     path: TPath,
     opts?: UseMutationOptions<TOutput, TRPCClientError, TInput>,
@@ -120,7 +120,7 @@ export function createReactQueryHooks<
    */
   function useSubscription<
     TPath extends keyof TSubscriptions & string,
-    TInput extends inferRouteInput<TSubscriptions[TPath]>,
+    TInput extends inferProcedureInput<TSubscriptions[TPath]>,
     TOutput extends inferSubscriptionOutput<TRouter, TPath>
   >(
     pathAndArgs: [TPath, TInput],
@@ -168,7 +168,7 @@ export function createReactQueryHooks<
    */
   function useLiveQuery<
     TPath extends keyof TSubscriptions & string,
-    TInput extends inferRouteInput<TSubscriptions[TPath]> & { cursor: any },
+    TInput extends inferProcedureInput<TSubscriptions[TPath]> & { cursor: any },
     TOutput extends (inferSubscriptionOutput<TRouter, TPath> &
       OutputWithCursor<TData>)[],
     TData
@@ -213,7 +213,7 @@ export function createReactQueryHooks<
 
   const prefetchQueryOnServer = async <
     TPath extends keyof TQueries & string,
-    TInput extends inferRouteInput<TQueries[TPath]>
+    TInput extends inferProcedureInput<TQueries[TPath]>
   >(
     router: TRouter,
     opts: {
@@ -240,7 +240,7 @@ export function createReactQueryHooks<
 
   const prefetchInfiniteQueryOnServer = async <
     TPath extends keyof TQueries & string,
-    TInput extends inferRouteInput<TQueries[TPath]>
+    TInput extends inferProcedureInput<TQueries[TPath]>
   >(
     router: TRouter,
     opts: {
@@ -267,8 +267,8 @@ export function createReactQueryHooks<
 
   function prefetchQuery<
     TPath extends keyof TQueries & string,
-    TInput extends inferRouteInput<TQueries[TPath]>,
-    TOutput extends inferRouteOutput<TQueries[TPath]>
+    TInput extends inferProcedureInput<TQueries[TPath]>,
+    TOutput extends inferProcedureOutput<TQueries[TPath]>
   >(
     pathAndArgs: [TPath, TInput],
     opts?: FetchQueryOptions<TInput, TRPCClientError, TOutput>,
@@ -304,8 +304,8 @@ export function createReactQueryHooks<
 
   function _useInfiniteQuery<
     TPath extends keyof TQueries & string,
-    TInput extends inferRouteInput<TQueries[TPath]> & { cursor: TCursor },
-    TOutput extends inferRouteOutput<TQueries[TPath]>,
+    TInput extends inferProcedureInput<TQueries[TPath]> & { cursor: TCursor },
+    TOutput extends inferProcedureOutput<TQueries[TPath]>,
     TCursor extends any
   >(
     pathAndArgs: [TPath, Omit<TInput, 'cursor'>],

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/server",
-  "version": "2.2.0",
+  "version": "3.0.0-alpha.0",
   "description": "TRPC Server",
   "author": "KATT",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/server",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0-alpha.2",
   "description": "TRPC Server",
   "author": "KATT",
   "license": "MIT",

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -7,69 +7,75 @@ import { Subscription } from './subscription';
 import { format, Prefixer, ThenArg } from './types';
 assertNotBrowser();
 
-export type RouteInputParserZodEsque<TInput = unknown> = {
+export type ProcedureInputParserZodEsque<TInput = unknown> = {
   parse: (input: any) => TInput;
 };
 
-export type RouteInputParserCustomValidatorEsque<TInput = unknown> = (
+export type ProcedureInputParserCustomValidatorEsque<TInput = unknown> = (
   input: unknown,
 ) => TInput;
 
-export type RouteInputParserYupEsque<TInput = unknown> = {
+export type ProcedureInputParserYupEsque<TInput = unknown> = {
   validateSync: (input: unknown) => TInput;
 };
-export type RouteInputParser<TInput = unknown> =
-  | RouteInputParserZodEsque<TInput>
-  | RouteInputParserYupEsque<TInput>
-  | RouteInputParserCustomValidatorEsque<TInput>;
+export type ProcedureInputParser<TInput = unknown> =
+  | ProcedureInputParserZodEsque<TInput>
+  | ProcedureInputParserYupEsque<TInput>
+  | ProcedureInputParserCustomValidatorEsque<TInput>;
 
-export type RouteResolver<
+export type ProcedureResolver<
   TContext = unknown,
   TInput = unknown,
   TOutput = unknown
 > = (opts: { ctx: TContext; input: TInput }) => Promise<TOutput> | TOutput;
 
-export type RouteWithInput<
+export type ProcedureWithInput<
   TContext = unknown,
   TInput = unknown,
   TOutput = unknown
 > = {
-  input: RouteInputParser<TInput>;
-  resolve: RouteResolver<TContext, TInput, TOutput>;
+  input: ProcedureInputParser<TInput>;
+  resolve: ProcedureResolver<TContext, TInput, TOutput>;
 };
 
-export type RouteWithoutInput<
+export type ProcedureWithoutInput<
   TContext = unknown,
   TInput = unknown,
   TOutput = unknown
 > = {
   input?: undefined | null;
-  resolve: RouteResolver<TContext, TInput, TOutput>;
+  resolve: ProcedureResolver<TContext, TInput, TOutput>;
 };
-export type Route<TContext = unknown, TInput = unknown, TOutput = unknown> = (
-  | RouteWithInput<TContext, TInput, TOutput>
-  | RouteWithoutInput<TContext, TInput, TOutput>
+export type Procedure<
+  TContext = unknown,
+  TInput = unknown,
+  TOutput = unknown
+> = (
+  | ProcedureWithInput<TContext, TInput, TOutput>
+  | ProcedureWithoutInput<TContext, TInput, TOutput>
 ) & {
   _middlewares?: MiddlewareFunction<TContext>[];
 };
 
-export type RouteRecord<
+export type ProcedureRecord<
   TContext = unknown,
   TInput = unknown,
   TOutput = unknown
-> = Record<string, Route<TContext, TInput, TOutput>>;
+> = Record<string, Procedure<TContext, TInput, TOutput>>;
 
-export type inferRouteInput<
-  TRoute extends Route<any, any, any>
-> = TRoute extends RouteWithInput<any, infer Input, any> ? Input : never;
+export type inferProcedureInput<
+  TProcedure extends Procedure<any, any, any>
+> = TProcedure extends ProcedureWithInput<any, infer Input, any>
+  ? Input
+  : never;
 
 export type inferAsyncReturnType<
   TFunction extends (...args: any) => any
 > = ThenArg<ReturnType<TFunction>>;
 
-export type inferRouteOutput<TRoute extends Route> = inferAsyncReturnType<
-  TRoute['resolve']
->;
+export type inferProcedureOutput<
+  TProcedure extends Procedure
+> = inferAsyncReturnType<TProcedure['resolve']>;
 export type inferSubscriptionOutput<
   TRouter extends AnyRouter,
   TPath extends keyof TRouter['_def']['subscriptions']
@@ -80,20 +86,22 @@ export type inferSubscriptionOutput<
 >;
 
 export type inferHandlerInput<
-  TRoute extends Route
-> = TRoute extends RouteWithInput<any, any, any>
-  ? [inferRouteInput<TRoute>]
+  TProcedure extends Procedure
+> = TProcedure extends ProcedureWithInput<any, any, any>
+  ? [inferProcedureInput<TProcedure>]
   : [undefined?];
 
-export type inferHandlerFn<TRoutes extends RouteRecord<any, any, any>> = <
-  TRoute extends TRoutes[TPath],
-  TPath extends keyof TRoutes & string
+export type inferHandlerFn<
+  TProcedures extends ProcedureRecord<any, any, any>
+> = <
+  TProcedure extends TProcedures[TPath],
+  TPath extends keyof TProcedures & string
 >(
   path: TPath,
-  ...args: TRoute extends RouteWithInput<any, any, any>
-    ? [inferRouteInput<TRoute>]
+  ...args: TProcedure extends ProcedureWithInput<any, any, any>
+    ? [inferProcedureInput<TProcedure>]
     : [undefined?]
-) => Promise<inferRouteOutput<TRoutes[TPath]>>;
+) => Promise<inferProcedureOutput<TProcedures[TPath]>>;
 
 export type AnyRouter<TContext = any> = Router<TContext, any, any, any, any>;
 
@@ -102,9 +110,13 @@ export type MiddlewareFunction<TContext> = (opts: {
 }) => Promise<void> | void;
 export class Router<
   TContext,
-  TQueries extends RouteRecord<TContext>,
-  TMutations extends RouteRecord<TContext>,
-  TSubscriptions extends RouteRecord<TContext, unknown, Subscription<unknown>>,
+  TQueries extends ProcedureRecord<TContext>,
+  TMutations extends ProcedureRecord<TContext>,
+  TSubscriptions extends ProcedureRecord<
+    TContext,
+    unknown,
+    Subscription<unknown>
+  >,
   TMiddleware extends MiddlewareFunction<TContext>
 > {
   readonly _def: Readonly<{
@@ -128,11 +140,11 @@ export class Router<
     };
   }
 
-  private static prefixRoutes<
-    TRoutes extends RouteRecord,
+  private static prefixProcedures<
+    TProcedures extends ProcedureRecord,
     TPrefix extends string
-  >(routes: TRoutes, prefix: TPrefix): Prefixer<TRoutes, TPrefix> {
-    const eps: RouteRecord = {};
+  >(routes: TProcedures, prefix: TPrefix): Prefixer<TProcedures, TPrefix> {
+    const eps: ProcedureRecord = {};
     for (const key in routes) {
       eps[prefix + key] = routes[key];
     }
@@ -141,7 +153,7 @@ export class Router<
 
   public query<TPath extends string, TInput, TOutput>(
     path: TPath,
-    route: Route<TContext, TInput, TOutput>,
+    route: Procedure<TContext, TInput, TOutput>,
   ): Router<
     TContext,
     format<TQueries & Record<TPath, typeof route>>,
@@ -162,9 +174,9 @@ export class Router<
   }
 
   // TODO / help: https://github.com/trpc/trpc/pull/37
-  // public queries<TRoutes extends RouteRecord<TContext, any, any>>(
-  //   routes: TRoutes,
-  // ): Router<TContext, TQueries & TRoutes, TMutations, TSubscriptions> {
+  // public queries<TProcedures extends ProcedureRecord<TContext, any, any>>(
+  //   routes: TProcedures,
+  // ): Router<TContext, TQueries & TProcedures, TMutations, TSubscriptions> {
   //   const router = new Router<TContext, any, {}, {}>({
   //     queries: routes,
   //     mutations: {},
@@ -176,7 +188,7 @@ export class Router<
 
   public mutation<TPath extends string, TInput, TOutput>(
     path: TPath,
-    route: Route<TContext, TInput, TOutput>,
+    route: Procedure<TContext, TInput, TOutput>,
   ): Router<
     TContext,
     TQueries,
@@ -207,7 +219,7 @@ export class Router<
     TOutput extends Subscription
   >(
     path: TPath,
-    route: Route<TContext, TInput, TOutput>,
+    route: Procedure<TContext, TInput, TOutput>,
   ): Router<
     TContext,
     TQueries,
@@ -294,29 +306,29 @@ export class Router<
       queries: {
         ...this._def.queries,
         ...this.inhertMiddlewares(
-          Router.prefixRoutes(router._def.queries, prefix),
+          Router.prefixProcedures(router._def.queries, prefix),
         ),
       },
       mutations: {
         ...this._def.mutations,
         ...this.inhertMiddlewares(
-          Router.prefixRoutes(router._def.mutations, prefix),
+          Router.prefixProcedures(router._def.mutations, prefix),
         ),
       },
       subscriptions: {
         ...this._def.subscriptions,
         ...this.inhertMiddlewares(
-          Router.prefixRoutes(router._def.subscriptions, prefix),
+          Router.prefixProcedures(router._def.subscriptions, prefix),
         ),
       },
       middlewares: this._def.middlewares,
     });
   }
 
-  private inhertMiddlewares<TRoutes extends RouteRecord<TCtx>, TCtx>(
-    routes: TRoutes,
-  ): TRoutes {
-    const newRoutes = {} as TRoutes;
+  private inhertMiddlewares<TProcedures extends ProcedureRecord<TCtx>, TCtx>(
+    routes: TProcedures,
+  ): TProcedures {
+    const newRoutes = {} as TProcedures;
     for (const key in routes) {
       const route = routes[key];
       newRoutes[key] = {
@@ -330,12 +342,12 @@ export class Router<
     }
     return newRoutes;
   }
-  private static getInput<TRoute extends Route<any, any, any>>(
-    route: TRoute,
+  private static getInput<TProcedure extends Procedure<any, any, any>>(
+    route: TProcedure,
     rawInput: unknown,
-  ): inferRouteInput<TRoute> {
+  ): inferProcedureInput<TProcedure> {
     if (!route.input) {
-      return undefined as inferRouteInput<TRoute>;
+      return undefined as inferProcedureInput<TProcedure>;
     }
 
     try {
@@ -368,7 +380,7 @@ export class Router<
       throw new RouteNotFoundError(`No such route "${opts.path}"`);
     }
     const target = this._def[opts.target];
-    const route: Route<TContext> = target[opts.path as any];
+    const route: Procedure<TContext> = target[opts.path as any];
     const { ctx } = opts;
     for (const fn of route._middlewares ?? []) {
       await fn({ ctx });

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -325,7 +325,7 @@ export class Router<
     });
   }
 
-  private inheritMiddlewares<TProcedures extends ProcedureRecord<TCtx>, TCtx>(
+  private inheritMiddlewares<TProcedures extends ProcedureRecord<TContext>>(
     procedures: TProcedures,
   ): TProcedures {
     const newProcedures = {} as TProcedures;
@@ -334,7 +334,6 @@ export class Router<
       newProcedures[key] = {
         ...procedure,
         _middlewares: [
-          //
           ...this._def.middlewares,
           ...(procedure._middlewares ?? []),
         ],

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -143,10 +143,10 @@ export class Router<
   private static prefixProcedures<
     TProcedures extends ProcedureRecord,
     TPrefix extends string
-  >(routes: TProcedures, prefix: TPrefix): Prefixer<TProcedures, TPrefix> {
+  >(procedures: TProcedures, prefix: TPrefix): Prefixer<TProcedures, TPrefix> {
     const eps: ProcedureRecord = {};
-    for (const key in routes) {
-      eps[prefix + key] = routes[key];
+    for (const key in procedures) {
+      eps[prefix + key] = procedures[key];
     }
     return eps as any;
   }
@@ -175,10 +175,10 @@ export class Router<
 
   // TODO / help: https://github.com/trpc/trpc/pull/37
   // public queries<TProcedures extends ProcedureRecord<TContext, any, any>>(
-  //   routes: TProcedures,
+  //   procedures: TProcedures,
   // ): Router<TContext, TQueries & TProcedures, TMutations, TSubscriptions> {
   //   const router = new Router<TContext, any, {}, {}>({
-  //     queries: routes,
+  //     queries: procedures,
   //     mutations: {},
   //     subscriptions: {},
   //   });
@@ -326,21 +326,21 @@ export class Router<
   }
 
   private inheritMiddlewares<TProcedures extends ProcedureRecord<TCtx>, TCtx>(
-    routes: TProcedures,
+    procedures: TProcedures,
   ): TProcedures {
-    const newRoutes = {} as TProcedures;
-    for (const key in routes) {
-      const route = routes[key];
-      newRoutes[key] = {
-        ...route,
+    const newProcedures = {} as TProcedures;
+    for (const key in procedures) {
+      const procedure = procedures[key];
+      newProcedures[key] = {
+        ...procedure,
         _middlewares: [
           //
           ...this._def.middlewares,
-          ...(route._middlewares ?? []),
+          ...(procedure._middlewares ?? []),
         ],
       };
     }
-    return newRoutes;
+    return newProcedures;
   }
   private static getInput<TProcedure extends Procedure<any, any, any>>(
     route: TProcedure,
@@ -377,7 +377,7 @@ export class Router<
     input?: unknown;
   }): Promise<unknown> {
     if (!this.has(opts.target, opts.path)) {
-      throw new RouteNotFoundError(`No such route "${opts.path}"`);
+      throw new RouteNotFoundError(`No such procedure "${opts.path}"`);
     }
     const target = this._def[opts.target];
     const route: Procedure<TContext> = target[opts.path as any];
@@ -395,7 +395,7 @@ export class Router<
   }
 
   /**
-   * Function to be called before any route is invoked
+   * Function to be called before any procedure is invoked
    * Can be async or sync
    */
   middleware(fn: TMiddleware) {

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -305,19 +305,19 @@ export class Router<
     return new Router<TContext, any, any, any, any>({
       queries: {
         ...this._def.queries,
-        ...this.inhertMiddlewares(
+        ...this.inheritMiddlewares(
           Router.prefixProcedures(router._def.queries, prefix),
         ),
       },
       mutations: {
         ...this._def.mutations,
-        ...this.inhertMiddlewares(
+        ...this.inheritMiddlewares(
           Router.prefixProcedures(router._def.mutations, prefix),
         ),
       },
       subscriptions: {
         ...this._def.subscriptions,
-        ...this.inhertMiddlewares(
+        ...this.inheritMiddlewares(
           Router.prefixProcedures(router._def.subscriptions, prefix),
         ),
       },
@@ -325,7 +325,7 @@ export class Router<
     });
   }
 
-  private inhertMiddlewares<TProcedures extends ProcedureRecord<TCtx>, TCtx>(
+  private inheritMiddlewares<TProcedures extends ProcedureRecord<TCtx>, TCtx>(
     routes: TProcedures,
   ): TProcedures {
     const newRoutes = {} as TProcedures;

--- a/packages/server/test/index.test.tsx
+++ b/packages/server/test/index.test.tsx
@@ -120,7 +120,7 @@ describe('integration tests', () => {
         throw new Error('Not TRPCClientError');
       }
       expect(err.message).toMatchInlineSnapshot(
-        `"No such route \\"notFound\\""`,
+        `"No such procedure \\"notFound\\""`,
       );
       expect(err.res?.status).toBe(404);
     }


### PR DESCRIPTION
Feedback from @schickling:

> - Given you’re calling things “trpc” I’d drop the “route” term and embrace RPC


### Actions in this PR

- All instances of _route_ has been renamed to _procedure_
- Router is still called Router as that terminology still makes sense
- Will be a major version bump, however, for standard usage it won't be a breaking change. As you can see in the `examples/*`-diff no changes are needed, except when you want to infer the output, e.g. https://github.com/trpc/trpc/pull/98/files#diff-0c1e6158e63285d8d9c7b53591ba5a08b31fd1759bdb478608fb4490c624d4d0.
