### PR TITLE
fix: wss missing initial msgs if slow `createContext()`-fn

### DIFF
--- a/packages/client/src/links/wsLink.ts
+++ b/packages/client/src/links/wsLink.ts
@@ -241,6 +241,7 @@ export function createWSClient(opts: WebSocketClientOptions) {
     return () => {
       const callbacks = pendingRequests[id]?.callbacks;
       delete pendingRequests[id];
+      outgoing = outgoing.filter((msg) => msg.id !== id);
 
       callbacks?.onDone?.();
       if (op.type === 'subscription') {

--- a/packages/server/src/ws/wssHandler.ts
+++ b/packages/server/src/ws/wssHandler.ts
@@ -5,7 +5,7 @@ import { TRPCError } from '../TRPCError';
 import { CreateContextFn } from '../http';
 import { BaseHandlerOptions } from '../internals/BaseHandlerOptions';
 import { callProcedure } from '../internals/callProcedure';
-import { AnyRouter, ProcedureType } from '../router';
+import { AnyRouter, inferRouterContext, ProcedureType } from '../router';
 import {
   TRPCErrorResponse,
   TRPCReconnectNotification,
@@ -14,10 +14,6 @@ import {
 } from '../rpc';
 import { Subscription } from '../subscription';
 import { CombinedDataTransformer } from '../transformer';
-// https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
-const WEBSOCKET_STATUS_CODES = {
-  ABNORMAL_CLOSURE: 1006,
-};
 
 /* istanbul ignore next */
 function assertIsObject(obj: unknown): asserts obj is Record<string, unknown> {
@@ -97,7 +93,7 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
   const { wss, createContext, router } = opts;
 
   const { transformer } = router._def;
-  wss.on('connection', async (client, req) => {
+  wss.on('connection', (client, req) => {
     const clientSubscriptions = new Map<
       number | string,
       Subscription<TRouter>
@@ -106,177 +102,188 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
     function respond(json: TRPCResponse) {
       client.send(JSON.stringify(json));
     }
-    try {
-      const ctx = await createContext({ req, res: client });
+    const ctxPromise = createContext({ req, res: client });
+    let ctx: inferRouterContext<TRouter> | undefined = undefined;
 
-      async function handleRequest(msg: TRPCRequest) {
-        const { id } = msg;
-        /* istanbul ignore next */
-        if (id === null) {
-          throw new TRPCError({
-            code: 'BAD_REQUEST',
-            message: '`id` is required',
-          });
+    async function handleRequest(msg: TRPCRequest) {
+      const { id } = msg;
+      /* istanbul ignore next */
+      if (id === null) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: '`id` is required',
+        });
+      }
+      if (msg.method === 'subscription.stop') {
+        const sub = clientSubscriptions.get(id);
+        clientSubscriptions.delete(id);
+        if (sub) {
+          sub.destroy();
         }
-        if (msg.method === 'subscription.stop') {
-          const sub = clientSubscriptions.get(id);
-          clientSubscriptions.delete(id);
-          if (sub) {
-            sub.destroy();
-          }
-          return;
-        }
-        const { path, input } = msg.params;
-        const type = msg.method;
-        try {
-          const result = await callProcedure({
-            path,
-            input,
-            type,
-            router,
-            ctx,
-          });
+        return;
+      }
+      const { path, input } = msg.params;
+      const type = msg.method;
+      try {
+        await ctxPromise; // asserts context has been set
+        const result = await callProcedure({
+          path,
+          input,
+          type,
+          router,
+          ctx,
+        });
 
-          if (!(result instanceof Subscription)) {
-            respond({
-              id,
-              result: {
-                type: 'data',
-                data: transformer.output.serialize(result),
-              },
-            });
-            return;
-          }
-
-          const sub = result;
-          /* istanbul ignore next */
-          if (client.readyState !== client.OPEN) {
-            // if the client got disconnected whilst initializing the subscription
-            sub.destroy();
-            return;
-          }
-          /* istanbul ignore next */
-          if (clientSubscriptions.has(id)) {
-            // duplicate request ids for client
-            sub.destroy();
-            throw new TRPCError({
-              message: `Duplicate id ${id}`,
-              code: 'BAD_REQUEST',
-            });
-          }
-          clientSubscriptions.set(id, sub);
-          sub.on('data', (data: unknown) => {
-            respond({
-              id,
-              result: {
-                type: 'data',
-                data: transformer.output.serialize(data),
-              },
-            });
-          });
-          sub.on('error', (_error: unknown) => {
-            const error = getErrorFromUnknown(_error);
-            const json: TRPCErrorResponse = {
-              id,
-              error: transformer.output.serialize(
-                router.getErrorShape({
-                  error,
-                  type,
-                  path,
-                  input,
-                  ctx,
-                }),
-              ),
-            };
-            opts.onError?.({ error, path, type, ctx, req, input });
-            respond(json);
-          });
-          sub.on('destroy', () => {
-            respond({
-              id,
-              result: {
-                type: 'stopped',
-              },
-            });
-          });
-
+        if (!(result instanceof Subscription)) {
           respond({
             id,
             result: {
-              type: 'started',
+              type: 'data',
+              data: transformer.output.serialize(result),
             },
           });
-          await sub.start();
-        } catch (_error) /* istanbul ignore next */ {
-          // procedure threw an error
-          const error = getErrorFromUnknown(_error);
-          const json = router.getErrorShape({
-            error: _error,
-            type,
-            path,
-            input,
-            ctx,
-          });
-          opts.onError?.({ error, path, type, ctx, req, input });
-          respond({ id, error: transformer.output.serialize(json) });
+          return;
         }
-      }
-      client.on('message', async (message) => {
-        const msgJSON: unknown = JSON.parse(message as string);
-        const msgs: unknown[] = Array.isArray(msgJSON) ? msgJSON : [msgJSON];
-        try {
-          msgs.map((raw) => parseMessage(raw, transformer)).map(handleRequest);
-        } catch (originalError) {
-          const error = new TRPCError({
-            code: 'PARSE_ERROR',
-            originalError,
-          });
 
+        const sub = result;
+        /* istanbul ignore next */
+        if (client.readyState !== client.OPEN) {
+          // if the client got disconnected whilst initializing the subscription
+          sub.destroy();
+          return;
+        }
+        /* istanbul ignore next */
+        if (clientSubscriptions.has(id)) {
+          // duplicate request ids for client
+          sub.destroy();
+          throw new TRPCError({
+            message: `Duplicate id ${id}`,
+            code: 'BAD_REQUEST',
+          });
+        }
+        clientSubscriptions.set(id, sub);
+        sub.on('data', (data: unknown) => {
           respond({
-            id: null,
+            id,
+            result: {
+              type: 'data',
+              data: transformer.output.serialize(data),
+            },
+          });
+        });
+        sub.on('error', (_error: unknown) => {
+          const error = getErrorFromUnknown(_error);
+          const json: TRPCErrorResponse = {
+            id,
             error: transformer.output.serialize(
               router.getErrorShape({
                 error,
-                type: 'unknown',
-                path: undefined,
-                input: undefined,
-                ctx: undefined,
+                type,
+                path,
+                input,
+                ctx,
               }),
             ),
+          };
+          opts.onError?.({ error, path, type, ctx, req, input });
+          respond(json);
+        });
+        sub.on('destroy', () => {
+          respond({
+            id,
+            result: {
+              type: 'stopped',
+            },
           });
-        }
-      });
+        });
 
-      client.once('close', () => {
-        for (const sub of clientSubscriptions.values()) {
-          sub.destroy();
-        }
-        clientSubscriptions.clear();
-      });
-    } catch (err) /* istanbul ignore next */ {
-      // failed to create context
-      const error = getErrorFromUnknown(err);
-
-      client.send({
-        id: -1,
-        error: router.getErrorShape({
-          error,
-          type: 'unknown',
-          path: undefined,
-          input: undefined,
-          ctx: undefined,
-        }),
-      });
-      opts.onError?.({
-        error,
-        path: undefined,
-        type: 'unknown',
-        ctx: undefined,
-        req,
-        input: undefined,
-      });
-      client.close(WEBSOCKET_STATUS_CODES.ABNORMAL_CLOSURE);
+        respond({
+          id,
+          result: {
+            type: 'started',
+          },
+        });
+        await sub.start();
+      } catch (_error) /* istanbul ignore next */ {
+        // procedure threw an error
+        const error = getErrorFromUnknown(_error);
+        const json = router.getErrorShape({
+          error: _error,
+          type,
+          path,
+          input,
+          ctx,
+        });
+        opts.onError?.({ error, path, type, ctx, req, input });
+        respond({ id, error: transformer.output.serialize(json) });
+      }
     }
+    client.on('message', async (message) => {
+      const msgJSON: unknown = JSON.parse(message as string);
+      const msgs: unknown[] = Array.isArray(msgJSON) ? msgJSON : [msgJSON];
+      try {
+        msgs.map((raw) => parseMessage(raw, transformer)).map(handleRequest);
+      } catch (originalError) {
+        const error = new TRPCError({
+          code: 'PARSE_ERROR',
+          originalError,
+        });
+
+        respond({
+          id: null,
+          error: transformer.output.serialize(
+            router.getErrorShape({
+              error,
+              type: 'unknown',
+              path: undefined,
+              input: undefined,
+              ctx: undefined,
+            }),
+          ),
+        });
+      }
+    });
+
+    client.once('close', () => {
+      for (const sub of clientSubscriptions.values()) {
+        sub.destroy();
+      }
+      clientSubscriptions.clear();
+    });
+    async function createContextAsync() {
+      try {
+        ctx = await ctxPromise;
+      } catch (err) {
+        const error = getErrorFromUnknown(err);
+        const json: TRPCErrorResponse = {
+          id: null,
+          error: transformer.output.serialize(
+            router.getErrorShape({
+              error,
+              type: 'unknown',
+              path: undefined,
+              input: undefined,
+              ctx,
+            }),
+          ),
+        };
+        opts.onError?.({
+          error,
+          path: undefined,
+          type: 'unknown',
+          ctx,
+          req,
+          input: undefined,
+        });
+        respond(json);
+
+        // close in next tick
+        (global.setImmediate ?? global.setTimeout)(() => {
+          client.close();
+        });
+      }
+    }
+    createContextAsync();
   });
 
   return {

--- a/packages/server/src/ws/wssHandler.ts
+++ b/packages/server/src/ws/wssHandler.ts
@@ -219,9 +219,9 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
       }
     }
     client.on('message', async (message) => {
-      const msgJSON: unknown = JSON.parse(message as string);
-      const msgs: unknown[] = Array.isArray(msgJSON) ? msgJSON : [msgJSON];
       try {
+        const msgJSON: unknown = JSON.parse(message as string);
+        const msgs: unknown[] = Array.isArray(msgJSON) ? msgJSON : [msgJSON];
         msgs.map((raw) => parseMessage(raw, transformer)).map(handleRequest);
       } catch (originalError) {
         const error = new TRPCError({

--- a/packages/server/src/ws/wssHandler.ts
+++ b/packages/server/src/ws/wssHandler.ts
@@ -116,10 +116,10 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
       }
       if (msg.method === 'subscription.stop') {
         const sub = clientSubscriptions.get(id);
-        clientSubscriptions.delete(id);
         if (sub) {
           sub.destroy();
         }
+        clientSubscriptions.delete(id);
         return;
       }
       const { path, input } = msg.params;

--- a/packages/server/test/_testHelpers.ts
+++ b/packages/server/test/_testHelpers.ts
@@ -90,8 +90,13 @@ export function routerToServerAndClient<TRouter extends AnyRouter>(
     httpPort,
     wssPort,
     httpUrl,
+    wssUrl,
     applyWSSHandlerOpts,
     wssHandler,
     wss,
   };
+}
+
+export async function waitMs(ms: number) {
+  await new Promise<void>((resolve) => setTimeout(resolve, ms));
 }

--- a/packages/server/test/websockets.test.ts
+++ b/packages/server/test/websockets.test.ts
@@ -468,7 +468,7 @@ test('batching', async () => {
   t.close();
 });
 
-describe.only('regression test - slow createContext', () => {
+describe('regression test - slow createContext', () => {
   test('send messages immediately on connection', async () => {
     const t = factory({
       async createContext() {


### PR DESCRIPTION
fixes edge-case where `createContext()` takes longer than it takes to receive the first message from the client, leading to initial messages being lost