### PR TITLE
BUG: Combined transformers not transforming errors on server

### DIFF
--- a/packages/server/src/http/internals/getHTTPStatusCode.ts
+++ b/packages/server/src/http/internals/getHTTPStatusCode.ts
@@ -1,5 +1,5 @@
 import { TRPCResponse, TRPC_ERROR_CODES_BY_KEY } from '../../rpc';
-import { DataTransformer } from '../../transformer';
+import { CombinedDataTransformer } from '../../transformer';
 import { invert } from './invert';
 
 export const TRPC_ERROR_CODES_BY_NUMBER = invert(TRPC_ERROR_CODES_BY_KEY);
@@ -25,13 +25,13 @@ const JSONRPC2_TO_HTTP_CODE: Record<
 
 export function getHTTPStatusCode(
   json: TRPCResponse | TRPCResponse[],
-  transformer: DataTransformer,
+  transformer: CombinedDataTransformer,
 ) {
   const arr = Array.isArray(json) ? json : [json];
   const codes = new Set(
     arr.map((res) => {
       if ('error' in res) {
-        return transformer.deserialize(res.error).code;
+        return transformer.output.deserialize(res.error).code;
       }
       return 200;
     }),

--- a/packages/server/src/http/requestHandler.ts
+++ b/packages/server/src/http/requestHandler.ts
@@ -113,7 +113,7 @@ export async function requestHandler<
 
     input =
       rawInput !== undefined
-        ? router._def.transformer.deserialize(rawInput)
+        ? router._def.transformer.input.deserialize(rawInput)
         : undefined;
     ctx = await createContext?.({ req, res });
 
@@ -147,7 +147,7 @@ export async function requestHandler<
             id,
             result: {
               type: 'data',
-              data: router._def.transformer.serialize(output),
+              data: router._def.transformer.output.serialize(output),
             },
           };
           return json;
@@ -156,7 +156,7 @@ export async function requestHandler<
 
           const json: TRPCErrorResponse = {
             id,
-            error: router._def.transformer.serialize(
+            error: router._def.transformer.output.serialize(
               router.getErrorShape({ error, type, path, input, ctx }),
             ),
           };
@@ -173,7 +173,7 @@ export async function requestHandler<
 
     const json: TRPCErrorResponse = {
       id: -1,
-      error: router._def.transformer.serialize(
+      error: router._def.transformer.output.serialize(
         router.getErrorShape({ error, type, path: undefined, input, ctx }),
       ),
     };


### PR DESCRIPTION
https://github.com/trpc/trpc/blob/8e6ea59f07de33addc486ec6cc956deb40789109/packages/server/src/http/internals/getHTTPStatusCode.ts#L34

When using combined transformers, this line is calling `transformer.input.deserialize`, but it is parsing an error which is serialized with `transformer.output.serialize`.