### PR TITLE
`invalidateQuery()`-helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,11 +533,11 @@ trpc.router<Context>()
   .query('infinitePosts', {
     input: z.object({
       limit: z.number().min(1).max(100).optional(),
-      cursor: z.number().optional(), // <-- "cursor" needs to exist, but can be `any` type
+      cursor: z.number().optional(), // <-- "cursor" needs to exist, but can be any type
     }),
     async resolve({ input: { limit = 50, cursor } }) {
       const items = await prisma.post.findMany({
-        take: limit + 1, // get an extra item at the end
+        take: limit + 1, // get an extra item at the end which we'll use as next cursor
         where: {
           title: {
             contains: 'Prisma' /* Optional filter */,

--- a/README.md
+++ b/README.md
@@ -37,9 +37,12 @@ tRPC is a framework for building strongly typed RPC APIs with TypeScript. Altern
   - [Router middlewares](#router-middlewares)
   - [Data transformers](#data-transformers)
   - [Authorization](#authorization)
-  - [Server-side rendering (SSR / SSG)](#server-side-rendering-ssr--ssg)
-    - [Using `ssr.prefetchOnServer()` (recommended)](#using-ssrprefetchonserver-recommended)
-    - [Invoking directly](#invoking-directly)
+  - [React-specific helpers (`@trpc/react`)](#react-specific-helpers-trpcreact)
+    - [`useInfiniteQuery()`](#useinfinitequery)
+    - [`invalidateQuery()`](#invalidatequery)
+    - [`ssr()`: Server-side rendering (SSR / SSG)](#ssr-server-side-rendering-ssr--ssg)
+      - [Using `ssr.prefetchOnServer()` (recommended)](#using-ssrprefetchonserver-recommended)
+      - [Invoking directly](#invoking-directly)
 - [Further reading](#further-reading)
   - [Who is this for?](#who-is-this-for)
   - [HTTP Methods <-> Type mapping](#http-methods---type-mapping)
@@ -510,12 +513,100 @@ export const appRouter = createRouter()
 ```
 </details>
 
-## Server-side rendering (SSR / SSG)
+## React-specific helpers (`@trpc/react`)
+
+_Docs relevant to `@trpc/react`. Follow [Next.js-guide](#nextjs) before doing the below._
+
+### `useInfiniteQuery()`
+
+- Your procedure needs to accept a `cursor` input of `any` type
+- For more details read the [react-query docs](https://react-query.tanstack.com/reference/useInfiniteQuery)
+- Example here is using Prisma - see their docs on [cursor-based pagination](https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination)
+
+<details><summary>Example procedure (dummy code)</summary>
+
+```tsx
+import * as trpc from '@trpc/server';
+import { Context } from './[trpc]';
+
+trpc.router<Context>()
+  .query('infinitePosts', {
+    input: z.object({
+      limit: z.number().min(1).max(100).optional(),
+      cursor: z.number().optional(), // <-- "cursor" needs to exist, but can be `any` type
+    }),
+    async resolve({ input: { limit = 50, cursor } }) {
+      const items = await prisma.post.findMany({
+        take: limit + 1, // get an extra item at the end
+        where: {
+          title: {
+            contains: 'Prisma' /* Optional filter */,
+          },
+        },
+        cursor: cursor ? { myCursor: cursor } : undefined,
+        orderBy: {
+          myCursor: 'asc',
+        },
+      })
+      let nextCursor: typeof cursor | null = null;
+      if (items.length > limit) {
+        const nextItem = items.pop()
+        nextCursor = nextItem!.myCursor;
+      }
+
+      return {
+        items,
+        nextCursor,
+      };
+    })
+```
+</details>
+<details><summary>Example component</summary>
+
+```tsx
+import { trpc } from '../utils/trpc';
+
+function MyComponent() {
+  const myQuery = trpc.useInfiniteQuery(
+    [
+      'paginatedPosts',
+      {
+        limit: 1,
+      },
+    ],
+    {
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
+    },
+  );
+}
+
+```
+</details>
+
+### `invalidateQuery()`
+
+Helper for invalidating a specific query. Simply a type safe wrapper around calling `queryClient.invalidateQueries()` [See react-query docs](https://react-query.tanstack.com/guides/query-invalidation).
+
+<details>
+
+```tsx
+import { trpc } from '../utils/trpc'
+
+const mutation = trpc.useMutation('editPost', {
+  onSuccess: () => {
+    queryClient.invalidateQuery(['allPosts']);
+    queryClient.invalidateQuery(['postById', postId]);
+  },
+})
+```
+</details>
+
+### `ssr()`: Server-side rendering (SSR / SSG)
 
 > - See the [chat example](./examples/next-ssg-chat) for a working example.
-> - Follow [Getting started with Next.js](#getting-started-with-nextjs) before doing the below
+> - Follow [Next.js-guide](#nextjs) before doing the below
 
-### Using `ssr.prefetchOnServer()` (recommended)
+#### Using `ssr.prefetchOnServer()` (recommended)
 
 
 
@@ -545,7 +636,7 @@ export async function getStaticProps() {
 This will cache the `messages.list` so it's instant when `useQuery(['message.list', { limit: 100 }])` gets called.
 
 
-### Invoking directly
+#### Invoking directly
 
 You can also invoke a procedure directly and get the data in a promise.
 

--- a/README.md
+++ b/README.md
@@ -578,6 +578,7 @@ function MyComponent() {
       getNextPageParam: (lastPage) => lastPage.nextCursor,
     },
   );
+  // [...]
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -515,13 +515,13 @@ export const appRouter = createRouter()
 
 ## React-specific helpers (`@trpc/react`)
 
-_Docs relevant to `@trpc/react`. Follow [Next.js-guide](#nextjs) before doing the below._
+> _Docs relevant to `@trpc/react`. Follow [Next.js-guide](#nextjs) before doing the below._
 
 ### `useInfiniteQuery()`
 
-- Your procedure needs to accept a `cursor` input of `any` type
-- For more details read the [react-query docs](https://react-query.tanstack.com/reference/useInfiniteQuery)
-- Example here is using Prisma - see their docs on [cursor-based pagination](https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination)
+> - Your procedure needs to accept a `cursor` input of `any` type
+> - For more details read the [react-query docs](https://react-query.tanstack.com/reference/useInfiniteQuery)
+> - Example here is using Prisma - see their docs on [cursor-based pagination](https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination)
 
 <details><summary>Example procedure (dummy code)</summary>
 

--- a/README.md
+++ b/README.md
@@ -585,7 +585,7 @@ function MyComponent() {
 
 ### `invalidateQuery()`
 
-Helper for invalidating a specific query. Simply a type safe wrapper around calling `queryClient.invalidateQueries()` [See react-query docs](https://react-query.tanstack.com/guides/query-invalidation).
+A type safe wrapper around calling `queryClient.invalidateQueries()`, all it does is to call `queryClient.invalidateQueries()` with the passed args. [See react-query docs](https://react-query.tanstack.com/guides/query-invalidation) if you want more fine-grained control.
 
 <details>
 

--- a/README.md
+++ b/README.md
@@ -569,9 +569,9 @@ import { trpc } from '../utils/trpc';
 function MyComponent() {
   const myQuery = trpc.useInfiniteQuery(
     [
-      'paginatedPosts',
+      'infinitePosts',
       {
-        limit: 1,
+        limit: 10,
       },
     ],
     {

--- a/README.md
+++ b/README.md
@@ -593,9 +593,9 @@ A type safe wrapper around calling `queryClient.invalidateQueries()`, all it doe
 import { trpc } from '../utils/trpc'
 
 const mutation = trpc.useMutation('editPost', {
-  onSuccess: () => {
+  onSuccess(input) {
     queryClient.invalidateQuery(['allPosts']);
-    queryClient.invalidateQuery(['postById', postId]);
+    queryClient.invalidateQuery(['postById', input.id]);
   },
 })
 ```

--- a/examples/next-ssg-chat/pages/api/trpc/[trpc].ts
+++ b/examples/next-ssg-chat/pages/api/trpc/[trpc].ts
@@ -64,7 +64,7 @@ const router = createRouter()
           cursor: z.date().optional(),
           take: z.number().min(1).max(50).optional(),
         }),
-        resolve: async ({ input: { take = 10, cursor } }) => {
+        async resolve({ input: { take = 10, cursor } }) {
           // `cursor` is of type `Date | undefined`
           // `take` is of type `number | undefined`
           const page = await prisma.message.findMany({

--- a/packages/react/src/createReactQueryHooks.ts
+++ b/packages/react/src/createReactQueryHooks.ts
@@ -32,8 +32,10 @@ export type OutputWithCursor<TData, TCursor extends any = any> = {
   data: TData;
 };
 
-const CACHE_PREFIX_INFINITE_QUERIES = 'INFINITE_QUERY';
-const CACHE_PREFIX_LIVE_QUERY = 'LIVE_QUERY';
+const CACHE_KEY_INFINITE_QUERY = 'TRPC_INFINITE_QUERY';
+const CACHE_KEY_LIVE_QUERY = 'TRPC_LIVE_QUERY';
+const CACHE_KEY_STANDARD_QUERY = 'TRPC_QUERY';
+
 export function createReactQueryHooks<
   TRouter extends AnyRouter<TContext>,
   TContext
@@ -62,7 +64,7 @@ export function createReactQueryHooks<
   ): UseQueryResult<TOutput, TRPCClientError> {
     const path = pathAndArgs[0];
     const input = pathAndArgs[1];
-    const cacheKey = [path, input ?? null];
+    const cacheKey = [path, input ?? null, CACHE_KEY_STANDARD_QUERY];
 
     return useQuery(cacheKey, () => client.query(...pathAndArgs) as any, opts);
   }
@@ -149,7 +151,7 @@ export function createReactQueryHooks<
     const [path, userInput] = pathAndArgs;
 
     const currentCursor = useRef<any>(null);
-    const cacheKey = [path, CACHE_PREFIX_LIVE_QUERY, userInput];
+    const cacheKey = [path, userInput ?? null, CACHE_KEY_LIVE_QUERY];
 
     const hook = useQuery<TInput, TRPCClientError, TOutput>(
       cacheKey,
@@ -196,7 +198,7 @@ export function createReactQueryHooks<
       ...pathAndArgs: [path: TPath, ...args: inferHandlerInput<TProcedure>]
     ) => {
       const [path, input] = pathAndArgs;
-      const cacheKey = [path, input ?? null];
+      const cacheKey = [path, input ?? null, CACHE_KEY_STANDARD_QUERY];
 
       return queryClient.prefetchQuery(cacheKey, async () => {
         const data = await caller.query(...pathAndArgs);
@@ -212,7 +214,7 @@ export function createReactQueryHooks<
       ...pathAndArgs: [path: TPath, ...args: inferHandlerInput<TProcedure>]
     ) => {
       const [path, input] = pathAndArgs;
-      const cacheKey = [path, CACHE_PREFIX_INFINITE_QUERIES, input ?? null];
+      const cacheKey = [path, input ?? null, CACHE_KEY_INFINITE_QUERY];
 
       return queryClient.prefetchInfiniteQuery(cacheKey, async () => {
         const data = await caller.query(...pathAndArgs);
@@ -277,7 +279,7 @@ export function createReactQueryHooks<
   ) {
     const [path, input] = pathAndArgs;
     return useInfiniteQuery(
-      [path, CACHE_PREFIX_INFINITE_QUERIES, input],
+      [path, CACHE_KEY_INFINITE_QUERY, input],
       ({ pageParam }) => {
         const actualInput = { ...input, cursor: pageParam };
         return (client.query as any)(path, actualInput);

--- a/packages/react/src/createReactQueryHooks.ts
+++ b/packages/react/src/createReactQueryHooks.ts
@@ -32,9 +32,9 @@ export type OutputWithCursor<TData, TCursor extends any = any> = {
   data: TData;
 };
 
-const CACHE_KEY_INFINITE_QUERY = 'TRPC_INFINITE_QUERY';
-const CACHE_KEY_LIVE_QUERY = 'TRPC_LIVE_QUERY';
-const CACHE_KEY_QUERY = 'TRPC_QUERY';
+const CACHE_KEY_INFINITE_QUERY = 'TRPC_INFINITE_QUERY' as const;
+const CACHE_KEY_LIVE_QUERY = 'TRPC_LIVE_QUERY' as const;
+const CACHE_KEY_QUERY = 'TRPC_QUERY' as const;
 
 export function createReactQueryHooks<
   TRouter extends AnyRouter<TContext>,

--- a/packages/react/src/createReactQueryHooks.ts
+++ b/packages/react/src/createReactQueryHooks.ts
@@ -278,8 +278,9 @@ export function createReactQueryHooks<
     opts?: UseInfiniteQueryOptions<TOutput, TRPCClientError, TOutput, TOutput>,
   ) {
     const [path, input] = pathAndArgs;
+    const cacheKey = [path, input ?? null, CACHE_KEY_INFINITE_QUERY];
     return useInfiniteQuery(
-      [path, CACHE_KEY_INFINITE_QUERY, input],
+      cacheKey,
       ({ pageParam }) => {
         const actualInput = { ...input, cursor: pageParam };
         return (client.query as any)(path, actualInput);

--- a/packages/react/src/createReactQueryHooks.ts
+++ b/packages/react/src/createReactQueryHooks.ts
@@ -62,8 +62,7 @@ export function createReactQueryHooks<
       TOutput
     >,
   ): UseQueryResult<TOutput, TRPCClientError> {
-    const path = pathAndArgs[0];
-    const input = pathAndArgs[1];
+    const [path, input] = pathAndArgs;
     const cacheKey = [path, input ?? null, CACHE_KEY_QUERY];
 
     return useQuery(cacheKey, () => client.query(...pathAndArgs) as any, opts);
@@ -232,22 +231,19 @@ export function createReactQueryHooks<
 
   function prefetchQuery<
     TPath extends keyof TQueries & string,
-    TInput extends inferProcedureInput<TQueries[TPath]>,
-    TOutput extends inferProcedureOutput<TQueries[TPath]>
+    TProcedure extends TQueries[TPath],
+    TOutput extends inferProcedureOutput<TProcedure>,
+    TInput extends inferProcedureInput<TProcedure>
   >(
-    pathAndArgs: [TPath, TInput],
+    pathAndArgs: [path: TPath, ...args: inferHandlerInput<TProcedure>],
     opts?: FetchQueryOptions<TInput, TRPCClientError, TOutput>,
   ) {
     const [path, input] = pathAndArgs;
+    const cacheKey = [path, input ?? null, CACHE_KEY_QUERY];
 
     return queryClient.prefetchQuery(
-      pathAndArgs,
-      () =>
-        client.request({
-          type: 'query',
-          path,
-          input,
-        }) as any,
+      cacheKey,
+      () => client.query(...pathAndArgs) as any,
       opts as any,
     );
   }

--- a/packages/react/src/createReactQueryHooks.ts
+++ b/packages/react/src/createReactQueryHooks.ts
@@ -288,6 +288,18 @@ export function createReactQueryHooks<
     );
   }
 
+  function invalidateQuery<
+    TPath extends keyof TQueries & string,
+    TInput extends inferProcedureInput<TQueries[TPath]>
+  >(pathAndArgs: [TPath, TInput?]): void;
+  function invalidateQuery<
+    TPath extends keyof TSubscriptions & string,
+    TInput extends inferProcedureInput<TSubscriptions[TPath]>
+  >(pathAndArgs: [TPath, TInput?]): void;
+  function invalidateQuery(pathAndArgs: [string, unknown?] | string) {
+    queryClient.invalidateQueries(pathAndArgs);
+  }
+
   return {
     client,
     dehydrate: _dehydrate,
@@ -300,5 +312,6 @@ export function createReactQueryHooks<
     useQuery: _useQuery,
     useSubscription,
     ssr,
+    invalidateQuery,
   };
 }

--- a/packages/react/src/createReactQueryHooks.ts
+++ b/packages/react/src/createReactQueryHooks.ts
@@ -34,7 +34,7 @@ export type OutputWithCursor<TData, TCursor extends any = any> = {
 
 const CACHE_KEY_INFINITE_QUERY = 'TRPC_INFINITE_QUERY';
 const CACHE_KEY_LIVE_QUERY = 'TRPC_LIVE_QUERY';
-const CACHE_KEY_STANDARD_QUERY = 'TRPC_QUERY';
+const CACHE_KEY_QUERY = 'TRPC_QUERY';
 
 export function createReactQueryHooks<
   TRouter extends AnyRouter<TContext>,
@@ -64,7 +64,7 @@ export function createReactQueryHooks<
   ): UseQueryResult<TOutput, TRPCClientError> {
     const path = pathAndArgs[0];
     const input = pathAndArgs[1];
-    const cacheKey = [path, input ?? null, CACHE_KEY_STANDARD_QUERY];
+    const cacheKey = [path, input ?? null, CACHE_KEY_QUERY];
 
     return useQuery(cacheKey, () => client.query(...pathAndArgs) as any, opts);
   }
@@ -198,7 +198,7 @@ export function createReactQueryHooks<
       ...pathAndArgs: [path: TPath, ...args: inferHandlerInput<TProcedure>]
     ) => {
       const [path, input] = pathAndArgs;
-      const cacheKey = [path, input ?? null, CACHE_KEY_STANDARD_QUERY];
+      const cacheKey = [path, input ?? null, CACHE_KEY_QUERY];
 
       return queryClient.prefetchQuery(cacheKey, async () => {
         const data = await caller.query(...pathAndArgs);

--- a/packages/server/test/react.test.tsx
+++ b/packages/server/test/react.test.tsx
@@ -468,8 +468,12 @@ test('prefetchInfiniteQuery()', async () => {
 test('invalidateQueries()', async () => {
   const { hooks, resolvers } = factory;
   function MyComponent() {
-    const allPostsQuery = hooks.useQuery(['allPosts']);
-    const postByIdQuery = hooks.useQuery(['postById', '1']);
+    const allPostsQuery = hooks.useQuery(['allPosts'], {
+      staleTime: Infinity,
+    });
+    const postByIdQuery = hooks.useQuery(['postById', '1'], {
+      staleTime: Infinity,
+    });
 
     return (
       <>
@@ -504,6 +508,9 @@ test('invalidateQueries()', async () => {
   await waitFor(() => {
     expect(utils.container).toHaveTextContent('postByIdQuery:success');
     expect(utils.container).toHaveTextContent('allPostsQuery:success');
+
+    expect(utils.container).toHaveTextContent('postByIdQuery:not-stale');
+    expect(utils.container).toHaveTextContent('allPostsQuery:not-stale');
   });
 
   expect(resolvers.allPosts).toHaveBeenCalledTimes(1);

--- a/packages/server/test/react.test.tsx
+++ b/packages/server/test/react.test.tsx
@@ -30,16 +30,21 @@ function createAppRouter() {
     ],
   };
   const postLiveInputs: unknown[] = [];
+
+  const allPosts = jest.fn();
+  const postById = jest.fn();
   const appRouter = trpc
     .router<Context>()
     .query('allPosts', {
       resolve() {
+        allPosts();
         return db.posts;
       },
     })
     .query('postById', {
       input: z.string(),
       resolve({ input }) {
+        postById(input);
         const post = db.posts.find((p) => p.id === input);
         if (!post) {
           throw trpc.httpError.notFound();
@@ -132,6 +137,10 @@ function createAppRouter() {
     close,
     db,
     postLiveInputs,
+    resolvers: {
+      postById,
+      allPosts,
+    },
   };
 }
 let factory: ReturnType<typeof createAppRouter>;
@@ -305,11 +314,14 @@ test('dehydrate', async () => {
   expect(dehydrated).toHaveLength(1);
 
   const [cache] = dehydrated;
-  expect(cache.queryHash).toMatchInlineSnapshot(`"[\\"allPosts\\",null]"`);
+  expect(cache.queryHash).toMatchInlineSnapshot(
+    `"[\\"allPosts\\",null,\\"TRPC_QUERY\\"]"`,
+  );
   expect(cache.queryKey).toMatchInlineSnapshot(`
     Array [
       "allPosts",
       null,
+      "TRPC_QUERY",
     ]
   `);
   expect(cache.state.data).toEqual(db.posts);
@@ -451,4 +463,63 @@ test('prefetchInfiniteQuery()', async () => {
   const data = JSON.stringify(hooks.dehydrate());
   expect(data).toContain('first post');
   expect(data).not.toContain('second post');
+});
+
+test('invalidateQueries()', async () => {
+  const { hooks, resolvers } = factory;
+  function MyComponent() {
+    const allPostsQuery = hooks.useQuery(['allPosts']);
+    const postByIdQuery = hooks.useQuery(['postById', '1']);
+
+    return (
+      <>
+        <pre>
+          allPostsQuery:{allPostsQuery.status} allPostsQuery:
+          {allPostsQuery.isStale ? 'stale' : 'not-stale'}{' '}
+        </pre>
+        <pre>
+          postByIdQuery:{postByIdQuery.status} postByIdQuery:
+          {postByIdQuery.isStale ? 'stale' : 'not-stale'}
+        </pre>
+        <button
+          data-testid="refetch"
+          onClick={() => {
+            hooks.queryClient.invalidateQueries('allPosts');
+            hooks.queryClient.invalidateQueries('postById');
+          }}
+        />
+      </>
+    );
+  }
+  function App() {
+    return (
+      <QueryClientProvider client={hooks.queryClient}>
+        <MyComponent />
+      </QueryClientProvider>
+    );
+  }
+
+  const utils = render(<App />);
+
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent('postByIdQuery:success');
+    expect(utils.container).toHaveTextContent('allPostsQuery:success');
+  });
+
+  expect(resolvers.allPosts).toHaveBeenCalledTimes(1);
+  expect(resolvers.postById).toHaveBeenCalledTimes(1);
+
+  utils.getByTestId('refetch').click();
+
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent('postByIdQuery:stale');
+    expect(utils.container).toHaveTextContent('allPostsQuery:stale');
+  });
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent('postByIdQuery:not-stale');
+    expect(utils.container).toHaveTextContent('allPostsQuery:not-stale');
+  });
+
+  expect(resolvers.allPosts).toHaveBeenCalledTimes(2);
+  expect(resolvers.postById).toHaveBeenCalledTimes(2);
 });

--- a/packages/server/test/react.test.tsx
+++ b/packages/server/test/react.test.tsx
@@ -464,69 +464,70 @@ test('prefetchInfiniteQuery()', async () => {
   expect(data).toContain('first post');
   expect(data).not.toContain('second post');
 });
+describe.only('invalidateQueries()', async () => {
+  test('from queryClient', async () => {
+    const { hooks, resolvers } = factory;
+    function MyComponent() {
+      const allPostsQuery = hooks.useQuery(['allPosts'], {
+        staleTime: Infinity,
+      });
+      const postByIdQuery = hooks.useQuery(['postById', '1'], {
+        staleTime: Infinity,
+      });
 
-test('invalidateQueries()', async () => {
-  const { hooks, resolvers } = factory;
-  function MyComponent() {
-    const allPostsQuery = hooks.useQuery(['allPosts'], {
-      staleTime: Infinity,
+      return (
+        <>
+          <pre>
+            allPostsQuery:{allPostsQuery.status} allPostsQuery:
+            {allPostsQuery.isStale ? 'stale' : 'not-stale'}{' '}
+          </pre>
+          <pre>
+            postByIdQuery:{postByIdQuery.status} postByIdQuery:
+            {postByIdQuery.isStale ? 'stale' : 'not-stale'}
+          </pre>
+          <button
+            data-testid="refetch"
+            onClick={() => {
+              hooks.queryClient.invalidateQueries('allPosts');
+              hooks.queryClient.invalidateQueries('postById');
+            }}
+          />
+        </>
+      );
+    }
+    function App() {
+      return (
+        <QueryClientProvider client={hooks.queryClient}>
+          <MyComponent />
+        </QueryClientProvider>
+      );
+    }
+
+    const utils = render(<App />);
+
+    await waitFor(() => {
+      expect(utils.container).toHaveTextContent('postByIdQuery:success');
+      expect(utils.container).toHaveTextContent('allPostsQuery:success');
+
+      expect(utils.container).toHaveTextContent('postByIdQuery:not-stale');
+      expect(utils.container).toHaveTextContent('allPostsQuery:not-stale');
     });
-    const postByIdQuery = hooks.useQuery(['postById', '1'], {
-      staleTime: Infinity,
+
+    expect(resolvers.allPosts).toHaveBeenCalledTimes(1);
+    expect(resolvers.postById).toHaveBeenCalledTimes(1);
+
+    utils.getByTestId('refetch').click();
+
+    await waitFor(() => {
+      expect(utils.container).toHaveTextContent('postByIdQuery:stale');
+      expect(utils.container).toHaveTextContent('allPostsQuery:stale');
+    });
+    await waitFor(() => {
+      expect(utils.container).toHaveTextContent('postByIdQuery:not-stale');
+      expect(utils.container).toHaveTextContent('allPostsQuery:not-stale');
     });
 
-    return (
-      <>
-        <pre>
-          allPostsQuery:{allPostsQuery.status} allPostsQuery:
-          {allPostsQuery.isStale ? 'stale' : 'not-stale'}{' '}
-        </pre>
-        <pre>
-          postByIdQuery:{postByIdQuery.status} postByIdQuery:
-          {postByIdQuery.isStale ? 'stale' : 'not-stale'}
-        </pre>
-        <button
-          data-testid="refetch"
-          onClick={() => {
-            hooks.queryClient.invalidateQueries('allPosts');
-            hooks.queryClient.invalidateQueries('postById');
-          }}
-        />
-      </>
-    );
-  }
-  function App() {
-    return (
-      <QueryClientProvider client={hooks.queryClient}>
-        <MyComponent />
-      </QueryClientProvider>
-    );
-  }
-
-  const utils = render(<App />);
-
-  await waitFor(() => {
-    expect(utils.container).toHaveTextContent('postByIdQuery:success');
-    expect(utils.container).toHaveTextContent('allPostsQuery:success');
-
-    expect(utils.container).toHaveTextContent('postByIdQuery:not-stale');
-    expect(utils.container).toHaveTextContent('allPostsQuery:not-stale');
+    expect(resolvers.allPosts).toHaveBeenCalledTimes(2);
+    expect(resolvers.postById).toHaveBeenCalledTimes(2);
   });
-
-  expect(resolvers.allPosts).toHaveBeenCalledTimes(1);
-  expect(resolvers.postById).toHaveBeenCalledTimes(1);
-
-  utils.getByTestId('refetch').click();
-
-  await waitFor(() => {
-    expect(utils.container).toHaveTextContent('postByIdQuery:stale');
-    expect(utils.container).toHaveTextContent('allPostsQuery:stale');
-  });
-  await waitFor(() => {
-    expect(utils.container).toHaveTextContent('postByIdQuery:not-stale');
-    expect(utils.container).toHaveTextContent('allPostsQuery:not-stale');
-  });
-
-  expect(resolvers.allPosts).toHaveBeenCalledTimes(2);
-  expect(resolvers.postById).toHaveBeenCalledTimes(2);
 });


### PR DESCRIPTION
- allows you to use `trpc.invalidateQuery([path, input])` in a type-safe way
