### PR TITLE
v7

### DIFF
--- a/examples/express-server/package.json
+++ b/examples/express-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/express-server",
-  "version": "6.5.0",
+  "version": "7.0.0-alpha.0",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server.ts",
@@ -12,9 +12,9 @@
     "test-start": "start-server-and-test 'node dist/server' 2021 'node dist/client'"
   },
   "dependencies": {
-    "@trpc/client": "^6.5.0",
-    "@trpc/react": "^6.5.0",
-    "@trpc/server": "^6.5.0",
+    "@trpc/client": "^7.0.0-alpha.0",
+    "@trpc/react": "^7.0.0-alpha.0",
+    "@trpc/server": "^7.0.0-alpha.0",
     "@types/node-fetch": "^2.5.8",
     "abort-controller": "^3.0.0",
     "body-parser": "^1.19.0",

--- a/examples/express-server/src/client.ts
+++ b/examples/express-server/src/client.ts
@@ -19,7 +19,7 @@ async function main() {
     },
 
     onError(err) {
-      console.log('❌ ', err.json?.statusCode, err.message);
+      console.log('❌ ', err.result?.statusCode, err.message);
     },
   });
   await sleep();
@@ -47,7 +47,7 @@ async function main() {
     },
 
     onError(err) {
-      console.log('❌ ', err.json?.statusCode, err.message);
+      console.log('❌ ', err.result?.statusCode, err.message);
     },
     headers: () => ({
       authorization: 'secret',

--- a/examples/express-server/src/client.ts
+++ b/examples/express-server/src/client.ts
@@ -49,7 +49,7 @@ async function main() {
     onError(err) {
       console.log('❌ ', err.json?.statusCode, err.message);
     },
-    getHeaders: () => ({
+    headers: () => ({
       authorization: 'secret',
     }),
   });

--- a/examples/next-chat/package.json
+++ b/examples/next-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/chat",
-  "version": "6.5.0",
+  "version": "7.0.0-alpha.0",
   "private": true,
   "scripts": {
     "dx:next": "prisma generate && next dev",
@@ -18,10 +18,10 @@
   },
   "dependencies": {
     "@prisma/client": "^2.18.0",
-    "@trpc/client": "^6.5.0",
-    "@trpc/next": "^6.5.0",
-    "@trpc/react": "^6.5.0",
-    "@trpc/server": "^6.5.0",
+    "@trpc/client": "^7.0.0-alpha.0",
+    "@trpc/next": "^7.0.0-alpha.0",
+    "@trpc/react": "^7.0.0-alpha.0",
+    "@trpc/server": "^7.0.0-alpha.0",
     "jest": "^26.6.3",
     "jest-playwright": "^0.0.1",
     "jest-playwright-preset": "^1.4.5",

--- a/examples/next-prisma-starter/package.json
+++ b/examples/next-prisma-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/next-starter",
-  "version": "6.5.0",
+  "version": "7.0.0-alpha.0",
   "private": true,
   "scripts": {
     "build:1-generate": "prisma generate",
@@ -30,10 +30,10 @@
   },
   "dependencies": {
     "@prisma/client": "^2.18.0",
-    "@trpc/client": "^6.5.0",
-    "@trpc/next": "^6.5.0",
-    "@trpc/react": "^6.5.0",
-    "@trpc/server": "^6.5.0",
+    "@trpc/client": "^7.0.0-alpha.0",
+    "@trpc/next": "^7.0.0-alpha.0",
+    "@trpc/react": "^7.0.0-alpha.0",
+    "@trpc/server": "^7.0.0-alpha.0",
     "clsx": "^1.1.1",
     "next": "^10.0.5",
     "react": "^17.0.1",

--- a/examples/next-prisma-starter/package.json
+++ b/examples/next-prisma-starter/package.json
@@ -39,7 +39,6 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-query": "^3.6.0",
-    "react-query-devtools": "^2.6.3",
     "start-server-and-test": "^1.12.0",
     "zod": "^3.0.0"
   },

--- a/examples/next-prisma-starter/src/pages/_app.tsx
+++ b/examples/next-prisma-starter/src/pages/_app.tsx
@@ -37,6 +37,9 @@ export default withTRPC(
      * @link https://trpc.io/docs/ssr
      */
     return {
+      /**
+       * @link https://trpc.io/docs/links
+       */
       links: [
         loggerLink({
           enabled: ({ event }) =>
@@ -60,6 +63,6 @@ export default withTRPC(
     /**
      * @link https://trpc.io/docs/ssr
      */
-    ssr: false,
+    ssr: true,
   },
 )(MyApp);

--- a/examples/next-prisma-starter/src/pages/_app.tsx
+++ b/examples/next-prisma-starter/src/pages/_app.tsx
@@ -44,14 +44,12 @@ export default withTRPC<AppRouter>(
       links: [
         () =>
           ({ prev, next, op }) => {
-            /**
-             * custom link, doesn't do anything apart from passing results through
-             * you can safely delete this
-             * @link https://www-git-feature-loggerlink.tmp.trpc.io/docs/links#custom-link
-             */
-            // custom link, doesn't do anything apart from passing results through
-            // you can safely delete this
+            // this is when passing the result to the next link
             next(op, (result) => {
+              // this is when we've gotten result from the server
+              if (result instanceof Error) {
+                // maybe send to bugsnag?
+              }
               prev(result);
             });
           },

--- a/examples/next-prisma-starter/src/pages/_app.tsx
+++ b/examples/next-prisma-starter/src/pages/_app.tsx
@@ -1,3 +1,4 @@
+import { TRPCLink } from '@trpc/client';
 import { httpBatchLink } from '@trpc/client/links/httpBatchLink';
 import { loggerLink } from '@trpc/client/links/loggerLink';
 import { withTRPC } from '@trpc/next';
@@ -42,17 +43,7 @@ export default withTRPC<AppRouter>(
        * @link https://trpc.io/docs/links
        */
       links: [
-        () =>
-          ({ prev, next, op }) => {
-            // this is when passing the result to the next link
-            next(op, (result) => {
-              // this is when we've gotten result from the server
-              if (result instanceof Error) {
-                // maybe send to bugsnag?
-              }
-              prev(result);
-            });
-          },
+        // adds pretty logs to your console in development and logs errors in production
         loggerLink({
           enabled: (opts) =>
             process.env.NODE_ENV === 'development' ||

--- a/examples/next-prisma-starter/src/pages/_app.tsx
+++ b/examples/next-prisma-starter/src/pages/_app.tsx
@@ -42,19 +42,19 @@ export default withTRPC<AppRouter>(
        * @link https://trpc.io/docs/links
        */
       links: [
-        // () =>
-        //   ({ prev, next, op }) => {
-        //     /**
-        //      * custom link, doesn't do anything apart from passing results through
-        //      * you can safely delete this
-        //      * @link https://www-git-feature-loggerlink.tmp.trpc.io/docs/links#custom-link
-        //      */
-        //     // custom link, doesn't do anything apart from passing results through
-        //     // you can safely delete this
-        //     next(op, (res) => {
-        //       prev(res);
-        //     });
-        //   },
+        () =>
+          ({ prev, next, op }) => {
+            /**
+             * custom link, doesn't do anything apart from passing results through
+             * you can safely delete this
+             * @link https://www-git-feature-loggerlink.tmp.trpc.io/docs/links#custom-link
+             */
+            // custom link, doesn't do anything apart from passing results through
+            // you can safely delete this
+            next(op, (result) => {
+              prev(result);
+            });
+          },
         loggerLink({
           enabled: (opts) =>
             process.env.NODE_ENV === 'development' ||

--- a/examples/next-prisma-starter/src/pages/_app.tsx
+++ b/examples/next-prisma-starter/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import { httpBatchLink } from '@trpc/client/links/httpBatchLink';
 import { loggerLink } from '@trpc/client/links/loggerLink';
 import { withTRPC } from '@trpc/next';
 import { AppType } from 'next/dist/next-server/lib/utils';
+import { AppRouter } from './api/trpc/[trpc]';
 // import { transformer } from '../utils/trpc';
 
 const MyApp: AppType = ({ Component, pageProps }) => {
@@ -30,7 +31,7 @@ function getBaseUrl() {
   return `http://localhost:${process.env.PORT ?? 3000}`;
 }
 
-export default withTRPC(
+export default withTRPC<AppRouter>(
   () => {
     /**
      * If you want to use SSR, you need to use the server's full URL
@@ -42,8 +43,9 @@ export default withTRPC(
        */
       links: [
         loggerLink({
-          enabled: ({ event }) =>
-            process.env.NODE_ENV === 'development' || event === 'error',
+          enabled: (opts) =>
+            process.env.NODE_ENV === 'development' ||
+            (opts.direction === 'down' && opts.result instanceof Error),
         }),
         httpBatchLink({
           url: `${getBaseUrl()}/api/trpc`,

--- a/examples/next-prisma-starter/src/pages/_app.tsx
+++ b/examples/next-prisma-starter/src/pages/_app.tsx
@@ -42,6 +42,19 @@ export default withTRPC<AppRouter>(
        * @link https://trpc.io/docs/links
        */
       links: [
+        // () =>
+        //   ({ prev, next, op }) => {
+        //     /**
+        //      * custom link, doesn't do anything apart from passing results through
+        //      * you can safely delete this
+        //      * @link https://www-git-feature-loggerlink.tmp.trpc.io/docs/links#custom-link
+        //      */
+        //     // custom link, doesn't do anything apart from passing results through
+        //     // you can safely delete this
+        //     next(op, (res) => {
+        //       prev(res);
+        //     });
+        //   },
         loggerLink({
           enabled: (opts) =>
             process.env.NODE_ENV === 'development' ||

--- a/examples/next-prisma-todomvc/package.json
+++ b/examples/next-prisma-todomvc/package.json
@@ -37,7 +37,6 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-query": "^3.6.0",
-    "react-query-devtools": "^2.6.3",
     "start-server-and-test": "^1.12.0",
     "superjson": "^1.5.2",
     "todomvc-app-css": "^2.3.0",

--- a/examples/next-prisma-todomvc/package.json
+++ b/examples/next-prisma-todomvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/todo-web",
-  "version": "6.5.0",
+  "version": "7.0.0-alpha.0",
   "private": true,
   "scripts": {
     "migrate-sqlite": "npx prisma migrate dev --name init --schema=./prisma/_sqlite/schema.prisma",
@@ -24,10 +24,10 @@
   },
   "dependencies": {
     "@prisma/client": "^2.18.0",
-    "@trpc/client": "^6.5.0",
-    "@trpc/next": "^6.5.0",
-    "@trpc/react": "^6.5.0",
-    "@trpc/server": "^6.5.0",
+    "@trpc/client": "^7.0.0-alpha.0",
+    "@trpc/next": "^7.0.0-alpha.0",
+    "@trpc/react": "^7.0.0-alpha.0",
+    "@trpc/server": "^7.0.0-alpha.0",
     "clsx": "^1.1.1",
     "jest": "^26.6.3",
     "jest-playwright": "^0.0.1",

--- a/examples/standalone-server/package.json
+++ b/examples/standalone-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/standalone-server",
-  "version": "6.5.0",
+  "version": "7.0.0-alpha.0",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server.ts",
@@ -12,9 +12,9 @@
     "test-start": "start-server-and-test 'node dist/server' 2022 'node dist/client'"
   },
   "dependencies": {
-    "@trpc/client": "^6.5.0",
-    "@trpc/react": "^6.5.0",
-    "@trpc/server": "^6.5.0",
+    "@trpc/client": "^7.0.0-alpha.0",
+    "@trpc/react": "^7.0.0-alpha.0",
+    "@trpc/server": "^7.0.0-alpha.0",
     "@types/node-fetch": "^2.5.8",
     "abort-controller": "^3.0.0",
     "node-fetch": "^2.6.1",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.5.0",
+  "version": "7.0.0-alpha.0",
   "registry": "https://registry.npmjs.org/",
   "publishConfig": {
     "access": "public"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/client",
-  "version": "6.5.0",
+  "version": "7.0.0-alpha.0",
   "description": "tRPC Client lib",
   "author": "KATT",
   "license": "MIT",
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.9.0",
-    "@trpc/server": "^6.5.0"
+    "@trpc/server": "^7.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -94,10 +94,6 @@ export type CreateTRPCClientOptions<TRouter extends AnyRouter> = {
    * add ponyfills for fetch / abortcontroller
    */
   fetchOpts?: FetchOptions;
-  /**
-   * @deprecated use `headers` instead
-   */
-  getHeaders?: () => Record<string, string | string[] | undefined>;
   headers?:
     | LinkRuntimeOptions['headers']
     | ReturnType<LinkRuntimeOptions['headers']>;
@@ -114,10 +110,6 @@ type TRPCType = 'subscription' | 'query' | 'mutation';
 
 export class TRPCClient<TRouter extends AnyRouter> {
   private readonly links: OperationLink<TRouter>[];
-  /**
-   * @deprecated use `runtime` instead
-   */
-  public readonly transformer: DataTransformer;
   private opts: CreateTRPCClientOptions<TRouter>;
   public readonly runtime: LinkRuntimeOptions;
 
@@ -142,9 +134,6 @@ export class TRPCClient<TRouter extends AnyRouter> {
       if (opts.headers) {
         const headers = opts.headers;
         return typeof headers === 'function' ? headers : () => headers;
-      }
-      if (opts.getHeaders) {
-        return opts.getHeaders;
       }
       return () => ({});
     }

--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -251,10 +251,7 @@ export class TRPCClient<TRouter extends AnyRouter> {
         } catch (_err) {
           const err: TRPCClientError<TRouter> = _err;
 
-          if (
-            (err.result as Maybe<HTTPErrorResponseEnvelope<TRouter>>)
-              ?.statusCode === 408
-          ) {
+          if (err.result?.statusCode === 408) {
             // server told us to reconnect
             exec();
           } else {

--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -31,10 +31,7 @@ const retryDelay = (attemptIndex: number) =>
   attemptIndex === 0 ? 0 : Math.min(1000 * 2 ** attemptIndex, 30000);
 
 export class TRPCClientError<TRouter extends AnyRouter> extends Error {
-  public readonly json?: Maybe<TRPCProcedureErrorEnvelope<TRouter>>;
-  /**
-   * @deprecated will always be `undefined` and will be removed in next major
-   */
+  public readonly result?: Maybe<TRPCProcedureErrorEnvelope<TRouter>>;
   public readonly res?: Maybe<Response>;
   public readonly originalError?: Maybe<Error>;
   public readonly shape?: TRPCProcedureErrorEnvelope<TRouter>['error'];
@@ -42,18 +39,18 @@ export class TRPCClientError<TRouter extends AnyRouter> extends Error {
   constructor(
     message: string,
     {
-      json,
+      result: result,
       originalError,
     }: {
-      json: Maybe<TRPCProcedureErrorEnvelope<TRouter>>;
+      result: Maybe<TRPCProcedureErrorEnvelope<TRouter>>;
       originalError: Maybe<Error>;
     },
   ) {
     super(message);
     this.message = message;
-    this.json = json;
+    this.result = result;
     this.originalError = originalError;
-    this.shape = this.json?.error;
+    this.shape = this.result?.error;
 
     Object.setPrototypeOf(this, TRPCClientError.prototype);
   }
@@ -64,7 +61,7 @@ export class TRPCClientError<TRouter extends AnyRouter> extends Error {
     if (!(result instanceof Error)) {
       return new TRPCClientError<TRouter>((result.error as any).message ?? '', {
         originalError: null,
-        json: result,
+        result: result,
       });
     }
 
@@ -74,7 +71,7 @@ export class TRPCClientError<TRouter extends AnyRouter> extends Error {
 
     return new TRPCClientError<TRouter>(result.message, {
       originalError: result,
-      json: null,
+      result: null,
     });
   }
 }
@@ -266,7 +263,7 @@ export class TRPCClient<TRouter extends AnyRouter> {
           const err: TRPCClientError<TRouter> = _err;
 
           if (
-            (err.json as Maybe<HTTPErrorResponseEnvelope<TRouter>>)
+            (err.result as Maybe<HTTPErrorResponseEnvelope<TRouter>>)
               ?.statusCode === 408
           ) {
             // server told us to reconnect

--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -39,7 +39,7 @@ export class TRPCClientError<TRouter extends AnyRouter> extends Error {
   constructor(
     message: string,
     {
-      result: result,
+      result,
       originalError,
     }: {
       result: Maybe<TRPCProcedureErrorEnvelope<TRouter>>;
@@ -61,7 +61,7 @@ export class TRPCClientError<TRouter extends AnyRouter> extends Error {
     if (!(result instanceof Error)) {
       return new TRPCClientError<TRouter>((result.error as any).message ?? '', {
         originalError: null,
-        result: result,
+        result,
       });
     }
 

--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -115,7 +115,7 @@ export class TRPCClient<TRouter extends AnyRouter> {
 
   constructor(opts: CreateTRPCClientOptions<TRouter>) {
     this.opts = opts;
-    const transformer: DataTransformer = (this.transformer = opts.transformer
+    const transformer: DataTransformer = opts.transformer
       ? 'input' in opts.transformer
         ? {
             serialize: opts.transformer.input.serialize,
@@ -125,7 +125,7 @@ export class TRPCClient<TRouter extends AnyRouter> {
       : {
           serialize: (data) => data,
           deserialize: (data) => data,
-        });
+        };
 
     const _fetch = getFetch(opts.fetchOpts?.fetch);
     const AC = getAbortController(opts.fetchOpts?.AbortController);

--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -3,7 +3,6 @@ import type {
   AnyRouter,
   ClientDataTransformerOptions,
   DataTransformer,
-  HTTPErrorResponseEnvelope,
   inferHandlerInput,
   inferProcedureInput,
   inferProcedureOutput,

--- a/packages/client/src/internals/executeChain.ts
+++ b/packages/client/src/internals/executeChain.ts
@@ -4,17 +4,15 @@ import {
   Operation,
   OperationResult,
   PrevCallback,
-  OperationContext,
 } from '../links/core';
 import { AnyRouter } from 'packages/server/src/router';
 
 export function executeChain<TRouter extends AnyRouter>(opts: {
   links: OperationLink<TRouter>[];
-  op: Omit<Operation<TRouter>, 'context'> & { context?: OperationContext };
+  op: Operation;
 }) {
   const $result = observable<OperationResult<TRouter> | null>(null);
   const $destroyed = observable(false);
-  const { context = {} } = opts.op;
 
   function walk({
     index,
@@ -47,7 +45,7 @@ export function executeChain<TRouter extends AnyRouter>(opts: {
       },
     });
   }
-  walk({ index: 0, op: { ...opts.op, context }, stack: [] });
+  walk({ index: 0, op: opts.op, stack: [] });
   return {
     get: $result.get,
     subscribe: (callback: (value: OperationResult<TRouter>) => void) => {

--- a/packages/client/src/links/core.ts
+++ b/packages/client/src/links/core.ts
@@ -12,7 +12,7 @@ export type Operation<TInput = unknown> = {
 };
 
 export type OperationResult<TRouter extends AnyRouter> =
-  | TRPCProcedureSuccessEnvelope<TRouter>
+  | TRPCProcedureSuccessEnvelope<unknown>
   | TRPCClientError<TRouter>;
 
 export type PrevCallback<TRouter extends AnyRouter> = (

--- a/packages/client/src/links/core.ts
+++ b/packages/client/src/links/core.ts
@@ -1,4 +1,8 @@
-import { DataTransformer, HTTPResponseEnvelope } from '@trpc/server';
+import {
+  DataTransformer,
+  TRPCProcedureSuccessEnvelope,
+  AnyRouter,
+} from '@trpc/server';
 import { TRPCClientError } from '../createTRPCClient';
 
 export type Operation<TInput = unknown> = {
@@ -6,20 +10,24 @@ export type Operation<TInput = unknown> = {
   input: TInput;
   path: string;
 };
-type ResponseEnvelope = HTTPResponseEnvelope<any, any>;
-type ErrorResult = TRPCClientError<any>;
 
-export type OperationResult = ResponseEnvelope | ErrorResult;
+export type OperationResult<TRouter extends AnyRouter> =
+  | TRPCProcedureSuccessEnvelope<TRouter>
+  | TRPCClientError<TRouter>;
 
-export type PrevCallback = (result: OperationResult) => void;
-export type OperationLink = (opts: {
+export type PrevCallback<TRouter extends AnyRouter> = (
+  result: OperationResult<TRouter>,
+) => void;
+export type OperationLink<TRouter extends AnyRouter> = (opts: {
   op: Operation;
-  prev: PrevCallback;
-  next: (op: Operation, callback: PrevCallback) => void;
+  prev: PrevCallback<TRouter>;
+  next: (op: Operation, callback: PrevCallback<TRouter>) => void;
   onDestroy: (callback: () => void) => void;
 }) => void;
 
-export type TRPCLink = (opts: LinkRuntimeOptions) => OperationLink;
+export type TRPCLink<TRouter extends AnyRouter> = (
+  opts: LinkRuntimeOptions,
+) => OperationLink<TRouter>;
 
 export type LinkRuntimeOptions = Readonly<{
   transformer: DataTransformer;

--- a/packages/client/src/links/httpBatchLink.ts
+++ b/packages/client/src/links/httpBatchLink.ts
@@ -1,52 +1,61 @@
-import { HTTPResponseEnvelope } from '@trpc/server';
-import { ProcedureType } from '@trpc/server';
-import { HttpLinkOptions, TRPCLink } from './core';
-import { httpRequest } from '../internals/httpRequest';
+import { HTTPResponseEnvelope, ProcedureType, AnyRouter } from '@trpc/server';
+import { TRPCClientError } from '../createTRPCClient';
 import { dataLoader } from '../internals/dataLoader';
+import { httpRequest } from '../internals/httpRequest';
+import { HttpLinkOptions, TRPCLink } from './core';
 
-export function httpBatchLink(opts: HttpLinkOptions): TRPCLink {
+export function httpBatchLink<TRouter extends AnyRouter>(
+  opts: HttpLinkOptions,
+): TRPCLink<TRouter> {
   const { url } = opts;
   // initialized config
   return (runtime) => {
     // initialized in app
+    type Key = { path: string; input: unknown };
+    const fetcher = (type: ProcedureType) => (keyInputPairs: Key[]) => {
+      const path = keyInputPairs.map(({ path }) => path).join(',');
+      const input = keyInputPairs.map(({ input }) => input);
 
-    const fetcher =
-      (type: ProcedureType) =>
-      (keyInputPairs: { path: string; input: unknown }[]) => {
-        const path = keyInputPairs.map(({ path }) => path).join(',');
-        const input = keyInputPairs.map(({ input }) => input);
+      const { promise, cancel } = httpRequest<
+        HTTPResponseEnvelope<unknown, any>[]
+      >({
+        url,
+        input,
+        path,
+        runtime,
+        type,
+        searchParams: 'batch=1',
+      });
 
-        const { promise, cancel } = httpRequest<
-          HTTPResponseEnvelope<unknown, any>[]
-        >({
-          url,
-          input,
-          path,
-          runtime,
-          type,
-          searchParams: 'batch=1',
-        });
-
-        return {
-          promise: promise.then((res: unknown[] | unknown) => {
-            if (!Array.isArray(res)) {
-              return keyInputPairs.map(() => res);
-            }
-            return res;
-          }),
-          cancel,
-        };
+      return {
+        promise: promise.then((res: unknown[] | unknown) => {
+          if (!Array.isArray(res)) {
+            return keyInputPairs.map(() => res);
+          }
+          return res;
+        }),
+        cancel,
       };
-    const query = dataLoader(fetcher('query'));
-    const mutation = dataLoader(fetcher('mutation'));
-    const subscription = dataLoader(fetcher('subscription'));
+    };
+    const query = dataLoader<Key, HTTPResponseEnvelope<TRouter, unknown>>(
+      fetcher('query'),
+    );
+    const mutation = dataLoader<Key, HTTPResponseEnvelope<TRouter, unknown>>(
+      fetcher('mutation'),
+    );
+    const subscription = dataLoader<
+      Key,
+      HTTPResponseEnvelope<TRouter, unknown>
+    >(fetcher('subscription'));
 
     const loaders = { query, subscription, mutation };
     return ({ op, prev, onDestroy }) => {
       const loader = loaders[op.type];
       const { promise, cancel } = loader.load(op);
       onDestroy(() => cancel());
-      promise.then(prev).catch(prev);
+      promise
+        .then((v) => (v.ok ? prev(v) : prev(TRPCClientError.from<TRouter>(v))))
+        .catch((v) => prev(TRPCClientError.from<TRouter>(v)));
     };
   };
 }

--- a/packages/client/src/links/httpBatchLink.ts
+++ b/packages/client/src/links/httpBatchLink.ts
@@ -52,7 +52,7 @@ export function httpBatchLink<TRouter extends AnyRouter>(
       const { promise, cancel } = loader.load(op);
       onDestroy(() => cancel());
       promise
-        .then((v) => (v.ok ? prev(v) : prev(TRPCClientError.from<TRouter>(v))))
+        .then((v) => prev(v.ok ? v : TRPCClientError.from(v)))
         .catch((v) => prev(TRPCClientError.from<TRouter>(v)));
     };
   };

--- a/packages/client/src/links/httpBatchLink.ts
+++ b/packages/client/src/links/httpBatchLink.ts
@@ -52,8 +52,10 @@ export function httpBatchLink<TRouter extends AnyRouter>(
       const { promise, cancel } = loader.load(op);
       onDestroy(() => cancel());
       promise
-        .then((v) => prev(v.ok ? v : TRPCClientError.from(v)))
-        .catch((v) => prev(TRPCClientError.from<TRouter>(v)));
+        .then((result) =>
+          prev(result.ok ? result : TRPCClientError.from(result)),
+        )
+        .catch((err) => prev(TRPCClientError.from<TRouter>(err)));
     };
   };
 }

--- a/packages/client/src/links/httpBatchLink.ts
+++ b/packages/client/src/links/httpBatchLink.ts
@@ -16,9 +16,7 @@ export function httpBatchLink<TRouter extends AnyRouter>(
       const path = keyInputPairs.map(({ path }) => path).join(',');
       const input = keyInputPairs.map(({ input }) => input);
 
-      const { promise, cancel } = httpRequest<
-        HTTPResponseEnvelope<unknown, any>[]
-      >({
+      const { promise, cancel } = httpRequest<TRouter>({
         url,
         input,
         path,

--- a/packages/client/src/links/httpLink.ts
+++ b/packages/client/src/links/httpLink.ts
@@ -22,7 +22,9 @@ export function httpLink<TRouter extends AnyRouter>(
       });
       onDestroy(() => cancel());
       promise
-        .then((v) => prev(v.ok ? v : TRPCClientError.from(v)))
+        .then((result) =>
+          prev(result.ok ? result : TRPCClientError.from(result)),
+        )
         .catch((err) => TRPCClientError.from(err));
     };
   };

--- a/packages/client/src/links/httpLink.ts
+++ b/packages/client/src/links/httpLink.ts
@@ -1,7 +1,10 @@
 import { HttpLinkOptions, TRPCLink } from './core';
 import { httpRequest } from '../internals/httpRequest';
+import { AnyRouter } from '@trpc/server/router';
 
-export function httpLink(opts: HttpLinkOptions): TRPCLink {
+export function httpLink<TRouter extends AnyRouter>(
+  opts: HttpLinkOptions,
+): TRPCLink<TRouter> {
   const { url } = opts;
 
   // initialized config

--- a/packages/client/src/links/loggerLink.ts
+++ b/packages/client/src/links/loggerLink.ts
@@ -95,8 +95,9 @@ export function loggerLink<TRouter extends AnyRouter = AnyRouter>(
       props.direction === 'down' &&
       props.result &&
       (props.result instanceof Error || !props.result.ok)
-        ? 'log'
-        : 'error';
+        ? 'error'
+        : 'log';
+
     c[fn].apply(null, [parts.join(' ')].concat(args));
   };
   const { log: logger = defaultLogger } = opts;

--- a/packages/client/src/links/loggerLink.ts
+++ b/packages/client/src/links/loggerLink.ts
@@ -55,8 +55,9 @@ type LoggerLinkOptions<TRouter extends AnyRouter> = {
   console?: ConsoleEsque;
 };
 
+// maybe this should be moved to it's own package
 const defaultLogger =
-  <TRouter extends AnyRouter>(c: ConsoleEsque): LogFn<TRouter> =>
+  <TRouter extends AnyRouter>(c: ConsoleEsque = console): LogFn<TRouter> =>
   (props) => {
     const { direction, requestId, input, type, path } = props;
     const [light, dark] = palette[type];
@@ -103,7 +104,7 @@ export function loggerLink<TRouter extends AnyRouter = AnyRouter>(
 ): TRPCLink<TRouter> {
   const { enabled = () => true } = opts;
 
-  const { logger = defaultLogger(opts.console ?? console) } = opts;
+  const { logger = defaultLogger(opts.console) } = opts;
   return () => {
     let requestId = 0;
     return ({ op, next, prev }) => {

--- a/packages/client/src/links/retryLink.ts
+++ b/packages/client/src/links/retryLink.ts
@@ -1,6 +1,9 @@
+import { AnyRouter } from 'packages/server/src/router';
 import { TRPCLink } from './core';
 
-export function retryLink(opts: { attempts: number }): TRPCLink {
+export function retryLink<TRouter extends AnyRouter = AnyRouter>(opts: {
+  attempts: number;
+}): TRPCLink<TRouter> {
   // initialized config
   return () => {
     // initialized in app

--- a/packages/client/src/links/splitLink.ts
+++ b/packages/client/src/links/splitLink.ts
@@ -1,16 +1,17 @@
+import { AnyRouter } from 'packages/server/src/router';
 import { TRPCLink, Operation } from './core';
 
-export function splitLink(opts: {
+export function splitLink<TRouter extends AnyRouter = AnyRouter>(opts: {
   /**
    * The link to execute next if the test function returns `true`.
    */
-  left: TRPCLink;
+  left: TRPCLink<TRouter>;
   /**
    * The link to execute next if the test function returns `false`.
    */
-  right: TRPCLink;
+  right: TRPCLink<TRouter>;
   condition: (op: Operation) => boolean;
-}): TRPCLink {
+}): TRPCLink<TRouter> {
   return (rt) => {
     const left = opts.left(rt);
     const right = opts.right(rt);

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/next",
-  "version": "6.5.0",
+  "version": "7.0.0-alpha.0",
   "description": "tRPC Next lib",
   "author": "KATT",
   "license": "MIT",
@@ -42,9 +42,9 @@
     "react-ssr-prepass": "^1.4.0"
   },
   "devDependencies": {
-    "@trpc/client": "^6.5.0",
-    "@trpc/react": "^6.5.0",
-    "@trpc/server": "^6.5.0",
+    "@trpc/client": "^7.0.0-alpha.0",
+    "@trpc/react": "^7.0.0-alpha.0",
+    "@trpc/server": "^7.0.0-alpha.0",
     "@types/express": "^4.17.11",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/react",
-  "version": "6.5.0",
+  "version": "7.0.0-alpha.0",
   "description": "tRPC React lib",
   "author": "KATT",
   "license": "MIT",
@@ -41,8 +41,8 @@
     "@babel/runtime": "^7.9.0"
   },
   "devDependencies": {
-    "@trpc/client": "^6.5.0",
-    "@trpc/server": "^6.5.0",
+    "@trpc/client": "^7.0.0-alpha.0",
+    "@trpc/server": "^7.0.0-alpha.0",
     "@types/express": "^4.17.11",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/server",
-  "version": "6.5.0",
+  "version": "7.0.0-alpha.0",
   "description": "tRPC Server",
   "author": "KATT",
   "license": "MIT",

--- a/packages/server/src/envelopes.ts
+++ b/packages/server/src/envelopes.ts
@@ -3,9 +3,17 @@ import { AnyRouter } from './router';
 export interface TRPCProcedureSuccessEnvelope<TOutput> {
   ok: true;
   data: TOutput;
+  /**
+   * Only available on HTTP requests
+   */
+  statusCode?: number;
 }
 
 export interface TRPCProcedureErrorEnvelope<TRouter extends AnyRouter> {
   ok: false;
   error: ReturnType<TRouter['_def']['errorFormatter']>;
+  /**
+   * Only available on HTTP requests
+   */
+  statusCode?: number;
 }

--- a/packages/server/src/envelopes.ts
+++ b/packages/server/src/envelopes.ts
@@ -1,0 +1,11 @@
+import { AnyRouter } from './router';
+
+export interface TRPCProcedureSuccessEnvelope<TOutput> {
+  ok: true;
+  data: TOutput;
+}
+
+export interface TRPCProcedureErrorEnvelope<TRouter extends AnyRouter> {
+  ok: false;
+  error: ReturnType<TRouter['_def']['errorFormatter']>;
+}

--- a/packages/server/src/http/envelopes.ts
+++ b/packages/server/src/http/envelopes.ts
@@ -1,17 +1,16 @@
+import { TRPCProcedureErrorEnvelope, TRPCProcedureSuccessEnvelope } from '../';
 import { AnyRouter } from '../router';
 
-export type HTTPSuccessResponseEnvelope<TOutput> = {
-  ok: true;
+export interface HTTPSuccessResponseEnvelope<TOutput>
+  extends TRPCProcedureSuccessEnvelope<TOutput> {
   statusCode: number;
-  data: TOutput;
-};
+}
 
-export type HTTPErrorResponseEnvelope<TRouter extends AnyRouter> = {
-  ok: false;
+export interface HTTPErrorResponseEnvelope<TRouter extends AnyRouter>
+  extends TRPCProcedureErrorEnvelope<TRouter> {
   statusCode: number;
-  error: ReturnType<TRouter['_def']['errorFormatter']>;
-};
+}
 
-export type HTTPResponseEnvelope<TOutput, TRouter extends AnyRouter> =
+export type HTTPResponseEnvelope<TRouter extends AnyRouter, TOutput> =
   | HTTPSuccessResponseEnvelope<TOutput>
   | HTTPErrorResponseEnvelope<TRouter>;

--- a/packages/server/src/http/requestHandler.ts
+++ b/packages/server/src/http/requestHandler.ts
@@ -260,8 +260,8 @@ export async function requestHandler<
   const isBatchCall = reqQueryParams.batch;
   function endResponse(
     json:
-      | HTTPResponseEnvelope<unknown, any>
-      | HTTPResponseEnvelope<unknown, any>[],
+      | HTTPResponseEnvelope<AnyRouter, unknown>
+      | HTTPResponseEnvelope<AnyRouter, unknown>[],
   ) {
     if (Array.isArray(json)) {
       const allCodes = Array.from(new Set(json.map((res) => res.statusCode)));

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5,3 +5,4 @@ export * from './subscription';
 export * from './transformer';
 export * from './assertNotBrowser';
 export * from './adapters/standalone';
+export * from './envelopes';

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -60,13 +60,6 @@ export type inferRouterContext<TRouter extends AnyRouter> = Parameters<
 >[0];
 
 export type AnyRouter<TContext = any> = Router<TContext, any, any, any, any>;
-export type UnknownRouter<
-  TContext = unknown,
-  TQueries extends ProcedureRecord = {},
-  TMutations extends ProcedureRecord = {},
-  TSubscriptions extends ProcedureRecord = {},
-  TErrorShape extends ErrorShape = ErrorShape,
-> = Router<TContext, TQueries, TMutations, TSubscriptions, TErrorShape>;
 
 const PROCEDURE_DEFINITION_MAP: Record<
   ProcedureType,

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -60,6 +60,13 @@ export type inferRouterContext<TRouter extends AnyRouter> = Parameters<
 >[0];
 
 export type AnyRouter<TContext = any> = Router<TContext, any, any, any, any>;
+export type UnknownRouter<
+  TContext = unknown,
+  TQueries extends ProcedureRecord = {},
+  TMutations extends ProcedureRecord = {},
+  TSubscriptions extends ProcedureRecord = {},
+  TErrorShape extends ErrorShape = ErrorShape,
+> = Router<TContext, TQueries, TMutations, TSubscriptions, TErrorShape>;
 
 const PROCEDURE_DEFINITION_MAP: Record<
   ProcedureType,

--- a/packages/server/src/subscription.ts
+++ b/packages/server/src/subscription.ts
@@ -83,7 +83,6 @@ export class Subscription<TOutput = unknown> {
 
   /**
    * This method is just here to help with `inferSubscriptionOutput` which I can't get working without it
-   * @deprecated
    */
   protected output(): TOutput {
     throw new Error('Legacy');

--- a/packages/server/test/errors.test.ts
+++ b/packages/server/test/errors.test.ts
@@ -43,9 +43,9 @@ test('basic', async () => {
   if (!(clientError instanceof TRPCClientError)) {
     throw new Error('Did not throw');
   }
-  expect(clientError.json?.statusCode).toBe(500);
-  expect(clientError.json?.error.message).toMatchInlineSnapshot(`"woop"`);
-  expect(clientError.json?.error.code).toMatchInlineSnapshot(
+  expect((clientError.result as any).statusCode).toBe(500);
+  expect(clientError.result?.error.message).toMatchInlineSnapshot(`"woop"`);
+  expect(clientError.result?.error.code).toMatchInlineSnapshot(
     `"INTERNAL_SERVER_ERROR"`,
   );
   expect(onError).toHaveBeenCalledTimes(1);
@@ -84,8 +84,8 @@ test('input error', async () => {
   if (!(clientError instanceof TRPCClientError)) {
     throw new Error('Did not throw');
   }
-  expect(clientError.json?.statusCode).toBe(400);
-  expect(clientError.json?.error.message).toMatchInlineSnapshot(`
+  expect((clientError.result as any).statusCode).toBe(400);
+  expect(clientError.result?.error.message).toMatchInlineSnapshot(`
     "[
       {
         \\"code\\": \\"invalid_type\\",
@@ -96,10 +96,10 @@ test('input error', async () => {
       }
     ]"
   `);
-  expect(clientError.json?.error.code).toMatchInlineSnapshot(
+  expect(clientError.result?.error.code).toMatchInlineSnapshot(
     `"BAD_USER_INPUT"`,
   );
-  expect(clientError.json?.error.path).toBe('err');
+  expect(clientError.result?.error.path).toBe('err');
   expect(onError).toHaveBeenCalledTimes(1);
   const serverError = onError.mock.calls[0][0].error;
 
@@ -135,11 +135,11 @@ test('httpError.unauthorized()', async () => {
   if (!(clientError instanceof TRPCClientError)) {
     throw new Error('Did not throw');
   }
-  expect(clientError.json?.statusCode).toBe(401);
-  expect(clientError.json?.error.message).toMatchInlineSnapshot(
+  expect((clientError.result as any).statusCode).toBe(401);
+  expect(clientError.result?.error.message).toMatchInlineSnapshot(
     `"Unauthorized"`,
   );
-  expect(clientError.json?.error.code).toMatchInlineSnapshot(
+  expect(clientError.result?.error.code).toMatchInlineSnapshot(
     `"UNAUTHENTICATED"`,
   );
   expect(onError).toHaveBeenCalledTimes(1);
@@ -192,8 +192,8 @@ test('formatError()', async () => {
     clientError = _err;
   }
   assertClientError(clientError);
-  expect(clientError.json?.statusCode).toBe(400);
-  expect(clientError.json?.error).toMatchInlineSnapshot(`
+  expect((clientError.result as any).statusCode).toBe(400);
+  expect(clientError.result?.error).toMatchInlineSnapshot(`
     Object {
       "errors": Array [
         Object {
@@ -236,8 +236,8 @@ test('make sure object is ignoring prototype', async () => {
     clientError = _err;
   }
   assertClientError(clientError);
-  expect(clientError.json?.statusCode).toBe(404);
-  expect(clientError.json?.error.code).toBe('NOT_FOUND');
+  expect((clientError.result as any).statusCode).toBe(404);
+  expect(clientError.result?.error.code).toBe('NOT_FOUND');
   expect(onError).toHaveBeenCalledTimes(1);
   const serverError = onError.mock.calls[0][0].error;
   expect(serverError.code).toBe('NOT_FOUND');

--- a/packages/server/test/errors.test.ts
+++ b/packages/server/test/errors.test.ts
@@ -43,7 +43,7 @@ test('basic', async () => {
   if (!(clientError instanceof TRPCClientError)) {
     throw new Error('Did not throw');
   }
-  expect((clientError.result as any).statusCode).toBe(500);
+  expect(clientError.result?.statusCode).toBe(500);
   expect(clientError.result?.error.message).toMatchInlineSnapshot(`"woop"`);
   expect(clientError.result?.error.code).toMatchInlineSnapshot(
     `"INTERNAL_SERVER_ERROR"`,
@@ -84,7 +84,7 @@ test('input error', async () => {
   if (!(clientError instanceof TRPCClientError)) {
     throw new Error('Did not throw');
   }
-  expect((clientError.result as any).statusCode).toBe(400);
+  expect(clientError.result?.statusCode).toBe(400);
   expect(clientError.result?.error.message).toMatchInlineSnapshot(`
     "[
       {
@@ -135,7 +135,7 @@ test('httpError.unauthorized()', async () => {
   if (!(clientError instanceof TRPCClientError)) {
     throw new Error('Did not throw');
   }
-  expect((clientError.result as any).statusCode).toBe(401);
+  expect(clientError.result?.statusCode).toBe(401);
   expect(clientError.result?.error.message).toMatchInlineSnapshot(
     `"Unauthorized"`,
   );
@@ -192,7 +192,7 @@ test('formatError()', async () => {
     clientError = _err;
   }
   assertClientError(clientError);
-  expect((clientError.result as any).statusCode).toBe(400);
+  expect(clientError.result?.statusCode).toBe(400);
   expect(clientError.result?.error).toMatchInlineSnapshot(`
     Object {
       "errors": Array [
@@ -236,7 +236,7 @@ test('make sure object is ignoring prototype', async () => {
     clientError = _err;
   }
   assertClientError(clientError);
-  expect((clientError.result as any).statusCode).toBe(404);
+  expect(clientError.result?.statusCode).toBe(404);
   expect(clientError.result?.error.code).toBe('NOT_FOUND');
   expect(onError).toHaveBeenCalledTimes(1);
   const serverError = onError.mock.calls[0][0].error;

--- a/packages/server/test/index.test.tsx
+++ b/packages/server/test/index.test.tsx
@@ -96,7 +96,7 @@ describe('integration tests', () => {
       expect(err.message).toMatchInlineSnapshot(
         `"No such query procedure \\"notFound\\""`,
       );
-      expect((err.result as any).statusCode).toBe(404);
+      expect(err.result?.statusCode).toBe(404);
     }
     close();
   });
@@ -124,7 +124,7 @@ describe('integration tests', () => {
       if (!(err instanceof TRPCClientError)) {
         throw new Error('Not TRPCClientError');
       }
-      expect((err.result as any).statusCode).toBe(400);
+      expect(err.result?.statusCode).toBe(400);
     }
     close();
   });

--- a/packages/server/test/index.test.tsx
+++ b/packages/server/test/index.test.tsx
@@ -96,7 +96,7 @@ describe('integration tests', () => {
       expect(err.message).toMatchInlineSnapshot(
         `"No such query procedure \\"notFound\\""`,
       );
-      expect(err.json?.statusCode).toBe(404);
+      expect((err.result as any).statusCode).toBe(404);
     }
     close();
   });
@@ -124,7 +124,7 @@ describe('integration tests', () => {
       if (!(err instanceof TRPCClientError)) {
         throw new Error('Not TRPCClientError');
       }
-      expect(err.json?.statusCode).toBe(400);
+      expect((err.result as any).statusCode).toBe(400);
     }
     close();
   });
@@ -273,7 +273,7 @@ describe('integration tests', () => {
           expectTypeOf(res).toMatchTypeOf<{ id: number; name: string }>();
         } catch (err) {
           threw = true;
-          expect(err.json.statusCode).toBe(401);
+          expect(err.result.statusCode).toBe(401);
         }
         if (!threw) {
           throw new Error("Didn't throw");

--- a/packages/server/test/links.test.ts
+++ b/packages/server/test/links.test.ts
@@ -340,11 +340,12 @@ test('loggerLink', () => {
         path: 'n/a',
       },
     });
+
     expect(logger.log.mock.calls[0][0]).toMatchInlineSnapshot(
-      `"%c ⏳ >> query #1 %cn/a%c %O"`,
+      `"%c >> query #1 %cn/a%c %O"`,
     );
     expect(logger.log.mock.calls[1][0]).toMatchInlineSnapshot(
-      `"%c ✅ << query #1 %cn/a%c %O"`,
+      `"%c << query #1 %cn/a%c %O"`,
     );
     logger.error.mockReset();
     logger.log.mockReset();
@@ -360,10 +361,10 @@ test('loggerLink', () => {
       },
     });
     expect(logger.log.mock.calls[0][0]).toMatchInlineSnapshot(
-      `"%c ⏳ >> subscription #2 %cn/a%c %O"`,
+      `"%c >> subscription #2 %cn/a%c %O"`,
     );
     expect(logger.log.mock.calls[1][0]).toMatchInlineSnapshot(
-      `"%c ✅ << subscription #2 %cn/a%c %O"`,
+      `"%c << subscription #2 %cn/a%c %O"`,
     );
     logger.error.mockReset();
     logger.log.mockReset();
@@ -380,10 +381,10 @@ test('loggerLink', () => {
     });
 
     expect(logger.log.mock.calls[0][0]).toMatchInlineSnapshot(
-      `"%c ⏳ >> mutation #3 %cn/a%c %O"`,
+      `"%c >> mutation #3 %cn/a%c %O"`,
     );
     expect(logger.log.mock.calls[1][0]).toMatchInlineSnapshot(
-      `"%c ✅ << mutation #3 %cn/a%c %O"`,
+      `"%c << mutation #3 %cn/a%c %O"`,
     );
     logger.error.mockReset();
     logger.log.mockReset();
@@ -399,10 +400,10 @@ test('loggerLink', () => {
       },
     });
     expect(logger.log.mock.calls[0][0]).toMatchInlineSnapshot(
-      `"%c ⏳ >> query #4 %cn/a%c %O"`,
+      `"%c >> query #4 %cn/a%c %O"`,
     );
     expect(logger.error.mock.calls[0][0]).toMatchInlineSnapshot(
-      `"%c ❌ << query #4 %cn/a%c %O"`,
+      `"%c << query #4 %cn/a%c %O"`,
     );
     logger.error.mockReset();
     logger.log.mockReset();
@@ -422,7 +423,7 @@ test('loggerLink', () => {
     const [firstCall, secondCall] = logFn.mock.calls.map((args) => args[0]);
     expect(firstCall).toMatchInlineSnapshot(`
       Object {
-        "event": "init",
+        "direction": "up",
         "input": null,
         "path": "n/a",
         "requestId": 1,
@@ -434,15 +435,11 @@ test('loggerLink', () => {
     expect(typeof elapsedMs).toBe('number');
     expect(other).toMatchInlineSnapshot(`
       Object {
-        "data": Object {
-          "error": null,
-          "ok": false,
-          "statusCode": 400,
-        },
-        "event": "error",
+        "direction": "down",
         "input": null,
         "path": "n/a",
         "requestId": 1,
+        "result": [Error: ..],
         "type": "query",
       }
     `);

--- a/packages/server/test/links.test.ts
+++ b/packages/server/test/links.test.ts
@@ -413,7 +413,7 @@ test('loggerLink', () => {
   {
     const logFn = jest.fn();
     executeChain({
-      links: [loggerLink({ log: logFn })(mockRuntime), errorLink],
+      links: [loggerLink({ logger: logFn })(mockRuntime), errorLink],
       op: {
         type: 'query',
         input: null,

--- a/packages/server/test/links.test.ts
+++ b/packages/server/test/links.test.ts
@@ -13,6 +13,7 @@ import { loggerLink } from '../../client/src/links/loggerLink';
 import { splitLink } from '../../client/src/links/splitLink';
 import * as trpc from '../src';
 import { routerToServerAndClient } from './_testHelpers';
+import { AnyRouter } from '../src';
 
 const mockRuntime: LinkRuntimeOptions = {
   transformer: {
@@ -331,10 +332,10 @@ test('loggerLink', () => {
   const logLink = loggerLink({
     console: logger,
   })(mockRuntime);
-  const okLink: OperationLink = ({ prev }) =>
+  const okLink: OperationLink<AnyRouter> = ({ prev }) =>
     prev({ ok: true, statusCode: 200, data: null });
-  const errorLink: OperationLink = ({ prev }) =>
-    prev({ ok: false, statusCode: 400, error: null });
+  const errorLink: OperationLink<AnyRouter> = ({ prev }) =>
+    prev({ ok: false, statusCode: 400, error: null as any });
   {
     executeChain({
       links: [logLink, okLink],
@@ -438,7 +439,7 @@ test('loggerLink', () => {
     expect(typeof elapsedMs).toBe('number');
     expect(other).toMatchInlineSnapshot(`
       Object {
-        "error": Object {
+        "data": Object {
           "error": null,
           "ok": false,
           "statusCode": 400,

--- a/packages/server/test/links.test.ts
+++ b/packages/server/test/links.test.ts
@@ -83,6 +83,7 @@ test('chainer', async () => {
       type: 'query',
       path: 'hello',
       input: null,
+      context: {},
     },
   });
 
@@ -132,6 +133,7 @@ test('cancel request', async () => {
       type: 'query',
       path: 'hello',
       input: null,
+      context: {},
     },
   });
 
@@ -173,6 +175,7 @@ describe('batching', () => {
         type: 'query',
         path: 'hello',
         input: null,
+        context: {},
       },
     });
 
@@ -182,6 +185,7 @@ describe('batching', () => {
         type: 'query',
         path: 'hello',
         input: 'alexdotjs',
+        context: {},
       },
     });
 
@@ -253,6 +257,7 @@ test('split link', () => {
       type: 'query',
       input: null,
       path: '',
+      context: {},
     },
   });
   expect(left).toHaveBeenCalledTimes(1);
@@ -339,6 +344,7 @@ test('loggerLink', () => {
         type: 'query',
         input: null,
         path: 'n/a',
+        context: {},
       },
     });
 
@@ -359,6 +365,7 @@ test('loggerLink', () => {
         type: 'subscription',
         input: null,
         path: 'n/a',
+        context: {},
       },
     });
     expect(logger.log.mock.calls[0][0]).toMatchInlineSnapshot(
@@ -378,6 +385,7 @@ test('loggerLink', () => {
         type: 'mutation',
         input: null,
         path: 'n/a',
+        context: {},
       },
     });
 
@@ -398,6 +406,7 @@ test('loggerLink', () => {
         type: 'query',
         input: null,
         path: 'n/a',
+        context: {},
       },
     });
     expect(logger.log.mock.calls[0][0]).toMatchInlineSnapshot(
@@ -419,11 +428,13 @@ test('loggerLink', () => {
         type: 'query',
         input: null,
         path: 'n/a',
+        context: {},
       },
     });
     const [firstCall, secondCall] = logFn.mock.calls.map((args) => args[0]);
     expect(firstCall).toMatchInlineSnapshot(`
       Object {
+        "context": Object {},
         "direction": "up",
         "input": null,
         "path": "n/a",
@@ -436,6 +447,7 @@ test('loggerLink', () => {
     expect(typeof elapsedMs).toBe('number');
     expect(other).toMatchInlineSnapshot(`
       Object {
+        "context": Object {},
         "direction": "down",
         "input": null,
         "path": "n/a",

--- a/packages/server/test/middleware.test.ts
+++ b/packages/server/test/middleware.test.ts
@@ -110,7 +110,7 @@ test('allows you to throw an error (e.g. auth)', async () => {
 
   expect(await client.query('foo')).toBe('bar');
   await expect(client.query('admin.secretPlace')).rejects.toMatchObject({
-    json: { statusCode: 401 },
+    result: { statusCode: 401 },
   });
   expect(resolverMock).toHaveBeenCalledTimes(0);
   headers.authorization = 'meow';

--- a/packages/server/test/middleware.test.ts
+++ b/packages/server/test/middleware.test.ts
@@ -103,7 +103,7 @@ test('allows you to throw an error (e.g. auth)', async () => {
         },
       },
       client: {
-        getHeaders: () => headers,
+        headers,
       },
     },
   );

--- a/packages/server/test/react.test.tsx
+++ b/packages/server/test/react.test.tsx
@@ -688,8 +688,8 @@ test('formatError() react types test', async () => {
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    if (mutation.error && mutation.error.json && mutation.error.shape) {
-      expectTypeOf(mutation.error.json.error).toMatchTypeOf<
+    if (mutation.error && mutation.error.result && mutation.error.shape) {
+      expectTypeOf(mutation.error.result.error).toMatchTypeOf<
         DefaultErrorShape & {
           $test: string;
         }

--- a/www/docs/client/links.md
+++ b/www/docs/client/links.md
@@ -47,6 +47,7 @@ import { withTRPC } from '@trpc/next';
 import { AppType } from 'next/dist/next-server/lib/utils';
 // 👇 import the httpBatchLink
 import { httpBatchLink } from '@trpc/client/links/httpBatchLink';
+
 const MyApp: AppType = ({ Component, pageProps }) => {
   return <Component {...pageProps} />;
 };
@@ -63,7 +64,7 @@ export default withTRPC(
     };
   },
   {
-    ssr: false,
+    // [..]
   },
 )(MyApp);
 ```

--- a/www/docs/client/links.md
+++ b/www/docs/client/links.md
@@ -45,9 +45,7 @@ export default trpcNext.createNextApiHandler({
 ```ts
 import { withTRPC } from '@trpc/next';
 import { AppType } from 'next/dist/next-server/lib/utils';
-
-// import the http batch link
-import { httpBatchLink } from '@trpc/client/links/httpBatchLink';
+import { httpBatchLink } from '@trpc/client/links/httpBatchLink';  // 👈 import the http batch link
 const MyApp: AppType = ({ Component, pageProps }) => {
   return <Component {...pageProps} />;
 };
@@ -56,7 +54,7 @@ export default withTRPC(
   () => {
     return {
       links: [
-        // add the batch link
+        // 👇 add the batch link
         httpBatchLink({
           url: '/api/trpc',
         }),
@@ -68,4 +66,3 @@ export default withTRPC(
   },
 )(MyApp);
 ```
-

--- a/www/docs/client/links.md
+++ b/www/docs/client/links.md
@@ -13,7 +13,7 @@ Similar to urql's [_exchanges_](https://formidable.com/open-source/urql/docs/arc
 You can enable query batching in order to parallelise your requests to the server, this can make the below code produce exactly **one** HTTP request and on the server exactly **one** database query:
 
 ```tsx
-// below will be done the same request when batching is enabled
+// below will be done in the same request when batching is enabled
 const somePosts = await Promise.all([
   client.query('posts.byId', 1),
   client.query('posts.byId', 2),
@@ -32,8 +32,8 @@ In your `[trpc].ts`:
 ```ts
 export default trpcNext.createNextApiHandler({
   // [...]
+  // 👇 enable batching
   batching: {
-    // enable batching
     enabled: true,
   },
 });
@@ -45,7 +45,8 @@ export default trpcNext.createNextApiHandler({
 ```ts
 import { withTRPC } from '@trpc/next';
 import { AppType } from 'next/dist/next-server/lib/utils';
-import { httpBatchLink } from '@trpc/client/links/httpBatchLink';  // 👈 import the http batch link
+// 👇 import the httpBatchLink
+import { httpBatchLink } from '@trpc/client/links/httpBatchLink';
 const MyApp: AppType = ({ Component, pageProps }) => {
   return <Component {...pageProps} />;
 };

--- a/www/docs/client/links.md
+++ b/www/docs/client/links.md
@@ -1,20 +1,31 @@
 ---
 id: links
-title: Links
-sidebar_label: Links
+title: Links & Request Batching
+sidebar_label: Links & Request Batching
 slug: /links
 ---
 
-Similar to urql's [_exchanges_](https://formidable.com/open-source/urql/docs/architecture/) or Apollo's [links](https://www.apollographql.com/docs/react/api/link/introduction/).
-
-Links helps you customize the flow of data between TRPC Client and the tRPC-server.
+Similar to urql's [_exchanges_](https://formidable.com/open-source/urql/docs/architecture/) or Apollo's [links](https://www.apollographql.com/docs/react/api/link/introduction/). Links enables you to customize the flow of data between tRPC Client and the tRPC-server.
 
 
-## Example - Procedure call batching
+## Request batching
+
+You can enable query batching in order to parallelise your requests to the server, this can make the below code produce exactly **one** HTTP request and on the server exactly **one** database query:
+
+```tsx
+// below will be done the same request when batching is enabled
+const somePosts = await Promise.all([
+  client.query('posts.byId', 1),
+  client.query('posts.byId', 2),
+  client.query('posts.byId', 3),
+])
+```
+
+### Enabling request batching on a Next.js project
 
 > The below examples assuming you use Next.js, but the same as below can be added if you use the vanilla tRPC client
 
-### 1. Enable `batching` on your server:
+#### 1. Enable `batching` on your server:
 
 In your `[trpc].ts`:
 
@@ -22,17 +33,20 @@ In your `[trpc].ts`:
 export default trpcNext.createNextApiHandler({
   // [...]
   batching: {
+    // enable batching
     enabled: true,
   },
 });
 ```
 
-### 2. Add batching to your tRPC Client
+#### 2. Add batching to your tRPC Client
 
 
 ```ts
 import { withTRPC } from '@trpc/next';
 import { AppType } from 'next/dist/next-server/lib/utils';
+
+// import the http batch link
 import { httpBatchLink } from '@trpc/client/links/httpBatchLink';
 const MyApp: AppType = ({ Component, pageProps }) => {
   return <Component {...pageProps} />;
@@ -42,6 +56,7 @@ export default withTRPC(
   () => {
     return {
       links: [
+        // add the batch link
         httpBatchLink({
           url: '/api/trpc',
         }),

--- a/www/docs/client/links.md
+++ b/www/docs/client/links.md
@@ -56,6 +56,7 @@ export default withTRPC(
   () => {
     return {
       links: [
+        // [..]
         // 👇 add the batch link
         httpBatchLink({
           url: '/api/trpc',
@@ -67,4 +68,36 @@ export default withTRPC(
     // [..]
   },
 )(MyApp);
+```
+
+### Custom logger
+
+```tsx
+// 👇 import the loggerLink
+import { loggerLink } from '@trpc/client/links/loggerLink';
+
+
+export default withTRPC(
+  () => {
+    return {
+      links: [
+        loggerLink({
+          logger(opts) {
+            if (opts.event === 'error) {
+              // send to bugsnag, etc
+            }
+          }
+        }),
+        httpBatchLink({
+          url: '/api/trpc',
+        }),
+      ],
+    };
+  },
+  {
+    // [..]
+  },
+)(MyApp);
+
+
 ```

--- a/www/docs/client/links.md
+++ b/www/docs/client/links.md
@@ -70,7 +70,7 @@ export default withTRPC(
 )(MyApp);
 ```
 
-### Custom logger
+### Custom link
 
 ```tsx
 // 👇 import the loggerLink
@@ -81,16 +81,20 @@ export default withTRPC(
   () => {
     return {
       links: [
-        loggerLink({
-          logger(opts) {
-            if (opts.direction === 'down' && opts.result instanceof Error) {
-              // send to bugsnag, etc
-            }
-          }
-        }),
-        httpBatchLink({
-          url: '/api/trpc',
-        }),
+        () =>
+          ({ prev, next, op }) => {
+            // custom link, doesn't do anything apart from passing results through
+            // you can safely delete this
+            next(op, (res) => {
+              if (res instanceof Error) {
+                // maybe 
+                // console.log(res);
+              }
+              prev(res);
+            });
+          },
+        // [..]
+        // ❗ Make sure to end with a `httpBatchLink` or `httpLink`
       ],
     };
   },

--- a/www/docs/client/links.md
+++ b/www/docs/client/links.md
@@ -73,21 +73,28 @@ export default withTRPC(
 ### Custom link
 
 ```tsx
+import { TRPCLink } from '@trpc/client';
+
+const customLink: TRPCLink<AppRouter> = (runtime) => {
+  // here we just got initialized in the app - this happens once per app
+  // useful for storing cache for instance
+  return ({ prev, next, op }) => {
+    // this is when passing the result to the next link
+    next(op, (result) => {
+      // this is when we've gotten result from the server
+      if (result instanceof Error) {
+        // maybe send to bugsnag?
+      }
+      prev(result);
+    });
+  };
+};
+
 export default withTRPC(
   () => {
     return {
       links: [
-        () =>
-          ({ prev, next, op }) => {
-            // this is when passing the result to the next link
-            next(op, (result) => {
-              // this is when we've gotten result from the server
-              if (result instanceof Error) {
-                // maybe send to bugsnag?
-              }
-              prev(result);
-            });
-          },
+        customLink,
         // [..]
         // ❗ Make sure to end with a `httpBatchLink` or `httpLink`
       ],

--- a/www/docs/client/links.md
+++ b/www/docs/client/links.md
@@ -83,9 +83,9 @@ export default withTRPC(
       links: [
         () =>
           ({ prev, next, op }) => {
-            // custom link, doesn't do anything apart from passing results through
-            // you can safely delete this
+            // this is when passing the result to the next link
             next(op, (result) => {
+              // this is when we've gotten result from the server
               if (result instanceof Error) {
                 // maybe send to bugsnag?
               }

--- a/www/docs/client/links.md
+++ b/www/docs/client/links.md
@@ -73,10 +73,6 @@ export default withTRPC(
 ### Custom link
 
 ```tsx
-// 👇 import the loggerLink
-import { loggerLink } from '@trpc/client/links/loggerLink';
-
-
 export default withTRPC(
   () => {
     return {

--- a/www/docs/client/links.md
+++ b/www/docs/client/links.md
@@ -85,12 +85,11 @@ export default withTRPC(
           ({ prev, next, op }) => {
             // custom link, doesn't do anything apart from passing results through
             // you can safely delete this
-            next(op, (res) => {
-              if (res instanceof Error) {
-                // maybe 
-                // console.log(res);
+            next(op, (result) => {
+              if (result instanceof Error) {
+                // maybe send to bugsnag?
               }
-              prev(res);
+              prev(result);
             });
           },
         // [..]

--- a/www/docs/client/links.md
+++ b/www/docs/client/links.md
@@ -83,7 +83,7 @@ export default withTRPC(
       links: [
         loggerLink({
           logger(opts) {
-            if (opts.event === 'error) {
+            if (opts.direction === 'down' && opts.result instanceof Error) {
               // send to bugsnag, etc
             }
           }

--- a/www/docs/nextjs/ssr.md
+++ b/www/docs/nextjs/ssr.md
@@ -43,10 +43,9 @@ export default withTRPC<AppRouter>(
 
     return {
       url,
-      getHeaders() {
-        return {
-          'x-ssr': '1',
-        };
+      headers: {
+        // optional - inform server that it's an ssr request
+        'x-ssr': '1',
       },
     };
   },

--- a/www/docs/react/react-intro.md
+++ b/www/docs/react/react-intro.md
@@ -57,7 +57,7 @@ function App() {
       url: 'http://localhost:5000/trpc',
 
       // optional
-      getHeaders() {
+      headers() {
         return {
           authorization: getAuthCookie(),
         };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8126,14 +8126,6 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-match-sorter@^4.1.0:
-  version "4.2.1"
-  resolved "https://registry.npmjs.org/match-sorter/-/match-sorter-4.2.1.tgz#575b4b3737185ba9518b67612b66877ea0b37358"
-  integrity sha512-s+3h9TiZU9U1pWhIERHf8/f4LmBN6IXaRgo2CI17+XGByGS1GvG5VvXK9pcGyCjGe3WM3mSYRC3ipGrd5UEVgw==
-  dependencies:
-    "@babel/runtime" "^7.10.5"
-    remove-accents "0.4.2"
-
 match-sorter@^6.0.2:
   version "6.3.0"
   resolved "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.0.tgz#454a1b31ed218cddbce6231a0ecb5fdc549fed01"
@@ -10025,13 +10017,6 @@ react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
-
-react-query-devtools@^2.6.3:
-  version "2.6.3"
-  resolved "https://registry.npmjs.org/react-query-devtools/-/react-query-devtools-2.6.3.tgz#f7c982839d4b0001cee4d5ddfa826493c2f6341f"
-  integrity sha512-pSvWq5Q8zgIP7QbF0+4BerCHLaLn5HPzce7sIXYqz4XEizcYJHkJtcrAwn6bUkCu5JmAt1Y7fViQtZwOIG2SYA==
-  dependencies:
-    match-sorter "^4.1.0"
 
 react-query@^3.6.0:
   version "3.16.0"


### PR DESCRIPTION
- `TRPCError.json` moved to `TRPCError.result`
- removed some deprecated options
- make sure ending links return an error if the result isn't `ok`
- using new `TRPCProcedureSuccessEnvelope` rather than `HTTPResponseEnvelope` (prepare for websocket support)


closes #474 