### PR TITLE
docs: fix typo

### DIFF
--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -89,7 +89,7 @@ function Home() {
             />
             <figcaption>
               The client above is <strong>not</strong> importing any code from
-              the server, only it&apos;s type declarations.{' '}
+              the server, only its type declarations.{' '}
               <code>import type</code> only imports declarations to be used
               annotations and declarations. It{' '}
               <a href="https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export">


### PR DESCRIPTION
"it's" means "it is", and "its" indicates possession as intended in this sentence.