### PR TITLE
Simplify procedure types/overloads

### DIFF
--- a/packages/server/src/internals/procedure.ts
+++ b/packages/server/src/internals/procedure.ts
@@ -179,14 +179,21 @@ export class Procedure<TInputContext, TContext, TInput, TOutput> {
   }
 }
 
-export type CreateProcedureOptions<TContext, TInput, TOutput> =
-  | {
-      resolve: ProcedureResolver<TContext, TInput, TOutput>;
-    }
-  | {
-      input: ProcedureInputParser<TInput>;
-      resolve: ProcedureResolver<TContext, TInput, TOutput>;
-    };
+export type CreateProcedureWithInput<TContext, TInput, TOutput> = {
+  input: ProcedureInputParser<TInput>;
+  resolve: ProcedureResolver<TContext, TInput, TOutput>;
+};
+export type CreateProcedureWithoutInput<TContext, TOutput> = {
+  resolve: ProcedureResolver<TContext, undefined, TOutput>;
+};
+
+export type CreateProcedureOptions<
+  TContext = unknown,
+  TInput = unknown,
+  TOutput = unknown,
+> =
+  | CreateProcedureWithInput<TContext, TInput, TOutput>
+  | CreateProcedureWithoutInput<TContext, TOutput>;
 
 export function createProcedure<TContext, TInput, TOutput>(
   opts: CreateProcedureOptions<TContext, TInput, TOutput>,
@@ -206,9 +213,9 @@ export function createProcedure<TContext, TInput, TOutput>(
 
   return new Procedure({
     inputParser: inputParser as any,
-    resolver: opts.resolve,
+    resolver: opts.resolve as any,
     middlewares: [],
-  }) as any;
+  });
 }
 
 export type inferProcedureFromOptions<

--- a/packages/server/src/internals/procedure.ts
+++ b/packages/server/src/internals/procedure.ts
@@ -184,7 +184,7 @@ export type CreateProcedureWithInput<TContext, TInput, TOutput> = {
   resolve: ProcedureResolver<TContext, TInput, TOutput>;
 };
 export type CreateProcedureWithoutInput<TContext, TOutput> = {
-  resolve: ProcedureResolver<TContext, undefined | null, TOutput>;
+  resolve: ProcedureResolver<TContext, undefined, TOutput>;
 };
 
 export type CreateProcedureOptions<

