### PR TITLE
add guards for `Object.prototype`-props

### DIFF
--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -89,6 +89,27 @@ export type DefaultErrorShape = {
   stack?: string;
 };
 
+/**
+ * Create an empty object with `Object.create(null)`.
+ * Objects made from `Object.create(null)` are totally empty -- they do not inherit anything from Object.prototype.
+ */
+function safeObject(): {};
+
+/**
+ * Create an object without inheriting anything from `Object.prototype`
+ */
+function safeObject<TObj1>(obj: TObj1): TObj1;
+/**
+ * Merge two objects without inheritance from `Object.prototype`
+ */
+function safeObject<TObj1, TObj2>(
+  obj1: TObj1,
+  obj2: TObj2,
+): flatten<TObj1, TObj2>;
+function safeObject(...args: unknown[]) {
+  return Object.assign(Object.create(null), ...args);
+}
+
 export type MiddlewareFunction<TContext> = (opts: {
   ctx: TContext;
   type: ProcedureType;
@@ -121,9 +142,9 @@ export class Router<
     errorFormatter: ErrorFormatter<TContext, TErrorShape>;
   }) {
     this._def = def ?? {
-      queries: Object.create(null) as TQueries,
-      mutations: Object.create(null) as TMutations,
-      subscriptions: Object.create(null) as TSubscriptions,
+      queries: safeObject() as TQueries,
+      mutations: safeObject() as TMutations,
+      subscriptions: safeObject() as TSubscriptions,
       middlewares: [],
       errorFormatter: (({
         defaultShape,
@@ -139,7 +160,7 @@ export class Router<
     TProcedures extends ProcedureRecord,
     TPrefix extends string,
   >(procedures: TProcedures, prefix: TPrefix): Prefixer<TProcedures, TPrefix> {
-    const eps: ProcedureRecord = {};
+    const eps: ProcedureRecord = safeObject();
     for (const key in procedures) {
       eps[prefix + key] = procedures[key];
     }
@@ -177,11 +198,11 @@ export class Router<
     procedure: CreateProcedureOptions<TContext, TInput, TOutput>,
   ) {
     const router = new Router<TContext, any, {}, {}, any>({
-      queries: Object.assign(Object.create(null), {
+      queries: safeObject({
         [path]: createProcedure(procedure),
       }),
-      mutations: Object.create(null),
-      subscriptions: Object.create(null),
+      mutations: safeObject(),
+      subscriptions: safeObject(),
       middlewares: [],
       errorFormatter: () => ({}),
     });
@@ -220,11 +241,11 @@ export class Router<
     procedure: CreateProcedureOptions<TContext, TInput, TOutput>,
   ) {
     const router = new Router<TContext, {}, any, {}, any>({
-      queries: Object.create(null),
-      mutations: Object.assign(Object.create(null), {
+      queries: safeObject(),
+      mutations: safeObject({
         [path]: createProcedure(procedure),
       }),
-      subscriptions: Object.create(null),
+      subscriptions: safeObject(),
       middlewares: [],
       errorFormatter: () => ({}),
     });
@@ -274,9 +295,9 @@ export class Router<
     TOutput extends Subscription<unknown>,
   >(path: TPath, procedure: CreateProcedureOptions<TContext, TInput, TOutput>) {
     const router = new Router<TContext, {}, {}, any, any>({
-      queries: Object.create(null),
-      mutations: Object.create(null),
-      subscriptions: Object.assign(Object.create(null), {
+      queries: safeObject(),
+      mutations: safeObject(),
+      subscriptions: safeObject({
         [path]: createProcedure(procedure),
       }),
       middlewares: [],
@@ -355,7 +376,7 @@ export class Router<
     }
 
     const mergeProcedures = (defs: ProcedureRecord<any>) => {
-      const newDefs = {} as typeof defs;
+      const newDefs = safeObject() as typeof defs;
       for (const key in defs) {
         const procedure = defs[key];
         const newProcedure = procedure.inheritMiddlewares(
@@ -368,18 +389,15 @@ export class Router<
     };
 
     return new Router<TContext, any, any, any, TErrorShape>({
-      queries: Object.assign(
-        Object.create(null),
+      queries: safeObject(
         this._def.queries,
         mergeProcedures(childRouter._def.queries),
       ),
-      mutations: Object.assign(
-        Object.create(null),
+      mutations: safeObject(
         this._def.mutations,
         mergeProcedures(childRouter._def.mutations),
       ),
-      subscriptions: Object.assign(
-        Object.create(null),
+      subscriptions: safeObject(
         this._def.subscriptions,
         mergeProcedures(childRouter._def.subscriptions),
       ),

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -177,9 +177,9 @@ export class Router<
     procedure: CreateProcedureOptions<TContext, TInput, TOutput>,
   ) {
     const router = new Router<TContext, any, {}, {}, any>({
-      queries: {
+      queries: Object.assign(Object.create(null), {
         [path]: createProcedure(procedure),
-      },
+      }),
       mutations: Object.create(null),
       subscriptions: Object.create(null),
       middlewares: [],
@@ -221,9 +221,9 @@ export class Router<
   ) {
     const router = new Router<TContext, {}, any, {}, any>({
       queries: Object.create(null),
-      mutations: {
+      mutations: Object.assign(Object.create(null), {
         [path]: createProcedure(procedure),
-      },
+      }),
       subscriptions: Object.create(null),
       middlewares: [],
       errorFormatter: () => ({}),
@@ -276,9 +276,9 @@ export class Router<
     const router = new Router<TContext, {}, {}, any, any>({
       queries: Object.create(null),
       mutations: Object.create(null),
-      subscriptions: {
+      subscriptions: Object.assign(Object.create(null), {
         [path]: createProcedure(procedure),
-      },
+      }),
       middlewares: [],
       errorFormatter: () => ({}),
     });

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -17,46 +17,39 @@ import { flatten, Prefixer, ThenArg } from './types';
 assertNotBrowser();
 
 export type ProcedureType = 'query' | 'mutation' | 'subscription';
-export type ProcedureRecord<
-  TContext = any,
-  TInput = any,
-  TOutput = any
-> = Record<string, Procedure<TContext, TInput, TOutput>>;
+export type ProcedureRecord<TContext = any, TInput = any, TOutput = any> =
+  Record<string, Procedure<TContext, TInput, TOutput>>;
 
-export type inferProcedureInput<
-  TProcedure extends Procedure<any, any, any>
-> = TProcedure extends ProcedureWithInput<any, infer Input, any>
-  ? Input
-  : undefined;
+export type inferProcedureInput<TProcedure extends Procedure<any, any, any>> =
+  TProcedure extends ProcedureWithInput<any, infer Input, any>
+    ? Input
+    : undefined;
 
-export type inferAsyncReturnType<
-  TFunction extends (...args: any) => any
-> = ThenArg<ReturnType<TFunction>>;
+export type inferAsyncReturnType<TFunction extends (...args: any) => any> =
+  ThenArg<ReturnType<TFunction>>;
 
-export type inferProcedureOutput<
-  TProcedure extends Procedure
-> = inferAsyncReturnType<TProcedure['call']>;
+export type inferProcedureOutput<TProcedure extends Procedure> =
+  inferAsyncReturnType<TProcedure['call']>;
 
 export type inferSubscriptionOutput<
   TRouter extends AnyRouter,
-  TPath extends keyof TRouter['_def']['subscriptions']
+  TPath extends keyof TRouter['_def']['subscriptions'],
 > = ReturnType<
   inferAsyncReturnType<
     TRouter['_def']['subscriptions'][TPath]['call']
   >['output']
 >;
 
-export type inferHandlerInput<
-  TProcedure extends Procedure
-> = TProcedure extends ProcedureWithInput<any, infer TInput, any>
-  ? undefined extends TInput
-    ? [TInput?]
-    : [TInput]
-  : [undefined?];
+export type inferHandlerInput<TProcedure extends Procedure> =
+  TProcedure extends ProcedureWithInput<any, infer TInput, any>
+    ? undefined extends TInput
+      ? [TInput?]
+      : [TInput]
+    : [undefined?];
 
 type inferHandlerFn<TProcedures extends ProcedureRecord> = <
   TProcedure extends TProcedures[TPath],
-  TPath extends keyof TProcedures & string
+  TPath extends keyof TProcedures & string,
 >(
   path: TPath,
   ...args: inferHandlerInput<TProcedure>
@@ -110,7 +103,7 @@ export class Router<
     unknown,
     Subscription<unknown>
   >,
-  TErrorShape extends ErrorShape
+  TErrorShape extends ErrorShape,
 > {
   readonly _def: Readonly<{
     queries: Readonly<TQueries>;
@@ -144,7 +137,7 @@ export class Router<
 
   private static prefixProcedures<
     TProcedures extends ProcedureRecord,
-    TPrefix extends string
+    TPrefix extends string,
   >(procedures: TProcedures, prefix: TPrefix): Prefixer<TProcedures, TPrefix> {
     const eps: ProcedureRecord = {};
     for (const key in procedures) {
@@ -246,7 +239,7 @@ export class Router<
   public subscription<
     TPath extends string,
     TInput,
-    TOutput extends Subscription<unknown>
+    TOutput extends Subscription<unknown>,
   >(
     path: TPath,
     procedure: CreateProcedureWithInput<TContext, TInput, TOutput>,
@@ -264,7 +257,7 @@ export class Router<
    */
   public subscription<
     TPath extends string,
-    TOutput extends Subscription<unknown>
+    TOutput extends Subscription<unknown>,
   >(
     path: TPath,
     procedure: CreateProcedureWithoutInput<TContext, TOutput>,
@@ -278,7 +271,7 @@ export class Router<
   public subscription<
     TPath extends string,
     TInput,
-    TOutput extends Subscription<unknown>
+    TOutput extends Subscription<unknown>,
   >(path: TPath, procedure: CreateProcedureOptions<TContext, TInput, TOutput>) {
     const router = new Router<TContext, {}, {}, any, any>({
       queries: {},
@@ -407,19 +400,17 @@ export class Router<
     input?: unknown;
   }): Promise<unknown> {
     const defTarget = PROCEDURE_DEFINITION_MAP[type];
-    const target = this._def[defTarget][path];
+    const defs = this._def[defTarget];
 
-    if (!target) {
+    if (!defs.hasOwnProperty(path)) {
       throw notFoundError(`No such ${type} procedure "${path}"`);
     }
-    const procedure: Procedure<TContext> = target;
+    const procedure: Procedure<TContext> = defs[path];
 
     return procedure.call({ ctx, input, type, path });
   }
 
-  public createCaller(
-    ctx: TContext,
-  ): {
+  public createCaller(ctx: TContext): {
     query: inferHandlerFn<TQueries>;
     mutation: inferHandlerFn<TMutations>;
     subscription: inferHandlerFn<TSubscriptions>;

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -121,9 +121,9 @@ export class Router<
     errorFormatter: ErrorFormatter<TContext, TErrorShape>;
   }) {
     this._def = def ?? {
-      queries: {} as TQueries,
-      mutations: {} as TMutations,
-      subscriptions: {} as TSubscriptions,
+      queries: Object.create(null) as TQueries,
+      mutations: Object.create(null) as TMutations,
+      subscriptions: Object.create(null) as TSubscriptions,
       middlewares: [],
       errorFormatter: (({
         defaultShape,
@@ -180,8 +180,8 @@ export class Router<
       queries: {
         [path]: createProcedure(procedure),
       },
-      mutations: {},
-      subscriptions: {},
+      mutations: Object.create(null),
+      subscriptions: Object.create(null),
       middlewares: [],
       errorFormatter: () => ({}),
     });
@@ -220,11 +220,11 @@ export class Router<
     procedure: CreateProcedureOptions<TContext, TInput, TOutput>,
   ) {
     const router = new Router<TContext, {}, any, {}, any>({
-      queries: {},
+      queries: Object.create(null),
       mutations: {
         [path]: createProcedure(procedure),
       },
-      subscriptions: {},
+      subscriptions: Object.create(null),
       middlewares: [],
       errorFormatter: () => ({}),
     });
@@ -274,8 +274,8 @@ export class Router<
     TOutput extends Subscription<unknown>,
   >(path: TPath, procedure: CreateProcedureOptions<TContext, TInput, TOutput>) {
     const router = new Router<TContext, {}, {}, any, any>({
-      queries: {},
-      mutations: {},
+      queries: Object.create(null),
+      mutations: Object.create(null),
       subscriptions: {
         [path]: createProcedure(procedure),
       },
@@ -368,18 +368,21 @@ export class Router<
     };
 
     return new Router<TContext, any, any, any, TErrorShape>({
-      queries: {
-        ...this._def.queries,
-        ...mergeProcedures(childRouter._def.queries),
-      },
-      mutations: {
-        ...this._def.mutations,
-        ...mergeProcedures(childRouter._def.mutations),
-      },
-      subscriptions: {
-        ...this._def.subscriptions,
-        ...mergeProcedures(childRouter._def.subscriptions),
-      },
+      queries: Object.assign(
+        Object.create(null),
+        this._def.queries,
+        mergeProcedures(childRouter._def.queries),
+      ),
+      mutations: Object.assign(
+        Object.create(null),
+        this._def.mutations,
+        mergeProcedures(childRouter._def.mutations),
+      ),
+      subscriptions: Object.assign(
+        Object.create(null),
+        this._def.subscriptions,
+        mergeProcedures(childRouter._def.subscriptions),
+      ),
       middlewares: this._def.middlewares,
       errorFormatter: this._def.errorFormatter,
     });
@@ -401,11 +404,11 @@ export class Router<
   }): Promise<unknown> {
     const defTarget = PROCEDURE_DEFINITION_MAP[type];
     const defs = this._def[defTarget];
+    const procedure = defs[path] as Procedure<TContext> | undefined;
 
-    if (!defs.hasOwnProperty(path)) {
+    if (!procedure) {
       throw notFoundError(`No such ${type} procedure "${path}"`);
     }
-    const procedure: Procedure<TContext> = defs[path];
 
     return procedure.call({ ctx, input, type, path });
   }

--- a/packages/server/test/errors.test.ts
+++ b/packages/server/test/errors.test.ts
@@ -2,8 +2,17 @@
 import { z, ZodError } from 'zod';
 import { TRPCClientError } from '../../client/src';
 import * as trpc from '../src';
+import { AnyRouter } from '../src';
 import { getMessageFromUnkownError, TRPCError } from '../src/errors';
 import { routerToServerAndClient } from './_testHelpers';
+
+function assertClientError(
+  err: unknown,
+): asserts err is TRPCClientError<AnyRouter> {
+  if (!(err instanceof TRPCClientError)) {
+    throw new Error('Did not throw');
+  }
+}
 
 test('basic', async () => {
   class MyError extends Error {
@@ -150,7 +159,7 @@ test('getMessageFromUnkownError()', () => {
 
 test('formatError()', async () => {
   const onError = jest.fn();
-  const { client, close, router } = routerToServerAndClient(
+  const { client, close } = routerToServerAndClient(
     trpc
       .router()
       .formatError(({ error }) => {
@@ -182,14 +191,7 @@ test('formatError()', async () => {
   } catch (_err) {
     clientError = _err;
   }
-  function assertIt(
-    err: unknown,
-  ): asserts err is TRPCClientError<typeof router> {
-    if (!(err instanceof TRPCClientError)) {
-      throw new Error('Did not throw');
-    }
-  }
-  assertIt(clientError);
+  assertClientError(clientError);
   expect(clientError.res?.status).toBe(400);
   expect(clientError.json?.error).toMatchInlineSnapshot(`
     Object {
@@ -205,6 +207,37 @@ test('formatError()', async () => {
       "type": "zod",
     }
   `);
+  expect(onError).toHaveBeenCalledTimes(1);
+  const serverError = onError.mock.calls[0][0].error;
+
+  expect(serverError.originalError).toBeInstanceOf(ZodError);
+
+  close();
+});
+
+test('make sure object is created w/o prototype', async () => {
+  const onError = jest.fn();
+  const { client, close } = routerToServerAndClient(
+    trpc.router().query('hello', {
+      resolve() {
+        return 'there';
+      },
+    }),
+    {
+      server: {
+        onError,
+      },
+    },
+  );
+  let clientError: Error | null = null;
+  try {
+    await client.query('toString' as any);
+  } catch (_err) {
+    clientError = _err;
+  }
+  assertClientError(clientError);
+  expect(clientError.res?.status).toBe(404);
+  expect(clientError.json?.error).toMatchInlineSnapshot();
   expect(onError).toHaveBeenCalledTimes(1);
   const serverError = onError.mock.calls[0][0].error;
 

--- a/packages/server/test/errors.test.ts
+++ b/packages/server/test/errors.test.ts
@@ -237,11 +237,10 @@ test('make sure object is created w/o prototype', async () => {
   }
   assertClientError(clientError);
   expect(clientError.res?.status).toBe(404);
-  expect(clientError.json?.error).toMatchInlineSnapshot();
+  expect(clientError.json?.error.code).toBe('NOT_FOUND');
   expect(onError).toHaveBeenCalledTimes(1);
   const serverError = onError.mock.calls[0][0].error;
-
-  expect(serverError.originalError).toBeInstanceOf(ZodError);
+  expect(serverError.code).toBe('NOT_FOUND');
 
   close();
 });

--- a/packages/server/test/errors.test.ts
+++ b/packages/server/test/errors.test.ts
@@ -245,24 +245,23 @@ test('make sure object is ignoring prototype', async () => {
   close();
 });
 
-test('ability to use protected props', async () => {
-  const onError = jest.fn();
+test('allow using built-in Object-properties', async () => {
   const { client, close } = routerToServerAndClient(
-    trpc.router().query('toString', {
-      resolve() {
-        return 'there';
-      },
-    }),
-    {
-      server: {
-        onError,
-      },
-    },
+    trpc
+      .router()
+      .query('toString', {
+        resolve() {
+          return 'toStringValue';
+        },
+      })
+      .query('hasOwnProperty', {
+        resolve() {
+          return 'hasOwnPropertyValue';
+        },
+      }),
   );
 
-  const res = await client.query('toString' as any);
-
-  expect(res).toBe('there');
-
+  expect(await client.query('toString')).toBe('toStringValue');
+  expect(await client.query('hasOwnProperty')).toBe('hasOwnPropertyValue');
   close();
 });

--- a/packages/server/test/errors.test.ts
+++ b/packages/server/test/errors.test.ts
@@ -215,7 +215,7 @@ test('formatError()', async () => {
   close();
 });
 
-test('make sure object is created w/o prototype', async () => {
+test('make sure object is ignoring prototype', async () => {
   const onError = jest.fn();
   const { client, close } = routerToServerAndClient(
     trpc.router().query('hello', {
@@ -241,6 +241,28 @@ test('make sure object is created w/o prototype', async () => {
   expect(onError).toHaveBeenCalledTimes(1);
   const serverError = onError.mock.calls[0][0].error;
   expect(serverError.code).toBe('NOT_FOUND');
+
+  close();
+});
+
+test('ability to use protected props', async () => {
+  const onError = jest.fn();
+  const { client, close } = routerToServerAndClient(
+    trpc.router().query('toString', {
+      resolve() {
+        return 'there';
+      },
+    }),
+    {
+      server: {
+        onError,
+      },
+    },
+  );
+
+  const res = await client.query('toString' as any);
+
+  expect(res).toBe('there');
 
   close();
 });


### PR DESCRIPTION
## issue

just realised that we don't safe-guard from querying on built-in object properties. 

i.e. 

- `client.query('toString')` for example does _not_ return `NOT_FOUND` as it's part of the built-in stuff
- also, you can't use `toString` as a procedure key

## fix

- refactor router to create all objects with `Object.create(null)` instead of `null`
- refactor spread operators to `Object.assign(Object.create(null), x, y)` (via `safeObject`-fn)

## notes
did it TDD-style - both of these tests were failing as you can see in the commit history