### PR TITLE
Correcting usage of yarn create next-app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ There are a few [examples](https://trpc.io/docs/example-apps) that you can use f
 
 ```sh
 # yarn
-yarn create-next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-starter trpc-prisma-starter
+yarn create next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-starter trpc-prisma-starter
 # npm
 npx create-next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-starter trpc-prisma-starter
 ```

--- a/examples/next-prisma-starter-websockets/README.md
+++ b/examples/next-prisma-starter-websockets/README.md
@@ -23,7 +23,7 @@
 ## Setup
 
 ```bash
-yarn create-next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-starter-websockets trpc-prisma-starter-websockets
+yarn create next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-starter-websockets trpc-prisma-starter-websockets
 cd trpc-prisma-starter-websockets
 yarn
 yarn dev

--- a/examples/next-prisma-starter/README.md
+++ b/examples/next-prisma-starter/README.md
@@ -16,7 +16,7 @@
 
 **yarn:**
 ```bash
-yarn create-next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-starter trpc-prisma-starter
+yarn create next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-starter trpc-prisma-starter
 cd trpc-prisma-starter
 yarn
 yarn dx
@@ -41,7 +41,7 @@ yarn dx
 ### Start project
 
 ```bash
-yarn create-next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-starter trpc-prisma-starter
+yarn create next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-starter trpc-prisma-starter
 cd trpc-prisma-starter
 yarn
 yarn dx

--- a/examples/next-prisma-todomvc/README.md
+++ b/examples/next-prisma-todomvc/README.md
@@ -7,7 +7,7 @@
 ### Setup
 
 ```bash
-yarn create-next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-todomvc trpc-todo
+yarn create next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-todomvc trpc-todo
 cd trpc-todo
 yarn
 yarn dev

--- a/www/docs/main/example-apps.md
+++ b/www/docs/main/example-apps.md
@@ -24,7 +24,7 @@ Here's some example apps:
         <br/><br/>
         <details>
           <summary>Quick start with <code>create-next-app</code></summary>
-          <code>yarn create-next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-starter trpc-prisma-starter</code>
+          <code>yarn create next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-starter trpc-prisma-starter</code>
         </details>
       </td>
       <td><a href="https://nextjs.trpc.io">nextjs.trpc.io</a></td>
@@ -58,7 +58,7 @@ Here's some example apps:
         <br/><br/>
         <details>
           <summary>Quick start with <code>create-next-app</code></summary>
-          <code>yarn create-next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-starter-websockets trpc-prisma-starter-websockets</code>
+          <code>yarn create next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-starter-websockets trpc-prisma-starter-websockets</code>
         </details>
       </td>
       <td><a href="http://websockets.trpc.io">websockets.trpc.io</a></td>
@@ -75,7 +75,7 @@ Here's some example apps:
         <br/><br/>
         <details>
           <summary>Quick start with <code>create-next-app</code></summary>
-          <code>yarn create-next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-todomvc trpc-todo</code>
+          <code>yarn create next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-todomvc trpc-todo</code>
         </details>
       </td>
       <td><a href="https://todomvc.trpc.io">todomvc.trpc.io</a></td>

--- a/www/docs/nextjs/starter-projects.md
+++ b/www/docs/nextjs/starter-projects.md
@@ -22,7 +22,7 @@ Get started quickly with one of the sample projects! Copy the snippet from _Quic
         <br/><br/>
         <details>
           <summary>Quick start with <code>create-next-app</code></summary>
-          <code>yarn create-next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-starter trpc-prisma-starter</code>
+          <code>yarn create next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-starter trpc-prisma-starter</code>
         </details>
       </td>
       <td><a href="https://nextjs.trpc.io">nextjs.trpc.io</a></td>
@@ -57,7 +57,7 @@ Get started quickly with one of the sample projects! Copy the snippet from _Quic
         <br/><br/>
         <details>
           <summary>Quick start with <code>create-next-app</code></summary>
-          <code>yarn create-next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-todomvc trpc-todo</code>
+          <code>yarn create next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-todomvc trpc-todo</code>
         </details>
       </td>
       <td><a href="https://todomvc.trpc.io">todomvc.trpc.io</a></td>


### PR DESCRIPTION
The syntax to use `create-next-app` with `yarn`, is `yarn create next-app` and not `yarn create-next-app` like it states in the docs.

Small typo but could definitely trip someone up if they weren't paying attention! 😄 