### PR TITLE
Adding Discord link to www header

### DIFF
--- a/www/docusaurus.config.js
+++ b/www/docusaurus.config.js
@@ -58,6 +58,11 @@ module.exports = {
           label: 'Twitter',
           position: 'right',
         },
+        {
+          href: 'https://trpc.io/discord',
+          label: 'Discord',
+          position: 'right',
+        },
       ],
     },
     footer: {


### PR DESCRIPTION
I missed the Discord link (at the bottom of the page) at first, I think it'd be valuable for the community to have that link be more prominent on the page.
![image](https://user-images.githubusercontent.com/2000390/139340977-4adec87d-8733-4998-bbea-60221f6895e1.png)
