### PR TITLE
`splitLink`: `left`/`right` to `true`/`false`

### DIFF
--- a/packages/client/src/links/splitLink.ts
+++ b/packages/client/src/links/splitLink.ts
@@ -1,22 +1,45 @@
 import { AnyRouter } from '@trpc/server';
 import { TRPCLink, Operation } from './core';
 
-export function splitLink<TRouter extends AnyRouter = AnyRouter>(opts: {
-  /**
-   * The link to execute next if the test function returns `true`.
-   */
-  left: TRPCLink<TRouter>;
-  /**
-   * The link to execute next if the test function returns `false`.
-   */
-  right: TRPCLink<TRouter>;
-  condition: (op: Operation) => boolean;
-}): TRPCLink<TRouter> {
+export function splitLink<TRouter extends AnyRouter = AnyRouter>(
+  opts: {
+    condition: (op: Operation) => boolean;
+  } & (
+    | {
+        /**
+         * The link to execute next if the test function returns `true`.
+         */
+        left: TRPCLink<TRouter>;
+        /**
+         * The link to execute next if the test function returns `false`.
+         */
+        right: TRPCLink<TRouter>;
+      }
+    | {
+        /**
+         * The link to execute next if the test function returns `true`.
+         */
+        true: TRPCLink<TRouter>;
+        /**
+         * The link to execute next if the test function returns `false`.
+         */
+        false: TRPCLink<TRouter>;
+      }
+  ),
+): TRPCLink<TRouter> {
   return (rt) => {
-    const left = opts.left(rt);
-    const right = opts.right(rt);
+    const links =
+      'left' in opts
+        ? {
+            true: opts.left,
+            false: opts.right,
+          }
+        : opts;
+
+    const yes = links.true(rt);
+    const no = links.false(rt);
     return (props) => {
-      opts.condition(props.op) ? left(props) : right(props);
+      opts.condition(props.op) ? yes(props) : no(props);
     };
   };
 }

--- a/packages/client/src/links/splitLink.ts
+++ b/packages/client/src/links/splitLink.ts
@@ -8,10 +8,12 @@ export function splitLink<TRouter extends AnyRouter = AnyRouter>(
     | {
         /**
          * The link to execute next if the test function returns `true`.
+         * @deprecated use `true`
          */
         left: TRPCLink<TRouter>;
         /**
          * The link to execute next if the test function returns `false`.
+         * @deprecated use `false`
          */
         right: TRPCLink<TRouter>;
       }

--- a/packages/client/src/links/splitLink.ts
+++ b/packages/client/src/links/splitLink.ts
@@ -8,12 +8,10 @@ export function splitLink<TRouter extends AnyRouter = AnyRouter>(
     | {
         /**
          * The link to execute next if the test function returns `true`.
-         * @deprecated use `true`
          */
         left: TRPCLink<TRouter>;
         /**
          * The link to execute next if the test function returns `false`.
-         * @deprecated use `false`
          */
         right: TRPCLink<TRouter>;
       }

--- a/packages/server/test/links.test.ts
+++ b/packages/server/test/links.test.ts
@@ -256,32 +256,57 @@ describe('batching', () => {
     close();
   });
 });
-
-test('split link', () => {
-  const left = jest.fn();
-  const right = jest.fn();
-  executeChain({
-    links: [
-      splitLink({
-        left: () => left,
-        right: () => right,
-        condition(op) {
-          return op.type === 'query';
-        },
-      })(mockRuntime),
-    ],
-    op: {
-      id: 1,
-      type: 'query',
-      input: null,
-      path: '',
-      context: {},
-    },
+describe('splitLink', () => {
+  test('left/right', () => {
+    const left = jest.fn();
+    const right = jest.fn();
+    executeChain({
+      links: [
+        splitLink({
+          left: () => left,
+          right: () => right,
+          condition(op) {
+            return op.type === 'query';
+          },
+        })(mockRuntime),
+      ],
+      op: {
+        id: 1,
+        type: 'query',
+        input: null,
+        path: '',
+        context: {},
+      },
+    });
+    expect(left).toHaveBeenCalledTimes(1);
+    expect(right).toHaveBeenCalledTimes(0);
   });
-  expect(left).toHaveBeenCalledTimes(1);
-  expect(right).toHaveBeenCalledTimes(0);
-});
 
+  test('true/false', () => {
+    const trueLink = jest.fn();
+    const falseLink = jest.fn();
+    executeChain({
+      links: [
+        splitLink({
+          true: () => trueLink,
+          false: () => falseLink,
+          condition(op) {
+            return op.type === 'query';
+          },
+        })(mockRuntime),
+      ],
+      op: {
+        id: 1,
+        type: 'query',
+        input: null,
+        path: '',
+        context: {},
+      },
+    });
+    expect(trueLink).toHaveBeenCalledTimes(1);
+    expect(falseLink).toHaveBeenCalledTimes(0);
+  });
+});
 test('create client with links', async () => {
   let attempt = 0;
   const serverCall = jest.fn();


### PR DESCRIPTION
I find `left`/`right` very unintuitive (`right` means `false`)


 todos:

- [ ] update docs
- [ ] review
- [ ] deprecate old?