### PR TITLE
`@trpc/server` - inherit stack trace

### DIFF
--- a/packages/server/src/internals/BaseHandlerOptions.ts
+++ b/packages/server/src/internals/BaseHandlerOptions.ts
@@ -10,6 +10,14 @@ export type BaseRequest = http.IncomingMessage & {
 };
 export type BaseResponse = http.ServerResponse;
 
+export type OnErrorFunction<TRouter extends AnyRouter, TRequest> = (opts: {
+  error: TRPCError;
+  type: ProcedureType | 'unknown';
+  path: string | undefined;
+  req: TRequest;
+  input: unknown;
+  ctx: undefined | inferRouterContext<TRouter>;
+}) => void;
 /**
  * Base interface for any HTTP/WSS handlers
  */
@@ -19,14 +27,7 @@ export interface BaseHandlerOptions<
 > {
   teardown?: () => Promise<void>;
   maxBodySize?: number;
-  onError?: (opts: {
-    error: TRPCError;
-    type: ProcedureType | 'unknown';
-    path: string | undefined;
-    req: TRequest;
-    input: unknown;
-    ctx: undefined | inferRouterContext<TRouter>;
-  }) => void;
+  onError?: OnErrorFunction<TRouter, TRequest>;
   batching?: {
     enabled: boolean;
   };

--- a/packages/server/src/internals/errors.ts
+++ b/packages/server/src/internals/errors.ts
@@ -20,5 +20,11 @@ export function getErrorFromUnknown(originalError: unknown): TRPCError {
   if (originalError instanceof Error && originalError.name === 'TRPCError') {
     return originalError as TRPCError;
   }
-  return new TRPCError({ code: 'INTERNAL_SERVER_ERROR', originalError });
+  const err = new TRPCError({ code: 'INTERNAL_SERVER_ERROR', originalError });
+
+  // take stack trace from originalError
+  if (originalError instanceof Error) {
+    err.stack = originalError.stack;
+  }
+  return err;
 }

--- a/packages/server/test/_testHelpers.ts
+++ b/packages/server/test/_testHelpers.ts
@@ -100,3 +100,15 @@ export function routerToServerAndClient<TRouter extends AnyRouter>(
 export async function waitMs(ms: number) {
   await new Promise<void>((resolve) => setTimeout(resolve, ms));
 }
+
+export async function waitError(
+  fn: () => Promise<unknown> | unknown,
+): Promise<Error> {
+  try {
+    await fn();
+  } catch (err) {
+    expect(err).toBeInstanceOf(Error);
+    return err;
+  }
+  throw new Error('Function did not throw');
+}

--- a/packages/server/test/errors.test.ts
+++ b/packages/server/test/errors.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { z, ZodError } from 'zod';
@@ -314,8 +315,11 @@ test('retain stack trace', async () => {
   expect(serverError).toBeInstanceOf(TRPCError);
   expect(serverError.originalError).toBeInstanceOf(CustomError);
 
-  console.log('stack', serverError.stack);
   expect(serverError.stack).not.toContain('getErrorFromUnknown');
+  const stackParts = serverError.stack!.split('\n');
+
+  // first line of stack trace
+  expect(stackParts[1]).toContain(__filename);
 
   close();
 });


### PR DESCRIPTION
Inherit stack trace from original error when throwing

## Before

Useless stack trace

```
      TRPCError: CustomError.msg
          at Object.getErrorFromUnknown ([redacted]/trpc/packages/server/src/internals/errors.ts:23:15)
          at [redacted]/trpc/packages/server/src/http/requestHandler.ts:173:25
          at processTicksAndRejections (internal/process/task_queues.js:95:5)
          at async Promise.all (index 0)
          at Object.requestHandler ([redacted]/trpc/packages/server/src/http/requestHandler.ts:153:21)
          at [redacted]/trpc/packages/server/src/adapters/standalone.ts:30:5
```

## After

Useful stack trace

```
    CustomError: CustomError.msg
        at ProcedureWithoutInput.resolve [as resolver] ([redacted]/trpc/packages/server/test/errors.test.ts:296:17)
        at ProcedureWithoutInput.call ([redacted]/trpc/packages/server/src/procedure.ts:106:31)
        at Router.invoke ([redacted]/trpc/packages/server/src/router.ts:461:22)
        at Object.query ([redacted]/trpc/packages/server/src/router.ts:471:21)
        at Object.callProcedure ([redacted]/trpc/packages/server/src/internals/callProcedure.ts:18:19)
        at [redacted]/trpc/packages/server/src/http/requestHandler.ts:157:32
        at Array.map (<anonymous>)
        at Object.requestHandler ([redacted]/trpc/packages/server/src/http/requestHandler.ts:154:13)
        at processTicksAndRejections (internal/process/task_queues.js:95:5)
        at [redacted]/trpc/packages/server/src/adapters/standalone.ts:30:5
```

