### PR TITLE
fix: url for next-prisma-starter-websockets

### DIFF
--- a/www/docs/main/example-apps.md
+++ b/www/docs/main/example-apps.md
@@ -64,7 +64,7 @@ Here's some example apps:
       <td><a href="http://websockets.trpc.io">websockets.trpc.io</a></td>
       <td>
         <ul>
-          <li><a href="https://codesandbox.io/s/github/trpc/trpc/tree/main/examples/next-prisma-starter?file=/src/pages/index.tsx">CodeSandbox</a></li>
+          <li><a href="https://codesandbox.io/s/github/trpc/trpc/tree/main/examples/next-prisma-starter-websockets?file=/src/pages/index.tsx">CodeSandbox</a></li>
           <li><a href="https://github.com/trpc/trpc/tree/main/examples/next-prisma-starter-websockets">Source</a></li>
         </ul>
       </td>


### PR DESCRIPTION
Right now it's pointing to wrong example.