### PR TITLE
BUGFIX Transform undefined input

### DIFF
--- a/packages/server/src/http/requestHandler.ts
+++ b/packages/server/src/http/requestHandler.ts
@@ -289,7 +289,10 @@ export async function requestHandler<
       type,
     });
 
-    input = transformer.input.deserialize(rawInput);
+    input =
+      rawInput !== undefined
+        ? transformer.input.deserialize(rawInput)
+        : undefined;
     ctx = await createContext?.({ req, res });
 
     const caller = router.createCaller(ctx);

--- a/packages/server/test/transformer.test.ts
+++ b/packages/server/test/transformer.test.ts
@@ -29,6 +29,36 @@ test('superjson up and down', async () => {
   close();
 });
 
+test('empty superjson up and down', async () => {
+  const transformer = superjson;
+
+  const { client, close } = routerToServerAndClient(
+    trpc
+      .router()
+      .query('empty-up', {
+        resolve() {
+          return 'hello world';
+        },
+      })
+      .query('empty-down', {
+        input: z.string(),
+        resolve() {
+          return 'hello world';
+        },
+      }),
+    {
+      client: { transformer },
+      server: { transformer },
+    },
+  );
+  const res1 = await client.query('empty-up');
+  expect(res1).toBe('hello world');
+  const res2 = await client.query('empty-down', '');
+  expect(res2).toBe('hello world');
+
+  close();
+});
+
 test('devalue up and down', async () => {
   const transformer: trpc.DataTransformer = {
     serialize: (object) => devalue(object),


### PR DESCRIPTION
Currently we are only serializing input in trpc/client if there actually is an input. But in trpc/server we deserialize the input even if it is `undefined`. In other words: we try to deserialize a value (`undefined`) which was not serialized at all. (SuperJSON for example throws an error then.)

In this PR I've added a test to capture this behavior and the fix in trpc/server.