### PR TITLE
`next-prisma-starter`: add ci + subtree mirror + fix linting

### DIFF
--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: nxtlvlsoftware/git-subtree-action@1
+      - uses: nxtlvlsoftware/git-subtree-action@1.1
         with:
           repo: 'trpc/${{ matrix.path }}'
           path: 'examples/${{ matrix.path }}'

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -10,9 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         path:
-          - command
-          - database
-          - support
+          - next-prisma-starter
 
     name: Update downstream ${{ matrix.path }} package
 
@@ -22,7 +20,7 @@ jobs:
           fetch-depth: 0
       - uses: nxtlvlsoftware/git-subtree-action@1
         with:
-          repo: 'nxtlvlsoftware/${{ matrix.path }}'
-          path: 'src/${{ matrix.path }}'
+          repo: 'trpc/${{ matrix.path }}'
+          path: 'examples/${{ matrix.path }}'
           deploy_key: ${{ secrets.TRPC_GITHUB_TOKEN }}
           force: true # will force push to the downstream repository

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -1,0 +1,28 @@
+name: subtree-matrix
+
+on: [push]
+
+jobs:
+  sync-downstream:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        path:
+          - command
+          - database
+          - support
+
+    name: Update downstream ${{ matrix.path }} package
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: nxtlvlsoftware/git-subtree-action@1
+        with:
+          repo: 'nxtlvlsoftware/${{ matrix.path }}'
+          path: 'src/${{ matrix.path }}'
+          deploy_key: ${{ secrets.TRPC_GITHUB_TOKEN }}
+          force: true # will force push to the downstream repository

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -22,5 +22,5 @@ jobs:
         with:
           repo: 'trpc/${{ matrix.path }}'
           path: 'examples/${{ matrix.path }}'
-          deploy_key: ${{ secrets.TRPC_GITHUB_TOKEN }}
+          deploy_key: ${{ secrets.TRPC_DEPLOY_TOKEN }}
           force: true # will force push to the downstream repository

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - uses: nxtlvlsoftware/git-subtree-action@1.1
         with:
-          repo: 'trpc/${{ matrix.path }}'
+          repo: 'trpc/examples-${{ matrix.path }}'
           path: 'examples/${{ matrix.path }}'
           deploy_key: ${{ secrets.TRPC_DEPLOY_TOKEN }}
           force: true # will force push to the downstream repository

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "printWidth": 80,
-  "trailingComma": "all",
-  "singleQuote": true
-}

--- a/examples/next-prisma-starter/.github/dependabot.yml
+++ b/examples/next-prisma-starter/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 2

--- a/examples/next-prisma-starter/.github/workflows/codeql-analysis.yml
+++ b/examples/next-prisma-starter/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,71 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ main, 0.x ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main ]
+  schedule:
+    - cron: '27 0 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'typescript' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
+        # Learn more:
+        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/examples/next-prisma-starter/.github/workflows/main.yml
+++ b/examples/next-prisma-starter/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Examples E2E
+name: E2E-testing
 on: [push]
 jobs:
   e2e:
@@ -21,8 +21,9 @@ jobs:
 
       - uses: microsoft/playwright-github-action@v1
 
-      - name: Install deps and build (with cache)
-        uses: bahmutov/npm-install@v1
+      # - name: Install deps and build (with cache)
+      #   uses: bahmutov/npm-install@v1
+      - run: yarn install
 
       - run: yarn build
         env:

--- a/examples/next-prisma-starter/.github/workflows/main.yml
+++ b/examples/next-prisma-starter/.github/workflows/main.yml
@@ -1,0 +1,36 @@
+name: Examples E2E
+on: [push]
+jobs:
+  e2e:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node: ['14.x']
+        os: [ubuntu-latest]
+    services:
+      postgres:
+        image: postgres:12.1
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_DB: trpcdb
+        ports:
+          - 5432:5432
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - uses: microsoft/playwright-github-action@v1
+
+      - name: Install deps and build (with cache)
+        uses: bahmutov/npm-install@v1
+
+      - run: yarn build
+        env:
+          DATABASE_URL: postgresql://postgres:@localhost:5432/trpcdb
+      - run: yarn lint
+      - run: yarn test-start
+        env:
+          DATABASE_URL: postgresql://postgres:@localhost:5432/trpcdb
+      - run: yarn test-dev
+        env:
+          DATABASE_URL: postgresql://postgres:@localhost:5432/trpcdb

