### PR TITLE
Add `beforeEnd:`-function on HTTP response handlers

### DIFF
--- a/examples/next-prisma-starter/src/pages/api/trpc/[trpc].ts
+++ b/examples/next-prisma-starter/src/pages/api/trpc/[trpc].ts
@@ -26,4 +26,10 @@ export default trpcNext.createNextApiHandler({
   batching: {
     enabled: true,
   },
+  /**
+   * @link https://trpc.io/docs/caching#api-response-caching
+   */
+  // beforeEnd() {
+  //   // ...
+  // },
 });

--- a/packages/server/src/adapters/express.ts
+++ b/packages/server/src/adapters/express.ts
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type * as express from 'express';
-import { CreateContextFn, CreateContextFnOptions } from '../http';
-import { requestHandler } from '../http';
-import { BaseHandlerOptions } from '../internals/BaseHandlerOptions';
+import { CreateContextFnOptions, requestHandler } from '../http';
+import { HTTPHandlerOptions } from '../http/internals/HTTPHandlerOptions';
 import { AnyRouter } from '../router';
 
 export type CreateExpressContextOptions = CreateContextFnOptions<
@@ -10,16 +9,8 @@ export type CreateExpressContextOptions = CreateContextFnOptions<
   express.Response
 >;
 
-export type CreateExpressContextFn<TRouter extends AnyRouter> = CreateContextFn<
-  TRouter,
-  express.Request,
-  express.Response
->;
-
 export function createExpressMiddleware<TRouter extends AnyRouter>(
-  opts: {
-    createContext: CreateExpressContextFn<TRouter>;
-  } & BaseHandlerOptions<TRouter, express.Request>,
+  opts: HTTPHandlerOptions<TRouter, express.Request, express.Response>,
 ): express.Handler {
   return (req, res) => {
     const endpoint = req.path.substr(1);

--- a/packages/server/src/adapters/next.ts
+++ b/packages/server/src/adapters/next.ts
@@ -1,26 +1,19 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
-import { CreateContextFn, CreateContextFnOptions, requestHandler } from '../';
-import { TRPCError } from '../TRPCError';
-import { BaseHandlerOptions } from '../internals/BaseHandlerOptions';
+import { CreateContextFnOptions, requestHandler } from '../';
+import { HTTPHandlerOptions } from '../http/internals/HTTPHandlerOptions';
 import { AnyRouter } from '../router';
 import { TRPCErrorResponse } from '../rpc';
+import { TRPCError } from '../TRPCError';
 
 export type CreateNextContextOptions = CreateContextFnOptions<
   NextApiRequest,
   NextApiResponse
 >;
 
-export type CreateNextContextFn<TRouter extends AnyRouter> = CreateContextFn<
-  TRouter,
-  NextApiRequest,
-  NextApiResponse
->;
 export function createNextApiHandler<TRouter extends AnyRouter>(
-  opts: {
-    createContext: CreateNextContextFn<TRouter>;
-  } & BaseHandlerOptions<TRouter, NextApiRequest>,
+  opts: HTTPHandlerOptions<TRouter, NextApiRequest, NextApiResponse>,
 ): NextApiHandler {
   return async (req, res) => {
     function getPath(): string | null {

--- a/packages/server/src/adapters/standalone.ts
+++ b/packages/server/src/adapters/standalone.ts
@@ -2,9 +2,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import http from 'http';
 import url from 'url';
-import { CreateContextFn, CreateContextFnOptions } from '../http';
-import { requestHandler } from '../http';
-import { BaseHandlerOptions } from '../internals/BaseHandlerOptions';
+import { CreateContextFnOptions, requestHandler } from '../http';
+import { HTTPHandlerOptions } from '../http/internals/HTTPHandlerOptions';
 import { AnyRouter } from '../router';
 
 export type CreateHttpContextOptions = CreateContextFnOptions<
@@ -12,16 +11,9 @@ export type CreateHttpContextOptions = CreateContextFnOptions<
   http.ServerResponse
 >;
 
-export type CreateHttpContextFn<TRouter extends AnyRouter> = CreateContextFn<
-  TRouter,
-  http.IncomingMessage,
-  http.ServerResponse
->;
+export type CreateHttpHandlerOptions<TRouter extends AnyRouter> =
+  HTTPHandlerOptions<TRouter, http.IncomingMessage, http.ServerResponse>;
 
-export interface CreateHttpHandlerOptions<TRouter extends AnyRouter>
-  extends BaseHandlerOptions<TRouter, http.IncomingMessage> {
-  createContext: CreateHttpContextFn<TRouter>;
-}
 export function createHttpHandler<TRouter extends AnyRouter>(
   opts: CreateHttpHandlerOptions<TRouter>,
 ) {

--- a/packages/server/src/http/internals/HTTPHandlerOptions.ts
+++ b/packages/server/src/http/internals/HTTPHandlerOptions.ts
@@ -1,0 +1,40 @@
+import {
+  BaseHandlerOptions,
+  BaseRequest,
+  BaseResponse,
+} from '../../internals/BaseHandlerOptions';
+import {
+  AnyRouter,
+  inferRouterContext,
+  inferRouterError,
+  ProcedureType,
+} from '../../router';
+import { TRPCResponse } from '../../rpc';
+import { CreateContextFn } from '../requestHandler';
+
+type BeforeEndFunction<TRouter extends AnyRouter> = (opts: {
+  data: TRPCResponse<unknown, inferRouterError<TRouter>>[];
+  ctx?: inferRouterContext<TRouter>;
+  /**
+   * The different tRPC paths requested
+   **/
+  paths?: string[];
+  type: ProcedureType | 'unknown';
+}) => void;
+
+export interface HTTPHandlerOptions<
+  TRouter extends AnyRouter,
+  TRequest extends BaseRequest,
+  TResponse extends BaseResponse,
+> extends BaseHandlerOptions<TRouter, TRequest> {
+  /**
+   * @link https://trpc.io/docs/context
+   **/
+  createContext: CreateContextFn<TRouter, TRequest, TResponse>;
+  /**
+   * Add handler to be called before response is sent to the user
+   * Useful for setting cache headers
+   * @link https://trpc.io/docs/caching
+   */
+  beforeEnd?: BeforeEndFunction<TRouter>;
+}

--- a/packages/server/src/http/requestHandler.ts
+++ b/packages/server/src/http/requestHandler.ts
@@ -128,6 +128,7 @@ export async function requestHandler<
       type,
     });
 
+    const paths = isBatchCall ? opts.path.split(',') : [opts.path];
     ctx = await createContext?.({ req, res });
 
     const getInputs = (): Record<number, unknown> => {
@@ -157,7 +158,6 @@ export async function requestHandler<
       return input;
     };
     const inputs = getInputs();
-    const paths = isBatchCall ? opts.path.split(',') : [opts.path];
     const rawResults = await Promise.all(
       paths.map(async (path, index) => {
         const id = null;

--- a/packages/server/src/http/requestHandler.ts
+++ b/packages/server/src/http/requestHandler.ts
@@ -1,11 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import url from 'url';
 import { assertNotBrowser } from '../assertNotBrowser';
-import {
-  BaseHandlerOptions,
-  BaseRequest,
-  BaseResponse,
-} from '../internals/BaseHandlerOptions';
+import { BaseRequest, BaseResponse } from '../internals/BaseHandlerOptions';
 import { callProcedure } from '../internals/callProcedure';
 import { getErrorFromUnknown } from '../internals/errors';
 import { transformTRPCResponse } from '../internals/transformTRPCResponse';
@@ -20,6 +16,7 @@ import { TRPCError } from '../TRPCError';
 import { getHTTPStatusCode } from './internals/getHTTPStatusCode';
 import { getPostBody } from './internals/getPostBody';
 import { getQueryInput } from './internals/getQueryInput';
+import { HTTPHandlerOptions } from './internals/HTTPHandlerOptions';
 
 assertNotBrowser();
 
@@ -67,7 +64,6 @@ async function getRequestParams({
 
 export async function requestHandler<
   TRouter extends AnyRouter,
-  TCreateContextFn extends CreateContextFn<TRouter, TRequest, TResponse>,
   TRequest extends BaseRequest,
   TResponse extends BaseResponse,
 >(
@@ -75,8 +71,7 @@ export async function requestHandler<
     req: TRequest;
     res: TResponse;
     path: string;
-    createContext: TCreateContextFn;
-  } & BaseHandlerOptions<TRouter, TRequest>,
+  } & HTTPHandlerOptions<TRouter, TRequest, TResponse>,
 ) {
   const { req, res, createContext, teardown, onError, maxBodySize, router } =
     opts;
@@ -108,7 +103,7 @@ export async function requestHandler<
 
     res.setHeader('Content-Type', 'application/json');
 
-    router._def.beforeEnd({
+    opts.beforeEnd?.({
       ctx,
       paths,
       type,

--- a/packages/server/src/http/requestHandler.ts
+++ b/packages/server/src/http/requestHandler.ts
@@ -90,6 +90,7 @@ export async function requestHandler<
   const type =
     HTTP_METHOD_PROCEDURE_TYPE_MAP[req.method!] ?? ('unknown' as const);
   let ctx: inferRouterContext<TRouter> | undefined = undefined;
+  let paths: string[] | undefined = undefined;
 
   const reqQueryParams = req.query
     ? req.query
@@ -106,6 +107,15 @@ export async function requestHandler<
     }
 
     res.setHeader('Content-Type', 'application/json');
+
+    router._def.beforeEnd({
+      ctx,
+      paths,
+      type,
+      data: Array.isArray(untransformedJSON)
+        ? untransformedJSON
+        : [untransformedJSON],
+    });
 
     const transformedJSON = transformTRPCResponse(router, untransformedJSON);
 
@@ -128,7 +138,7 @@ export async function requestHandler<
       type,
     });
 
-    const paths = isBatchCall ? opts.path.split(',') : [opts.path];
+    paths = isBatchCall ? opts.path.split(',') : [opts.path];
     ctx = await createContext?.({ req, res });
 
     const getInputs = (): Record<number, unknown> => {

--- a/packages/server/src/internals/BaseHandlerOptions.ts
+++ b/packages/server/src/internals/BaseHandlerOptions.ts
@@ -1,13 +1,7 @@
 import http from 'http';
 import qs from 'qs';
+import { AnyRouter, inferRouterContext, ProcedureType } from '../router';
 import { TRPCError } from '../TRPCError';
-import {
-  AnyRouter,
-  inferRouterContext,
-  inferRouterError,
-  ProcedureType,
-} from '../router';
-import { TRPCResponse } from '../rpc';
 
 export type BaseRequest = http.IncomingMessage & {
   method?: string;

--- a/packages/server/src/internals/BaseHandlerOptions.ts
+++ b/packages/server/src/internals/BaseHandlerOptions.ts
@@ -1,7 +1,13 @@
 import http from 'http';
 import qs from 'qs';
 import { TRPCError } from '../TRPCError';
-import { AnyRouter, inferRouterContext, ProcedureType } from '../router';
+import {
+  AnyRouter,
+  inferRouterContext,
+  inferRouterError,
+  ProcedureType,
+} from '../router';
+import { TRPCResponse } from '../rpc';
 
 export type BaseRequest = http.IncomingMessage & {
   method?: string;
@@ -32,4 +38,8 @@ export interface BaseHandlerOptions<
     enabled: boolean;
   };
   router: TRouter;
+  beforeRequestEnd?: (opts: {
+    data: TRPCResponse<unknown, inferRouterError<TRouter>>[];
+    ctx: inferRouterContext<TRouter>;
+  }) => void;
 }

--- a/packages/server/src/internals/BaseHandlerOptions.ts
+++ b/packages/server/src/internals/BaseHandlerOptions.ts
@@ -38,8 +38,4 @@ export interface BaseHandlerOptions<
     enabled: boolean;
   };
   router: TRouter;
-  beforeRequestEnd?: (opts: {
-    data: TRPCResponse<unknown, inferRouterError<TRouter>>[];
-    ctx: inferRouterContext<TRouter>;
-  }) => void;
 }

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -64,9 +64,6 @@ function getDataTransformer(
   return { input: transformer, output: transformer };
 }
 
-/**
- * Function triggered before requests are sent out the user
- **/
 type BeforeEndFunction<TRouter extends AnyRouter> = (opts: {
   data: TRPCResponse<unknown, inferRouterError<TRouter>>[];
   ctx?: inferRouterContext<TRouter>;

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -439,6 +439,7 @@ export class Router<
     };
 
     return new Router<TContext, any, any, any, TErrorShape>({
+      ...this._def,
       queries: safeObject(
         this._def.queries,
         mergeProcedures(childRouter._def.queries),
@@ -451,10 +452,6 @@ export class Router<
         this._def.subscriptions,
         mergeProcedures(childRouter._def.subscriptions),
       ),
-      middlewares: this._def.middlewares,
-      errorFormatter: this._def.errorFormatter,
-      transformer: this._def.transformer,
-      beforeEnd: this._def.beforeEnd,
     });
   }
 

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -613,16 +613,10 @@ export class Router<
         'You seem to have double `beforeEnd()`-calls in your router tree',
       );
     }
-    return new Router<
-      TContext,
-      TQueries,
-      TMutations,
-      TSubscriptions,
-      TErrorShape
-    >({
+    return new Router({
       ...this._def,
       beforeEnd,
-    });
+    }) as this;
   }
 }
 

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -74,6 +74,7 @@ type BeforeEndFunction<TRouter extends AnyRouter> = (opts: {
    * The different tRPC paths requested
    **/
   paths?: string[];
+  type: ProcedureType | 'unknown';
 }) => void;
 
 export type inferHandlerInput<TProcedure extends Procedure> =

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -528,19 +528,19 @@ export class Router<
    */
   public formatError<TErrorFormatter extends ErrorFormatter<TContext, any>>(
     errorFormatter: TErrorFormatter,
-  ) {
+  ): Router<
+    TContext,
+    TQueries,
+    TMutations,
+    TSubscriptions,
+    ReturnType<TErrorFormatter>
+  > {
     if (this._def.errorFormatter !== (defaultFormatter as any)) {
       throw new Error(
         'You seem to have double `formatError()`-calls in your router tree',
       );
     }
-    return new Router<
-      TContext,
-      TQueries,
-      TMutations,
-      TSubscriptions,
-      ReturnType<TErrorFormatter>
-    >({
+    return new Router({
       ...this._def,
       errorFormatter,
     });

--- a/packages/server/src/ws/wssHandler.ts
+++ b/packages/server/src/ws/wssHandler.ts
@@ -223,7 +223,9 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
       try {
         const msgJSON: unknown = JSON.parse(message as string);
         const msgs: unknown[] = Array.isArray(msgJSON) ? msgJSON : [msgJSON];
-        msgs.map((raw) => parseMessage(raw, transformer)).map(handleRequest);
+        msgs
+          .map((raw) => parseMessage(raw, transformer))
+          .forEach(handleRequest);
       } catch (originalError) {
         const error = new TRPCError({
           code: 'PARSE_ERROR',

--- a/packages/server/src/ws/wssHandler.ts
+++ b/packages/server/src/ws/wssHandler.ts
@@ -223,9 +223,7 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
       try {
         const msgJSON: unknown = JSON.parse(message as string);
         const msgs: unknown[] = Array.isArray(msgJSON) ? msgJSON : [msgJSON];
-        msgs
-          .map((raw) => parseMessage(raw, transformer))
-          .forEach(handleRequest);
+        msgs.map((raw) => parseMessage(raw, transformer)).map(handleRequest);
       } catch (originalError) {
         const error = new TRPCError({
           code: 'PARSE_ERROR',

--- a/packages/server/test/beforeEnd.test.ts
+++ b/packages/server/test/beforeEnd.test.ts
@@ -1,0 +1,43 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import fetch from 'node-fetch';
+import { z } from 'zod';
+import * as trpc from '../src';
+import { routerToServerAndClient } from './_testHelpers';
+test('duplicate beforeEnd', () => {
+  expect(() =>
+    trpc
+      .router()
+      .beforeEnd(() => {})
+      .beforeEnd(() => {}),
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"You seem to have double \`transformer()\`-calls in your router tree"`,
+  );
+});
+
+test('set custom headers in beforeEnd', async () => {
+  const TEAPOT_ERROR_CODE = 418;
+  const onError = jest.fn();
+  const { close, httpUrl } = routerToServerAndClient(
+    trpc
+      .router<trpc.CreateHttpContextOptions>()
+      //
+      .query('q', {
+        input: z.string(),
+        resolve() {
+          return null;
+        },
+      }),
+    {
+      server: {
+        onError,
+      },
+    },
+  );
+  const res = await fetch(`${httpUrl}/q`);
+
+  expect(res.ok).toBeFalsy();
+  expect(res.status).toBe(TEAPOT_ERROR_CODE);
+
+  close();
+});

--- a/packages/server/test/beforeEnd.test.ts
+++ b/packages/server/test/beforeEnd.test.ts
@@ -21,14 +21,14 @@ test('set custom headers in beforeEnd', async () => {
       .router<trpc.CreateHttpContextOptions>()
       .beforeEnd(({ ctx, paths, data, type }) => {
         // assuming you have all your public routes with the kewyord `public` in them
-        const isPublic =
-          paths && !paths.some((path) => !path.includes('public'));
+        const allPublic =
+          paths && paths.every((path) => path.includes('public'));
         // checking that no responses contains an error
-        const allOk = !data.some((data) => 'error' in data);
+        const allOk = data.every((data) => 'result' in data);
         // checking we're doing a query request
         const isQuery = type === 'query';
 
-        if (ctx?.res && isPublic && allOk && isQuery) {
+        if (ctx?.res && allPublic && allOk && isQuery) {
           // cache request for 1 day + revalidate once every second
           const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
           ctx.res.setHeader(

--- a/www/docs/server/caching.md
+++ b/www/docs/server/caching.md
@@ -62,8 +62,7 @@ Since all queries are normal HTTP `GET`s we can use normal HTTP headers to cache
 
 ### Using `beforeEnd()` to cache responses
 
-
-Assuming you're deploying your site somewhere that can handle stale-while-revalidate cache headers:
+> Assuming you're deploying your API somewhere that can handle stale-while-revalidate cache headers like Vercel.
 
 ```tsx
 import * as trpc from '@trpc/server';

--- a/www/docs/server/caching.md
+++ b/www/docs/server/caching.md
@@ -92,14 +92,14 @@ const waitFor = async (ms: number) =>
 export const appRouter = createRouter()
   .beforeEnd(({ ctx, paths, data, type }) => {
     // assuming you have all your public routes with the kewyord `public` in them
-    const isPublic =
-      paths && !paths.some((path) => !path.includes('public'));
+    const allPublic =
+      paths && paths.every((path) => path.includes('public'));
     // checking that no responses contains an error
-    const allOk = !data.some((data) => 'error' in data);
+    const allOk = data.every((data) => 'result' in data);
     // checking we're doing a query request
     const isQuery = type === 'query';
 
-    if (ctx?.res && isPublic && allOk && isQuery) {
+    if (ctx?.res && allPublic && allOk && isQuery) {
       // cache request for 1 day + revalidate once every second
       const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
       ctx.res.setHeader(

--- a/www/docs/server/caching.md
+++ b/www/docs/server/caching.md
@@ -60,7 +60,10 @@ export default withTRPC({
 
 Since all queries are normal HTTP `GET`s we can use normal HTTP headers to cache responses, make the responses snappy, give your database a rest, and easier scale your API to gazillions of users.
 
-### Example code
+### Using `beforeEnd()` to cache responses
+
+
+Assuming you're deploying your site somewhere that can handle stale-while-revalidate cache headers:
 
 ```tsx
 import * as trpc from '@trpc/server';
@@ -71,21 +74,6 @@ export const createContext = async ({
   req,
   res,
 }: trpcNext.CreateNextContextOptions) => {
-  // get the tRPC-paths called in this request
-  const paths = (req.query.trpc as string).split(',');
-  // assuming you have a router prefixed with `public.` where you colocate publicly accessible routes
-  const isPublic = !paths.some((path) => !path.startsWith('public.'));
-
-  // check if it's a query & public
-  if (req.method === 'GET' && isPublic) {
-    // cache request for 1 day + revalidate once every second
-    const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
-    res.setHeader(
-      'Cache-Control',
-      `s-maxage=1, stale-while-revalidate=${ONE_DAY_IN_SECONDS}`,
-    );
-  }
-
   return {
     req,
     res,
@@ -102,9 +90,26 @@ export function createRouter() {
 const waitFor = async (ms: number) =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
-// Important: only use this export with SSR/SSG
 export const appRouter = createRouter()
-  .query('slow-query-cached', {
+  .beforeEnd(({ ctx, paths, data, type }) => {
+    // assuming you have all your public routes with the kewyord `public` in them
+    const isPublic =
+      paths && !paths.some((path) => !path.includes('public'));
+    // checking that no responses contains an error
+    const allOk = !data.some((data) => 'error' in data);
+    // checking we're doing a query request
+    const isQuery = type === 'query';
+
+    if (ctx?.res && isPublic && allOk && isQuery) {
+      // cache request for 1 day + revalidate once every second
+      const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
+      ctx.res.setHeader(
+        'Cache-Control',
+        `s-maxage=1, stale-while-revalidate=${ONE_DAY_IN_SECONDS}`,
+      );
+    }
+  })
+  .query('public.slow-query-cached', {
     async resolve({ ctx }) {
       await waitFor(5000); // wait for 5s
 
@@ -114,14 +119,6 @@ export const appRouter = createRouter()
     },
   });
 
-// Exporting type _type_ AppRouter only exposes types that can be used for inference
-// https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export
-export type AppRouter = typeof appRouter;
-
-// export API handler
-export default trpcNext.createNextApiHandler({
-  router: appRouter,
-  createContext,
-});
+// [...]
 
 ```


### PR DESCRIPTION
- add new method `beforeEnd()` that is triggered before a request ends
- receives `type`, `paths`, and the unserialized `data` that is going out
- refactored some internals and removed some unnecessary exports on adapters - minor breaking changes if someone relied on something they shouldn't have :)
- See docs at 👉  https://www-git-feature-before-send.tmp.trpc.io/docs/caching#api-response-caching


### Questions for the reviewers

- unsure about the naming `beforeEnd`
- considering changing it to be `getResponseHeaders`- this will work better once we add svelte support as in Svelte the is no `res.headers` / `res.statusCode` to mutate. See alternative in #816
- ~unsure if it should actually live on the router - maybe it's better to put it as `beforeEnd:` on the API handler, similar to `createContext`? (i.e. the `[trpc].ts`-file)~ I think it's better to do it in api handler - refactored in #815 