### PR TITLE
fix(examples): avoid destructuring 'process.env'. it's not safe

### DIFF
--- a/examples/next-prisma-starter-websockets/src/pages/api/auth/[...nextauth].ts
+++ b/examples/next-prisma-starter-websockets/src/pages/api/auth/[...nextauth].ts
@@ -4,10 +4,9 @@ import GithubProvider from 'next-auth/providers/github';
 import CredentialsProvider from 'next-auth/providers/credentials';
 
 let useMockProvider = process.env.NODE_ENV === 'test';
-const { GITHUB_CLIENT_ID, GITHUB_SECRET, NODE_ENV, APP_ENV } = process.env;
 if (
-  (NODE_ENV !== 'production' || APP_ENV === 'test') &&
-  (!GITHUB_CLIENT_ID || !GITHUB_SECRET)
+  (process.env.NODE_ENV !== 'production' || process.env.APP_ENV === 'test') &&
+  (!process.env.GITHUB_CLIENT_ID || !process.env.GITHUB_SECRET)
 ) {
   console.log('⚠️ Using mocked GitHub auth correct credentails were not added');
   useMockProvider = true;
@@ -34,8 +33,8 @@ if (useMockProvider) {
 } else {
   providers.push(
     GithubProvider({
-      clientId: GITHUB_CLIENT_ID,
-      clientSecret: GITHUB_SECRET,
+      clientId: process.env.GITHUB_CLIENT_ID,
+      clientSecret: process.env.GITHUB_SECRET,
       profile(profile) {
         return {
           id: profile.id,


### PR DESCRIPTION
[Next.js docs:
](https://nextjs.org/docs/basic-features/environment-variables)

> Note: In order to keep server-only secrets safe, Next.js replaces `process.env.*` with the correct values at build time. This means that process.env is not a standard JavaScript object, so you’re not able to use [object destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment). Environment variables must be referenced as e.g. `process.env.PUBLISHABLE_KEY`, not `const { PUBLISHABLE_KEY } = process.env`.