### PR TITLE
refactor(zod): update imports as v3 recommends

### DIFF
--- a/examples/next-hello-world/pages/api/trpc/[trpc].ts
+++ b/examples/next-hello-world/pages/api/trpc/[trpc].ts
@@ -1,7 +1,7 @@
 import * as trpc from '@trpc/server';
 import { inferAsyncReturnType } from '@trpc/server';
 import * as trpcNext from '@trpc/server/adapters/next';
-import * as z from 'zod';
+import { z } from 'zod';
 import { postsRouter } from './posts';
 
 // The app's context - is generated for each incoming request

--- a/examples/next-hello-world/pages/api/trpc/posts.ts
+++ b/examples/next-hello-world/pages/api/trpc/posts.ts
@@ -2,7 +2,7 @@
  * Example of a sub router
  */
 
-import * as z from 'zod';
+import { z } from 'zod';
 import { createRouter } from './[trpc]';
 const randomId = () => Math.random().toString(36).substr(2, 9);
 // example db

--- a/examples/next-prisma-todomvc/pages/api/trpc/todoRouter.ts
+++ b/examples/next-prisma-todomvc/pages/api/trpc/todoRouter.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import { z } from 'zod';
 import { createRouter } from './[trpc]';
 
 export const todoRouter = createRouter()

--- a/examples/next-ssg-chat/pages/api/trpc/[trpc].ts
+++ b/examples/next-ssg-chat/pages/api/trpc/[trpc].ts
@@ -1,7 +1,7 @@
 import { Message, PrismaClient } from '@prisma/client';
 import * as trpc from '@trpc/server';
 import * as trpcNext from '@trpc/server/adapters/next';
-import * as z from 'zod';
+import { z } from 'zod';
 import superjson from 'superjson';
 const prisma = new PrismaClient();
 

--- a/examples/playground/src/server.ts
+++ b/examples/playground/src/server.ts
@@ -2,7 +2,7 @@ import bodyParser from 'body-parser';
 import { EventEmitter } from 'events';
 import express from 'express';
 import * as trpc from '@trpc/server';
-import * as z from 'zod';
+import { z } from 'zod';
 import * as trpcExpress from '@trpc/server/adapters/express';
 
 const createContext = ({

--- a/examples/standalone-server/src/server.ts
+++ b/examples/standalone-server/src/server.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
 import * as trpc from '@trpc/server';
-import * as z from 'zod';
+import { z } from 'zod';
 
 type Context = {};
 

--- a/packages/server/test/errors.test.ts
+++ b/packages/server/test/errors.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import * as z from 'zod';
-import { ZodError } from 'zod';
+import { z, ZodError } from 'zod';
 import { TRPCClientError } from '../../client/src';
 import * as trpc from '../src';
 import { getMessageFromUnkownError, TRPCError } from '../src/errors';

--- a/packages/server/test/express.test.tsx
+++ b/packages/server/test/express.test.tsx
@@ -4,7 +4,7 @@ import bodyParser from 'body-parser';
 import express from 'express';
 import http from 'http';
 import fetch from 'node-fetch';
-import * as z from 'zod';
+import { z } from 'zod';
 import { createTRPCClient } from '../../client/src';
 import * as trpc from '../src';
 import * as trpcExpress from '../src/adapters/express';

--- a/packages/server/test/index.test.tsx
+++ b/packages/server/test/index.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/ban-types */
 import { expectTypeOf } from 'expect-type';
-import * as z from 'zod';
+import { z } from 'zod';
 import { TRPCClientError } from '../../client/src';
 import * as trpc from '../src';
 import { CreateHttpContextOptions } from '../src';

--- a/packages/server/test/react.test.tsx
+++ b/packages/server/test/react.test.tsx
@@ -26,8 +26,7 @@ import {
   useQueryClient,
 } from 'react-query';
 import { dehydrate } from 'react-query/hydration';
-import * as z from 'zod';
-import { ZodError } from 'zod';
+import { z, ZodError } from 'zod';
 import { withTRPC } from '../../next/src';
 import { createReactQueryHooks, OutputWithCursor } from '../../react/src';
 import { createSSGHelpers } from '../../react/ssg';

--- a/packages/server/test/subscriptions.test.tsx
+++ b/packages/server/test/subscriptions.test.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import { EventEmitter } from 'events';
 import { expectTypeOf } from 'expect-type';
-import * as z from 'zod';
+import { z } from 'zod';
 import * as trpc from '../src';
 import { routerToServerAndClient } from './_testHelpers';
 

--- a/packages/server/test/validators.test.ts
+++ b/packages/server/test/validators.test.ts
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom';
 import { expectTypeOf } from 'expect-type';
 import myzod from 'myzod';
 import * as yup from 'yup';
-import * as z from 'zod';
+import { z } from 'zod';
 import * as trpc from '../src';
 import { routerToServerAndClient } from './_testHelpers';
 

--- a/www/docs/react/nextjs.md
+++ b/www/docs/react/nextjs.md
@@ -86,7 +86,7 @@ Paste the following code:
 ```ts
 import * as trpc from '@trpc/server';
 import * as trpcNext from '@trpc/server/adapters/next';
-import * as z from 'zod';
+import { z } from 'zod';
 
 // The app's context - is generated for each incoming request
 export type Context = {};

--- a/www/docs/server/procedures.md
+++ b/www/docs/server/procedures.md
@@ -41,7 +41,7 @@ export const appRouter = trpc.router<Context>()
 
 ```tsx
 import * as trpc from '@trpc/server';
-import * as z from 'zod';
+import { z } from 'zod';
 
 // [...]
 


### PR DESCRIPTION
As zod v3 has just been released, a [new import syntax](https://github.com/trpc/trpc/pull/388#issuecomment-843209188) is now [recommended by the docs](https://github.com/colinhacks/zod#basic-usage).