### PR TITLE
rename `originalError` to `cause` + deprecate `originalError`

### DIFF
--- a/packages/client/src/TRPCClientError.ts
+++ b/packages/client/src/TRPCClientError.ts
@@ -11,7 +11,11 @@ export class TRPCClientError<TRouter extends AnyRouter>
   extends Error
   implements TRPCClientErrorLike<TRouter>
 {
+  /**
+   * @deprecated use `cause`
+   */
   public readonly originalError;
+  public readonly cause;
   public readonly shape: Maybe<inferRouterError<TRouter>>;
   public readonly data: Maybe<inferRouterError<TRouter>['data']>;
   /**
@@ -26,16 +30,21 @@ export class TRPCClientError<TRouter extends AnyRouter>
       originalError,
       isDone = false,
       result,
+      cause,
     }: {
       result: Maybe<TRPCErrorResponse<inferRouterError<TRouter>>>;
-      originalError: Maybe<Error>;
+      /**
+       * @deprecated use cause
+       **/
+      originalError?: Maybe<Error>;
+      cause?: Maybe<Error>;
       isDone?: boolean;
     },
   ) {
     super(message);
     this.isDone = isDone;
     this.message = message;
-    this.originalError = originalError;
+    this.cause = this.originalError = cause ?? originalError;
     this.shape = result?.error;
     this.data = result?.error.data;
     this.name = 'TRPCClientError';
@@ -50,7 +59,7 @@ export class TRPCClientError<TRouter extends AnyRouter>
     if (!(result instanceof Error)) {
       return new TRPCClientError<TRouter>((result.error as any).message ?? '', {
         ...opts,
-        originalError: null,
+        cause: null,
         result: result,
       });
     }
@@ -60,7 +69,7 @@ export class TRPCClientError<TRouter extends AnyRouter>
 
     return new TRPCClientError<TRouter>(result.message, {
       ...opts,
-      originalError: result,
+      cause: result,
       result: null,
     });
   }

