### PR TITLE
add optional request context

### DIFF
--- a/examples/express-server/package.json
+++ b/examples/express-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/express-server",
-  "version": "6.4.0",
+  "version": "6.5.0-alpha.0",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server.ts",
@@ -12,9 +12,9 @@
     "test-start": "start-server-and-test 'node dist/server' 2021 'node dist/client'"
   },
   "dependencies": {
-    "@trpc/client": "^6.4.0",
-    "@trpc/react": "^6.4.0",
-    "@trpc/server": "^6.4.0",
+    "@trpc/client": "^6.5.0-alpha.0",
+    "@trpc/react": "^6.5.0-alpha.0",
+    "@trpc/server": "^6.5.0-alpha.0",
     "@types/node-fetch": "^2.5.8",
     "abort-controller": "^3.0.0",
     "body-parser": "^1.19.0",

--- a/examples/next-chat/package.json
+++ b/examples/next-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/chat",
-  "version": "6.4.0",
+  "version": "6.5.0-alpha.0",
   "private": true,
   "scripts": {
     "dx:next": "prisma generate && next dev",
@@ -18,10 +18,10 @@
   },
   "dependencies": {
     "@prisma/client": "^2.18.0",
-    "@trpc/client": "^6.4.0",
-    "@trpc/next": "^6.4.0",
-    "@trpc/react": "^6.4.0",
-    "@trpc/server": "^6.4.0",
+    "@trpc/client": "^6.5.0-alpha.0",
+    "@trpc/next": "^6.5.0-alpha.0",
+    "@trpc/react": "^6.5.0-alpha.0",
+    "@trpc/server": "^6.5.0-alpha.0",
     "jest": "^26.6.3",
     "jest-playwright": "^0.0.1",
     "jest-playwright-preset": "^1.4.5",

--- a/examples/next-prisma-starter/package.json
+++ b/examples/next-prisma-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/next-starter",
-  "version": "6.4.0",
+  "version": "6.5.0-alpha.0",
   "private": true,
   "scripts": {
     "build:1-generate": "prisma generate",
@@ -30,10 +30,10 @@
   },
   "dependencies": {
     "@prisma/client": "^2.18.0",
-    "@trpc/client": "^6.4.0",
-    "@trpc/next": "^6.4.0",
-    "@trpc/react": "^6.4.0",
-    "@trpc/server": "^6.4.0",
+    "@trpc/client": "^6.5.0-alpha.0",
+    "@trpc/next": "^6.5.0-alpha.0",
+    "@trpc/react": "^6.5.0-alpha.0",
+    "@trpc/server": "^6.5.0-alpha.0",
     "clsx": "^1.1.1",
     "next": "^10.0.5",
     "react": "^17.0.1",

--- a/examples/next-prisma-todomvc/package.json
+++ b/examples/next-prisma-todomvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/todo-web",
-  "version": "6.4.0",
+  "version": "6.5.0-alpha.0",
   "private": true,
   "scripts": {
     "migrate-sqlite": "npx prisma migrate dev --name init --schema=./prisma/_sqlite/schema.prisma",
@@ -24,10 +24,10 @@
   },
   "dependencies": {
     "@prisma/client": "^2.18.0",
-    "@trpc/client": "^6.4.0",
-    "@trpc/next": "^6.4.0",
-    "@trpc/react": "^6.4.0",
-    "@trpc/server": "^6.4.0",
+    "@trpc/client": "^6.5.0-alpha.0",
+    "@trpc/next": "^6.5.0-alpha.0",
+    "@trpc/react": "^6.5.0-alpha.0",
+    "@trpc/server": "^6.5.0-alpha.0",
     "clsx": "^1.1.1",
     "jest": "^26.6.3",
     "jest-playwright": "^0.0.1",

--- a/examples/standalone-server/package.json
+++ b/examples/standalone-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/standalone-server",
-  "version": "6.4.0",
+  "version": "6.5.0-alpha.0",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server.ts",
@@ -12,9 +12,9 @@
     "test-start": "start-server-and-test 'node dist/server' 2022 'node dist/client'"
   },
   "dependencies": {
-    "@trpc/client": "^6.4.0",
-    "@trpc/react": "^6.4.0",
-    "@trpc/server": "^6.4.0",
+    "@trpc/client": "^6.5.0-alpha.0",
+    "@trpc/react": "^6.5.0-alpha.0",
+    "@trpc/server": "^6.5.0-alpha.0",
     "@types/node-fetch": "^2.5.8",
     "abort-controller": "^3.0.0",
     "node-fetch": "^2.6.1",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.4.0",
+  "version": "6.5.0-alpha.0",
   "registry": "https://registry.npmjs.org/",
   "publishConfig": {
     "access": "public"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/client",
-  "version": "6.4.0",
+  "version": "6.5.0-alpha.0",
   "description": "tRPC Client lib",
   "author": "KATT",
   "license": "MIT",
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.9.0",
-    "@trpc/server": "^6.4.0"
+    "@trpc/server": "^6.5.0-alpha.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/client/src/internals/executeChain.ts
+++ b/packages/client/src/internals/executeChain.ts
@@ -4,11 +4,16 @@ import {
   Operation,
   OperationResult,
   PrevCallback,
+  OperationContext,
 } from '../links/core';
 
-export function executeChain(opts: { links: OperationLink[]; op: Operation }) {
+export function executeChain(opts: {
+  links: OperationLink[];
+  op: Omit<Operation, 'context'> & { context?: OperationContext };
+}) {
   const $result = observable<OperationResult | null>(null);
   const $destroyed = observable(false);
+  const { context = {} } = opts.op;
 
   function walk({
     index,
@@ -41,7 +46,7 @@ export function executeChain(opts: { links: OperationLink[]; op: Operation }) {
       },
     });
   }
-  walk({ index: 0, op: opts.op, stack: [] });
+  walk({ index: 0, op: { ...opts.op, context }, stack: [] });
   return {
     get: $result.get,
     subscribe: (callback: (value: OperationResult) => void) => {

--- a/packages/client/src/links/core.ts
+++ b/packages/client/src/links/core.ts
@@ -1,10 +1,12 @@
 import { DataTransformer, HTTPResponseEnvelope } from '@trpc/server';
 import { TRPCClientError } from '../createTRPCClient';
 
+export type OperationContext = Record<string, unknown>;
 export type Operation<TInput = unknown> = {
   type: 'query' | 'mutation' | 'subscription';
   input: TInput;
   path: string;
+  context: OperationContext;
 };
 type ResponseEnvelope = HTTPResponseEnvelope<any, any>;
 type ErrorResult = TRPCClientError<any>;

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/next",
-  "version": "6.4.0",
+  "version": "6.5.0-alpha.0",
   "description": "tRPC Next lib",
   "author": "KATT",
   "license": "MIT",
@@ -42,9 +42,9 @@
     "react-ssr-prepass": "^1.4.0"
   },
   "devDependencies": {
-    "@trpc/client": "^6.4.0",
-    "@trpc/react": "^6.4.0",
-    "@trpc/server": "^6.4.0",
+    "@trpc/client": "^6.5.0-alpha.0",
+    "@trpc/react": "^6.5.0-alpha.0",
+    "@trpc/server": "^6.5.0-alpha.0",
     "@types/express": "^4.17.11",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/react",
-  "version": "6.4.0",
+  "version": "6.5.0-alpha.0",
   "description": "tRPC React lib",
   "author": "KATT",
   "license": "MIT",
@@ -41,8 +41,8 @@
     "@babel/runtime": "^7.9.0"
   },
   "devDependencies": {
-    "@trpc/client": "^6.4.0",
-    "@trpc/server": "^6.4.0",
+    "@trpc/client": "^6.5.0-alpha.0",
+    "@trpc/server": "^6.5.0-alpha.0",
     "@types/express": "^4.17.11",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -1,6 +1,7 @@
 import {
   createTRPCClient,
   CreateTRPCClientOptions,
+  OperationContext,
   TRPCClient,
   TRPCClientError,
 } from '@trpc/client';
@@ -49,6 +50,10 @@ interface TRPCUseQueryBaseOptions {
    * Opt out of SSR for this query by passing `ssr: false`
    */
   ssr?: boolean;
+  /**
+   * Pass additional context to links
+   */
+  context?: OperationContext;
 }
 
 interface UseTRPCQueryOptions<TInput, TError, TOutput>
@@ -202,7 +207,10 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
 
     const query = useQuery(
       cacheKey,
-      () => client.query(...pathAndArgs) as any,
+      () =>
+        (client.query as any)(pathAndArgs[0], pathAndArgs[1], {
+          context: opts.context,
+        }),
       {
         ...opts,
         suspense: isPrepass && opts.ssr !== false ? true : opts.suspense,

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/server",
-  "version": "6.4.0",
+  "version": "6.5.0-alpha.0",
   "description": "tRPC Server",
   "author": "KATT",
   "license": "MIT",

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -43,7 +43,7 @@ export type inferSubscriptionOutput<
 export type inferHandlerInput<TProcedure extends Procedure> =
   TProcedure extends ProcedureWithInput<any, infer TInput, any>
     ? undefined extends TInput
-      ? [TInput?]
+      ? [(TInput | null | undefined)?]
       : [TInput]
     : [(undefined | null)?];
 

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -45,7 +45,7 @@ export type inferHandlerInput<TProcedure extends Procedure> =
     ? undefined extends TInput
       ? [TInput?]
       : [TInput]
-    : [undefined?];
+    : [(undefined | null)?];
 
 type inferHandlerFn<TProcedures extends ProcedureRecord> = <
   TProcedure extends TProcedures[TPath],

--- a/packages/server/src/subscription.ts
+++ b/packages/server/src/subscription.ts
@@ -85,8 +85,10 @@ export class Subscription<TOutput = unknown> {
    * This method is just here to help with `inferSubscriptionOutput` which I can't get working without it
    * @deprecated
    */
-  protected output(): TOutput {
-    throw new Error('Legacy');
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  private output(): TOutput {
+    throw new Error('Not in use');
   }
 
   /**

--- a/packages/server/test/links.test.ts
+++ b/packages/server/test/links.test.ts
@@ -35,6 +35,7 @@ test('retrylink', () => {
       type: 'query',
       input: null,
       path: '',
+      context: {},
     },
     prev: prev,
     next: (_ctx, callback) => {
@@ -411,4 +412,25 @@ test('loggerLink', () => {
     logger.error.mockReset();
     logger.log.mockReset();
   }
+});
+
+test('pass a context', () => {
+  const context = {
+    hello: 'there',
+  };
+  const callback = jest.fn();
+  executeChain({
+    links: [
+      ({ op }) => {
+        callback(op.context);
+      },
+    ],
+    op: {
+      type: 'query',
+      input: null,
+      path: '',
+      context,
+    },
+  });
+  expect(callback).toHaveBeenCalledWith(context);
 });


### PR DESCRIPTION
- allow you to add additonal context on requests
- useful to pass to to a `splitLink` and for instance route slow queries to `httpLink` rather than `httpBatchLink`