### PR TITLE
Fix prefetching infinite query

### DIFF
--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -118,8 +118,13 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
 
               return queryClient.fetchInfiniteQuery(
                 cacheKey,
-                () =>
-                  (client as any).query(...getArgs(pathAndInput, opts)) as any,
+                ({ pageParam }) => {
+                  const [path, input] = pathAndInput;
+                  const actualInput = { ...(input as any), cursor: pageParam };
+                  return (client as any).query(
+                    ...getArgs([path, actualInput], opts),
+                  );
+                },
                 opts,
               );
             },
@@ -146,8 +151,13 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
 
               return queryClient.prefetchInfiniteQuery(
                 cacheKey,
-                () =>
-                  (client as any).query(...getArgs(pathAndInput, opts)) as any,
+                ({ pageParam }) => {
+                  const [path, input] = pathAndInput;
+                  const actualInput = { ...(input as any), cursor: pageParam };
+                  return (client as any).query(
+                    ...getArgs([path, actualInput], opts),
+                  );
+                },
                 opts,
               );
             },
@@ -321,7 +331,7 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
       cacheKey,
       ({ pageParam }) => {
         const actualInput = { ...input, cursor: pageParam };
-        return (client.query as any)(path, actualInput);
+        return (client as any).query(...getArgs([path, actualInput], opts));
       },
       opts,
     );

