### PR TITLE
Add default server error handler as a fallback

### DIFF
--- a/packages/server/src/http/requestHandler.ts
+++ b/packages/server/src/http/requestHandler.ts
@@ -84,8 +84,24 @@ export async function requestHandler<
     createContext: TCreateContextFn;
   } & BaseHandlerOptions<TRouter, TRequest>,
 ) {
-  const { req, res, createContext, teardown, onError, maxBodySize, router } =
-    opts;
+  const {
+    req,
+    res,
+    createContext,
+    teardown,
+    onError = ({ error, type, path, input }) => {
+      if (error.code === 'INTERNAL_SERVER_ERROR') {
+        console.error('API error:', {
+          type,
+          path,
+          input,
+          cause: error.originalError,
+        });
+      }
+    },
+    maxBodySize,
+    router,
+  } = opts;
   const batchingEnabled = opts.batching?.enabled ?? true;
   if (req.method === 'HEAD') {
     // can be used for lambda warmup

--- a/www/docs/server/error-handling.md
+++ b/www/docs/server/error-handling.md
@@ -7,6 +7,8 @@ slug: /error-handling
 
 If a procedure fails we trigger a function with information about the procedure & ctx.
 
+Internal server errors are logged to the console unless a custom `onError` handler is specified.
+
 ## Example with Next.js
 
 ```ts
@@ -15,14 +17,13 @@ export default trpcNext.createNextApiHandler({
   onError({ error }) {
     console.error('Error:', error);
     if (error.code === 'INTERNAL_SERVER_ERROR') {
-      // send to bug reporting
+      // send to bug reporting, overriding the original `console.log` behavior
     }
   },
 });
 ```
 
 ## All properties sent to `onError()`
-
 
 ```ts
 {
@@ -47,16 +48,18 @@ export default trpcNext.createNextApiHandler({
 });
 ```
 
-
 ## Error helpers
 
 ```ts
 import { TRPCError } from '@trpc/server';
 
-throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Optional Message' });
+throw new TRPCError({
+  code: 'INTERNAL_SERVER_ERROR',
+  message: 'Optional Message',
+});
 
 // Some available codes:
-// 
+//
 // "FORBIDDEN"
 // "BAD_REQUEST"
 // "INTERNAL_SERVER_ERROR"


### PR DESCRIPTION
Resolves #384.

As it turns out, errors should also be logged in production by default, so when a log drain is in use, no additional setup is required.