### PR TITLE
chore: update readme link in next-prisma-starter

### DIFF
--- a/examples/next-prisma-starter/README.md
+++ b/examples/next-prisma-starter/README.md
@@ -82,7 +82,7 @@ Go to [dashboard.render.com/blueprints](https://dashboard.render.com/blueprints)
       <td>Prisma schema</td>
     </tr>
     <tr>
-      <td><a href="./src/api/trpc/[trpc].tsx"><code>./src/api/trpc/[trpc].tsx</code></a></td>
+      <td><a href="./src/pages/api/trpc/[trpc].ts"><code>./src/pages/api/trpc/[trpc].ts</code></a></td>
       <td>tRPC response handler</td>
     </tr>
     <tr>


### PR DESCRIPTION
Fix a broken link in next-prisma-starter readme