### PR TITLE
docs: the "createRouter" function must be explicitly defined

### DIFF
--- a/www/docs/server/merging-routers.md
+++ b/www/docs/server/merging-routers.md
@@ -19,6 +19,10 @@ Thanks to TypeScript 4.1 template literal types we can also prefix the procedure
 
 
 ```ts
+const createRouter = () => {
+  return trpc.router<Context>();
+}
+
 const posts = createRouter()
   .mutation('create', {
     input: z.object({


### PR DESCRIPTION
It took me a few minutes to realize that the "createRouter" was a helper function, not a trpc function.