--- a/packages/server/src/internals/procedure.ts
+++ b/packages/server/src/internals/procedure.ts
@@ -71,12 +71,7 @@ function getParseFn<TInput>(
 /**
  * @internal
  */
-export abstract class Procedure<
-  TInputContext, //
-  TContext,
-  TInput,
-  TOutput,
-> {
+export class Procedure<TInputContext, TContext, TInput, TOutput> {
   private middlewares: Readonly<Array<MiddlewareFunction<any, any>>>;
   private resolver: ProcedureResolver<TContext, TInput, TOutput>;
   private readonly inputParser: ProcedureInputParser<TInput>;
@@ -184,87 +179,45 @@ export abstract class Procedure<
   }
 }
 
-export class ProcedureWithoutInput<
-  TInputContext,
-  TContext,
-  TOutput,
-> extends Procedure<TInputContext, TContext, undefined, TOutput> {}
+export type CreateProcedureOptions<TContext, TInput, TOutput> =
+  | {
+      resolve: ProcedureResolver<TContext, TInput, TOutput>;
+    }
+  | {
+      input: ProcedureInputParser<TInput>;
+      resolve: ProcedureResolver<TContext, TInput, TOutput>;
+    };
 
-export class ProcedureWithInput<
-  TInputContext,
-  TContext,
-  TInput,
-  TOutput,
-> extends Procedure<TInputContext, TContext, TInput, TOutput> {}
-
-export type CreateProcedureWithInput<TContext, TInput, TOutput> = {
-  input: ProcedureInputParser<TInput>;
-  resolve: ProcedureResolver<TContext, TInput, TOutput>;
-};
-export type CreateProcedureWithoutInput<TContext, TOutput> = {
-  resolve: ProcedureResolver<TContext, undefined, TOutput>;
-};
-
-export type CreateProcedureOptions<
-  TContext = unknown,
-  TInput = unknown,
-  TOutput = unknown,
-> =
-  | CreateProcedureWithInput<TContext, TInput, TOutput>
-  | CreateProcedureWithoutInput<TContext, TOutput>;
-
-function isProcedureWithInput<TContext, TInput, TOutput>(
-  opts: any,
-): opts is CreateProcedureWithInput<TContext, TInput, TOutput> {
-  return !!opts.input;
-}
-export function createProcedure<TInputContext, TContext, TInput, TOutput>(
-  opts: CreateProcedureWithInput<TContext, TInput, TOutput>,
-): ProcedureWithInput<TInputContext, TContext, TInput, TOutput>;
-export function createProcedure<TInputContext, TContext, TOutput>(
-  opts: CreateProcedureWithoutInput<TContext, TOutput>,
-): ProcedureWithoutInput<TInputContext, TContext, TOutput>;
-export function createProcedure<TInputContext, TContext, TInput, TOutput>(
-  opts: CreateProcedureOptions<TContext, TInput, TOutput>,
-): Procedure<TInputContext, TContext, TInput, TOutput>;
 export function createProcedure<TContext, TInput, TOutput>(
   opts: CreateProcedureOptions<TContext, TInput, TOutput>,
-) {
-  if (isProcedureWithInput<TContext, TInput, TOutput>(opts)) {
-    return new ProcedureWithInput({
-      inputParser: opts.input,
-      resolver: opts.resolve,
-      middlewares: [],
-    });
-  }
-  return new ProcedureWithoutInput({
+): Procedure<unknown, TContext, TInput, TOutput> {
+  const inputParser =
+    'input' in opts
+      ? opts.input
+      : (input: unknown) => {
+          if (input != null) {
+            throw new TRPCError({
+              code: 'BAD_REQUEST',
+              message: 'No input expected',
+            });
+          }
+          return undefined;
+        };
+
+  return new Procedure({
+    inputParser: inputParser as any,
     resolver: opts.resolve,
     middlewares: [],
-    inputParser(input: unknown) {
-      if (input != null) {
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'No input expected',
-        });
-      }
-      return undefined;
-    },
-  });
+  }) as any;
 }
 
 export type inferProcedureFromOptions<
   TInputContext,
   TOptions extends CreateProcedureOptions<any, any, any>,
-> = TOptions extends CreateProcedureWithInput<
+> = TOptions extends CreateProcedureOptions<
   infer TContext,
   infer TInput,
   infer TOutput
 >
-  ? ProcedureWithInput<TInputContext, TContext, TInput, TOutput>
-  : TOptions extends CreateProcedureWithoutInput<
-      //
-      infer TContext,
-      infer TOutput
-    >
-  ? ProcedureWithoutInput<TInputContext, TContext, TOutput>
-  : Procedure<unknown, unknown, unknown, unknown>;
+  ? Procedure<TInputContext, TContext, TInput, TOutput>
+  : never;

