### PR TITLE
Revert "add `fetchOptions` on client runtime"

### DIFF
--- a/packages/client/src/internals/TRPCClient.ts
+++ b/packages/client/src/internals/TRPCClient.ts
@@ -19,7 +19,6 @@ import {
   OperationContext,
   OperationLink,
   TRPCLink,
-  FetchFnOptions,
 } from '../links/core';
 import { httpBatchLink } from '../links/httpBatchLink';
 import { TRPCClientError } from '../TRPCClientError';
@@ -28,15 +27,12 @@ type CancellablePromise<T = unknown> = Promise<T> & {
   cancel: CancelFn;
 };
 
-/**
- * @deprecated no longer used
- */
 export interface FetchOptions {
   fetch?: typeof fetch;
   AbortController?: typeof AbortController;
 }
 let idCounter = 0;
-function getRequestId() {
+export function getRequestId() {
   return ++idCounter;
 }
 
@@ -45,11 +41,6 @@ export type CreateTRPCClientOptions<TRouter extends AnyRouter> = {
    * Add ponyfill for fetch
    */
   fetch?: typeof fetch;
-  /**
-   * Add options to fetch
-   * @example { credentials: 'include' }
-   */
-  fetchOptions?: FetchFnOptions;
   /**
    * add ponyfill for AbortController
    */
@@ -115,7 +106,6 @@ export class TRPCClient<TRouter extends AnyRouter> {
       transformer,
       AbortController: AC as any,
       fetch: _fetch as any,
-      fetchOptions: opts.fetchOptions ?? {},
       headers: getHeadersFn(),
     };
 

--- a/packages/client/src/internals/TRPCClient.ts
+++ b/packages/client/src/internals/TRPCClient.ts
@@ -27,12 +27,15 @@ type CancellablePromise<T = unknown> = Promise<T> & {
   cancel: CancelFn;
 };
 
+/**
+ * @deprecated no longer used
+ */
 export interface FetchOptions {
   fetch?: typeof fetch;
   AbortController?: typeof AbortController;
 }
 let idCounter = 0;
-export function getRequestId() {
+function getRequestId() {
   return ++idCounter;
 }
 

--- a/packages/client/src/internals/httpRequest.ts
+++ b/packages/client/src/internals/httpRequest.ts
@@ -66,7 +66,6 @@ export function httpRequest<TResponseShape = TRPCResponse>(
           body: getBody(),
           headers: {
             'content-type': 'application/json',
-            ...(rt.fetchOptions.headers ?? {}),
             ...headers,
           },
         }),

--- a/packages/client/src/links/core.ts
+++ b/packages/client/src/links/core.ts
@@ -46,14 +46,10 @@ export interface HTTPLinkOptions {
 export type HttpLinkOptions = HTTPLinkOptions;
 
 export type HTTPHeaders = Record<string, string | string[] | undefined>;
-
-export type FetchFnOptions = RequestInit;
-
 export type LinkRuntimeOptions = Readonly<{
   transformer: DataTransformer;
   headers: () => HTTPHeaders | Promise<HTTPHeaders>;
   fetch: typeof fetch;
-  fetchOptions: FetchFnOptions;
   AbortController?: typeof AbortController;
 }>;
 

--- a/packages/server/test/headers.test.tsx
+++ b/packages/server/test/headers.test.tsx
@@ -27,14 +27,12 @@ test('pass headers', async () => {
     },
   );
   {
-    // no headers sent
     const client = createTRPCClient({
       url: httpUrl,
     });
     expect(await client.query('hello')).toMatchInlineSnapshot(`Object {}`);
   }
   {
-    // custom header sent
     const client = createTRPCClient({
       url: httpUrl,
       headers() {
@@ -49,35 +47,18 @@ Object {
 }
 `);
   }
-
   {
-    // async headers
     const client = createTRPCClient({
       url: httpUrl,
       async headers() {
-        return { 'X-Special': 'async special header' };
+        return {
+          'X-Special': 'async special header',
+        };
       },
     });
     expect(await client.query('hello')).toMatchInlineSnapshot(`
 Object {
   "x-special": "async special header",
-}
-`);
-  }
-
-  {
-    // header sent through `fetchOptions`
-    const client = createTRPCClient({
-      url: httpUrl,
-      fetchOptions: {
-        headers: {
-          'x-special': 'fetchOptions.headers',
-        },
-      },
-    });
-    expect(await client.query('hello')).toMatchInlineSnapshot(`
-Object {
-  "x-special": "fetchOptions.headers",
 }
 `);
   }

--- a/packages/server/test/headers.test.tsx
+++ b/packages/server/test/headers.test.tsx
@@ -27,12 +27,15 @@ test('pass headers', async () => {
     },
   );
   {
+    // no headers sent
     const client = createTRPCClient({
       url: httpUrl,
     });
     expect(await client.query('hello')).toMatchInlineSnapshot(`Object {}`);
   }
+
   {
+    // async headers
     const client = createTRPCClient({
       url: httpUrl,
       headers() {

--- a/packages/server/test/headers.test.tsx
+++ b/packages/server/test/headers.test.tsx
@@ -35,7 +35,7 @@ test('pass headers', async () => {
   }
 
   {
-    // async headers
+    // custom headers sent
     const client = createTRPCClient({
       url: httpUrl,
       headers() {
@@ -51,6 +51,7 @@ Object {
 `);
   }
   {
+    // async headers
     const client = createTRPCClient({
       url: httpUrl,
       async headers() {

--- a/packages/server/test/links.test.ts
+++ b/packages/server/test/links.test.ts
@@ -24,7 +24,6 @@ const mockRuntime: LinkRuntimeOptions = {
   fetch: fetch as any,
   AbortController: AbortController as any,
   headers: () => ({}),
-  fetchOptions: {},
 };
 test('retrylink', () => {
   let attempts = 0;

--- a/www/docs/nextjs/nextjs.md
+++ b/www/docs/nextjs/nextjs.md
@@ -176,7 +176,6 @@ The `config`-argument is a function that returns an object that configures the t
   - `headers`: an object or a function that returns an object of outgoing tRPC requests
   - `transformer`: a transformer applied to outgoing payloads. Read more about [Data Transformers](/docs/data-transformers)
   - `fetch`: customize the implementation of `fetch` used by tRPC internally
-  - `fetchOptions`: customize the base parameters sent to `fetch()`
   - `AbortController`: customize the implementation of `AbortController` used by tRPC internally
 
 ### `ssr`-boolean (default: `false`)


### PR DESCRIPTION
Reverts #908 (never made it to a release)

Might be a better implementation to be able to make a `getFetch`-fn (see conversation here https://github.com/trpc/trpc/pull/908#issuecomment-916145019) but I don't have energy to implement it.