### PR TITLE
docs: use unused variable

### DIFF
--- a/www/docs/server/express.md
+++ b/www/docs/server/express.md
@@ -98,7 +98,7 @@ app.use(
   '/trpc',
   trpcExpress.createExpressMiddleware({
     router: appRouter,
-    createContext: () => null, // no context
+    createContext,
   })
 );
 


### PR DESCRIPTION
`createContext` is defined but never used so either it should be used in the `createExpressMiddleware` (that's what I did) or should be removed.