### PR TITLE
Replace deprecated `httpError` in Middleware example

### DIFF
--- a/www/docs/server/middlewares.md
+++ b/www/docs/server/middlewares.md
@@ -10,7 +10,7 @@ You can are able to add middlewares to a whole router with the `middleware()` me
 
 
 
-## Example, from [the tests](https://github.com/trpc/trpc/tree/main/packages/server/test/middleware.test.ts):
+## Example
 
 
 In the example below any call to `admin.*` will ensure that the user is an "admin" before executing any query or mutation.

--- a/www/docs/server/middlewares.md
+++ b/www/docs/server/middlewares.md
@@ -30,7 +30,7 @@ trpc
       .router<Context>()
       .middleware(async ({ ctx }) => {
         if (!ctx.user?.isAdmin) {
-          throw httpError.unauthorized();
+          throw new TRPCError({ code: "UNAUTHORIZED" });
         }
       })
       .query('secretPlace', {
@@ -42,3 +42,7 @@ trpc
       }),
   )
 ```
+
+:::tip
+See [Error Handling](error-handling.md) to learn more about the `TRPCError` thrown in the above example.
+:::


### PR DESCRIPTION
Hi there, thanks for this library! I'm checking it out and appreciate how it feels like a much more lightweight approach to my typical Prisma-Nexus-Apollo-GQL Codegen stack.

I was a little confused at the use of `httpError` in the middleware example and where it came from. This PR updates this deprecated call to the new error API and adds a tip referencing the error handling page.

Looks like the [test in question](https://github.com/trpc/trpc/blob/be9d168e0b994d28af32875b7ca3942ab956e3bf/packages/server/test/middleware.test.ts#L78-L80) still uses the deprecated API -- I didn't take a look at that. (I also think it would be great to contextualize the scope and current limitations of middlewares vis-a-vis their "typical" usage in frameworks like Koa, as mentioned in #586, since there's not much explanation in the docs about this currently and I had to do some digging.)

Hope this helps regardless!