### PR TITLE
docs: update react introduction

### DIFF
--- a/www/docs/react/react-intro.md
+++ b/www/docs/react/react-intro.md
@@ -15,16 +15,17 @@ slug: /react
 
 > tRPC works fine with Create React App!
 
-### 1. Install tRPC dependencies
+### Server Side
+
+#### 1. Install dependencies
 
 ```bash
-yarn add @trpc/client @trpc/server @trpc/react react-query zod
+yarn add @trpc/server zod
 ```
 
-- React Query: `@trpc/react` provides a thin wrapper over [react-query](https://react-query.tanstack.com/overview). It is required as a peer dependency.
 - Zod: most examples use [Zod](https://github.com/colinhacks/zod) for input validation and we highly recommended it, though it isn't required. You can use a validation library of your choice ([Yup](https://github.com/jquense/yup), [Superstruct](https://github.com/ianstormtaylor/superstruct), [io-ts](https://github.com/gcanti/io-ts), etc). In fact, any object containing a `parse`, `create` or `validateSync` method will work.
 
-### 2. Enable strict mode
+#### 2. Enable strict mode
 
 If you want to use Zod for input validation, make sure you have enabled strict mode in your `tsconfig.json`:
 
@@ -52,11 +53,21 @@ If strict mode is too much, at least enable `strictNullChecks`:
 }
 ```
 
-### 3. Implement your `appRouter`
+#### 3. Implement your `appRouter`
 
 Follow the [Quickstart](/docs/quickstart) and read the [`@trpc/server` docs](/docs/router) for guidance on this. Once you have your API implemented and listening via HTTP, continue to the next step.
 
-### 4. Create tRPC hooks
+### Client Side
+
+#### 1. Install dependencies
+
+```bash
+yarn add @trpc/client @trpc/server @trpc/react react-query
+```
+- @trpc/server: This is a peer dependency of `@trpc/client` so you have to install it again!
+- React Query: @trpc/react provides a thin wrapper over react-query. It is required as a peer dependency.
+
+#### 2. Create tRPC hooks
 
 Create a set of strongly-typed React hooks from your `AppRouter` type signature with `createReactQueryHooks`.
 
@@ -69,7 +80,7 @@ export const trpc = createReactQueryHooks<AppRouter>();
 // => { useQuery: ..., useMutation: ...}
 ```
 
-### 5. Add tRPC providers
+#### 3. Add tRPC providers
 
 In your `App.tsx`
 
@@ -103,7 +114,7 @@ function App() {
 }
 ```
 
-### 6. Fetch data
+#### 4. Fetch data
 
 ```tsx
 import { trpc } from '../utils/trpc';

--- a/www/docs/react/react-intro.md
+++ b/www/docs/react/react-intro.md
@@ -13,8 +13,6 @@ slug: /react
 
 ## Add tRPC to existing React project
 
-> tRPC works fine with Create React App!
-
 ### Server Side
 
 #### 1. Install dependencies
@@ -58,6 +56,8 @@ If strict mode is too much, at least enable `strictNullChecks`:
 Follow the [Quickstart](/docs/quickstart) and read the [`@trpc/server` docs](/docs/router) for guidance on this. Once you have your API implemented and listening via HTTP, continue to the next step.
 
 ### Client Side
+
+> tRPC works fine with Create React App!
 
 #### 1. Install dependencies
 


### PR DESCRIPTION
- added distinction between things that should be done in server-side vs client-side. It complicates the docs but in my opinion, is necessary.
- added a note about installing `@trpc/server` on the client. this prevents problems like #1463 to happen again.