### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/examples/next-prisma-starter-websockets/test/playwright.test.ts
+++ b/examples/next-prisma-starter-websockets/test/playwright.test.ts
@@ -11,7 +11,7 @@ test('send message', async () => {
   const nonce = Math.random()
     .toString(36)
     .replace(/[^a-z]+/g, '')
-    .substr(0, 6);
+    .slice(0, 6);
   await page.type('[name=name]', nonce);
   await page.click('[type=submit]');
   await page.type('[name=text]', nonce);

--- a/examples/next-prisma-todomvc/test/playwright.test.ts
+++ b/examples/next-prisma-todomvc/test/playwright.test.ts
@@ -6,7 +6,7 @@ test('add todo', async () => {
   const nonce = Math.random()
     .toString(36)
     .replace(/[^a-z]+/g, '')
-    .substr(0, 6);
+    .slice(0, 6);
   await page.type('.new-todo', nonce);
   await page.keyboard.press('Enter');
   await page.waitForResponse('**/trpc/**');

--- a/packages/server/src/adapters/express.ts
+++ b/packages/server/src/adapters/express.ts
@@ -16,7 +16,7 @@ export function createExpressMiddleware<TRouter extends AnyRouter>(
   opts: NodeHTTPHandlerOptions<TRouter, express.Request, express.Response>,
 ): express.Handler {
   return (req, res) => {
-    const endpoint = req.path.substr(1);
+    const endpoint = req.path.slice(1);
 
     nodeHTTPRequestHandler({
       ...opts,

--- a/packages/server/src/adapters/standalone.ts
+++ b/packages/server/src/adapters/standalone.ts
@@ -21,7 +21,7 @@ export function createHTTPHandler<TRouter extends AnyRouter>(
   opts: CreateHTTPHandlerOptions<TRouter>,
 ) {
   return async (req: http.IncomingMessage, res: http.ServerResponse) => {
-    const endpoint = url.parse(req.url!).pathname!.substr(1);
+    const endpoint = url.parse(req.url!).pathname!.slice(1);
     await nodeHTTPRequestHandler({
       ...opts,
       req,


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.