--- a/packages/client/src/TRPCClientError.ts
+++ b/packages/client/src/TRPCClientError.ts
@@ -26,12 +26,7 @@ export class TRPCClientError<TRouter extends AnyRouter>
 
   constructor(
     message: string,
-    {
-      originalError,
-      isDone = false,
-      result,
-      cause,
-    }: {
+    opts: {
       result: Maybe<TRPCErrorResponse<inferRouterError<TRouter>>>;
       /**
        * @deprecated use cause
@@ -41,12 +36,17 @@ export class TRPCClientError<TRouter extends AnyRouter>
       isDone?: boolean;
     },
   ) {
-    super(message);
-    this.isDone = isDone;
-    this.message = message;
-    this.cause = this.originalError = cause ?? originalError;
-    this.shape = result?.error;
-    this.data = result?.error.data;
+    const cause = opts.cause ?? opts.originalError;
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore https://github.com/tc39/proposal-error-cause
+    super(message, { cause });
+
+    this.isDone = opts.isDone ?? false;
+
+    this.cause = this.originalError = cause;
+    this.shape = opts.result?.error;
+    this.data = opts.result?.error.data;
     this.name = 'TRPCClientError';
 
     Object.setPrototypeOf(this, TRPCClientError.prototype);

--- a/packages/server/src/TRPCError.ts
+++ b/packages/server/src/TRPCError.ts
@@ -2,21 +2,30 @@ import { TRPC_ERROR_CODE_KEY } from './rpc/codes';
 import { getMessageFromUnkownError } from './internals/errors';
 
 export class TRPCError extends Error {
+  /**
+   * @deprecated use `cause`
+   */
   public readonly originalError?: unknown;
+  public readonly cause?: unknown;
   public readonly code;
 
-  constructor({
-    message,
-    code,
-    originalError,
-  }: {
+  constructor(opts: {
     message?: string;
     code: TRPC_ERROR_CODE_KEY;
+    /**
+     * @deprecated use `cause`
+     */
     originalError?: unknown;
+    cause?: unknown;
   }) {
-    super(message ?? getMessageFromUnkownError(originalError, code));
+    const cause = opts.cause ?? opts.originalError;
+    const code = opts.code;
+    const message = opts.message ?? getMessageFromUnkownError(cause, code);
+
+    super(message);
+
     this.code = code;
-    this.originalError = originalError;
+    this.cause = this.originalError = cause;
     this.name = 'TRPCError';
 
     Object.setPrototypeOf(this, new.target.prototype);

--- a/packages/server/src/TRPCError.ts
+++ b/packages/server/src/TRPCError.ts
@@ -22,7 +22,9 @@ export class TRPCError extends Error {
     const code = opts.code;
     const message = opts.message ?? getMessageFromUnkownError(cause, code);
 
-    super(message);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore https://github.com/tc39/proposal-error-cause
+    super(message, { cause });
 
     this.code = code;
     this.cause = this.originalError = cause;

--- a/packages/server/src/http/internals/getQueryInput.ts
+++ b/packages/server/src/http/internals/getQueryInput.ts
@@ -8,10 +8,10 @@ export function getQueryInput(query: qs.ParsedQs) {
   }
   try {
     return JSON.parse(queryInput as string);
-  } catch (originalError) {
+  } catch (cause) {
     throw new TRPCError({
       code: 'BAD_REQUEST',
-      originalError,
+      cause,
     });
   }
 }

--- a/packages/server/src/internals/errors.ts
+++ b/packages/server/src/internals/errors.ts
@@ -14,17 +14,20 @@ export function getMessageFromUnkownError(
   return fallback;
 }
 
-export function getErrorFromUnknown(originalError: unknown): TRPCError {
+export function getErrorFromUnknown(cause: unknown): TRPCError {
   // this should ideally be an `instanceof TRPCError` but for some reason that isn't working
   // ref https://github.com/trpc/trpc/issues/331
-  if (originalError instanceof Error && originalError.name === 'TRPCError') {
-    return originalError as TRPCError;
+  if (cause instanceof Error && cause.name === 'TRPCError') {
+    return cause as TRPCError;
   }
-  const err = new TRPCError({ code: 'INTERNAL_SERVER_ERROR', originalError });
+  const err = new TRPCError({
+    code: 'INTERNAL_SERVER_ERROR',
+    cause,
+  });
 
-  // take stack trace from originalError
-  if (originalError instanceof Error) {
-    err.stack = originalError.stack;
+  // take stack trace from cause
+  if (cause instanceof Error) {
+    err.stack = cause.stack;
   }
   return err;
 }

--- a/packages/server/src/procedure.ts
+++ b/packages/server/src/procedure.ts
@@ -104,10 +104,10 @@ export abstract class Procedure<
   private parseInput(rawInput: unknown): TInput {
     try {
       return this.parse(rawInput);
-    } catch (originalError) {
+    } catch (cause) {
       throw new TRPCError({
         code: 'BAD_REQUEST',
-        originalError,
+        cause,
       });
     }
   }

--- a/packages/server/src/ws/wssHandler.ts
+++ b/packages/server/src/ws/wssHandler.ts
@@ -232,10 +232,10 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
         const msgJSON: unknown = JSON.parse(message as string);
         const msgs: unknown[] = Array.isArray(msgJSON) ? msgJSON : [msgJSON];
         msgs.map((raw) => parseMessage(raw, transformer)).map(handleRequest);
-      } catch (originalError) {
+      } catch (cause) {
         const error = new TRPCError({
           code: 'PARSE_ERROR',
-          originalError,
+          cause,
         });
 
         respond({

--- a/packages/server/test/errors.test.ts
+++ b/packages/server/test/errors.test.ts
@@ -42,6 +42,7 @@ test('basic', async () => {
     throw new Error('Wrong error');
   }
   expect(serverError.originalError).toBeInstanceOf(MyError);
+  expect(serverError.cause).toBeInstanceOf(MyError);
 
   close();
 });
@@ -86,6 +87,7 @@ test('input error', async () => {
   //   throw new Error('Wrong error');
   // }
   expect(serverError.originalError).toBeInstanceOf(ZodError);
+  expect(serverError.cause).toBeInstanceOf(ZodError);
 
   close();
 });

--- a/www/docs/server/error-formatting.md
+++ b/www/docs/server/error-formatting.md
@@ -22,8 +22,8 @@ const router = trpc.router<Context>()
         ...shape.data,
         zodError:
           error.code === 'BAD_USER_INPUT' &&
-          error.originalError instanceof ZodError
-            ? error.originalError.flatten()
+          error.cause instanceof ZodError
+            ? error.cause.flatten()
             : null,
       };
     };

--- a/www/docs/server/error-handling.md
+++ b/www/docs/server/error-handling.md
@@ -42,7 +42,7 @@ export default trpcNext.createNextApiHandler({
   // [...]
   onError({ error }) {
     console.error('Error:', error);
-    console.log('Original error thrown', error.originalError);
+    console.log('Original error thrown', error.cause);
   },
 });
 ```


### PR DESCRIPTION
- rename `originalError` to `cause` to align with https://github.com/tc39/proposal-error-cause
- change `Error`-super call to `super(message, { cause })` for future compat

closes #879