### PR TITLE
fix: export all interfaces from createReactQueryHooks

### DIFF
--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -39,18 +39,18 @@ export type OutputWithCursor<TData, TCursor extends any = any> = {
   data: TData;
 };
 
-interface TRPCUseQueryBaseOptions extends TRPCRequestOptions {
+export interface TRPCUseQueryBaseOptions extends TRPCRequestOptions {
   /**
    * Opt out of SSR for this query by passing `ssr: false`
    */
   ssr?: boolean;
 }
 
-interface UseTRPCQueryOptions<TPath, TInput, TOutput, TError>
+export interface UseTRPCQueryOptions<TPath, TInput, TOutput, TError>
   extends UseQueryOptions<TOutput, TError, TOutput, [TPath, TInput]>,
     TRPCUseQueryBaseOptions {}
 
-interface UseTRPCInfiniteQueryOptions<TPath, TInput, TOutput, TError>
+export interface UseTRPCInfiniteQueryOptions<TPath, TInput, TOutput, TError>
   extends UseInfiniteQueryOptions<
       TOutput,
       TError,
@@ -60,7 +60,7 @@ interface UseTRPCInfiniteQueryOptions<TPath, TInput, TOutput, TError>
     >,
     TRPCUseQueryBaseOptions {}
 
-interface UseTRPCMutationOptions<TInput, TError, TOutput>
+export interface UseTRPCMutationOptions<TInput, TError, TOutput>
   extends UseMutationOptions<TOutput, TError, TInput>,
     TRPCUseQueryBaseOptions {}
 


### PR DESCRIPTION
Consider the following code:

```typescript
import type { SuperCoolRouter } from 'my-router-package'
import { createReactQueryHooks } from '@trpc/react'
import { AnyRouter } from '@trpc/server'

export const createClient = <TRouter extends AnyRouter>() =>
  createReactQueryHooks<TRouter>()

export const client = createClient<SuperCoolRouter>()

export const {
  useMutation,
  useSubscription,
  useQuery,
  useDehydratedState,
  useInfiniteQuery,
} = client
```

On `trpc:main` we get the following error messages:
```typescript
Exported variable 'createClient' has or is using name 'UseTRPCQueryOptions' from external module "{path}/node_modules/@trpc/react/dist/declarations/src/createReactQueryHooks" but cannot be named.

Exported variable 'createClient' has or is using name 'UseTRPCMutationOptions' from external module "{path}/node_modules/@trpc/react/dist/declarations/src/createReactQueryHooks" but cannot be named.

Exported variable 'createClient' has or is using name 'UseTRPCInfiniteQueryOptions' from external module "{path}/node_modules/@trpc/react/dist/declarations/src/createReactQueryHooks" but cannot be named.

const createClient: <TRouter extends AnyRouter<any>>() => {
    Provider: ({ client, queryClient, children, isPrepass, }: {
        queryClient: QueryClient;
        client: TRPCClient<TRouter>;
        children: ReactNode;
        isPrepass?: boolean;
    }) => JSX.Element;
    ... 6 more ...;
    useInfiniteQuery: <TPath_3 extends inferInfiniteQueryNames<...> & string>(pathAndInput: [path: ...], opts?: UseTRPCInfiniteQueryOptions<...>) => UseInfiniteQueryResult<...>;
}
```

This PR fixes that. 

Note that it seems that the problem still appears when using `pnpm` due to their directory structure inside `node_modules`
