### PR TITLE
Allow createContext to be optional if there's no context

### DIFF
--- a/packages/server/src/http/internals/HTTPHandlerOptions.ts
+++ b/packages/server/src/http/internals/HTTPHandlerOptions.ts
@@ -25,19 +25,25 @@ type ResponseMetaFn<TRouter extends AnyRouter> = (opts: {
   errors: TRPCError[];
 }) => ResponseMeta;
 
-export interface HTTPHandlerOptions<
+export type HTTPHandlerOptions<
   TRouter extends AnyRouter,
   TRequest extends BaseRequest,
   TResponse extends BaseResponse,
-> extends BaseHandlerOptions<TRouter, TRequest> {
-  /**
-   * @link https://trpc.io/docs/context
-   **/
-  createContext: CreateContextFn<TRouter, TRequest, TResponse>;
+> = BaseHandlerOptions<TRouter, TRequest> & {
   /**
    * Add handler to be called before response is sent to the user
    * Useful for setting cache headers
    * @link https://trpc.io/docs/caching
    */
   responseMeta?: ResponseMetaFn<TRouter>;
-}
+} & (inferRouterContext<TRouter> extends void ? {
+  /**
+   * @link https://trpc.io/docs/context
+   **/
+  createContext?: CreateContextFn<TRouter, TRequest, TResponse>;
+} : {
+  /**
+   * @link https://trpc.io/docs/context
+   **/
+  createContext: CreateContextFn<TRouter, TRequest, TResponse>;
+});

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -570,6 +570,6 @@ export class Router<
   }
 }
 
-export function router<TContext>() {
+export function router<TContext = void>() {
   return new Router<TContext, {}, {}, {}, DefaultErrorShape>();
 }

--- a/packages/server/src/ws/wssHandler.ts
+++ b/packages/server/src/ws/wssHandler.ts
@@ -82,11 +82,15 @@ function parseMessage(
 /**
  * Web socket server handler
  */
-export type WSSHandlerOptions<TRouter extends AnyRouter> = {
-  wss: ws.Server;
-  createContext: CreateContextFn<TRouter, http.IncomingMessage, ws>;
-  process?: NodeJS.Process;
-} & BaseHandlerOptions<TRouter, http.IncomingMessage>;
+export type WSSHandlerOptions<TRouter extends AnyRouter> =
+  BaseHandlerOptions<TRouter, http.IncomingMessage> & {
+    wss: ws.Server;
+    process?: NodeJS.Process;
+  } & (inferRouterContext<TRouter> extends void ? {
+    createContext?: CreateContextFn<TRouter, http.IncomingMessage, ws>;
+  } : {
+    createContext: CreateContextFn<TRouter, http.IncomingMessage, ws>;
+  });
 
 export function applyWSSHandler<TRouter extends AnyRouter>(
   opts: WSSHandlerOptions<TRouter>,
@@ -105,7 +109,7 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
         JSON.stringify(transformTRPCResponse(router, untransformedJSON)),
       );
     }
-    const ctxPromise = createContext({ req, res: client });
+    const ctxPromise = createContext?.({ req, res: client });
     let ctx: inferRouterContext<TRouter> | undefined = undefined;
 
     async function handleRequest(msg: TRPCRequest) {

--- a/packages/server/test/_testHelpers.ts
+++ b/packages/server/test/_testHelpers.ts
@@ -53,7 +53,7 @@ export function routerToServerAndClient<TRouter extends AnyRouter>(
     wss,
     router,
     createContext: ({ req, res }) => ({ req, res }),
-    ...(opts?.wssServer ?? {}),
+    ...(opts?.wssServer as any ?? {}),
   };
   const wssHandler = applyWSSHandler(applyWSSHandlerOpts);
   const wssUrl = `ws://localhost:${wssPort}`;

--- a/packages/server/test/links.test.ts
+++ b/packages/server/test/links.test.ts
@@ -165,7 +165,6 @@ describe('batching', () => {
         server: {
           createContext() {
             contextCall();
-            return {};
           },
           batching: {
             enabled: true,

--- a/packages/server/test/websockets.test.ts
+++ b/packages/server/test/websockets.test.ts
@@ -17,7 +17,7 @@ import { routerToServerAndClient, waitMs } from './_testHelpers';
 type Message = {
   id: string;
 };
-function factory(config?: { createContext: () => Promise<unknown> }) {
+function factory(config?: { createContext: () => Promise<any> }) {
   const ee = new EventEmitter();
   const subRef: {
     current: trpc.Subscription<Message>;


### PR DESCRIPTION
With this PR we can omit the `createContext` prop if there's no context. The prop becomes required again if a context type is specified.

---

Closes #218 