### PR TITLE
fix:added test directory to tsconfig files

### DIFF
--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src"]
+  "include": [
+    "src",
+    "test"
+  ]
 }


### PR DESCRIPTION
Fixes several type errors in test files. 

@KATT since you aren't seeing these, you might have somehow overridden the default tsconfig values globally on your computer? 

I also ran `yarn build` and this didn't result in any undesirable artefacts in `dist` (I was worried this change would cause `test` to be compiled in addition to `src` but that's not the case.