### PR TITLE
rename `context` to `meta` in `@trpc/client`

### DIFF
--- a/packages/client/src/links/core.ts
+++ b/packages/client/src/links/core.ts
@@ -2,13 +2,17 @@ import { AnyRouter, DataTransformer } from '@trpc/server';
 import { TRPCResult } from '@trpc/server/rpc';
 import { TRPCClientError } from '../TRPCClientError';
 
-export type OperationContext = Record<string, unknown>;
+export type OperationMeta = Record<string, unknown>;
 export type Operation<TInput = unknown> = {
   id: number;
   type: 'query' | 'mutation' | 'subscription';
   input: TInput;
   path: string;
-  context: OperationContext;
+  meta: OperationMeta;
+  /**
+   * @deprecated use `meta`
+   */
+  context: OperationMeta;
 };
 
 export type OperationResponse<TRouter extends AnyRouter, TOutput = unknown> =

--- a/packages/client/src/links/loggerLink.ts
+++ b/packages/client/src/links/loggerLink.ts
@@ -55,7 +55,7 @@ type LoggerLinkOptions<TRouter extends AnyRouter> = {
 const defaultLogger =
   <TRouter extends AnyRouter>(c: ConsoleEsque = console): LogFn<TRouter> =>
   (props) => {
-    const { direction, input, type, path, context, id } = props;
+    const { direction, input, type, path, meta, id } = props;
     const [light, dark] = palette[type];
 
     const css = `
@@ -78,13 +78,13 @@ const defaultLogger =
       `${css}; font-weight: normal;`,
     ];
     if (props.direction === 'up') {
-      args.push({ input, context });
+      args.push({ input, meta });
     } else {
       args.push({
         input,
         result: props.result,
         elapsedMs: props.elapsedMs,
-        context,
+        meta,
       });
     }
     const fn: 'error' | 'log' =

--- a/packages/server/test/links.test.ts
+++ b/packages/server/test/links.test.ts
@@ -39,6 +39,7 @@ test('retrylink', () => {
       input: null,
       path: '',
       context: {},
+      meta: {},
     },
     prev: prev,
     next: (_ctx, callback) => {
@@ -84,6 +85,7 @@ test('chainer', async () => {
       path: 'hello',
       input: null,
       context: {},
+      meta: {},
     },
   });
 
@@ -143,6 +145,7 @@ test('cancel request', async () => {
       path: 'hello',
       input: null,
       context: {},
+      meta: {},
     },
   });
 
@@ -185,6 +188,7 @@ describe('batching', () => {
         path: 'hello',
         input: null,
         context: {},
+        meta: {},
       },
     });
 
@@ -196,6 +200,7 @@ describe('batching', () => {
         path: 'hello',
         input: 'alexdotjs',
         context: {},
+        meta: {},
       },
     });
 
@@ -275,6 +280,7 @@ describe('splitLink', () => {
         input: null,
         path: '',
         context: {},
+        meta: {},
       },
     });
     expect(left).toHaveBeenCalledTimes(1);
@@ -300,6 +306,7 @@ describe('splitLink', () => {
         input: null,
         path: '',
         context: {},
+        meta: {},
       },
     });
     expect(trueLink).toHaveBeenCalledTimes(1);
@@ -396,6 +403,7 @@ test('loggerLink', () => {
         input: null,
         path: 'n/a',
         context: {},
+        meta: {},
       },
     });
 
@@ -418,6 +426,7 @@ test('loggerLink', () => {
         input: null,
         path: 'n/a',
         context: {},
+        meta: {},
       },
     });
     expect(logger.log.mock.calls[0][0]).toMatchInlineSnapshot(
@@ -439,6 +448,7 @@ test('loggerLink', () => {
         input: null,
         path: 'n/a',
         context: {},
+        meta: {},
       },
     });
 
@@ -461,6 +471,7 @@ test('loggerLink', () => {
         input: null,
         path: 'n/a',
         context: {},
+        meta: {},
       },
     });
     expect(logger.log.mock.calls[0][0]).toMatchInlineSnapshot(
@@ -484,6 +495,7 @@ test('loggerLink', () => {
         input: null,
         path: 'n/a',
         context: {},
+        meta: {},
       },
     });
     const [firstCall, secondCall] = logFn.mock.calls.map((args) => args[0]);
@@ -493,6 +505,7 @@ test('loggerLink', () => {
         "direction": "up",
         "id": 1,
         "input": null,
+        "meta": Object {},
         "path": "n/a",
         "type": "query",
       }
@@ -506,6 +519,7 @@ test('loggerLink', () => {
         "direction": "down",
         "id": 1,
         "input": null,
+        "meta": Object {},
         "path": "n/a",
         "result": [TRPCClientError: ..],
         "type": "query",
@@ -514,8 +528,8 @@ test('loggerLink', () => {
   }
 });
 
-test('pass a context', () => {
-  const context = {
+test('pass meta', () => {
+  const meta = {
     hello: 'there',
   };
   const callback = jest.fn();
@@ -530,14 +544,15 @@ test('pass a context', () => {
       type: 'query',
       input: null,
       path: '',
-      context,
+      meta,
+      context: meta,
     },
   });
-  expect(callback).toHaveBeenCalledWith(context);
+  expect(callback).toHaveBeenCalledWith(meta);
 });
 
-test('pass a context', () => {
-  const context = {
+test('pass meta', () => {
+  const meta = {
     hello: 'there',
   };
   const callback = jest.fn();
@@ -552,8 +567,9 @@ test('pass a context', () => {
       type: 'query',
       input: null,
       path: '',
-      context,
+      context: meta,
+      meta,
     },
   });
-  expect(callback).toHaveBeenCalledWith(context);
+  expect(callback).toHaveBeenCalledWith(meta);
 });

--- a/www/docs/client/links.md
+++ b/www/docs/client/links.md
@@ -91,8 +91,8 @@ export default withTRPC<AppRouter>({
       links: [
         splitLink({
           condition(op) {
-            // check for context property `skipBatch`
-            return op.context.skipBatch === true;
+            // check for meta property `skipBatch`
+            return op.meta.skipBatch === true;
           },
           // when condition is true, use normal request
           true: httpLink({
@@ -113,7 +113,7 @@ export default withTRPC<AppRouter>({
 
 ```tsx
 const postsQuery = trpc.useQuery(['posts'], {
-  context: {
+  meta: {
     skipBatch: true,
   },
 });
@@ -121,7 +121,7 @@ const postsQuery = trpc.useQuery(['posts'], {
 // or
 
 const postResult = client.query('posts', null, {
-  context: {
+  meta: {
     skipBatch: true,
   },
 })


### PR DESCRIPTION
- Rename `context` to `meta` to avoid confusion with `ctx` on the server
- Deprecate `context` (but keep it backwards comapat)
- Aligns with `react-query`'s `meta` property


ℹ️  Will be merged in January.