### PR TITLE
fix `initialData` being `TInput`

### DIFF
--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -45,8 +45,8 @@ interface TRPCUseQueryBaseOptions extends TRPCRequestOptions {
   ssr?: boolean;
 }
 
-interface UseTRPCQueryOptions<TInput, TError, TOutput>
-  extends UseQueryOptions<TInput, TError, TOutput, QueryKey>,
+interface UseTRPCQueryOptions<TError, TOutput, TQueryKey extends unknown[]>
+  extends UseQueryOptions<TOutput, TError, TOutput, TQueryKey>,
     TRPCUseQueryBaseOptions {}
 
 interface UseTRPCInfiniteQueryOptions<
@@ -214,12 +214,14 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
   >(
     pathAndInput: [path: TPath, ...args: inferHandlerInput<TProcedure>],
     opts?: UseTRPCQueryOptions<
-      inferProcedureInput<TQueries[TPath]>,
       TError,
-      TOutput
+      TOutput,
+      [TPath, inferProcedureInput<TQueries[TPath]>]
     >,
   ): UseQueryResult<TOutput, TError> {
-    const cacheKey = getCacheKey(pathAndInput, CACHE_KEY_QUERY);
+    type TInput = inferProcedureInput<TProcedure>;
+    type TQueryKey = [TPath, TInput];
+    const cacheKey = getCacheKey(pathAndInput, CACHE_KEY_QUERY) as TQueryKey;
     const { client, isPrepass, queryClient, prefetchQuery } = useContext();
 
     if (

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -16,7 +16,6 @@ import React, { ReactNode, useCallback, useEffect, useMemo } from 'react';
 import {
   hashQueryKey,
   QueryClient,
-  QueryKey,
   useInfiniteQuery,
   UseInfiniteQueryOptions,
   useMutation,
@@ -50,10 +49,10 @@ interface UseTRPCQueryOptions<TError, TOutput, TQueryKey extends unknown[]>
     TRPCUseQueryBaseOptions {}
 
 interface UseTRPCInfiniteQueryOptions<
-  TInput = unknown,
-  TError = unknown,
-  TOutput = TInput,
-> extends UseInfiniteQueryOptions<TInput, TError, TOutput, TOutput, QueryKey>,
+  TError,
+  TOutput,
+  TQueryKey extends unknown[],
+> extends UseInfiniteQueryOptions<TOutput, TError, TOutput, TOutput, TQueryKey>,
     TRPCUseQueryBaseOptions {}
 
 interface UseTRPCMutationOptions<TInput, TError, TOutput>
@@ -312,12 +311,18 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
     TCursor extends any,
   >(
     pathAndInput: [TPath, Omit<TInput, 'cursor'>],
-    // FIXME: this typing is wrong but it works
-    opts?: UseTRPCInfiniteQueryOptions<TOutput, TError, TOutput>,
+    opts?: UseTRPCInfiniteQueryOptions<
+      TError,
+      TOutput,
+      [TPath, Omit<TInput, 'cursor'>]
+    >,
   ) {
     const { client, isPrepass, prefetchInfiniteQuery, queryClient } =
       useContext();
-    const cacheKey = getCacheKey(pathAndInput, CACHE_KEY_INFINITE_QUERY);
+    const cacheKey = getCacheKey(pathAndInput, CACHE_KEY_INFINITE_QUERY) as [
+      TPath,
+      Omit<TInput, 'cursor'>,
+    ];
     const [path, input] = pathAndInput;
 
     if (

--- a/packages/server/test/regression/issue-990-initialData.test.tsx
+++ b/packages/server/test/regression/issue-990-initialData.test.tsx
@@ -1,0 +1,61 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable @typescript-eslint/ban-types */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
+import * as trpcServer from '../../src';
+jest.mock('@trpc/server', () => trpcServer);
+import * as trpcClient from '@trpc/client/src';
+jest.mock('@trpc/client', () => trpcClient);
+import * as trpcReact from '../../../react/src';
+jest.mock('@trpc/react', () => trpcReact);
+import * as trpcReact__ssg from '../../../react/src/ssg';
+jest.mock('@trpc/react/ssg', () => trpcReact__ssg);
+
+import '@testing-library/jest-dom';
+import { render, waitFor } from '@testing-library/react';
+import React, { useState } from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { routerToServerAndClient } from '../_testHelpers';
+
+test('initialData type', async () => {
+  const { client, router, close } = routerToServerAndClient(
+    trpcServer.router().query('hello', {
+      resolve() {
+        return {
+          text: 'world',
+        };
+      },
+    }),
+  );
+  const trpc = trpcReact.createReactQueryHooks<typeof router>();
+
+  function MyComponent() {
+    const query = trpc.useQuery(['hello'], {
+      initialData: {
+        text: 'alexdotjs',
+      },
+      enabled: false,
+    });
+
+    return <pre>{JSON.stringify(query.data ?? 'n/a', null, 4)}</pre>;
+  }
+  function App() {
+    const [queryClient] = useState(() => new QueryClient());
+    return (
+      <trpc.Provider {...{ queryClient, client }}>
+        <QueryClientProvider client={queryClient}>
+          <MyComponent />
+        </QueryClientProvider>
+      </trpc.Provider>
+    );
+  }
+
+  const utils = render(<App />);
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent('alexdotjs');
+  });
+
+  close();
+});


### PR DESCRIPTION
Closes #990.


This is actually blocked by https://github.com/tannerlinsley/react-query/pull/2715 but this feature should automerge as soon as there's a new version of react-query fixing it.