### PR TITLE
rename `invalidateQuery()` to `invalidateQueries()`

### DIFF
--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -162,7 +162,16 @@ export function createReactQueryHooks<TRouter extends AnyRouter>() {
             },
             [client, queryClient],
           ),
+          /**
+           * @deprecated use `invalidateQueries`
+           */
           invalidateQuery: useCallback(
+            (pathAndInput) => {
+              return queryClient.invalidateQueries(pathAndInput);
+            },
+            [queryClient],
+          ),
+          invalidateQueries: useCallback(
             (pathAndInput) => {
               return queryClient.invalidateQueries(pathAndInput);
             },

--- a/packages/react/src/internals/context.tsx
+++ b/packages/react/src/internals/context.tsx
@@ -72,11 +72,20 @@ export type TRPCContextState<TRouter extends AnyRouter> = {
     >,
   ) => Promise<void>;
 
+  /**
+   * @deprecated use `invalidateQueries`
+   */
   invalidateQuery: <
     TPath extends keyof TRouter['_def']['queries'] & string,
     TInput extends inferProcedureInput<TRouter['_def']['queries'][TPath]>,
   >(
     pathAndInput: [TPath, TInput?],
+  ) => Promise<void>;
+  invalidateQueries: <
+    TPath extends keyof TRouter['_def']['queries'] & string,
+    TInput extends inferProcedureInput<TRouter['_def']['queries'][TPath]>,
+  >(
+    pathAndInput: [TPath, TInput?] | TPath,
   ) => Promise<void>;
   cancelQuery: <
     TPath extends keyof TRouter['_def']['queries'] & string,

--- a/packages/server/test/react.test.tsx
+++ b/packages/server/test/react.test.tsx
@@ -1194,6 +1194,74 @@ describe('invalidate queries', () => {
     expect(resolvers.allPosts).toHaveBeenCalledTimes(2);
     expect(resolvers.postById).toHaveBeenCalledTimes(2);
   });
+  test('invalidateQueries()', async () => {
+    const { trpc, resolvers, client } = factory;
+    function MyComponent() {
+      const allPostsQuery = trpc.useQuery(['allPosts'], {
+        staleTime: Infinity,
+      });
+      const postByIdQuery = trpc.useQuery(['postById', '1'], {
+        staleTime: Infinity,
+      });
+      const utils = trpc.useContext();
+      return (
+        <>
+          <pre>
+            allPostsQuery:{allPostsQuery.status} allPostsQuery:
+            {allPostsQuery.isStale ? 'stale' : 'not-stale'}{' '}
+          </pre>
+          <pre>
+            postByIdQuery:{postByIdQuery.status} postByIdQuery:
+            {postByIdQuery.isStale ? 'stale' : 'not-stale'}
+          </pre>
+          <button
+            data-testid="refetch"
+            onClick={() => {
+              utils.invalidateQueries(['allPosts']);
+              utils.invalidateQueries(['postById', '1']);
+            }}
+          />
+        </>
+      );
+    }
+    function App() {
+      const [queryClient] = useState(() => new QueryClient());
+      return (
+        <trpc.Provider {...{ queryClient, client }}>
+          <QueryClientProvider client={queryClient}>
+            <MyComponent />
+          </QueryClientProvider>
+        </trpc.Provider>
+      );
+    }
+
+    const utils = render(<App />);
+
+    await waitFor(() => {
+      expect(utils.container).toHaveTextContent('postByIdQuery:success');
+      expect(utils.container).toHaveTextContent('allPostsQuery:success');
+
+      expect(utils.container).toHaveTextContent('postByIdQuery:not-stale');
+      expect(utils.container).toHaveTextContent('allPostsQuery:not-stale');
+    });
+
+    expect(resolvers.allPosts).toHaveBeenCalledTimes(1);
+    expect(resolvers.postById).toHaveBeenCalledTimes(1);
+
+    utils.getByTestId('refetch').click();
+
+    await waitFor(() => {
+      expect(utils.container).toHaveTextContent('postByIdQuery:stale');
+      expect(utils.container).toHaveTextContent('allPostsQuery:stale');
+    });
+    await waitFor(() => {
+      expect(utils.container).toHaveTextContent('postByIdQuery:not-stale');
+      expect(utils.container).toHaveTextContent('allPostsQuery:not-stale');
+    });
+
+    expect(resolvers.allPosts).toHaveBeenCalledTimes(2);
+    expect(resolvers.postById).toHaveBeenCalledTimes(2);
+  });
 });
 
 test('formatError() react types test', async () => {

--- a/www/docs/react/invalidateQuery.md
+++ b/www/docs/react/invalidateQuery.md
@@ -1,8 +1,8 @@
 ---
-id: invalidateQuery
-title: invalidateQuery
-sidebar_label: invalidateQuery()
-slug: /invalidateQuery
+id: invalidateQueries
+title: invalidateQueries
+sidebar_label: invalidateQueries()
+slug: /invalidateQueries
 ---
 
 
@@ -21,8 +21,8 @@ const utils = trpc.useContext();
 
 const mutation = trpc.useMutation('editPost', {
   onSuccess(input) {
-    utils.invalidateQuery(['allPosts']);
-    utils.invalidateQuery(['postById', input.id]);
+    utils.invalidateQueries(['allPosts']);
+    utils.invalidateQueries(['postById', input.id]);
   },
 })
 ```


### PR DESCRIPTION
- Better alignment with `react-query`
- Deprecates `invalidateQuery()`