### PR TITLE
Added trpc export. Aliased createTRPCClient to createClient.

### DIFF
--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -317,3 +317,5 @@ export function createTRPCClient<TRouter extends AnyRouter>(
 ) {
   return new TRPCClient<TRouter>(opts);
 }
+
+export { createTRPCClient as createClient };

--- a/packages/server/src/exports.ts
+++ b/packages/server/src/exports.ts
@@ -1,0 +1,6 @@
+export * from './http';
+export * from './router';
+export * from './types';
+export * from './subscription';
+export * from './transformer';
+export * from './adapters/standalone';

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,7 +1,3 @@
-export * from './http';
-export * from './router';
-export * from './types';
-export * from './subscription';
-export * from './transformer';
-
-export * from './adapters/standalone';
+import * as trpc from './exports';
+export * from './exports';
+export { trpc };


### PR DESCRIPTION
`import * as` imports aren't a great developer experience. There's no way to get autocompleting imports that way. This makes a simple change that allows for importing from @trpc/server like this:

```ts
import { trpc } from "@trpc/server";
```

I also aliased `createTRPCClient` to `createClient`. Since the user is importing from `@trpc/client` I think having "TRPC" in the function name is redundant (and doesn't look very good imo).