### PR TITLE
@typescript-eslint/no-floating-promises

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,8 @@
   ],
   "parserOptions": {
     "ecmaVersion": 2018, // Allows for the parsing of modern ECMAScript features
-    "sourceType": "module" // Allows for the use of imports
+    "sourceType": "module", // Allows for the use of imports
+    "project": "./tsconfig.eslint.json" // Allows for the use of rules which require parserServices to be generated
   },
   "rules": {
     // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
@@ -16,13 +17,21 @@
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "react/react-in-jsx-scope": "off",
     "react/prop-types": "off",
-    "@typescript-eslint/no-explicit-any": "off"
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-floating-promises": "error"
   },
   "overrides": [
     {
       "files": ["examples/**/*"],
       "rules": {
-        "@typescript-eslint/no-unused-vars": "off"
+        "@typescript-eslint/no-unused-vars": "off",
+        "@typescript-eslint/no-floating-promises": "off"
+      }
+    },
+    {
+      "files": ["**/test/**/*"],
+      "rules": {
+        "@typescript-eslint/no-floating-promises": "off"
       }
     }
   ],

--- a/packages/server/src/adapters/express.ts
+++ b/packages/server/src/adapters/express.ts
@@ -18,7 +18,7 @@ export function createExpressMiddleware<TRouter extends AnyRouter>(
   return (req, res) => {
     const endpoint = req.path.slice(1);
 
-    nodeHTTPRequestHandler({
+    void nodeHTTPRequestHandler({
       ...opts,
       req,
       res,

--- a/packages/server/src/adapters/fastify/fastifyRequestHandler.ts
+++ b/packages/server/src/adapters/fastify/fastifyRequestHandler.ts
@@ -72,8 +72,8 @@ export async function fastifyRequestHandler<
     if (typeof value === 'undefined') {
       continue;
     }
-    res.header(key, value);
+    void res.header(key, value);
   }
 
-  res.send(result.body);
+  void res.send(result.body);
 }

--- a/packages/server/src/adapters/fastify/fastifyTRPCPlugin.ts
+++ b/packages/server/src/adapters/fastify/fastifyTRPCPlugin.ts
@@ -32,7 +32,7 @@ export function fastifyTRPCPlugin<TRouter extends AnyRouter>(
 
   fastify.all(`${opts.prefix ?? ''}/:path`, (req, res) => {
     const path = (req.params as any).path;
-    fastifyRequestHandler({ ...opts.trpcOptions, req, res, path });
+    void fastifyRequestHandler({ ...opts.trpcOptions, req, res, path });
   });
 
   if (opts.useWSS) {

--- a/packages/server/src/adapters/ws.ts
+++ b/packages/server/src/adapters/ws.ts
@@ -285,7 +285,7 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
         });
       }
     }
-    createContextAsync();
+    void createContextAsync();
   });
 
   return {

--- a/packages/server/src/subscription.ts
+++ b/packages/server/src/subscription.ts
@@ -147,7 +147,7 @@ export function subscriptionPullFactory<TOutput>(opts: {
   }
 
   return new Subscription<TOutput>((emit) => {
-    _pull(emit);
+    void _pull(emit);
     return () => {
       clearTimeout(timer);
       stopped = true;

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "include": [".eslintrc", "**/*"],
+  "exclude": ["node_modules"],
+}


### PR DESCRIPTION
Added `@typescript-eslint/no-floating-promises` rule and resolved resulting errors. 

Closes https://github.com/trpc/trpc/issues/1577