--- a/packages/server/src/internals/procedure.ts
+++ b/packages/server/src/internals/procedure.ts
@@ -184,7 +184,7 @@ export type CreateProcedureWithInput<TContext, TInput, TOutput> = {
   resolve: ProcedureResolver<TContext, TInput, TOutput>;
 };
 export type CreateProcedureWithoutInput<TContext, TOutput> = {
-  resolve: ProcedureResolver<TContext, undefined, TOutput>;
+  resolve: ProcedureResolver<TContext, undefined | null, TOutput>;
 };
 
 export type CreateProcedureOptions<

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -7,12 +7,9 @@ import { MiddlewareFunction } from './internals/middlewares';
 import {
   createProcedure,
   CreateProcedureOptions,
-  CreateProcedureWithInput,
-  CreateProcedureWithoutInput,
   inferProcedureFromOptions,
   Procedure,
   ProcedureCallOptions,
-  ProcedureWithInput,
 } from './internals/procedure';
 import {
   TRPCErrorShape,
@@ -47,7 +44,7 @@ export type ProcedureRecord<
  */
 export type inferProcedureInput<
   TProcedure extends Procedure<any, any, any, any>,
-> = TProcedure extends ProcedureWithInput<any, any, infer Input, any>
+> = TProcedure extends Procedure<any, any, infer Input, any>
   ? Input
   : undefined;
 
@@ -90,7 +87,7 @@ function getDataTransformer(
  */
 export type inferHandlerInput<
   TProcedure extends Procedure<any, any, any, any>,
-> = TProcedure extends ProcedureWithInput<any, any, infer TInput, any>
+> = TProcedure extends Procedure<any, any, infer TInput, any>
   ? undefined extends TInput // ? is input optional
     ? unknown extends TInput // ? is input unset
       ? [(null | undefined)?] // -> there is no input
@@ -278,36 +275,18 @@ export class Router<
 
   public query<TPath extends string, TInput, TOutput>(
     path: TPath,
-    procedure: CreateProcedureWithInput<TContext, TInput, TOutput>,
-  ): Router<
-    TInputContext,
-    TContext,
-    flatten<
-      TQueries,
-      Record<TPath, inferProcedureFromOptions<TInputContext, typeof procedure>>
-    >,
-    TMutations,
-    TSubscriptions,
-    TErrorShape
-  >;
-  public query<TPath extends string, TOutput>(
-    path: TPath,
-    procedure: CreateProcedureWithoutInput<TContext, TOutput>,
-  ): Router<
-    TInputContext,
-    TContext,
-    flatten<
-      TQueries,
-      Record<TPath, inferProcedureFromOptions<TInputContext, typeof procedure>>
-    >,
-    TMutations,
-    TSubscriptions,
-    TErrorShape
-  >;
-  public query<TPath extends string, TInput, TOutput>(
-    path: TPath,
     procedure: CreateProcedureOptions<TContext, TInput, TOutput>,
-  ) {
+  ): Router<
+    TInputContext,
+    TContext,
+    flatten<
+      TQueries,
+      Record<TPath, inferProcedureFromOptions<TInputContext, typeof procedure>>
+    >,
+    TMutations,
+    TSubscriptions,
+    TErrorShape
+  > {
     const router = new Router<TContext, TContext, any, {}, {}, any>({
       queries: safeObject({
         [path]: createProcedure(procedure),
@@ -319,36 +298,18 @@ export class Router<
 
   public mutation<TPath extends string, TInput, TOutput>(
     path: TPath,
-    procedure: CreateProcedureWithInput<TContext, TInput, TOutput>,
-  ): Router<
-    TInputContext,
-    TContext,
-    TQueries,
-    flatten<
-      TMutations,
-      Record<TPath, inferProcedureFromOptions<TInputContext, typeof procedure>>
-    >,
-    TSubscriptions,
-    TErrorShape
-  >;
-  public mutation<TPath extends string, TOutput>(
-    path: TPath,
-    procedure: CreateProcedureWithoutInput<TContext, TOutput>,
-  ): Router<
-    TInputContext,
-    TContext,
-    TQueries,
-    flatten<
-      TMutations,
-      Record<TPath, inferProcedureFromOptions<TInputContext, typeof procedure>>
-    >,
-    TSubscriptions,
-    TErrorShape
-  >;
-  public mutation<TPath extends string, TInput, TOutput>(
-    path: TPath,
     procedure: CreateProcedureOptions<TContext, TInput, TOutput>,
-  ) {
+  ): Router<
+    TInputContext,
+    TContext,
+    TQueries,
+    flatten<
+      TMutations,
+      Record<TPath, inferProcedureFromOptions<TInputContext, typeof procedure>>
+    >,
+    TSubscriptions,
+    TErrorShape
+  > {
     const router = new Router<TContext, TContext, {}, any, {}, any>({
       mutations: safeObject({
         [path]: createProcedure(procedure),
@@ -366,7 +327,7 @@ export class Router<
     TOutput extends Subscription<unknown>,
   >(
     path: TPath,
-    procedure: CreateProcedureWithInput<TContext, TInput, TOutput>,
+    procedure: CreateProcedureOptions<TContext, TInput, TOutput>,
   ): Router<
     TInputContext,
     TContext,
@@ -375,33 +336,7 @@ export class Router<
     TSubscriptions &
       Record<TPath, inferProcedureFromOptions<TInputContext, typeof procedure>>,
     TErrorShape
-  >;
-  /**
-   * @beta Might change without a major version bump
-   */
-  public subscription<
-    TPath extends string,
-    TOutput extends Subscription<unknown>,
-  >(
-    path: TPath,
-    procedure: CreateProcedureWithoutInput<TContext, TOutput>,
-  ): Router<
-    TInputContext,
-    TContext,
-    TQueries,
-    TMutations,
-    TSubscriptions &
-      Record<TPath, inferProcedureFromOptions<TInputContext, typeof procedure>>,
-    TErrorShape
-  >;
-  /**
-   * @beta Might change without a major version bump
-   */
-  public subscription<
-    TPath extends string,
-    TInput,
-    TOutput extends Subscription<unknown>,
-  >(path: TPath, procedure: CreateProcedureOptions<TContext, TInput, TOutput>) {
+  > {
     const router = new Router<TContext, TContext, {}, {}, any, any>({
       subscriptions: safeObject({
         [path]: createProcedure(procedure),

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -7,6 +7,8 @@ import { MiddlewareFunction } from './internals/middlewares';
 import {
   createProcedure,
   CreateProcedureOptions,
+  CreateProcedureWithInput,
+  CreateProcedureWithoutInput,
   inferProcedureFromOptions,
   Procedure,
   ProcedureCallOptions,
@@ -275,7 +277,7 @@ export class Router<
 
   public query<TPath extends string, TInput, TOutput>(
     path: TPath,
-    procedure: CreateProcedureOptions<TContext, TInput, TOutput>,
+    procedure: CreateProcedureWithInput<TContext, TInput, TOutput>,
   ): Router<
     TInputContext,
     TContext,
@@ -286,7 +288,24 @@ export class Router<
     TMutations,
     TSubscriptions,
     TErrorShape
-  > {
+  >;
+
+  public query<TPath extends string, TOutput>(
+    path: TPath,
+    procedure: CreateProcedureWithoutInput<TContext, TOutput>,
+  ): Router<
+    TInputContext,
+    TContext,
+    flatten<
+      TQueries,
+      Record<TPath, inferProcedureFromOptions<TInputContext, typeof procedure>>
+    >,
+    TMutations,
+    TSubscriptions,
+    TErrorShape
+  >;
+
+  query(path: string, procedure: CreateProcedureOptions<TContext, any, any>) {
     const router = new Router<TContext, TContext, any, {}, {}, any>({
       queries: safeObject({
         [path]: createProcedure(procedure),
@@ -298,7 +317,7 @@ export class Router<
 
   public mutation<TPath extends string, TInput, TOutput>(
     path: TPath,
-    procedure: CreateProcedureOptions<TContext, TInput, TOutput>,
+    procedure: CreateProcedureWithInput<TContext, TInput, TOutput>,
   ): Router<
     TInputContext,
     TContext,
@@ -309,7 +328,27 @@ export class Router<
     >,
     TSubscriptions,
     TErrorShape
-  > {
+  >;
+
+  public mutation<TPath extends string, TOutput>(
+    path: TPath,
+    procedure: CreateProcedureWithoutInput<TContext, TOutput>,
+  ): Router<
+    TInputContext,
+    TContext,
+    TQueries,
+    flatten<
+      TMutations,
+      Record<TPath, inferProcedureFromOptions<TInputContext, typeof procedure>>
+    >,
+    TSubscriptions,
+    TErrorShape
+  >;
+
+  public mutation(
+    path: string,
+    procedure: CreateProcedureOptions<TContext, any, any>,
+  ) {
     const router = new Router<TContext, TContext, {}, any, {}, any>({
       mutations: safeObject({
         [path]: createProcedure(procedure),
@@ -318,6 +357,7 @@ export class Router<
 
     return this.merge(router);
   }
+
   /**
    * @beta Might change without a major version bump
    */
@@ -327,7 +367,7 @@ export class Router<
     TOutput extends Subscription<unknown>,
   >(
     path: TPath,
-    procedure: CreateProcedureOptions<TContext, TInput, TOutput>,
+    procedure: CreateProcedureWithInput<TContext, TInput, TOutput>,
   ): Router<
     TInputContext,
     TContext,
@@ -336,7 +376,31 @@ export class Router<
     TSubscriptions &
       Record<TPath, inferProcedureFromOptions<TInputContext, typeof procedure>>,
     TErrorShape
-  > {
+  >;
+
+  /**
+   * @beta Might change without a major version bump
+   */
+  public subscription<
+    TPath extends string,
+    TOutput extends Subscription<unknown>,
+  >(
+    path: TPath,
+    procedure: CreateProcedureWithoutInput<TContext, TOutput>,
+  ): Router<
+    TInputContext,
+    TContext,
+    TQueries,
+    TMutations,
+    TSubscriptions &
+      Record<TPath, inferProcedureFromOptions<TInputContext, typeof procedure>>,
+    TErrorShape
+  >;
+
+  public subscription(
+    path: string,
+    procedure: CreateProcedureOptions<TContext, any, any>,
+  ) {
     const router = new Router<TContext, TContext, {}, {}, any, any>({
       subscriptions: safeObject({
         [path]: createProcedure(procedure),

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -47,7 +47,9 @@ export type ProcedureRecord<
 export type inferProcedureInput<
   TProcedure extends Procedure<any, any, any, any>,
 > = TProcedure extends Procedure<any, any, infer Input, any>
-  ? Input
+  ? undefined extends Input
+    ? Input | null
+    : Input
   : undefined;
 
 /**

--- a/packages/server/test/inference.test.ts
+++ b/packages/server/test/inference.test.ts
@@ -27,7 +27,7 @@ test('infer input & output', async () => {
   {
     const input: inferProcedureInput<TQueries['noInput']> = null as any;
     const output: inferProcedureOutput<TQueries['noInput']> = null as any;
-    expectTypeOf(input).toMatchTypeOf<undefined>();
-    expectTypeOf(output).toMatchTypeOf<{ input: undefined }>();
+    expectTypeOf(input).toMatchTypeOf<undefined | null>();
+    expectTypeOf(output).toMatchTypeOf<{ input: undefined | null }>();
   }
 });

--- a/packages/server/test/inference.test.ts
+++ b/packages/server/test/inference.test.ts
@@ -28,6 +28,6 @@ test('infer input & output', async () => {
     const input: inferProcedureInput<TQueries['noInput']> = null as any;
     const output: inferProcedureOutput<TQueries['noInput']> = null as any;
     expectTypeOf(input).toMatchTypeOf<undefined | null>();
-    expectTypeOf(output).toMatchTypeOf<{ input: undefined | null }>();
+    expectTypeOf(output).toMatchTypeOf<{ input: undefined }>();
   }
 });

--- a/packages/server/test/regression/issue-949-inferProcedureInput.test.ts
+++ b/packages/server/test/regression/issue-949-inferProcedureInput.test.ts
@@ -1,0 +1,71 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// IMPORTANT:
+// needs to be imported from compiled output otherwise we get a false-positive
+import * as trpc from '../../dist/trpc-server.cjs';
+import { expectTypeOf } from 'expect-type';
+import { z } from 'zod';
+
+// https://github.com/trpc/trpc/issues/949
+// https://github.com/trpc/trpc/pull/955
+test('inferProcedureFromInput regression', async () => {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  type Context = {};
+  const appRouter = trpc.router<Context>().merge(
+    'admin.',
+    trpc
+      .router<Context>()
+      .mutation('testMutation', {
+        input: z.object({
+          in: z.string(),
+        }),
+        resolve: async () => `out` as const,
+      })
+      .query('hello', {
+        input: z.object({
+          in: z.string(),
+        }),
+        resolve() {
+          return 'out' as const;
+        },
+      })
+      .middleware(async ({ next, ctx }) =>
+        next({
+          ctx: {
+            ...ctx,
+            _test: '1',
+          },
+        }),
+      )
+      .query('hello-2', {
+        input: z.object({
+          in: z.string(),
+        }),
+        resolve() {
+          return 'out' as const;
+        },
+      }),
+  );
+
+  type Mutations = typeof appRouter._def.mutations;
+  type Queries = typeof appRouter._def.queries;
+
+  expectTypeOf<
+    trpc.inferProcedureInput<Queries['admin.hello']>
+  >().toEqualTypeOf<{
+    in: string;
+  }>();
+
+  expectTypeOf<
+    trpc.inferProcedureInput<Queries['admin.hello-2']>
+  >().toEqualTypeOf<{
+    in: string;
+  }>();
+
+  expectTypeOf<
+    trpc.inferProcedureInput<Mutations['admin.testMutation']>
+  >().toEqualTypeOf<{ in: string }>();
+
+  expectTypeOf<
+    trpc.inferProcedureInput<Mutations['admin.testMutation']>
+  >().not.toBeUnknown();
+});

--- a/packages/server/test/regression/issue-949-inferProcedureInput.test.ts
+++ b/packages/server/test/regression/issue-949-inferProcedureInput.test.ts
@@ -28,6 +28,9 @@ test('inferProcedureFromInput regression', async () => {
           return 'out' as const;
         },
       })
+      .query('noinput', {
+        resolve: async () => 'out' as const,
+      })
       .middleware(async ({ next, ctx }) =>
         next({
           ctx: {
@@ -54,6 +57,14 @@ test('inferProcedureFromInput regression', async () => {
   >().toEqualTypeOf<{
     in: string;
   }>();
+
+  expectTypeOf<
+    trpc.inferProcedureInput<Queries['admin.noinput']>
+  >().toBeUnknown();
+
+  expectTypeOf<
+    trpc.inferProcedureOutput<Queries['admin.noinput']>
+  >().toEqualTypeOf<'out'>();
 
   expectTypeOf<
     trpc.inferProcedureInput<Queries['admin.hello-2']>

--- a/packages/server/test/regression/issue-949-inferProcedureInput.test.ts
+++ b/packages/server/test/regression/issue-949-inferProcedureInput.test.ts
@@ -28,7 +28,7 @@ test('inferProcedureFromInput regression', async () => {
           return 'out' as const;
         },
       })
-      .query('noinput', {
+      .query('noInput', {
         resolve: async () => 'out' as const,
       })
       .middleware(async ({ next, ctx }) =>
@@ -59,11 +59,11 @@ test('inferProcedureFromInput regression', async () => {
   }>();
 
   expectTypeOf<
-    trpc.inferProcedureInput<Queries['admin.noinput']>
-  >().toBeUnknown();
+    trpc.inferProcedureInput<Queries['admin.noInput']>
+  >().toBeUndefined();
 
   expectTypeOf<
-    trpc.inferProcedureOutput<Queries['admin.noinput']>
+    trpc.inferProcedureOutput<Queries['admin.noInput']>
   >().toEqualTypeOf<'out'>();
 
   expectTypeOf<

--- a/packages/server/test/regression/issue-949-inferProcedureInput.test.ts
+++ b/packages/server/test/regression/issue-949-inferProcedureInput.test.ts
@@ -60,7 +60,7 @@ test('inferProcedureFromInput regression', async () => {
 
   expectTypeOf<
     trpc.inferProcedureInput<Queries['admin.noInput']>
-  >().toBeUndefined();
+  >().toEqualTypeOf<undefined | null>();
 
   expectTypeOf<
     trpc.inferProcedureOutput<Queries['admin.noInput']>


### PR DESCRIPTION
~Fixes #949~

Follow-up to #955

This simplifies Procedure down to one type:

- ~`CreateProcedureWithInput`, `CreateProcedureWithoutInput`, `CreateProcedureOptions` -> `CreateProcedureOptions` (a single union type)~
- `ProcedureWithInput`, `ProcedureWithoutInput`, `Procedure` -> `Procedure` (a single non-abstract class which _always_ has a `TInput`. The input just happens to be undefined if it was created without an input parser specified)

~Note: there is one downside to this approach which is that for procedures with no inputs, the `input` prop passed to the resolver is typed as `unknown`, where ideally it'd be `undefined` or `never`. IMHO that's a pretty ok tradeoff given how much this simplifies both `procedure.ts` and `router.ts`.~