### PR TITLE
fix `withTRPC()` response headers

### DIFF
--- a/packages/next/src/withTRPC.tsx
+++ b/packages/next/src/withTRPC.tsx
@@ -226,9 +226,9 @@ export function withTRPC<TRouter extends AnyRouter>(
                   ? [err as TRPCClientError<TRouter>]
                   : [],
               ),
-          }) ?? {};
+          }) || {};
 
-        for (const [key, value] of Object.entries(meta)) {
+        for (const [key, value] of Object.entries(meta.headers || {})) {
           if (typeof value === 'string') {
             ctx.res?.setHeader(key, value);
           }


### PR DESCRIPTION
The `responseMeta()`-callback was not returning the correct headers