### PR TITLE
Added support for useQuery(path, input, opts) and useQuery(path, opts)

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -30,7 +30,8 @@
   "dependencies": {
     "@babel/runtime": "^7.9.0",
     "@trpc/client": "^4.0.0",
-    "@trpc/server": "^4.0.0"
+    "@trpc/server": "^4.0.0",
+    "tslib": "^2.1.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.11",

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,4 +1,6 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -2,5 +2,9 @@
   "extends": "../../tsconfig.json",
   "include": [
     "src"
-  ]
+  ],
+  "compilerOptions": {
+    "importHelpers": false,
+    "downlevelIteration": true
+  }
 }

--- a/packages/server/test/react.test.tsx
+++ b/packages/server/test/react.test.tsx
@@ -171,7 +171,7 @@ afterEach(() => {
 });
 
 describe('useQuery()', () => {
-  test('no input', async () => {
+  test('pathAndArgs: no input', async () => {
     const { hooks } = factory;
     function MyComponent() {
       const allPostsQuery = hooks.useQuery(['allPosts']);
@@ -193,10 +193,58 @@ describe('useQuery()', () => {
     });
   });
 
-  test('with input', async () => {
+  test('pathAndArgs: with input', async () => {
     const { hooks } = factory;
     function MyComponent() {
       const allPostsQuery = hooks.useQuery(['paginatedPosts', { limit: 1 }]);
+
+      return <pre>{JSON.stringify(allPostsQuery.data ?? 'n/a', null, 4)}</pre>;
+    }
+    function App() {
+      return (
+        <QueryClientProvider client={hooks.queryClient}>
+          <MyComponent />
+        </QueryClientProvider>
+      );
+    }
+
+    const utils = render(<App />);
+    await waitFor(() => {
+      expect(utils.container).toHaveTextContent('first post');
+    });
+    expect(utils.container).not.toHaveTextContent('second post');
+  });
+
+  test('path, opts: no input', async () => {
+    const { hooks } = factory;
+    function MyComponent() {
+      const allPostsQuery = hooks.useQuery('allPosts', { retry: false });
+      expectTypeOf(allPostsQuery.data!).toMatchTypeOf<Post[]>();
+
+      return <pre>{JSON.stringify(allPostsQuery.data ?? 'n/a', null, 4)}</pre>;
+    }
+    function App() {
+      return (
+        <QueryClientProvider client={hooks.queryClient}>
+          <MyComponent />
+        </QueryClientProvider>
+      );
+    }
+
+    const utils = render(<App />);
+    await waitFor(() => {
+      expect(utils.container).toHaveTextContent('first post');
+    });
+  });
+
+  test('path, args, opts: with input', async () => {
+    const { hooks } = factory;
+    function MyComponent() {
+      const allPostsQuery = hooks.useQuery(
+        'paginatedPosts',
+        { limit: 1 },
+        { retry: false },
+      );
 
       return <pre>{JSON.stringify(allPostsQuery.data ?? 'n/a', null, 4)}</pre>;
     }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,8 +1,14 @@
 {
   "compilerOptions": {
     "module": "esnext",
-    "lib": ["es5", "es6", "dom", "dom.iterable"],
+    "lib": [
+      "es5",
+      "es6",
+      "dom",
+      "dom.iterable"
+    ],
     "importHelpers": true,
+    "downlevelIteration": true,
     "declaration": true,
     "sourceMap": true,
     "strict": true,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -8,7 +8,6 @@
       "dom.iterable"
     ],
     "importHelpers": true,
-    "downlevelIteration": true,
     "declaration": true,
     "sourceMap": true,
     "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2973,7 +2973,7 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript-eslint/eslint-plugin@^4.11.1", "@typescript-eslint/eslint-plugin@^4.17.0":
+"@typescript-eslint/eslint-plugin@^4.17.0":
   version "4.19.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.19.0.tgz#56f8da9ee118fe9763af34d6a526967234f6a7f0"
   integrity sha512-CRQNQ0mC2Pa7VLwKFbrGVTArfdVDdefS+gTw0oC98vSI98IX5A8EVH4BzJ2FOB0YlCmm8Im36Elad/Jgtvveaw==
@@ -2998,16 +2998,6 @@
     "@typescript-eslint/typescript-estree" "4.19.0"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
-
-"@typescript-eslint/parser@^4.11.1":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.19.0.tgz#4ae77513b39f164f1751f21f348d2e6cb2d11128"
-  integrity sha512-/uabZjo2ZZhm66rdAu21HA8nQebl3lAIDcybUoOxoI7VbZBYavLIwtOOmykKCJy+Xq6Vw6ugkiwn8Js7D6wieA==
-  dependencies:
-    "@typescript-eslint/scope-manager" "4.19.0"
-    "@typescript-eslint/types" "4.19.0"
-    "@typescript-eslint/typescript-estree" "4.19.0"
-    debug "^4.1.1"
 
 "@typescript-eslint/scope-manager@4.19.0":
   version "4.19.0"
@@ -11665,7 +11655,7 @@ trim-off-newlines@^1.0.0:
   resolved "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
   integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
 
-ts-jest@^26.4.4, ts-jest@^26.5.3:
+ts-jest@^26.5.3:
   version "26.5.4"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.4.tgz#207f4c114812a9c6d5746dd4d1cdf899eafc9686"
   integrity sha512-I5Qsddo+VTm94SukBJ4cPimOoFZsYTeElR2xy6H2TOVs+NsvgYglW8KuQgKoApOKuaU/Ix/vrF9ebFZlb5D2Pg==
@@ -11705,7 +11695,7 @@ tslib@^1.8.1, tslib@^1.9.0:
 
 tslib@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
 tsutils@^3.17.1:
@@ -11823,7 +11813,7 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.1.3, typescript@^4.2.3:
+typescript@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
   integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==


### PR DESCRIPTION
- Added support for useQuery(path, input, opts)
- Added new tests to react.test.ts to test new syntax

Important note: implementing this overload requires a runtime-only way of distinguishing between the `useQuery(path, input, opts)` usage and `useQuery(path, opts)` usage. It is assumed that `useQuery(path, opts)` usage is intended if:

1) the third argument is undefined
2) the second argument is an object
3) the second argument exclusively contains keys that exist on react-query's `UseQueryOptions`

If by chance the procedures `input` type extends `UseQueryOptions` then this may mistakenly result in the function treating the second argument as `opts` instead of `input`. I think this is a worthwhile tradeoff since it results in a much cleaner API and there's a low probability of this occurrence, since the keys are fairly obscure:

```
enabled
staleTime
refetchInterval
refetchIntervalInBackground
refetchOnWindowFocus
refetchOnReconnect
refetchOnMount
retryOnMount
notifyOnChangeProps
notifyOnChangePropsExclusions
onSuccess
onError
onSettled
useErrorBoundary
select
suspense
keepPreviousData
placeholderData
optimisticResults
retry
retryDelay
cacheTime
isDataEqual
queryFn
queryHash
queryKey
queryKeyHashFn
initialData
initialDataUpdatedAt
behavior
structuralSharing
getPreviousPageParam
getNextPageParam
_defaulted
```

One way to avoid this is to eliminate the `useQuery(path, opts)` usage. Like so:

```ts
trpc.useQuery('allPosts');
trpc.useQuery('allPosts', undefined, { retry: false });
```

The user must explicitly pass `undefined` as the input if they wish to pass `UseQueryOptions` to react-query. I think this is the best solution.