### PR TITLE
infer new context in middlewares

### DIFF
--- a/packages/server/src/internals/middlewares.ts
+++ b/packages/server/src/internals/middlewares.ts
@@ -2,30 +2,61 @@ import { ProcedureType } from '../router';
 import { TRPCError } from '../TRPCError';
 
 export const middlewareMarker = Symbol('middlewareMarker');
-interface MiddlewareResultBase {
+interface MiddlewareResultBase<TContext> {
   /**
    * All middlewares should pass through their `next()`'s output.
    * Requiring this marker makes sure that can't be forgotten at compile-time.
    */
   readonly marker: typeof middlewareMarker;
+  ctx: TContext;
 }
 
-interface MiddlewareOKResult extends MiddlewareResultBase {
+interface MiddlewareOKResult<TContext> extends MiddlewareResultBase<TContext> {
   ok: true;
   data: unknown;
   // this could be extended with `input`/`rawInput` later
 }
-interface MiddlewareErrorResult extends MiddlewareResultBase {
+interface MiddlewareErrorResult<TContext>
+  extends MiddlewareResultBase<TContext> {
   ok: false;
   error: TRPCError;
   // we could guarantee it's always of this type
 }
 
-export type MiddlewareResult = MiddlewareOKResult | MiddlewareErrorResult;
+export type MiddlewareResult<TContext> =
+  | MiddlewareOKResult<TContext>
+  | MiddlewareErrorResult<TContext>;
 
-export type MiddlewareFunction<TContext> = (opts: {
+export interface MiddlewareFunctionOptionsBase<TContext> {
   ctx: TContext;
   type: ProcedureType;
   path: string;
-  next: () => Promise<MiddlewareResult>;
-}) => Promise<MiddlewareResult>;
+}
+
+export interface MiddlewareFunctionKeepContextOptions<TContext>
+  extends MiddlewareFunctionOptionsBase<TContext> {
+  next: Promise<MiddlewareResult<TContext>>;
+}
+export interface NextWithContextOptions<TNewContext> {
+  ctx: TNewContext;
+}
+export interface MiddlewareFunctionNewContextOptions<TContext, TNewContext>
+  extends MiddlewareFunctionOptionsBase<TContext> {
+  next: (
+    opts: NextWithContextOptions<TNewContext>,
+  ) => Promise<MiddlewareResult<TNewContext>>;
+}
+
+export type MiddlewareFunctionKeepContext<TContext> = (opts: {
+  ctx: TContext;
+  type: ProcedureType;
+  path: string;
+  next: () => Promise<MiddlewareResult<TContext>>;
+}) => Promise<MiddlewareResult<TContext>>;
+
+export type MiddlewareFunctionWithNewContext<TContext, TNewContext> = (opts: {
+  ctx: TContext;
+  type: ProcedureType;
+  path: string;
+  next: (opts: { ctx: TNewContext }) => Promise<MiddlewareResult<TNewContext>>;
+}) => Promise<MiddlewareResult<TNewContext>>;

--- a/packages/server/src/procedure.ts
+++ b/packages/server/src/procedure.ts
@@ -1,7 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { assertNotBrowser } from './assertNotBrowser';
 import { ProcedureType } from './router';
-import { MiddlewareFunction, middlewareMarker } from './internals/middlewares';
+import {
+  MiddlewareFunctionKeepContext,
+  middlewareMarker,
+} from './internals/middlewares';
 import { TRPCError } from './TRPCError';
 import { getErrorFromUnknown } from './internals/errors';
 assertNotBrowser();
@@ -33,7 +36,7 @@ export type ProcedureResolver<
 }) => Promise<TOutput> | TOutput;
 
 interface ProcedureOptions<TContext, TInput, TOutput> {
-  middlewares: MiddlewareFunction<TContext>[];
+  middlewares: MiddlewareFunctionKeepContext<TContext>[];
   resolver: ProcedureResolver<TContext, TInput, TOutput>;
   inputParser: ProcedureInputParser<TInput>;
 }
@@ -89,7 +92,7 @@ export abstract class Procedure<
   TInput = unknown,
   TOutput = unknown,
 > {
-  private middlewares: Readonly<MiddlewareFunction<TContext>[]>;
+  private middlewares: Readonly<MiddlewareFunctionKeepContext<TContext>[]>;
   private resolver: ProcedureResolver<TContext, TInput, TOutput>;
   private readonly inputParser: ProcedureInputParser<TInput>;
   private parse: ParseFn<TInput>;
@@ -166,7 +169,9 @@ export abstract class Procedure<
    * Create new procedure with passed middlewares
    * @param middlewares
    */
-  public inheritMiddlewares(middlewares: MiddlewareFunction<TContext>[]): this {
+  public inheritMiddlewares(
+    middlewares: MiddlewareFunctionKeepContext<TContext>[],
+  ): this {
     const Constructor: {
       new (opts: ProcedureOptions<TContext, TInput, TOutput>): Procedure<
         TContext,

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -552,7 +552,15 @@ export class Router<
 
     return new Router({
       ...this._def,
-      middlewares: [...this._def.middlewares, middleware as any],
+      middlewares: [
+        ...this._def.middlewares,
+        // transform to middleware
+        // right now assumed ctx is not actually changed and only asserted - needs to be fixed
+        async ({ next, ctx }) => {
+          await middleware({ ctx });
+          return next();
+        },
+      ],
     }) as any as Router<
       TInferredContext,
       SwapContext<TQueries, TInferredContext>,

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -529,7 +529,30 @@ export class Router<
 
     return new Router({
       ...this._def,
-      middlewares: [...this._def.middlewares, middleware],
+      middlewares: [...this._def.middlewares, middleware as any],
+    }) as any as Router<
+      TInferredContext,
+      SwapContext<TQueries, TInferredContext>,
+      SwapContext<TMutations, TInferredContext>,
+      SwapContext<TSubscriptions, TInferredContext>,
+      TErrorShape
+    >;
+  }
+
+  /**
+   * Swap context middleware
+   * @link https://trpc.io/docs/middlewares
+   */
+  public swapContext<
+    TMiddlewareFn extends (opts: {
+      ctx: TContext;
+    }) => Promise<unknown> | unknown,
+  >(middleware: TMiddlewareFn) {
+    type TInferredContext = inferAsyncReturnType<TMiddlewareFn>;
+
+    return new Router({
+      ...this._def,
+      middlewares: [...this._def.middlewares, middleware as any],
     }) as any as Router<
       TInferredContext,
       SwapContext<TQueries, TInferredContext>,


### PR DESCRIPTION
- attempt to have a new middleware type that can infer the context - called `middlewareSwapContext` here
- managed to get the inference working (ish) with the simpler `swapContext` one
- ideally i'd just have `middleware` and if one would call `next({ctx})` it'd be inferred (kinda where I'm going with `middlewareSwapContext`

> I probably won't spend much more time on this as it's kinda a nice to have and has some other side effects, but if someone wants to pick it up and have a stab at it, please have a go

requested by @mmkal  in https://github.com/trpc/trpc/issues/810#issuecomment-902930210