### PR TITLE
add combined transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,15 +91,15 @@ In another terminal, you can for instance navigate to `examples/next-hello-world
 ## Testing
 
 ```bash
-cd packages/server
 yarn test --watch
 ```
+
+Testing is currently coalesced in [./packages/server/test](./packages/server/test) - we import the different libs from here, this makes it easier for us to do integration testing + getting test coverage on the whole codebase.
 
 > [![codecov](https://codecov.io/gh/trpc/trpc/branch/main/graph/badge.svg?token=KPPS918B0G)](https://codecov.io/gh/trpc/trpc) 
 > 
 > Some things regarding subscriptions is excluded in the coverage as it's an experimental feature
 
-Testing is currently coalesced in [./packages/server/test](./packages/server/test) - we import the different libs from here, this makes it easier for us to do integration testing + getting test coverage on the whole codebase.
 
 # Contributors ✨
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lerna": "lerna",
     "start": "preconstruct watch",
     "dev": "yarn start",
-    "test": "lerna run test --scope @trpc/* --stream --",
+    "test": "cd packages/server && yarn test --",
     "lint": "eslint --ext \".js,.ts,.tsx\" --ignore-path .gitignore .",
     "lint-fix": "yarn lint --fix && manypkg fix",
     "postinstall": "preconstruct dev",

--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -2,7 +2,7 @@
 import type {
   AnyRouter,
   DataTransformer,
-  DataTransformerOptions,
+  ClientDataTransformerOptions,
   HTTPErrorResponseEnvelope,
   HTTPResponseEnvelope,
   HTTPSuccessResponseEnvelope,
@@ -63,7 +63,7 @@ export interface CreateTRPCClientOptions<TRouter extends AnyRouter> {
   getHeaders?: () => Record<string, string | string[] | undefined>;
   onSuccess?: (data: HTTPSuccessResponseEnvelope<unknown>) => void;
   onError?: (error: TRPCClientError<TRouter>) => void;
-  transformer?: DataTransformerOptions;
+  transformer?: ClientDataTransformerOptions;
 }
 type TRPCType = 'subscription' | 'query' | 'mutation';
 

--- a/packages/react/src/ssg.ts
+++ b/packages/react/src/ssg.ts
@@ -1,7 +1,7 @@
 import {
   AnyRouter,
   assertNotBrowser,
-  DataTransformerOptions,
+  ClientDataTransformerOptions,
   inferHandlerInput,
   inferRouterContext,
 } from '@trpc/server';
@@ -23,7 +23,7 @@ assertNotBrowser();
 export interface CreateSSGHelpersOptions<TRouter extends AnyRouter> {
   router: TRouter;
   ctx: inferRouterContext<TRouter>;
-  transformer?: DataTransformerOptions;
+  transformer?: ClientDataTransformerOptions;
   queryClientConfig?: QueryClientConfig;
 }
 

--- a/packages/react/src/ssg.ts
+++ b/packages/react/src/ssg.ts
@@ -2,6 +2,7 @@ import {
   AnyRouter,
   assertNotBrowser,
   DataTransformer,
+  CombinedDataTransformer,
   inferHandlerInput,
   inferRouterContext,
 } from '@trpc/server';
@@ -23,7 +24,7 @@ assertNotBrowser();
 export interface CreateSSGHelpersOptions<TRouter extends AnyRouter> {
   router: TRouter;
   ctx: inferRouterContext<TRouter>;
-  transformer?: DataTransformer;
+  transformer?: DataTransformer | CombinedDataTransformer;
   queryClientConfig?: QueryClientConfig;
 }
 
@@ -112,7 +113,9 @@ export function createSSGHelpers<TRouter extends AnyRouter>({
       },
     },
   ): DehydratedState {
-    const serialize = transformer?.serialize ?? ((obj: unknown) => obj);
+    const serialize = transformer
+      ? ('up' in transformer ? transformer.up : transformer).serialize
+      : (obj: unknown) => obj;
 
     return serialize(dehydrate(queryClient, opts));
   }

--- a/packages/react/src/ssg.ts
+++ b/packages/react/src/ssg.ts
@@ -1,8 +1,7 @@
 import {
   AnyRouter,
   assertNotBrowser,
-  DataTransformer,
-  CombinedDataTransformer,
+  DataTransformerOptions,
   inferHandlerInput,
   inferRouterContext,
 } from '@trpc/server';
@@ -24,7 +23,7 @@ assertNotBrowser();
 export interface CreateSSGHelpersOptions<TRouter extends AnyRouter> {
   router: TRouter;
   ctx: inferRouterContext<TRouter>;
-  transformer?: DataTransformer | CombinedDataTransformer;
+  transformer?: DataTransformerOptions;
   queryClientConfig?: QueryClientConfig;
 }
 
@@ -45,7 +44,7 @@ export function createSSGHelpers<TRouter extends AnyRouter>({
   >;
   const prefetchQuery = async <
     TPath extends keyof TQueries & string,
-    TProcedure extends TQueries[TPath]
+    TProcedure extends TQueries[TPath],
   >(
     ...pathAndArgs: [path: TPath, ...args: inferHandlerInput<TProcedure>]
   ) => {
@@ -61,7 +60,7 @@ export function createSSGHelpers<TRouter extends AnyRouter>({
 
   const prefetchInfiniteQuery = async <
     TPath extends keyof TQueries & string,
-    TProcedure extends TQueries[TPath]
+    TProcedure extends TQueries[TPath],
   >(
     ...pathAndArgs: [path: TPath, ...args: inferHandlerInput<TProcedure>]
   ) => {
@@ -76,7 +75,7 @@ export function createSSGHelpers<TRouter extends AnyRouter>({
 
   const fetchQuery = async <
     TPath extends keyof TQueries & string,
-    TProcedure extends TQueries[TPath]
+    TProcedure extends TQueries[TPath],
   >(
     ...pathAndArgs: [path: TPath, ...args: inferHandlerInput<TProcedure>]
   ) => {
@@ -92,7 +91,7 @@ export function createSSGHelpers<TRouter extends AnyRouter>({
 
   const fetchInfiniteQuery = async <
     TPath extends keyof TQueries & string,
-    TProcedure extends TQueries[TPath]
+    TProcedure extends TQueries[TPath],
   >(
     ...pathAndArgs: [path: TPath, ...args: inferHandlerInput<TProcedure>]
   ) => {
@@ -114,7 +113,7 @@ export function createSSGHelpers<TRouter extends AnyRouter>({
     },
   ): DehydratedState {
     const serialize = transformer
-      ? ('up' in transformer ? transformer.up : transformer).serialize
+      ? ('input' in transformer ? transformer.input : transformer).serialize
       : (obj: unknown) => obj;
 
     return serialize(dehydrate(queryClient, opts));

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -42,6 +42,7 @@
     "@testing-library/user-event": "^13.0.7",
     "@types/express": "^4.17.11",
     "@types/hash-sum": "^1.0.0",
+    "devalue": "^2.0.1",
     "express": "^4.17.1",
     "hash-sum": "^2.0.0",
     "jest": "^26.6.3",

--- a/packages/server/src/transformer.ts
+++ b/packages/server/src/transformer.ts
@@ -6,6 +6,8 @@ export type DataTransformer = {
 };
 
 export type CombinedDataTransformer = {
-  up: DataTransformer;
-  down: DataTransformer;
+  input: DataTransformer;
+  output: DataTransformer;
 };
+
+export type DataTransformerOptions = DataTransformer | CombinedDataTransformer;

--- a/packages/server/src/transformer.ts
+++ b/packages/server/src/transformer.ts
@@ -10,4 +10,13 @@ export type CombinedDataTransformer = {
   output: DataTransformer;
 };
 
+export type CombinedDataTransformerClient = {
+  input: Pick<DataTransformer, 'serialize'>;
+  output: Pick<DataTransformer, 'deserialize'>;
+};
+
 export type DataTransformerOptions = DataTransformer | CombinedDataTransformer;
+
+export type ClientDataTransformerOptions =
+  | DataTransformer
+  | CombinedDataTransformerClient;

--- a/packages/server/src/transformer.ts
+++ b/packages/server/src/transformer.ts
@@ -4,3 +4,8 @@ export type DataTransformer = {
   serialize(object: any): any;
   deserialize(object: any): any;
 };
+
+export type CombinedDataTransformer = {
+  up: DataTransformer;
+  down: DataTransformer;
+};

--- a/packages/server/test/transformer.test.ts
+++ b/packages/server/test/transformer.test.ts
@@ -1,15 +1,17 @@
 import * as trpc from '@trpc/server';
 import superjson from 'superjson';
+import { z } from 'zod';
 import { routerToServerAndClient } from './_testHelpers';
 
-test('superjson downstream', async () => {
+test('superjson up and down', async () => {
   const date = new Date();
+  const fn = jest.fn();
   const { client, close } = routerToServerAndClient(
     trpc.router().query('hello', {
-      resolve() {
-        return {
-          date,
-        };
+      input: z.date(),
+      resolve({ input }) {
+        fn(input);
+        return input;
       },
     }),
     {
@@ -17,8 +19,9 @@ test('superjson downstream', async () => {
       server: { transformer: superjson },
     },
   );
-  const res = await client.query('hello');
-  expect(res.date.getTime()).toBe(date.getTime());
+  const res = await client.query('hello', date);
+  expect(res.getTime()).toBe(date.getTime());
+  expect((fn.mock.calls[0][0] as Date).getTime()).toBe(date.getTime());
 
   close();
 });

--- a/packages/server/test/transformer.test.ts
+++ b/packages/server/test/transformer.test.ts
@@ -1,0 +1,24 @@
+import * as trpc from '@trpc/server';
+import superjson from 'superjson';
+import { routerToServerAndClient } from './_testHelpers';
+
+test('superjson downstream', async () => {
+  const date = new Date();
+  const { client, close } = routerToServerAndClient(
+    trpc.router().query('hello', {
+      resolve() {
+        return {
+          date,
+        };
+      },
+    }),
+    {
+      client: { transformer: superjson },
+      server: { transformer: superjson },
+    },
+  );
+  const res = await client.query('hello');
+  expect(res.date.getTime()).toBe(date.getTime());
+
+  close();
+});

--- a/packages/server/test/transformer.test.ts
+++ b/packages/server/test/transformer.test.ts
@@ -1,9 +1,12 @@
 import * as trpc from '@trpc/server';
 import superjson from 'superjson';
+import devalue from 'devalue';
 import { z } from 'zod';
 import { routerToServerAndClient } from './_testHelpers';
 
 test('superjson up and down', async () => {
+  const transformer = superjson;
+
   const date = new Date();
   const fn = jest.fn();
   const { client, close } = routerToServerAndClient(
@@ -15,8 +18,36 @@ test('superjson up and down', async () => {
       },
     }),
     {
-      client: { transformer: superjson },
-      server: { transformer: superjson },
+      client: { transformer },
+      server: { transformer },
+    },
+  );
+  const res = await client.query('hello', date);
+  expect(res.getTime()).toBe(date.getTime());
+  expect((fn.mock.calls[0][0] as Date).getTime()).toBe(date.getTime());
+
+  close();
+});
+
+test('devalue up and down', async () => {
+  const transformer: trpc.DataTransformer = {
+    serialize: (object) => devalue(object),
+    deserialize: (object) => eval(`(${object})`),
+  };
+
+  const date = new Date();
+  const fn = jest.fn();
+  const { client, close } = routerToServerAndClient(
+    trpc.router().query('hello', {
+      input: z.date(),
+      resolve({ input }) {
+        fn(input);
+        return input;
+      },
+    }),
+    {
+      client: { transformer },
+      server: { transformer },
     },
   );
   const res = await client.query('hello', date);

--- a/packages/server/test/transformer.test.ts
+++ b/packages/server/test/transformer.test.ts
@@ -56,3 +56,85 @@ test('devalue up and down', async () => {
 
   close();
 });
+
+test('superjson up and devalue down', async () => {
+  const transformer: trpc.CombinedDataTransformer = {
+    input: superjson,
+    output: {
+      serialize: (object) => devalue(object),
+      deserialize: (object) => eval(`(${object})`),
+    },
+  };
+
+  const date = new Date();
+  const fn = jest.fn();
+  const { client, close } = routerToServerAndClient(
+    trpc.router().query('hello', {
+      input: z.date(),
+      resolve({ input }) {
+        fn(input);
+        return input;
+      },
+    }),
+    {
+      client: { transformer },
+      server: { transformer },
+    },
+  );
+  const res = await client.query('hello', date);
+  expect(res.getTime()).toBe(date.getTime());
+  expect((fn.mock.calls[0][0] as Date).getTime()).toBe(date.getTime());
+
+  close();
+});
+
+test('all transformers running in correct order', async () => {
+  const world = 'foo';
+  const fn = jest.fn();
+
+  const transformer: trpc.CombinedDataTransformer = {
+    input: {
+      serialize: (object) => {
+        fn('client:serialized');
+        return object;
+      },
+      deserialize: (object) => {
+        fn('server:deserialized');
+        return object;
+      },
+    },
+    output: {
+      serialize: (object) => {
+        fn('server:serialized');
+        return object;
+      },
+      deserialize: (object) => {
+        fn('client:deserialized');
+        return object;
+      },
+    },
+  };
+
+  const { client, close } = routerToServerAndClient(
+    trpc.router().query('hello', {
+      input: z.string(),
+      resolve({ input }) {
+        fn(input);
+        return input;
+      },
+    }),
+    {
+      client: { transformer },
+      server: { transformer },
+    },
+  );
+  const res = await client.query('hello', world);
+  expect(res).toBe(world);
+  expect(fn.mock.calls[0][0]).toBe('client:serialized');
+  expect(fn.mock.calls[1][0]).toBe('server:deserialized');
+  expect(fn.mock.calls[2][0]).toBe(world);
+  expect(fn.mock.calls[3][0]).toBe('server:serialized');
+  expect(fn.mock.calls[4][0]).toBe('client:deserialized');
+
+  close();
+});

--- a/www/docs/server/data-transformers.md
+++ b/www/docs/server/data-transformers.md
@@ -56,7 +56,7 @@ If a transformer should only be used for one directon or different transformers 
 
 ### How to
 
-Here [superjson](https://github.com/blitz-js/superjson) is be used for uploading and [devalue](https://github.com/Rich-Harris/devalue) for downloading data, because devalue is a lot faster but insecure to use on the server. 
+Here [superjson](https://github.com/blitz-js/superjson) is be used for uploading and [devalue](https://github.com/Rich-Harris/devalue) for downloading data, because devalue is a lot faster but insecure to use on the server.
 
 #### 0. Install
 
@@ -73,8 +73,8 @@ import devalue from 'devalue';
 // [...]
 
 export const transformer = {
-  up: superjson,
-  down: {
+  input: superjson,
+  output: {
     serialize: (object) => devalue(object),
     deserialize: (object) => eval(`(${object})`),
   },
@@ -116,7 +116,7 @@ type DataTransformer = {
 };
 
 type CombinedDataTransformer = {
-  up: DataTransformer;
-  down: DataTransformer;
+  input: DataTransformer;
+  output: DataTransformer;
 };
 ```

