### PR TITLE
feat: pass procedure input to middleware

### DIFF
--- a/packages/server/src/internals/middlewares.ts
+++ b/packages/server/src/internals/middlewares.ts
@@ -31,6 +31,7 @@ export type MiddlewareFunction<TInputContext, TContext> = (opts: {
   ctx: TInputContext;
   type: ProcedureType;
   path: string;
+  input: unknown;
   next: {
     (): Promise<MiddlewareResult<TInputContext>>;
     <T>(opts: { ctx: T }): Promise<MiddlewareResult<T>>;

--- a/packages/server/src/internals/middlewares.ts
+++ b/packages/server/src/internals/middlewares.ts
@@ -31,7 +31,7 @@ export type MiddlewareFunction<TInputContext, TContext> = (opts: {
   ctx: TInputContext;
   type: ProcedureType;
   path: string;
-  input: unknown;
+  rawInput: unknown;
   next: {
     (): Promise<MiddlewareResult<TInputContext>>;
     <T>(opts: { ctx: T }): Promise<MiddlewareResult<T>>;

--- a/packages/server/src/internals/procedure.ts
+++ b/packages/server/src/internals/procedure.ts
@@ -102,11 +102,10 @@ export class Procedure<TInputContext, TContext, TInput, TOutput> {
   public async call(
     opts: ProcedureCallOptions<TInputContext>,
   ): Promise<TOutput> {
-    const input = this.parseInput(opts.rawInput);
-
     // wrap the actual resolver and treat as the last "middleware"
     const middlewaresWithResolver = this.middlewares.concat([
       async ({ ctx }: { ctx: TContext }) => {
+        const input = this.parseInput(opts.rawInput);
         const data = await this.resolver({ ...opts, ctx, input });
         return {
           marker: middlewareMarker,
@@ -122,9 +121,10 @@ export class Procedure<TInputContext, TContext, TInput, TOutput> {
       return async (nextOpts?: { ctx: TContext }) => {
         const res = await wrapCallSafe(() =>
           fn({
-            ...(opts as any),
-            ...(nextOpts as any),
-            input,
+            ctx: nextOpts ? nextOpts.ctx : opts.ctx,
+            type: opts.type,
+            path: opts.path,
+            rawInput: opts.rawInput,
             next: nextFns[index + 1],
           }),
         );

--- a/packages/server/src/internals/procedure.ts
+++ b/packages/server/src/internals/procedure.ts
@@ -102,10 +102,11 @@ export class Procedure<TInputContext, TContext, TInput, TOutput> {
   public async call(
     opts: ProcedureCallOptions<TInputContext>,
   ): Promise<TOutput> {
+    const input = this.parseInput(opts.rawInput);
+
     // wrap the actual resolver and treat as the last "middleware"
     const middlewaresWithResolver = this.middlewares.concat([
       async ({ ctx }: { ctx: TContext }) => {
-        const input = this.parseInput(opts.rawInput);
         const data = await this.resolver({ ...opts, ctx, input });
         return {
           marker: middlewareMarker,
@@ -123,6 +124,7 @@ export class Procedure<TInputContext, TContext, TInput, TOutput> {
           fn({
             ...(opts as any),
             ...(nextOpts as any),
+            input,
             next: nextFns[index + 1],
           }),
         );

--- a/packages/server/test/middleware.test.ts
+++ b/packages/server/test/middleware.test.ts
@@ -23,18 +23,31 @@ test('is called if def first', async () => {
         resolve() {
           return 'bar2';
         },
+      })
+      .query('foo3', {
+        input: String,
+        resolve() {
+          return 'bar3';
+        },
       }),
   );
 
-  expect(await client.query('foo1')).toBe('bar1');
   const calls = middleware.mock.calls;
+  expect(await client.query('foo1')).toBe('bar1');
   expect(calls[0][0]).toHaveProperty('type');
   expect(calls[0][0]).toHaveProperty('ctx');
   expect(calls[0][0].type).toBe('query');
+
   expect(await client.mutation('foo2')).toBe('bar2');
   expect(calls[1][0].type).toBe('mutation');
 
-  expect(middleware).toHaveBeenCalledTimes(2);
+  expect(await client.query('foo3', 'foo3input')).toBe('bar3');
+  expect(calls[2][0]).toHaveProperty('type');
+  expect(calls[2][0]).toHaveProperty('ctx');
+  expect(calls[2][0].type).toBe('query');
+  expect(calls[2][0].input).toBe('foo3input');
+
+  expect(middleware).toHaveBeenCalledTimes(3);
   close();
 });
 

--- a/packages/server/test/middleware.test.ts
+++ b/packages/server/test/middleware.test.ts
@@ -45,7 +45,7 @@ test('is called if def first', async () => {
   expect(calls[2][0]).toHaveProperty('type');
   expect(calls[2][0]).toHaveProperty('ctx');
   expect(calls[2][0].type).toBe('query');
-  expect(calls[2][0].input).toBe('foo3input');
+  expect(calls[2][0].rawInput).toBe('foo3input');
 
   expect(middleware).toHaveBeenCalledTimes(3);
   close();

--- a/www/docs/server/middlewares.md
+++ b/www/docs/server/middlewares.md
@@ -105,6 +105,31 @@ trpc
   });
 ```
 
+## Raw input
+
+A middleware can access the raw input that will be passed to a procedure. This can be used to for authentication / other preprocessing in the middleware that requires access to the procedure input, and can be especially useful when used in conjunction with Context Swapping.
+
+:::warn
+The raw input passed to a middleware has not yet been validated by a procedure's `input` schema / validator, so be careful when using it! Because of this, it has type `unknown`.
+:::
+
+```ts
+trpc
+  .router<Context>()
+  .middleware(async ({ next, rawInput, ctx }) => {
+    const userId = rawInput?.userId as string;
+    if (typeof userId !== "string") throw new TRPCError({ code: "BAD_REQUEST" });
+    // Verify user authentication
+    return next({ ctx: { ...ctx, userId }})
+  })
+  .query('foo', {
+    resolve({ ctx }) {
+      return ctx.userId;
+    },
+  });
+```
+
+
 ### `createProtectedRouter()`-helper
 
 This helper can be used anywhere in your app tree to enforce downstream procedures to be authorized.


### PR DESCRIPTION
@KATT

In many routers, the authentication step takes place in the procedure resolver instead of middleware because data needed to perform the authentication is located in the procedure input, which is currently not passed to middleware. It would be helpful to have access to procedure input in middleware so a set of procedures can be authenticated all at once by a single middleware.

To solve this, this PR adds `input` as a parameter to the middleware function. Because the middleware cannot infer the type of procedure input because they act on many procedures, the `input` is passed as `unknown`.

Please let me know if this makes sense / is useful for others!

Example usage:

```ts
const router = createRouter()
  .middleware(({ ctx, input }) => {
    checkUserAuth(ctx, input.userId); // throws if the ctx does not have access to the given user
    return next();
  })
  .query("getUser", {
    input: z.object({ userId: z.string() }),
    async resolve({ input }) {
      // No additional auth step needed
      const user = await getUser(input.userId);
      return user;
    }
  })
  .query("getUserTasks", {
    input: z.object({ userId: z.string() }),
    async resolve({ input }) {
      // No additional auth step needed
      const tasks = await getUserTasks(input.userId);
      return tasks;
    }
  });
```
