### PR TITLE
safe wrapper around `TRPCClient` to return `Either<>`-style responses

### DIFF
--- a/examples/standalone-server/src/client.ts
+++ b/examples/standalone-server/src/client.ts
@@ -3,6 +3,7 @@ import { createTRPCClient } from '@trpc/client';
 import { httpLink } from '@trpc/client/links/httpLink';
 import { splitLink } from '@trpc/client/links/splitLink';
 import { createWSClient, wsLink } from '@trpc/client/links/wsLink';
+import { wrapCallSafe } from './client/utils';
 import AbortController from 'abort-controller';
 import fetch from 'node-fetch';
 import ws from 'ws';
@@ -36,9 +37,11 @@ async function main() {
     ],
   });
 
-  const helloResponse = await client.query('hello', {
-    name: 'world',
-  });
+  const helloResponse = await wrapCallSafe(() =>
+    client.query('hello', {
+      name: 'world',
+    }),
+  );
 
   console.log('helloResponse', helloResponse);
 

--- a/examples/standalone-server/src/client.ts
+++ b/examples/standalone-server/src/client.ts
@@ -3,10 +3,10 @@ import { createTRPCClient } from '@trpc/client';
 import { httpLink } from '@trpc/client/links/httpLink';
 import { splitLink } from '@trpc/client/links/splitLink';
 import { createWSClient, wsLink } from '@trpc/client/links/wsLink';
-import { wrapCallSafe } from './client/utils';
 import AbortController from 'abort-controller';
 import fetch from 'node-fetch';
 import ws from 'ws';
+import { createSafeClient } from './client/utils';
 import type { AppRouter } from './server';
 
 // polyfill fetch & websocket
@@ -37,13 +37,15 @@ async function main() {
     ],
   });
 
-  const helloResponse = await wrapCallSafe(() =>
-    client.query('hello', {
-      name: 'world',
-    }),
-  );
+  const safeClient = createSafeClient(client);
+
+  const helloResponse = await safeClient.query('hello', { name: 'world' });
+  const helloResponseInvalid = await safeClient.query('hello', {
+    name: 123 as any,
+  });
 
   console.log('helloResponse', helloResponse);
+  console.log('helloResponseInvalid', helloResponseInvalid);
 
   const createPostRes = await client.mutation('createPost', {
     title: 'hello world',

--- a/examples/standalone-server/src/client/utils.ts
+++ b/examples/standalone-server/src/client/utils.ts
@@ -1,23 +1,50 @@
-import { inferRouterError } from '@trpc/server';
-import { AnyRouter } from '@trpc/server';
-import { TRPCClient, TRPCClientErrorLike, TRPCClientError } from '@trpc/client';
-import { AppRouter } from '../server';
-type AsyncFn<T> = (...args: any[]) => Promise<T> | T;
-/**
- * Wrap a function in a safe wrapper that never throws
- * Returns a discriminated union
- */
-export async function wrapCallSafe<TData, TError>(fn: AsyncFn<TData>) {
-  try {
-    const data = await fn();
-    return {
-      ok: true as const,
-      data,
-    };
-  } catch (cause) {
-    return {
-      ok: false as const,
-      error: cause as TRPCClientError<AppRouter>,
-    };
+import { TRPCClient, TRPCClientError, TRPCRequestOptions } from '@trpc/client';
+import { AnyRouter, inferHandlerInput } from '@trpc/server';
+
+export function createSafeClient<TRouter extends AnyRouter>(
+  client: TRPCClient<TRouter>,
+) {
+  type AsyncFn<T> = (...args: any[]) => Promise<T> | T;
+  /**
+   * Wrap a function in a safe wrapper that never throws
+   * Returns a discriminated union
+   */
+  async function wrapCallSafe<TData>(fn: AsyncFn<TData>) {
+    try {
+      const data = await fn();
+      return {
+        ok: true as const,
+        data,
+      };
+    } catch (cause) {
+      return {
+        ok: false as const,
+        error: cause as TRPCClientError<TRouter>,
+      };
+    }
   }
+
+  function query<
+    TQueries extends TRouter['_def']['queries'],
+    TPath extends string & keyof TQueries,
+  >(
+    path: TPath,
+    ...args: [...inferHandlerInput<TQueries[TPath]>, TRPCRequestOptions?]
+  ) {
+    return wrapCallSafe(() => client.query(path, ...args));
+  }
+  function mutation<
+    TMutations extends TRouter['_def']['mutations'],
+    TPath extends string & keyof TMutations,
+  >(
+    path: TPath,
+    ...args: [...inferHandlerInput<TMutations[TPath]>, TRPCRequestOptions?]
+  ) {
+    return wrapCallSafe(() => client.mutation(path, ...args));
+  }
+
+  return {
+    query,
+    mutation,
+  };
 }

--- a/examples/standalone-server/src/client/utils.ts
+++ b/examples/standalone-server/src/client/utils.ts
@@ -1,0 +1,23 @@
+import { inferRouterError } from '@trpc/server';
+import { AnyRouter } from '@trpc/server';
+import { TRPCClient, TRPCClientErrorLike, TRPCClientError } from '@trpc/client';
+import { AppRouter } from '../server';
+type AsyncFn<T> = (...args: any[]) => Promise<T> | T;
+/**
+ * Wrap a function in a safe wrapper that never throws
+ * Returns a discriminated union
+ */
+export async function wrapCallSafe<TData, TError>(fn: AsyncFn<TData>) {
+  try {
+    const data = await fn();
+    return {
+      ok: true as const,
+      data,
+    };
+  } catch (cause) {
+    return {
+      ok: false as const,
+      error: cause as TRPCClientError<AppRouter>,
+    };
+  }
+}


### PR DESCRIPTION
Not intended to be merged, just a demo from https://github.com/trpc/trpc/pull/1188