### PR TITLE
Allow passing no input on mutations with no input

### DIFF
--- a/examples/next-prisma-todomvc/src/pages/[filter].tsx
+++ b/examples/next-prisma-todomvc/src/pages/[filter].tsx
@@ -305,7 +305,7 @@ export default function TodosPage({
             <button
               className="clear-completed"
               onClick={() => {
-                clearCompleted.mutate(null);
+                clearCompleted.mutate();
               }}
             >
               Clear completed

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -74,8 +74,8 @@ type UseTRPCMutationResult<
   ? Override<
       UseMutationResult<TOutput, TError, TInput>,
       {
-        mutate: (options?: TOptions) => TOutput;
-        mutateAsync: (options?: TOptions) => Promise<TOutput>;
+        mutate: (variables?: null, options?: TOptions) => TOutput;
+        mutateAsync: (variables?: null, options?: TOptions) => Promise<TOutput>;
       }
     >
   : UseMutationResult<TOutput, TError, TInput>;


### PR DESCRIPTION
fixes #390

updates the `useMutation` mutate type to allow it to be without an input