--- a/www/docs/server/data-transformers.md
+++ b/www/docs/server/data-transformers.md
@@ -54,9 +54,9 @@ export default trpcNext.createNextApiHandler({
 
 If a transformer should only be used for one directon or different transformers should be used for upload and download (e.g. for performance reasons), you can provide individual transformers for upload and download. Make sure you use the same combined transformer everywhere.
 
-### Howto
+### How to
 
-For demonstration purpose [superjson](https://github.com/blitz-js/superjson) should be used for uploading and faster but insecure [devalue](https://github.com/Rich-Harris/devalue) for downloading data.
+Here [superjson](https://github.com/blitz-js/superjson) is be used for uploading and [devalue](https://github.com/Rich-Harris/devalue) for downloading data, because devalue is a lot faster but insecure to use on the server. 
 
 #### 0. Install
 
@@ -84,7 +84,7 @@ export const transformer = {
 #### 2. Add to `createTRPCCLient()`
 
 ```ts
-import { transformer } from 'utils/trpc.ts';
+import { transformer } from '../utils/trpc';
 
 // [...]
 
@@ -97,7 +97,7 @@ export const client = createTRPCClient<AppRouter>({
 #### 3. Add to API handler
 
 ```ts
-import { transformer } from 'utils/trpc.ts';
+import { transformer } from '../../utils/trpc';
 
 // [...]
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2975,7 +2975,7 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript-eslint/eslint-plugin@^4.11.1", "@typescript-eslint/eslint-plugin@^4.17.0":
+"@typescript-eslint/eslint-plugin@^4.17.0":
   version "4.24.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.24.0.tgz#03801ffc25b2af9d08f3dc9bccfc0b7ce3780d0f"
   integrity sha512-qbCgkPM7DWTsYQGjx9RTuQGswi+bEt0isqDBeo+CKV0953zqI0Tp7CZ7Fi9ipgFA6mcQqF4NOVNwS/f2r6xShw==
@@ -3000,16 +3000,6 @@
     "@typescript-eslint/typescript-estree" "4.24.0"
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
-
-"@typescript-eslint/parser@^4.11.1":
-  version "4.24.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.24.0.tgz#2e5f1cc78ffefe43bfac7e5659309a92b09a51bd"
-  integrity sha512-dj1ZIh/4QKeECLb2f/QjRwMmDArcwc2WorWPRlB8UNTZlY1KpTVsbX7e3ZZdphfRw29aTFUSNuGB8w9X5sS97w==
-  dependencies:
-    "@typescript-eslint/scope-manager" "4.24.0"
-    "@typescript-eslint/types" "4.24.0"
-    "@typescript-eslint/typescript-estree" "4.24.0"
-    debug "^4.1.1"
 
 "@typescript-eslint/scope-manager@4.24.0":
   version "4.24.0"
@@ -4951,6 +4941,11 @@ detect-node@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
   integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
+
+devalue@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/devalue/-/devalue-2.0.1.tgz#5d368f9adc0928e47b77eea53ca60d2f346f9762"
+  integrity sha512-I2TiqT5iWBEyB8GRfTDP0hiLZ0YeDJZ+upDxjBfOC2lebO5LezQMv7QvIUTzdb64jQyAKLf1AHADtGN+jw6v8Q==
 
 dezalgo@^1.0.0:
   version "1.0.3"
@@ -11703,7 +11698,7 @@ trim-off-newlines@^1.0.0:
   resolved "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
   integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
 
-ts-jest@^26.4.4, ts-jest@^26.5.3:
+ts-jest@^26.5.3:
   version "26.5.6"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.6.tgz#c32e0746425274e1dfe333f43cd3c800e014ec35"
   integrity sha512-rua+rCP8DxpA8b4DQD/6X2HQS8Zy/xzViVYfEs2OQu68tkCuKLV0Md8pmX55+W24uRIyAsf/BajRfxOs+R2MKA==
@@ -11866,7 +11861,7 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.1.3, typescript@^4.2.3:
+typescript@^4.2.3:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
   integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==


### PR DESCRIPTION
As discussed [here](https://github.com/trpc/trpc/issues/378) this adds a new interface `CombinedDataTransformer` which allows to specify different transformers for server->client and client->server communication. `CombinedDataTransformer`can be used interchangeable with `DataTransformer`.

```ts
type DataTransformer = {
  serialize(object: any): any;
  deserialize(object: any): any;
};

type CombinedDataTransformer = {
  input: DataTransformer;
  output: DataTransformer;
};
```

### Example usage with superjson and devalue

```ts
import superjson from 'superjson';
import devalue from 'devalue';

export const transformer = {
  input: superjson,
  output: {
    serialize: (object) => devalue(object),
    deserialize: (object) => eval(`(${object})`),
  },
};

// Add to `createTRPCCLient()`
export const client = createTRPCClient<AppRouter>({
  // [...]
  transformer: transformer,
});

// Add to API handler
export default trpcNext.createNextApiHandler({
  // [...]
  transformer: transformer,
});
```

### TODO

- [x] Code
- [x] Documentation
- [x] Tests
- [ ] Add to example

---

Closes #378