### PR TITLE
[RFC] Allow `useQuery(path)` for queries with no required input

### DIFF
--- a/examples/next-prisma-starter-websockets/src/server/routers/post.ts
+++ b/examples/next-prisma-starter-websockets/src/server/routers/post.ts
@@ -93,15 +93,13 @@ export const postRouter = createRouter()
     },
   })
   .query('infinite', {
-    input: z
-      .object({
-        cursor: z.date().nullish(),
-        take: z.number().min(1).max(50).nullish(),
-      })
-      .nullish(),
+    input: z.object({
+      cursor: z.date().nullish(),
+      take: z.number().min(1).max(50).nullish(),
+    }),
     async resolve({ input, ctx }) {
-      const take = input?.take ?? 10;
-      const cursor = input?.cursor;
+      const take = input.take ?? 10;
+      const cursor = input.cursor;
       // `cursor` is of type `Date | undefined`
       // `take` is of type `number | undefined`
       const page = await ctx.prisma.post.findMany({

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "release:canary": "changeset publish --tag canary",
     "commit-date": "git log -n 1 --date=format:'%Y-%m-%d-%H-%M-%S' --pretty=format:'%ad'",
     "canary-preid": "echo \"$(yarn --silent current-branch)-$(yarn --silent commit-date)\"",
-    "current-branch": "echo \"$(git rev-parse --abbrev-ref HEAD)\" | sed -E 's/refs\\/heads\\///' | sed -E 's/\\W|_/-/g'",
-    "publish-canary": "lerna publish --canary --preid $(yarn --silent canary-preid) --dist-tag $(yarn --silent current-branch)"
+    "current-branch": "echo \"$(git rev-parse --abbrev-ref HEAD)\" | sed -E 's/refs\\/heads\\///' | sed -E 's/\\W|_/-/g' | sed -e 's/\\//-/'",
+    "publish-canary": "lerna publish --force-publish --canary --preid $(yarn --silent canary-preid) --dist-tag $(yarn --silent current-branch)"
   },
   "dependencies": {
     "@babel/core": "^7.15.5",

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -16,11 +16,11 @@ import React, { ReactNode, useCallback, useEffect, useMemo } from 'react';
 import {
   hashQueryKey,
   QueryClient,
-  useInfiniteQuery,
+  useInfiniteQuery as __useInfiniteQuery,
   UseInfiniteQueryOptions,
-  useMutation,
+  useMutation as useMutationRQ,
   UseMutationOptions,
-  useQuery,
+  useQuery as __useQuery,
   UseQueryOptions,
   UseQueryResult,
 } from 'react-query';
@@ -220,7 +220,7 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
     return React.useContext(Context);
   }
 
-  function _useQuery<
+  function useQuery<
     TPath extends keyof TQueries & string,
     TProcedure extends TQueries[TPath],
   >(
@@ -232,7 +232,7 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
       TError
     >,
   ): UseQueryResult<inferProcedureOutput<TProcedure>, TError>;
-  function _useQuery<
+  function useQuery<
     TPath extends keyof TQueries & string,
     TProcedure extends TQueries[TPath],
     TOutput extends inferProcedureOutput<TProcedure>,
@@ -243,10 +243,7 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
       ? [UseTRPCQueryOptionsV2NullishInput<TPath, TInput, TOutput, TError>?]
       : [UseTRPCQueryOptionsV2RequiredInput<TPath, TInput, TOutput, TError>]
   ): UseQueryResult<TOutput, TError>;
-  function _useQuery(
-    pathOrTuple: string | [string, unknown?],
-    _opts: any = {},
-  ) {
+  function useQuery(pathOrTuple: string | [string, unknown?], _opts: any = {}) {
     // <determine> if is passed as a tuple or a string and assert args
     let path: string;
     let input: unknown;
@@ -274,7 +271,7 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
     ) {
       prefetchQuery(pathAndInput as any, opts as any);
     }
-    const query = useQuery(
+    const query = __useQuery(
       cacheKey,
       () => (client as any).query(...getArgs(pathAndInput, opts)) as any,
       opts,
@@ -282,7 +279,7 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
     return query;
   }
 
-  function _useMutation<
+  function useMutation<
     TPath extends keyof TMutations & string,
     TOutput extends inferProcedureOutput<TMutations[TPath]>,
   >(
@@ -294,7 +291,7 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
     >,
   ) {
     const client = useContext().client;
-    const hook = useMutation<
+    const hook = useMutationRQ<
       TOutput,
       TError,
       inferProcedureInput<TMutations[TPath]>
@@ -353,7 +350,7 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
     }, [queryKey, enabled]);
   }
 
-  function _useInfiniteQuery<
+  function useInfiniteQuery<
     TPath extends keyof TQueries & string,
     TInput extends inferProcedureInput<TQueries[TPath]> & { cursor: TCursor },
     TOutput extends inferProcedureOutput<TQueries[TPath]>,
@@ -384,7 +381,7 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
     ) {
       prefetchInfiniteQuery(pathAndInput as any, opts as any);
     }
-    const query = useInfiniteQuery(
+    const query = __useInfiniteQuery(
       cacheKey,
       ({ pageParam }) => {
         const actualInput = { ...input, cursor: pageParam };
@@ -413,10 +410,10 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
     Provider: TRPCProvider,
     createClient,
     useContext: useContext,
-    useQuery: _useQuery,
-    useMutation: _useMutation,
+    useQuery: useQuery,
+    useMutation,
     useSubscription,
     useDehydratedState,
-    useInfiniteQuery: _useInfiniteQuery,
+    useInfiniteQuery,
   };
 }

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -56,11 +56,11 @@ interface UseTRPCQueryOptions<TPath, TInput, TOutput, TError>
   extends UseQueryOptions<TOutput, TError, TOutput, [TPath, TInput]>,
     TRPCUseQueryBaseOptions {}
 
-interface UseTRPCQueryOptionsOptionalInput<TPath, TInput, TOutput, TError>
+interface UseTRPCQueryOptionalInputOptions<TPath, TInput, TOutput, TError>
   extends UseQueryOptions<TOutput, TError, TOutput, [TPath, TInput]>,
     TRPCUseQueryBaseOptionsOptionalInput<TInput> {}
 
-interface UseTRPCQueryOptionsRequiredInput<TPath, TInput, TOutput, TError>
+interface UseTRPCQueryRequiredInputOptions<TPath, TInput, TOutput, TError>
   extends UseQueryOptions<TOutput, TError, TOutput, [TPath, TInput]>,
     TRPCUseQueryBaseOptions,
     TRPCUseQueryBaseOptionsRequiredInput<TInput> {}
@@ -246,8 +246,8 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
   >(
     path: TPath,
     ...args: TInput extends undefined
-      ? [UseTRPCQueryOptionsOptionalInput<TPath, TInput, TOutput, TError>?]
-      : [UseTRPCQueryOptionsRequiredInput<TPath, TInput, TOutput, TError>]
+      ? [UseTRPCQueryOptionalInputOptions<TPath, TInput, TOutput, TError>?]
+      : [UseTRPCQueryRequiredInputOptions<TPath, TInput, TOutput, TError>]
   ): UseQueryResult<TOutput, TError>;
   function useQuery(pathOrTuple: string | [string, unknown?], _opts: any = {}) {
     // <determine> if is passed as a tuple or a string and assert args

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -254,10 +254,10 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
   }
 
   function useQuery<
-    TPath extends TQueriesWithOptionalInputs & string,
+    TPath extends keyof TQueries & string,
     TProcedure extends TQueries[TPath],
   >(
-    pathAndInput: TPath,
+    pathAndInput: [path: TPath, ...args: inferHandlerInput<TProcedure>],
     opts?: UseTRPCQueryOptions<
       TPath,
       inferProcedureInput<TProcedure>,
@@ -266,10 +266,10 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
     >,
   ): UseQueryResult<inferProcedureOutput<TProcedure>, TError>;
   function useQuery<
-    TPath extends keyof TQueries & string,
+    TPath extends TQueriesWithOptionalInputs & string,
     TProcedure extends TQueries[TPath],
   >(
-    pathAndInput: [path: TPath, ...args: inferHandlerInput<TProcedure>],
+    pathAndInput: TPath,
     opts?: UseTRPCQueryOptions<
       TPath,
       inferProcedureInput<TProcedure>,

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -44,8 +44,8 @@ interface TRPCUseQueryBaseOptions extends TRPCRequestOptions {
   ssr?: boolean;
 }
 
-interface UseTRPCQueryOptions<TOutput, TError, TQueryKey extends unknown[]>
-  extends UseQueryOptions<TOutput, TError, TOutput, TQueryKey>,
+interface UseTRPCQueryOptions<TPath, TInput, TOutput, TError>
+  extends UseQueryOptions<TOutput, TError, TOutput, [TPath, TInput]>,
     TRPCUseQueryBaseOptions {}
 
 interface UseTRPCInfiniteQueryOptions<
@@ -209,15 +209,15 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
   function _useQuery<
     TPath extends keyof TQueries & string,
     TProcedure extends TQueries[TPath],
-    TOutput extends inferProcedureOutput<TProcedure>,
   >(
     pathAndInput: [path: TPath, ...args: inferHandlerInput<TProcedure>],
     opts?: UseTRPCQueryOptions<
-      TOutput,
-      TError,
-      [TPath, inferProcedureInput<TQueries[TPath]>]
+      TPath,
+      inferProcedureInput<TProcedure>,
+      inferProcedureOutput<TProcedure>,
+      TError
     >,
-  ): UseQueryResult<TOutput, TError> {
+  ): UseQueryResult<inferProcedureOutput<TProcedure>, TError> {
     type TInput = inferProcedureInput<TProcedure>;
     type TQueryKey = [TPath, TInput];
     const cacheKey = getCacheKey(pathAndInput, CACHE_KEY_QUERY) as TQueryKey;

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -284,14 +284,21 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
 
   function _useMutation<
     TPath extends keyof TMutations & string,
-    TInput extends inferProcedureInput<TMutations[TPath]>,
     TOutput extends inferProcedureOutput<TMutations[TPath]>,
-  >(path: TPath, opts?: UseTRPCMutationOptions<TInput, TError, TOutput>) {
+  >(
+    path: TPath,
+    opts?: UseTRPCMutationOptions<
+      inferProcedureInput<TMutations[TPath]>,
+      TError,
+      TOutput
+    >,
+  ) {
     const client = useContext().client;
-    const hook = useMutation<TOutput, TError, TInput>(
-      (input) => (client.mutation as any)(path, input),
-      opts,
-    );
+    const hook = useMutation<
+      TOutput,
+      TError,
+      inferProcedureInput<TMutations[TPath]>
+    >((input) => (client.mutation as any)(path, input), opts);
 
     return hook;
   }

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -243,38 +243,41 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
       ? [UseTRPCQueryOptionsV2NullableInput<TPath, TInput, TOutput, TError>?]
       : [UseTRPCQueryOptionsV2RequiredInput<TPath, TInput, TOutput, TError>]
   ): UseQueryResult<TOutput, TError>;
-  function _useQuery(pathOrTuple: string | [string, unknown?], opts: any = {}) {
+  function _useQuery(
+    pathOrTuple: string | [string, unknown?],
+    _opts: any = {},
+  ) {
     // <determine> if is passed as a tuple or a string and assert args
-    let _path: string;
-    let _input: unknown;
-    let _opts: any;
+    let path: string;
+    let input: unknown;
+    let opts: any;
     if (Array.isArray(pathOrTuple)) {
-      [_path, _input] = pathOrTuple;
-      _opts = opts;
+      [path, input] = pathOrTuple;
+      opts = _opts;
     } else {
-      const { input, ...rest } = opts;
-      _path = pathOrTuple;
-      _input = input;
-      _opts = rest;
+      const { input: _input, ...rest } = _opts;
+      path = pathOrTuple;
+      input = _input;
+      opts = rest;
     }
     // </determine>
-    const pathAndInput: [string, unknown] = [_path, _input];
+    const pathAndInput: [string, unknown] = [path, input];
     const cacheKey = getCacheKey(pathAndInput, CACHE_KEY_QUERY);
     const { client, isPrepass, queryClient, prefetchQuery } = useContext();
 
     if (
       typeof window === 'undefined' &&
       isPrepass &&
-      _opts?.ssr !== false &&
-      _opts?.enabled !== false &&
+      opts?.ssr !== false &&
+      opts?.enabled !== false &&
       !queryClient.getQueryCache().find(cacheKey)
     ) {
-      prefetchQuery(pathAndInput as any, _opts as any);
+      prefetchQuery(pathAndInput as any, opts as any);
     }
     const query = useQuery(
       cacheKey,
-      () => (client as any).query(...getArgs(pathAndInput, _opts)) as any,
-      _opts,
+      () => (client as any).query(...getArgs(pathAndInput, opts)) as any,
+      opts,
     );
     return query;
   }

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -396,33 +396,15 @@ export function createReactQueryHooksV2<TRouter extends AnyRouter>() {
     TPath extends keyof TQueries & string,
     TProcedure extends TQueries[TPath],
     TOutput extends inferProcedureOutput<TProcedure>,
-    TInput extends inferProcedureInput<TProcedure> &
-      NonNullable<inferProcedureInput<TProcedure>>,
-  >(
-    path: TPath,
-    opts: UseTRPCQueryOptionsV2RequiredInput<TPath, TInput, TOutput, TError>,
-  ): UseQueryResult<TOutput, TError>;
-  function _useQuery<
-    TPath extends keyof TQueries & string,
-    TProcedure extends TQueries[TPath],
-    TOutput extends inferProcedureOutput<TProcedure>,
-    TInput extends inferProcedureInput<TProcedure> & (undefined | null),
-  >(
-    path: TPath,
-    opts?: UseTRPCQueryOptionsV2NullableInput<TPath, TInput, TOutput, TError>,
-  ): UseQueryResult<TOutput, TError>;
-  function _useQuery<
-    TPath extends keyof TQueries & string,
-    TProcedure extends TQueries[TPath],
-    TOutput extends inferProcedureOutput<TProcedure>,
     TInput extends inferProcedureInput<TProcedure>,
   >(
     path: TPath,
-    opts?:
-      | UseTRPCQueryOptionsV2RequiredInput<TPath, TInput, TOutput, TError>
-      | UseTRPCQueryOptionsV2NullableInput<TPath, TInput, TOutput, TError>,
+    ...args: TInput extends undefined | null
+      ? [UseTRPCQueryOptionsV2NullableInput<TPath, TInput, TOutput, TError>]
+      : [UseTRPCQueryOptionsV2RequiredInput<TPath, TInput, TOutput, TError>]
   ): UseQueryResult<TOutput, TError> {
-    const { input, ...rest } = opts ?? {};
+    const opts = args[0] ?? {};
+    const { input, ...rest } = opts;
 
     return v1.useQuery([path, input] as any, rest as any);
   }

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -400,7 +400,7 @@ export function createReactQueryHooksV2<TRouter extends AnyRouter>() {
   >(
     path: TPath,
     ...args: TInput extends undefined | null
-      ? [UseTRPCQueryOptionsV2NullableInput<TPath, TInput, TOutput, TError>]
+      ? [UseTRPCQueryOptionsV2NullableInput<TPath, TInput, TOutput, TError>?]
       : [UseTRPCQueryOptionsV2RequiredInput<TPath, TInput, TOutput, TError>]
   ): UseQueryResult<TOutput, TError> {
     const opts = args[0] ?? {};

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -48,6 +48,17 @@ interface UseTRPCQueryOptions<TPath, TInput, TOutput, TError>
   extends UseQueryOptions<TOutput, TError, TOutput, [TPath, TInput]>,
     TRPCUseQueryBaseOptions {}
 
+interface UseTRPCQueryOptionsV2NullableInput<TPath, TInput, TOutput, TError>
+  extends UseQueryOptions<TOutput, TError, TOutput, [TPath, TInput]>,
+    TRPCUseQueryBaseOptions {
+  input?: TInput;
+}
+
+interface UseTRPCQueryOptionsV2RequiredInput<TPath, TInput, TOutput, TError>
+  extends UseQueryOptions<TOutput, TError, TOutput, [TPath, TInput]>,
+    TRPCUseQueryBaseOptions {
+  input: TInput;
+}
 interface UseTRPCInfiniteQueryOptions<TPath, TInput, TOutput, TError>
   extends UseInfiniteQueryOptions<
       TOutput,
@@ -372,5 +383,52 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
     useSubscription,
     useDehydratedState,
     useInfiniteQuery: _useInfiniteQuery,
+  };
+}
+
+export function createReactQueryHooksV2<TRouter extends AnyRouter>() {
+  type TQueries = TRouter['_def']['queries'];
+  type TError = TRPCClientErrorLike<TRouter>;
+
+  const v1 = createReactQueryHooks<TRouter>();
+
+  function _useQuery<
+    TPath extends keyof TQueries & string,
+    TProcedure extends TQueries[TPath],
+    TOutput extends inferProcedureOutput<TProcedure>,
+    TInput extends inferProcedureInput<TProcedure> &
+      NonNullable<inferProcedureInput<TProcedure>>,
+  >(
+    path: TPath,
+    opts: UseTRPCQueryOptionsV2RequiredInput<TPath, TInput, TOutput, TError>,
+  ): UseQueryResult<TOutput, TError>;
+  function _useQuery<
+    TPath extends keyof TQueries & string,
+    TProcedure extends TQueries[TPath],
+    TOutput extends inferProcedureOutput<TProcedure>,
+    TInput extends inferProcedureInput<TProcedure> & (undefined | null),
+  >(
+    path: TPath,
+    opts?: UseTRPCQueryOptionsV2NullableInput<TPath, TInput, TOutput, TError>,
+  ): UseQueryResult<TOutput, TError>;
+  function _useQuery<
+    TPath extends keyof TQueries & string,
+    TProcedure extends TQueries[TPath],
+    TOutput extends inferProcedureOutput<TProcedure>,
+    TInput extends inferProcedureInput<TProcedure>,
+  >(
+    path: TPath,
+    opts?:
+      | UseTRPCQueryOptionsV2RequiredInput<TPath, TInput, TOutput, TError>
+      | UseTRPCQueryOptionsV2NullableInput<TPath, TInput, TOutput, TError>,
+  ): UseQueryResult<TOutput, TError> {
+    const { input, ...rest } = opts ?? {};
+
+    return v1.useQuery([path, input] as any, rest as any);
+  }
+
+  return {
+    ...v1,
+    useQuery: _useQuery,
   };
 }

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -395,6 +395,18 @@ export function createReactQueryHooksV2<TRouter extends AnyRouter>() {
   function _useQuery<
     TPath extends keyof TQueries & string,
     TProcedure extends TQueries[TPath],
+  >(
+    pathAndInput: [path: TPath, ...args: inferHandlerInput<TProcedure>],
+    opts?: UseTRPCQueryOptions<
+      TPath,
+      inferProcedureInput<TProcedure>,
+      inferProcedureOutput<TProcedure>,
+      TError
+    >,
+  ): UseQueryResult<inferProcedureOutput<TProcedure>, TError>;
+  function _useQuery<
+    TPath extends keyof TQueries & string,
+    TProcedure extends TQueries[TPath],
     TOutput extends inferProcedureOutput<TProcedure>,
     TInput extends inferProcedureInput<TProcedure>,
   >(
@@ -402,11 +414,18 @@ export function createReactQueryHooksV2<TRouter extends AnyRouter>() {
     ...args: TInput extends undefined | null
       ? [UseTRPCQueryOptionsV2NullableInput<TPath, TInput, TOutput, TError>?]
       : [UseTRPCQueryOptionsV2RequiredInput<TPath, TInput, TOutput, TError>]
-  ): UseQueryResult<TOutput, TError> {
-    const opts = args[0] ?? {};
-    const { input, ...rest } = opts;
+  ): UseQueryResult<TOutput, TError>;
+  function _useQuery(pathOrTuple: string | [string, unknown?], opts: any = {}) {
+    const args = useMemo(() => {
+      if (Array.isArray(pathOrTuple)) {
+        return [pathOrTuple, opts];
+      }
+      const { input, ...rest } = opts;
 
-    return v1.useQuery([path, input] as any, rest as any);
+      return [[pathOrTuple, input], rest];
+    }, [pathOrTuple, opts]);
+
+    return (v1.useQuery as any)(...args);
   }
 
   return {

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -19,7 +19,7 @@ import {
   useInfiniteQuery as __useInfiniteQuery,
   UseInfiniteQueryOptions,
   UseInfiniteQueryResult,
-  useMutation as useMutationRQ,
+  useMutation as __useMutation,
   UseMutationOptions,
   useQuery as __useQuery,
   UseQueryOptions,
@@ -326,7 +326,7 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
     >,
   ) {
     const client = useContext().client;
-    const hook = useMutationRQ<
+    const hook = __useMutation<
       TOutput,
       TError,
       inferProcedureInput<TMutations[TPath]>

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -48,7 +48,7 @@ interface UseTRPCQueryOptions<TPath, TInput, TOutput, TError>
   extends UseQueryOptions<TOutput, TError, TOutput, [TPath, TInput]>,
     TRPCUseQueryBaseOptions {}
 
-interface UseTRPCQueryOptionsNullishInput<TPath, TInput, TOutput, TError>
+interface UseTRPCQueryOptionsOptionalInput<TPath, TInput, TOutput, TError>
   extends UseQueryOptions<TOutput, TError, TOutput, [TPath, TInput]>,
     TRPCUseQueryBaseOptions {
   input?: TInput;
@@ -239,8 +239,8 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
     TInput extends inferProcedureInput<TProcedure>,
   >(
     path: TPath,
-    ...args: TInput extends undefined | null
-      ? [UseTRPCQueryOptionsNullishInput<TPath, TInput, TOutput, TError>?]
+    ...args: TInput extends undefined
+      ? [UseTRPCQueryOptionsOptionalInput<TPath, TInput, TOutput, TError>?]
       : [UseTRPCQueryOptionsRequiredInput<TPath, TInput, TOutput, TError>]
   ): UseQueryResult<TOutput, TError>;
   function useQuery(pathOrTuple: string | [string, unknown?], _opts: any = {}) {

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -48,7 +48,7 @@ interface UseTRPCQueryOptions<TPath, TInput, TOutput, TError>
   extends UseQueryOptions<TOutput, TError, TOutput, [TPath, TInput]>,
     TRPCUseQueryBaseOptions {}
 
-interface UseTRPCQueryOptionsV2NullableInput<TPath, TInput, TOutput, TError>
+interface UseTRPCQueryOptionsV2NullishInput<TPath, TInput, TOutput, TError>
   extends UseQueryOptions<TOutput, TError, TOutput, [TPath, TInput]>,
     TRPCUseQueryBaseOptions {
   input?: TInput;
@@ -240,7 +240,7 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
   >(
     path: TPath,
     ...args: TInput extends undefined | null
-      ? [UseTRPCQueryOptionsV2NullableInput<TPath, TInput, TOutput, TError>?]
+      ? [UseTRPCQueryOptionsV2NullishInput<TPath, TInput, TOutput, TError>?]
       : [UseTRPCQueryOptionsV2RequiredInput<TPath, TInput, TOutput, TError>]
   ): UseQueryResult<TOutput, TError>;
   function _useQuery(

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -44,21 +44,27 @@ interface TRPCUseQueryBaseOptions extends TRPCRequestOptions {
   ssr?: boolean;
 }
 
+interface TRPCUseQueryBaseOptionsOptionalInput<TInput> {
+  input?: TInput;
+}
+
+interface TRPCUseQueryBaseOptionsRequiredInput<TInput> {
+  input: TInput;
+}
+
 interface UseTRPCQueryOptions<TPath, TInput, TOutput, TError>
   extends UseQueryOptions<TOutput, TError, TOutput, [TPath, TInput]>,
     TRPCUseQueryBaseOptions {}
 
 interface UseTRPCQueryOptionsOptionalInput<TPath, TInput, TOutput, TError>
   extends UseQueryOptions<TOutput, TError, TOutput, [TPath, TInput]>,
-    TRPCUseQueryBaseOptions {
-  input?: TInput;
-}
+    TRPCUseQueryBaseOptionsOptionalInput<TInput> {}
 
 interface UseTRPCQueryOptionsRequiredInput<TPath, TInput, TOutput, TError>
   extends UseQueryOptions<TOutput, TError, TOutput, [TPath, TInput]>,
-    TRPCUseQueryBaseOptions {
-  input: TInput;
-}
+    TRPCUseQueryBaseOptions,
+    TRPCUseQueryBaseOptionsRequiredInput<TInput> {}
+
 interface UseTRPCInfiniteQueryOptions<TPath, TInput, TOutput, TError>
   extends UseInfiniteQueryOptions<
       TOutput,
@@ -409,8 +415,8 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
   return {
     Provider: TRPCProvider,
     createClient,
-    useContext: useContext,
-    useQuery: useQuery,
+    useContext,
+    useQuery,
     useMutation,
     useSubscription,
     useDehydratedState,

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -127,14 +127,18 @@ function getOptions(pathOrTuple: string | [string, unknown?], _opts: any = {}) {
   };
 }
 
-type inferInfiniteQueryNames<TObj extends ProcedureRecord<any, any, any, any>> =
-  {
-    [TPath in keyof TObj]: inferProcedureInput<TObj[TPath]> extends {
-      cursor?: any;
-    }
-      ? TPath
-      : never;
-  }[keyof TObj];
+/**
+ * @internal
+ */
+export type inferInfiniteQueryNames<
+  TObj extends ProcedureRecord<any, any, any, any>,
+> = {
+  [TPath in keyof TObj]: inferProcedureInput<TObj[TPath]> extends {
+    cursor?: any;
+  }
+    ? TPath
+    : never;
+}[keyof TObj];
 
 export function createReactQueryHooks<TRouter extends AnyRouter>() {
   type TQueries = TRouter['_def']['queries'];
@@ -395,7 +399,7 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
   }
 
   function useInfiniteQuery<
-    TPath extends TInfiniteQueryNames & string,
+    TPath extends TInfiniteQueryNames,
     TProcedure extends TQueries[TPath],
     TOutput extends inferProcedureOutput<TQueries[TPath]>,
     TInput extends inferProcedureInput<TQueries[TPath]> & { cursor: TCursor },

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -76,14 +76,14 @@ interface UseTRPCInfiniteQueryOptions<TPath, TInput, TOutput, TError>
     >,
     TRPCUseQueryBaseOptions {}
 
-// interface UseTRPCInfiniteQueryRequiredInputOptions<
-//   TPath,
-//   TInput,
-//   TOutput,
-//   TError,
-// > extends UseInfiniteQueryOptions<TOutput, TError, TOutput, [TPath, TInput]>,
-//     TRPCUseQueryBaseOptions,
-//     TRPCUseQueryBaseOptionsRequiredInput<TInput> {}
+interface UseTRPCInfiniteQueryRequiredInputOptions<
+  TPath,
+  TInput,
+  TOutput,
+  TError,
+> extends UseInfiniteQueryOptions<TOutput, TError, TOutput, [TPath, TInput]>,
+    TRPCUseQueryBaseOptions,
+    TRPCUseQueryBaseOptionsRequiredInput<TInput> {}
 
 // interface UseTRPCInfiniteQueryOptionalInputOptions<
 //   TPath,
@@ -98,7 +98,7 @@ interface UseTRPCMutationOptions<TInput, TError, TOutput>
   extends UseMutationOptions<TOutput, TError, TInput>,
     TRPCUseQueryBaseOptions {}
 
-function getArgs<TPathAndInput extends unknown[], TOptions>(
+function getClientArgs<TPathAndInput extends unknown[], TOptions>(
   pathAndInput: TPathAndInput,
   opts: TOptions,
 ) {
@@ -162,7 +162,8 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
 
               return queryClient.fetchQuery(
                 cacheKey,
-                () => (client as any).query(...getArgs(pathAndInput, opts)),
+                () =>
+                  (client as any).query(...getClientArgs(pathAndInput, opts)),
                 opts,
               );
             },
@@ -181,7 +182,7 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
                   const [path, input] = pathAndInput;
                   const actualInput = { ...(input as any), cursor: pageParam };
                   return (client as any).query(
-                    ...getArgs([path, actualInput], opts),
+                    ...getClientArgs([path, actualInput], opts),
                   );
                 },
                 opts,
@@ -195,7 +196,8 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
 
               return queryClient.prefetchQuery(
                 cacheKey,
-                () => (client as any).query(...getArgs(pathAndInput, opts)),
+                () =>
+                  (client as any).query(...getClientArgs(pathAndInput, opts)),
                 opts,
               );
             },
@@ -214,7 +216,7 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
                   const [path, input] = pathAndInput;
                   const actualInput = { ...(input as any), cursor: pageParam };
                   return (client as any).query(
-                    ...getArgs([path, actualInput], opts),
+                    ...getClientArgs([path, actualInput], opts),
                   );
                 },
                 opts,
@@ -306,7 +308,7 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
     }
     const query = __useQuery(
       cacheKey,
-      () => (client as any).query(...getArgs(pathAndInput, opts)) as any,
+      () => (client as any).query(...getClientArgs(pathAndInput, opts)),
       opts,
     );
     return query;
@@ -386,11 +388,11 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
   function useInfiniteQuery<
     TPath extends keyof TQueries & string,
     TProcedure extends TQueries[TPath],
-    TInput extends inferProcedureInput<TQueries[TPath]> & { cursor: TCursor },
     TOutput extends inferProcedureOutput<TQueries[TPath]>,
+    TInput extends inferProcedureInput<TQueries[TPath]> & { cursor: TCursor },
     TCursor extends any,
   >(
-    pathAndInput: [TPath, Omit<TInput, 'cursor'>],
+    pathAndInput: [path: TPath, input: Omit<TInput, 'cursor'>],
     opts?: UseTRPCInfiniteQueryOptions<
       TPath,
       Omit<TInput, 'cursor'>,
@@ -398,6 +400,21 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
       TError
     >,
   ): UseInfiniteQueryResult<inferProcedureOutput<TProcedure>, TError>;
+  function useInfiniteQuery<
+    TPath extends keyof TQueries & string,
+    TProcedure extends TQueries[TPath],
+    TOutput extends inferProcedureOutput<TProcedure>,
+    TInput extends inferProcedureInput<TProcedure> & { cursor: TCursor },
+    TCursor extends any,
+  >(
+    path: TPath,
+    opts: UseTRPCInfiniteQueryRequiredInputOptions<
+      TPath,
+      Omit<TInput, 'cursor'>,
+      TOutput,
+      TError
+    >,
+  ): UseInfiniteQueryResult<TOutput, TError>;
   function useInfiniteQuery(
     pathOrTuple: string | [string, unknown?],
     _opts?: any,
@@ -421,7 +438,9 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
       cacheKey,
       ({ pageParam }) => {
         const actualInput = { ...((input as any) ?? {}), cursor: pageParam };
-        return (client as any).query(...getArgs([path, actualInput], opts));
+        return (client as any).query(
+          ...getClientArgs([path, actualInput], opts),
+        );
       },
       opts,
     );

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -325,14 +325,12 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
       TOutput
     >,
   ) {
-    const client = useContext().client;
-    const hook = __useMutation<
+    const { client } = useContext();
+    return __useMutation<
       TOutput,
       TError,
       inferProcedureInput<TMutations[TPath]>
     >((input) => (client.mutation as any)(path, input), opts);
-
-    return hook;
   }
 
   /* istanbul ignore next */
@@ -357,7 +355,7 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
   ) {
     const enabled = opts?.enabled ?? true;
     const queryKey = hashQueryKey(pathAndInput);
-    const client = useContext().client;
+    const { client } = useContext();
 
     return useEffect(() => {
       if (!enabled) {

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -44,13 +44,13 @@ interface TRPCUseQueryBaseOptions extends TRPCRequestOptions {
   ssr?: boolean;
 }
 
-interface UseTRPCQueryOptions<TError, TOutput, TQueryKey extends unknown[]>
+interface UseTRPCQueryOptions<TOutput, TError, TQueryKey extends unknown[]>
   extends UseQueryOptions<TOutput, TError, TOutput, TQueryKey>,
     TRPCUseQueryBaseOptions {}
 
 interface UseTRPCInfiniteQueryOptions<
-  TError,
   TOutput,
+  TError,
   TQueryKey extends unknown[],
 > extends UseInfiniteQueryOptions<TOutput, TError, TOutput, TOutput, TQueryKey>,
     TRPCUseQueryBaseOptions {}
@@ -213,8 +213,8 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
   >(
     pathAndInput: [path: TPath, ...args: inferHandlerInput<TProcedure>],
     opts?: UseTRPCQueryOptions<
-      TError,
       TOutput,
+      TError,
       [TPath, inferProcedureInput<TQueries[TPath]>]
     >,
   ): UseQueryResult<TOutput, TError> {
@@ -312,8 +312,8 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
   >(
     pathAndInput: [TPath, Omit<TInput, 'cursor'>],
     opts?: UseTRPCInfiniteQueryOptions<
-      TError,
       TOutput,
+      TError,
       [TPath, Omit<TInput, 'cursor'>]
     >,
   ) {

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -48,11 +48,14 @@ interface UseTRPCQueryOptions<TPath, TInput, TOutput, TError>
   extends UseQueryOptions<TOutput, TError, TOutput, [TPath, TInput]>,
     TRPCUseQueryBaseOptions {}
 
-interface UseTRPCInfiniteQueryOptions<
-  TOutput,
-  TError,
-  TQueryKey extends unknown[],
-> extends UseInfiniteQueryOptions<TOutput, TError, TOutput, TOutput, TQueryKey>,
+interface UseTRPCInfiniteQueryOptions<TPath, TInput, TOutput, TError>
+  extends UseInfiniteQueryOptions<
+      TOutput,
+      TError,
+      TOutput,
+      TOutput,
+      [TPath, TInput]
+    >,
     TRPCUseQueryBaseOptions {}
 
 interface UseTRPCMutationOptions<TInput, TError, TOutput>
@@ -312,9 +315,10 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
   >(
     pathAndInput: [TPath, Omit<TInput, 'cursor'>],
     opts?: UseTRPCInfiniteQueryOptions<
+      TPath,
+      Omit<TInput, 'cursor'>,
       TOutput,
-      TError,
-      [TPath, Omit<TInput, 'cursor'>]
+      TError
     >,
   ) {
     const { client, isPrepass, prefetchInfiniteQuery, queryClient } =

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -48,13 +48,13 @@ interface UseTRPCQueryOptions<TPath, TInput, TOutput, TError>
   extends UseQueryOptions<TOutput, TError, TOutput, [TPath, TInput]>,
     TRPCUseQueryBaseOptions {}
 
-interface UseTRPCQueryOptionsV2NullishInput<TPath, TInput, TOutput, TError>
+interface UseTRPCQueryOptionsNullishInput<TPath, TInput, TOutput, TError>
   extends UseQueryOptions<TOutput, TError, TOutput, [TPath, TInput]>,
     TRPCUseQueryBaseOptions {
   input?: TInput;
 }
 
-interface UseTRPCQueryOptionsV2RequiredInput<TPath, TInput, TOutput, TError>
+interface UseTRPCQueryOptionsRequiredInput<TPath, TInput, TOutput, TError>
   extends UseQueryOptions<TOutput, TError, TOutput, [TPath, TInput]>,
     TRPCUseQueryBaseOptions {
   input: TInput;
@@ -240,8 +240,8 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
   >(
     path: TPath,
     ...args: TInput extends undefined | null
-      ? [UseTRPCQueryOptionsV2NullishInput<TPath, TInput, TOutput, TError>?]
-      : [UseTRPCQueryOptionsV2RequiredInput<TPath, TInput, TOutput, TError>]
+      ? [UseTRPCQueryOptionsNullishInput<TPath, TInput, TOutput, TError>?]
+      : [UseTRPCQueryOptionsRequiredInput<TPath, TInput, TOutput, TError>]
   ): UseQueryResult<TOutput, TError>;
   function useQuery(pathOrTuple: string | [string, unknown?], _opts: any = {}) {
     // <determine> if is passed as a tuple or a string and assert args

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -127,18 +127,14 @@ function getOptions(pathOrTuple: string | [string, unknown?], _opts: any = {}) {
   };
 }
 
-/**
- * @internal
- */
-export type inferInfiniteQueryNames<
-  TObj extends ProcedureRecord<any, any, any, any>,
-> = {
-  [TPath in keyof TObj]: inferProcedureInput<TObj[TPath]> extends {
-    cursor?: any;
-  }
-    ? TPath
-    : never;
-}[keyof TObj];
+type inferInfiniteQueryNames<TObj extends ProcedureRecord<any, any, any, any>> =
+  {
+    [TPath in keyof TObj]: inferProcedureInput<TObj[TPath]> extends {
+      cursor?: any;
+    }
+      ? TPath
+      : never;
+  }[keyof TObj];
 
 export function createReactQueryHooks<TRouter extends AnyRouter>() {
   type TQueries = TRouter['_def']['queries'];

--- a/packages/server/test/react.test.tsx
+++ b/packages/server/test/react.test.tsx
@@ -1679,6 +1679,7 @@ describe('useQuery() v2', () => {
     const { trpcV2: trpc, client } = factory;
     function MyComponent() {
       const allPostsQuery = trpc.useQuery('allPosts');
+      trpc.useQuery(['allPosts']);
       expectTypeOf(allPostsQuery.data!).toMatchTypeOf<Post[]>();
 
       return <pre>{JSON.stringify(allPostsQuery.data ?? 'n/a', null, 4)}</pre>;

--- a/packages/server/test/react.test.tsx
+++ b/packages/server/test/react.test.tsx
@@ -29,11 +29,7 @@ import {
 import { dehydrate } from 'react-query/hydration';
 import { z, ZodError } from 'zod';
 import { withTRPC } from '../../next/src';
-import {
-  createReactQueryHooks,
-  createReactQueryHooksV2,
-  OutputWithCursor,
-} from '../../react/src';
+import { createReactQueryHooks, OutputWithCursor } from '../../react/src';
 import { createSSGHelpers } from '../../react/ssg';
 import { DefaultErrorShape } from '../src';
 import { routerToServerAndClient } from './_testHelpers';
@@ -237,7 +233,6 @@ function createAppRouter() {
   );
   const queryClient = new QueryClient();
   const trpc = createReactQueryHooks<typeof appRouter>();
-  const trpcV2 = createReactQueryHooksV2<typeof appRouter>();
 
   return {
     appRouter,
@@ -254,7 +249,6 @@ function createAppRouter() {
     queryClient,
     createContext,
     linkSpy,
-    trpcV2,
   };
 }
 let factory: ReturnType<typeof createAppRouter>;
@@ -1676,7 +1670,7 @@ describe('withTRPC()', () => {
 
 describe('useQuery() v2', () => {
   test('no input', async () => {
-    const { trpcV2: trpc, client } = factory;
+    const { trpc, client } = factory;
     function MyComponent() {
       const allPostsQuery = trpc.useQuery('allPosts');
       trpc.useQuery(['allPosts']);
@@ -1702,7 +1696,7 @@ describe('useQuery() v2', () => {
   });
 
   test('with input', async () => {
-    const { trpcV2: trpc, client } = factory;
+    const { trpc, client } = factory;
     function MyComponent() {
       // @ts-expect-error
       trpc.useQuery('paginatedPosts');

--- a/packages/server/test/react.test.tsx
+++ b/packages/server/test/react.test.tsx
@@ -1700,10 +1700,18 @@ describe('useQuery() v2', () => {
     function MyComponent() {
       // @ts-expect-error
       trpc.useQuery('paginatedPosts');
+      trpc.useQuery('paginatedPosts', {
+        input: {
+          limit: 1,
+          // we _should_ add a @ts-expect-error here
+          notExists: 'test',
+        },
+      });
 
       const allPostsQuery = trpc.useQuery('paginatedPosts', {
         input: {
           limit: 1,
+          extra: 12,
         },
       });
 

--- a/packages/server/test/react.test.tsx
+++ b/packages/server/test/react.test.tsx
@@ -1700,27 +1700,12 @@ describe('with a string path', () => {
 
     test('with input', async () => {
       const { trpc, client } = factory;
+
       function MyComponent() {
         // @ts-expect-error
         trpc.useQuery('paginatedPosts');
-        trpc.useQuery('paginatedPosts', {
-          input: {
-            limit: 1,
-            // we _should_ add a @ts-expect-error here
-            notExists: 'test',
-          },
-        });
 
-        const allPostsQuery = trpc.useQuery('paginatedPosts', {
-          input: {
-            limit: 1,
-            extra: 12,
-          },
-        });
-
-        return (
-          <pre>{JSON.stringify(allPostsQuery.data ?? 'n/a', null, 4)}</pre>
-        );
+        return null;
       }
       function App() {
         const [queryClient] = useState(() => new QueryClient());
@@ -1733,107 +1718,7 @@ describe('with a string path', () => {
         );
       }
 
-      const utils = render(<App />);
-      await waitFor(() => {
-        expect(utils.container).toHaveTextContent('first post');
-      });
-      expect(utils.container).not.toHaveTextContent('second post');
+      render(<App />);
     });
-  });
-  test('useInfiniteQuery()', async () => {
-    const { trpc, client } = factory;
-
-    function MyComponent() {
-      const q = trpc.useInfiniteQuery('paginatedPosts', {
-        input: {
-          limit: 1,
-        },
-        getNextPageParam: (lastPage) => lastPage.nextCursor,
-      });
-      expectTypeOf(q.data?.pages[0].items).toMatchTypeOf<undefined | Post[]>();
-
-      return q.status === 'loading' ? (
-        <p>Loading...</p>
-      ) : q.status === 'error' ? (
-        <p>Error: {q.error.message}</p>
-      ) : (
-        <>
-          {q.data?.pages.map((group, i) => (
-            <Fragment key={i}>
-              {group.items.map((msg) => (
-                <Fragment key={msg.id}>
-                  <div>{msg.title}</div>
-                </Fragment>
-              ))}
-            </Fragment>
-          ))}
-          <div>
-            <button
-              onClick={() => q.fetchNextPage()}
-              disabled={!q.hasNextPage || q.isFetchingNextPage}
-              data-testid="loadMore"
-            >
-              {q.isFetchingNextPage
-                ? 'Loading more...'
-                : q.hasNextPage
-                ? 'Load More'
-                : 'Nothing more to load'}
-            </button>
-          </div>
-          <div>
-            {q.isFetching && !q.isFetchingNextPage ? 'Fetching...' : null}
-          </div>
-        </>
-      );
-    }
-    function App() {
-      const [queryClient] = useState(() => new QueryClient());
-      return (
-        <trpc.Provider {...{ queryClient, client }}>
-          <QueryClientProvider client={queryClient}>
-            <MyComponent />
-          </QueryClientProvider>
-        </trpc.Provider>
-      );
-    }
-
-    const utils = render(<App />);
-    await waitFor(() => {
-      expect(utils.container).toHaveTextContent('first post');
-    });
-    await waitFor(() => {
-      expect(utils.container).toHaveTextContent('first post');
-      expect(utils.container).not.toHaveTextContent('second post');
-      expect(utils.container).toHaveTextContent('Load More');
-    });
-    userEvent.click(utils.getByTestId('loadMore'));
-    await waitFor(() => {
-      expect(utils.container).toHaveTextContent('Loading more...');
-    });
-    await waitFor(() => {
-      expect(utils.container).toHaveTextContent('first post');
-      expect(utils.container).toHaveTextContent('second post');
-      expect(utils.container).toHaveTextContent('Nothing more to load');
-    });
-
-    expect(utils.container).toMatchInlineSnapshot(`
-      <div>
-        <div>
-          first post
-        </div>
-        <div>
-          second post
-        </div>
-        <div>
-          <button
-            data-testid="loadMore"
-            disabled=""
-          >
-            Nothing more to load
-          </button>
-        </div>
-        <div />
-      </div>
-    `);
   });
 });

--- a/packages/server/test/react.test.tsx
+++ b/packages/server/test/react.test.tsx
@@ -1678,9 +1678,7 @@ describe('useQuery() v2', () => {
   test('no input', async () => {
     const { trpcV2: trpc, client } = factory;
     function MyComponent() {
-      const allPostsQuery = trpc.useQuery('allPosts', {
-        input: null,
-      });
+      const allPostsQuery = trpc.useQuery('allPosts');
       expectTypeOf(allPostsQuery.data!).toMatchTypeOf<Post[]>();
 
       return <pre>{JSON.stringify(allPostsQuery.data ?? 'n/a', null, 4)}</pre>;

--- a/www/docs/react/useMutation.md
+++ b/www/docs/react/useMutation.md
@@ -1,7 +1,7 @@
 ---
 id: mutations
-title: Mutations
-sidebar_label: useMutation
+title: useMutation()
+sidebar_label: useMutation()
 slug: /react-mutations
 ---
 

--- a/www/docs/react/useMutation.md
+++ b/www/docs/react/useMutation.md
@@ -51,13 +51,13 @@ export function MyComponent() {
   const handleLogin = async () => {
     const name = 'John Doe';
 
-    await mutation.mutate({ name });
+    mutation.mutate({ name });
   };
 
   return (
     <div>
       <h1>Login Form</h1>
-      <button onClick={handleLogin} disabled={login.isLoading}>Login</button>
+      <button onClick={handleLogin} disabled={mutation.isLoading}>Login</button>
 
       {mutation.error && <p>Something went wrong! {mutation.error.message}</p>}
     </div>

--- a/www/docs/react/useMutation.md
+++ b/www/docs/react/useMutation.md
@@ -46,18 +46,20 @@ import { trpc } from '../utils/trpc';
 
 export function MyComponent() {
   // Note! This is not a tuple ['login', ...] but a string 'login'
-  const login = trpc.useMutation('login');
+  const mutation = trpc.useMutation('login');
 
   const handleLogin = async () => {
     const name = 'John Doe';
 
-    await login.mutateAsync({ name });
+    await mutation.mutate({ name });
   };
 
   return (
     <div>
       <h1>Login Form</h1>
-      <button onClick={handleLogin}>Login</button>
+      <button onClick={handleLogin} disabled={login.isLoading}>Login</button>
+
+      {mutation.error && <p>Something went wrong! {mutation.error.message}</p>}
     </div>
   );
 }

--- a/www/docs/react/useQuery.md
+++ b/www/docs/react/useQuery.md
@@ -7,9 +7,10 @@ slug: /react-queries
 
 > The hooks provided by `@trpc/react` are a thin wrapper around React Query. For in-depth information about options and usage patterns, refer to their docs on [Queries](https://react-query.tanstack.com/guides/queries).
 
-You pass a `[path, input]`-tuple as the first argument. You'll notice that you get autocompletion on the `path` and automatic typesafety on the `input`.
+- If the query has an optional `input`, you pass only it's procedure name as the first argument
+- If the query requires an input, you have to pass a `[path, input]`-tuple as the first argument
 
-If an `input`-argument is optional, you can omit the `, input` part of the argument.
+You'll notice that you get autocompletion on the `path` and automatic typesafety on the `input`.
 
 ### Example
 
@@ -45,6 +46,8 @@ import { trpc } from '../utils/trpc';
 export function MyComponent() {
   // input is optional, so we don't have to pass second argument
   const helloNoArgs = trpc.useQuery(['hello']);
+  // const helloNoArgs = trpc.useQuery('hello'); // we can also pass the the path as a string
+
   const helloWithArgs = trpc.useQuery(['hello', { text: 'client' }]);
 
   return (

--- a/www/docs/react/useQuery.md
+++ b/www/docs/react/useQuery.md
@@ -1,7 +1,7 @@
 ---
 id: queries
-title: Queries
-sidebar_label: useQuery
+title: useQuery()
+sidebar_label: useQuery()
 slug: /react-queries
 ---
 

--- a/www/docs/react/useQuery.md
+++ b/www/docs/react/useQuery.md
@@ -7,6 +7,13 @@ slug: /react-queries
 
 > The hooks provided by `@trpc/react` are a thin wrapper around React Query. For in-depth information about options and usage patterns, refer to their docs on [Queries](https://react-query.tanstack.com/guides/queries).
 
+```tsx
+function useQuery(
+  pathAndInput: string | [string, TInput?],
+  opts?: UseTRPCQueryOptions;
+)
+```
+
 - If the query has an optional `input`, you pass only it's procedure name as the first argument
 - If the query requires an input, you have to pass a `[path, input]`-tuple as the first argument
 

--- a/www/docs/react/useQuery.md
+++ b/www/docs/react/useQuery.md
@@ -51,10 +51,9 @@ trpc
 import { trpc } from '../utils/trpc';
 
 export function MyComponent() {
-  // input is optional, so we don't have to pass second argument
-  const helloNoArgs = trpc.useQuery(['hello']);
-  // const helloNoArgs = trpc.useQuery('hello'); // we can also pass the the path as a string
-
+  // input is optional, so can pass first argument as a string
+  const helloNoArgs = trpc.useQuery('hello'); // identical to `trpc.useQuery(['hello'])`
+  // if we want to pass an input, we pass a `[path, input]`-tuple
   const helloWithArgs = trpc.useQuery(['hello', { text: 'client' }]);
 
   return (


### PR DESCRIPTION
**ℹ️ Alternative to #1058** - diverges less from `react-query`.
 
---

- Allows you to do 
  - `useQuery(path)` for queries that have optional `input`
  - For queries with required input it's still `useQuery([path, input])`
- Fully backwards compatible

Other improvements

- `useInfiniteQuery()` can now only be used with queries that extends `{ cursor?: any }`
- [Update `useQuery()`-docs](https://www-git-refactor-queries-new-v2alt.tmp.trpc.io/docs/react-queries)
- [Tweak `useMutation()`-docs](https://www-git-refactor-queries-new-v2alt.tmp.trpc.io/docs/react-mutations)
