### PR TITLE
Fix DB constraints

### DIFF
--- a/examples/next-prisma-starter/prisma/schema.prisma
+++ b/examples/next-prisma-starter/prisma/schema.prisma
@@ -17,6 +17,6 @@ model Post {
 
   // To return `Date`s intact through the API we need to add data transformers
   // https://trpc.io/docs/data-transformers
-  createdAt DateTime @unique @default(now())
-  updatedAt DateTime @unique @default(now())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
 }


### PR DESCRIPTION
This PR removes the uniqueness constraint from the `createdAt` and `updatedAt` properties as it wasn't really required and would cause issues when writing to the DB in bulk using `createMany`.

It also adds the `@updatedAt` flag on the `updatedAt` field so it updates properly on each update.