--- a/examples/next-prisma-starter/README.md
+++ b/examples/next-prisma-starter/README.md
@@ -7,10 +7,13 @@ Try in CodeSandbox: [https://githubbox.com/trpc/trpc/tree/main/examples/next-pri
 
 - ⚡ Full-stack React with Next.js
 - ⚡ Database with Prisma
-- 🧙‍♂️ E2E type safety with [tRPC](https://trpc.io)
-- ✅ E2E testing with Playwright
-- 🎨 ESLint
 - ⚙️ VSCode extensions
+- 🎨 ESLint + Prettier
+- 🧙‍♂️ E2E type safety with [tRPC](https://trpc.io)
+- 💚 CI already setup using GitHub Actions:
+  - ✅ E2E testing with Playwright
+  - ✅ Linting
+
 
 ## Setup
 

--- a/examples/next-prisma-starter/README.md
+++ b/examples/next-prisma-starter/README.md
@@ -5,11 +5,11 @@ Try in CodeSandbox: [https://githubbox.com/trpc/trpc/tree/main/examples/next-pri
 
 ## Features
 
+- 🧙‍♂️ E2E type safety with [tRPC](https://trpc.io)
 - ⚡ Full-stack React with Next.js
 - ⚡ Database with Prisma
 - ⚙️ VSCode extensions
 - 🎨 ESLint + Prettier
-- 🧙‍♂️ E2E type safety with [tRPC](https://trpc.io)
 - 💚 CI setup using GitHub Actions:
   - ✅ E2E testing with [Playwright](https://playwright.dev/)
   - ✅ Linting

--- a/examples/next-prisma-starter/README.md
+++ b/examples/next-prisma-starter/README.md
@@ -10,8 +10,8 @@ Try in CodeSandbox: [https://githubbox.com/trpc/trpc/tree/main/examples/next-pri
 - ⚙️ VSCode extensions
 - 🎨 ESLint + Prettier
 - 🧙‍♂️ E2E type safety with [tRPC](https://trpc.io)
-- 💚 CI already setup using GitHub Actions:
-  - ✅ E2E testing with Playwright
+- 💚 CI setup using GitHub Actions:
+  - ✅ E2E testing with [Playwright](https://playwright.dev/)
   - ✅ Linting
 
 

--- a/examples/next-prisma-starter/package.json
+++ b/examples/next-prisma-starter/package.json
@@ -42,6 +42,7 @@
     "@types/node": "^15.0.1",
     "@types/react": "^17.0.0",
     "@typescript-eslint/eslint-plugin": "^4.25.0",
+    "@typescript-eslint/parser": "^4.26.0",
     "eslint": "^7.22.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.3.1",

--- a/examples/next-prisma-starter/package.json
+++ b/examples/next-prisma-starter/package.json
@@ -17,10 +17,16 @@
     "start": "next start",
     "studio": "prisma studio",
     "lint": "eslint src",
+    "lint-fix": "yarn lint --fix",
     "prisma-nuke": "rm -rf prisma/migrations prisma/*.db**",
     "test-dev": "start-server-and-test dev 3000 test",
     "test-start": "start-server-and-test start 3000 test",
     "test": "jest"
+  },
+  "prettier": {
+    "printWidth": 80,
+    "trailingComma": "all",
+    "singleQuote": true
   },
   "dependencies": {
     "@prisma/client": "^2.18.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
       "packages/*"
     ]
   },
+  "prettier": {
+    "printWidth": 80,
+    "trailingComma": "all",
+    "singleQuote": true
+  },
   "resolutions": {
     "**/@typescript-eslint/eslint-plugin": "^4.11.1",
     "**/@typescript-eslint/parser": "^4.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2959,7 +2959,7 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/parser@^4.11.1":
+"@typescript-eslint/parser@^4.11.1", "@typescript-eslint/parser@^4.26.0":
   version "4.26.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.26.0.tgz#31b6b732c9454f757b020dab9b6754112aa5eeaf"
   integrity sha512-b4jekVJG9FfmjUfmM4VoOItQhPlnt6MPOBUL0AQbiTmm+SSpSdhHYlwayOm4IW9KLI/4/cRKtQCmDl1oE2OlPg==


### PR DESCRIPTION
mirror prisma example to new repo using git subtrees

https://github.com/trpc/trpc/tree/main/examples/next-prisma-starter is now mirrored downstream to https://github.com/trpc/examples-next-prisma-starter automatically