### PR TITLE
update `tsconfig.json` appropriate for node>=14

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,6 +10,9 @@
     "url": "git+https://github.com/trpc/trpc.git",
     "directory": "packages/server"
   },
+  "engines": {
+    "node": ">=14"
+  },
   "eslintConfig": {
     "rules": {
       "explicit-module-boundary-types": "off"

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "include": ["src", "test"],
   "compilerOptions": {
-    "target": "ES2019",
-    "lib": ["ES2020.Promise"]
+    "lib": ["ES2020"],
+    "module": "commonjs",
+    "target": "ES2020"
   }
 }


### PR DESCRIPTION
- be explicit that we only support node `>=14`
- any downsides on this? i guess anyone using trpc already is on node>=14

https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping#node-14