### PR TITLE
Tweak SSG docs

### DIFF
--- a/www/docs/nextjs/ssg.md
+++ b/www/docs/nextjs/ssg.md
@@ -18,17 +18,6 @@ import Head from 'next/head';
 import { trpc } from '../utils/trpc';
 import { createSSGHelpers } from '@trpc/react/ssg';
 
-export default function Home() {
-  const hello = trpc.useQuery(['hello']);
-
-  if (!hello.data) return <div>Loading...</div>;
-  return (
-    <div>
-      <p>{hello.data.greeting}</p>
-    </div>
-  );
-}
-
 // Statically fetch the data in getStaticProps
 export const getStaticProps = async (
   context: GetStaticPropsContext<{ filter: string }>,
@@ -49,4 +38,17 @@ export const getStaticProps = async (
     revalidate: 1,
   };
 };
+
+export default function Home() {
+  // Retrieve data from the cache, if available. Otherwise make an HTTP request, as normal.
+  const hello = trpc.useQuery(['hello']);
+  
+  if (!hello.data) return <div>Loading...</div>;
+  return (
+    <div>
+      <p>{hello.data.greeting}</p>
+    </div>
+  );
+}
+
 ```


### PR DESCRIPTION
I was going to ask a discussion for a little clarification on the SSG docs, but thought I'd open the conversation as a pull request instead. If my understanding of how it works is right, maybe it could just be merged (instead of the age-old "does ABC work like XYZ?" - "Yes" - "Ok this could be documented a little more clearly" - "Feel free to open a PR" - "🦗 🦗 🦗" back-and-forth).

I moved `getStaticProps` above the page component since it happens "first", but that's mostly a personal preference. Happy to change it back if I'm the only one who finds it more intuitive that way. Mostly this is about the `// Retrieve data from the cache, if available. Otherwise make an HTTP request, as normal.` comment.

To rephrase this PR as a question - is the `// Retrieve data from the cache, if available. Otherwise make an HTTP request, as normal.` comment accurate?? If not, I'll close this.