--- a/packages/server/test/react.test.tsx
+++ b/packages/server/test/react.test.tsx
@@ -610,6 +610,273 @@ test('useInfiniteQuery()', async () => {
   `);
 });
 
+test('useInfiniteQuery and prefetchInfiniteQuery', async () => {
+  const { trpc, client } = factory;
+
+  function MyComponent() {
+    const trpcContext = trpc.useContext();
+    const q = trpc.useInfiniteQuery(
+      [
+        'paginatedPosts',
+        {
+          limit: 1,
+        },
+      ],
+      {
+        getNextPageParam: (lastPage) => lastPage.nextCursor,
+      },
+    );
+    expectTypeOf(q.data?.pages[0].items).toMatchTypeOf<undefined | Post[]>();
+
+    return q.status === 'loading' ? (
+      <p>Loading...</p>
+    ) : q.status === 'error' ? (
+      <p>Error: {q.error.message}</p>
+    ) : (
+      <>
+        {q.data?.pages.map((group, i) => (
+          <Fragment key={i}>
+            {group.items.map((msg) => (
+              <Fragment key={msg.id}>
+                <div>{msg.title}</div>
+              </Fragment>
+            ))}
+          </Fragment>
+        ))}
+        <div>
+          <button
+            onClick={() => q.fetchNextPage()}
+            disabled={!q.hasNextPage || q.isFetchingNextPage}
+            data-testid="loadMore"
+          >
+            {q.isFetchingNextPage
+              ? 'Loading more...'
+              : q.hasNextPage
+              ? 'Load More'
+              : 'Nothing more to load'}
+          </button>
+        </div>
+        <div>
+          <button
+            data-testid="prefetch"
+            onClick={() =>
+              trpcContext.prefetchInfiniteQuery([
+                'paginatedPosts',
+                { limit: 1 },
+              ])
+            }
+          >
+            Prefetch
+          </button>
+        </div>
+        <div>
+          {q.isFetching && !q.isFetchingNextPage ? 'Fetching...' : null}
+        </div>
+      </>
+    );
+  }
+  function App() {
+    const [queryClient] = useState(() => new QueryClient());
+    return (
+      <trpc.Provider {...{ queryClient, client }}>
+        <QueryClientProvider client={queryClient}>
+          <MyComponent />
+        </QueryClientProvider>
+      </trpc.Provider>
+    );
+  }
+
+  const utils = render(<App />);
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent('first post');
+  });
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent('first post');
+    expect(utils.container).not.toHaveTextContent('second post');
+    expect(utils.container).toHaveTextContent('Load More');
+  });
+  userEvent.click(utils.getByTestId('loadMore'));
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent('Loading more...');
+  });
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent('first post');
+    expect(utils.container).toHaveTextContent('second post');
+    expect(utils.container).toHaveTextContent('Nothing more to load');
+  });
+
+  expect(utils.container).toMatchInlineSnapshot(`
+    <div>
+      <div>
+        first post
+      </div>
+      <div>
+        second post
+      </div>
+      <div>
+        <button
+          data-testid="loadMore"
+          disabled=""
+        >
+          Nothing more to load
+        </button>
+      </div>
+      <div>
+        <button
+          data-testid="prefetch"
+        >
+          Prefetch
+        </button>
+      </div>
+      <div />
+    </div>
+  `);
+
+  userEvent.click(utils.getByTestId('prefetch'));
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent('Fetching...');
+  });
+  await waitFor(() => {
+    expect(utils.container).not.toHaveTextContent('Fetching...');
+  });
+
+  // It should correctly fetch both pages
+  expect(utils.container).toHaveTextContent('first post');
+  expect(utils.container).toHaveTextContent('second post');
+});
+
+test('useInfiniteQuery and fetchInfiniteQuery', async () => {
+  const { trpc, client } = factory;
+
+  function MyComponent() {
+    const trpcContext = trpc.useContext();
+    const q = trpc.useInfiniteQuery(
+      [
+        'paginatedPosts',
+        {
+          limit: 1,
+        },
+      ],
+      {
+        getNextPageParam: (lastPage) => lastPage.nextCursor,
+      },
+    );
+    expectTypeOf(q.data?.pages[0].items).toMatchTypeOf<undefined | Post[]>();
+
+    return q.status === 'loading' ? (
+      <p>Loading...</p>
+    ) : q.status === 'error' ? (
+      <p>Error: {q.error.message}</p>
+    ) : (
+      <>
+        {q.data?.pages.map((group, i) => (
+          <Fragment key={i}>
+            {group.items.map((msg) => (
+              <Fragment key={msg.id}>
+                <div>{msg.title}</div>
+              </Fragment>
+            ))}
+          </Fragment>
+        ))}
+        <div>
+          <button
+            onClick={() => q.fetchNextPage()}
+            disabled={!q.hasNextPage || q.isFetchingNextPage}
+            data-testid="loadMore"
+          >
+            {q.isFetchingNextPage
+              ? 'Loading more...'
+              : q.hasNextPage
+              ? 'Load More'
+              : 'Nothing more to load'}
+          </button>
+        </div>
+        <div>
+          <button
+            data-testid="fetch"
+            onClick={() =>
+              trpcContext.fetchInfiniteQuery(['paginatedPosts', { limit: 1 }])
+            }
+          >
+            Fetch
+          </button>
+        </div>
+        <div>
+          {q.isFetching && !q.isFetchingNextPage ? 'Fetching...' : null}
+        </div>
+      </>
+    );
+  }
+  function App() {
+    const [queryClient] = useState(() => new QueryClient());
+    return (
+      <trpc.Provider {...{ queryClient, client }}>
+        <QueryClientProvider client={queryClient}>
+          <MyComponent />
+        </QueryClientProvider>
+      </trpc.Provider>
+    );
+  }
+
+  const utils = render(<App />);
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent('first post');
+  });
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent('first post');
+    expect(utils.container).not.toHaveTextContent('second post');
+    expect(utils.container).toHaveTextContent('Load More');
+  });
+  userEvent.click(utils.getByTestId('loadMore'));
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent('Loading more...');
+  });
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent('first post');
+    expect(utils.container).toHaveTextContent('second post');
+    expect(utils.container).toHaveTextContent('Nothing more to load');
+  });
+
+  expect(utils.container).toMatchInlineSnapshot(`
+    <div>
+      <div>
+        first post
+      </div>
+      <div>
+        second post
+      </div>
+      <div>
+        <button
+          data-testid="loadMore"
+          disabled=""
+        >
+          Nothing more to load
+        </button>
+      </div>
+      <div>
+        <button
+          data-testid="fetch"
+        >
+          Fetch
+        </button>
+      </div>
+      <div />
+    </div>
+  `);
+
+  userEvent.click(utils.getByTestId('fetch'));
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent('Fetching...');
+  });
+  await waitFor(() => {
+    expect(utils.container).not.toHaveTextContent('Fetching...');
+  });
+
+  // It should correctly fetch both pages
+  expect(utils.container).toHaveTextContent('first post');
+  expect(utils.container).toHaveTextContent('second post');
+});
+
 test('prefetchInfiniteQuery()', async () => {
   const { appRouter } = factory;
   const ssg = createSSGHelpers({ router: appRouter, ctx: {} });


### PR DESCRIPTION
I've encountered an issue with prefetching infinite queries where all page contents were replaced by the content of the first page while the number of pages remained the same. I narrowed it down to a `pageParam` being ignored when prefetching and fetching infinite queries.

The PR fixes the issue and adds tests.