### PR TITLE
bug: SSR hydration with error doesn't set status `error`

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "commit-date": "git log -n 1 --date=format:'%Y-%m-%d-%H-%M-%S' --pretty=format:'%ad'",
     "canary-preid": "echo \"$(yarn --silent current-branch)-$(yarn --silent commit-date)\"",
     "current-branch": "echo \"$(git rev-parse --abbrev-ref HEAD)\" | sed -E 's/refs\\/heads\\///' | sed -E 's/\\W|_/-/g' | sed -e 's/\\//-/'",
-    "publish-canary": "lerna publish --force-publish --canary --preid $(yarn --silent canary-preid) --dist-tag $(yarn --silent current-branch)"
+    "publish-canary": "lerna publish --force-publish --canary --preid $(yarn --silent canary-preid) --dist-tag $(yarn --silent current-branch)",
+    "publish-prerelease": "yarn && yarn lerna publish prerelease --force-publish --dist-tag experimental --no-push && sleep 60 && git push --follow-tags"
   },
   "dependencies": {
     "@babel/core": "^7.15.5",

--- a/packages/next/src/withTRPC.tsx
+++ b/packages/next/src/withTRPC.tsx
@@ -74,7 +74,7 @@ export function withTRPC<TRouter extends AnyRouter>(
     config: WithTRPCConfig<TRouter>;
     queryClient: QueryClient;
     trpcClient: TRPCClient<TRouter>;
-    isPrepass: true;
+    ssrState: 'prepass';
     ssrContext: NextPageContext;
   };
   return (AppOrPage: NextComponentType<any, any, any>): NextComponentType => {
@@ -85,7 +85,7 @@ export function withTRPC<TRouter extends AnyRouter>(
         trpc?: TRPCPrepassProps;
       },
     ) => {
-      const [{ queryClient, trpcClient, isPrepass, ssrContext }] = useState(
+      const [{ queryClient, trpcClient, ssrState, ssrContext }] = useState(
         () => {
           if (props.trpc) {
             return props.trpc;
@@ -96,7 +96,7 @@ export function withTRPC<TRouter extends AnyRouter>(
           return {
             queryClient,
             trpcClient,
-            isPrepass: false,
+            ssrState: opts.ssr ? ('mounting' as const) : (false as const),
             ssrContext: null,
           };
         },
@@ -111,9 +111,8 @@ export function withTRPC<TRouter extends AnyRouter>(
         <trpc.Provider
           client={trpcClient}
           queryClient={queryClient}
-          isPrepass={isPrepass}
+          ssrState={ssrState}
           ssrContext={ssrContext}
-          ssrEnabled={opts.ssr}
         >
           <QueryClientProvider client={queryClient}>
             <Hydrate state={hydratedState}>
@@ -163,7 +162,7 @@ export function withTRPC<TRouter extends AnyRouter>(
           config,
           trpcClient,
           queryClient,
-          isPrepass: true,
+          ssrState: 'prepass',
           ssrContext: ctx,
         };
         const prepassProps = {

--- a/packages/next/src/withTRPC.tsx
+++ b/packages/next/src/withTRPC.tsx
@@ -113,6 +113,7 @@ export function withTRPC<TRouter extends AnyRouter>(
           queryClient={queryClient}
           isPrepass={isPrepass}
           ssrContext={ssrContext}
+          ssrEnabled={opts.ssr}
         >
           <QueryClientProvider client={queryClient}>
             <Hydrate state={hydratedState}>

--- a/packages/next/src/withTRPC.tsx
+++ b/packages/next/src/withTRPC.tsx
@@ -113,7 +113,6 @@ export function withTRPC<TRouter extends AnyRouter>(
           queryClient={queryClient}
           isPrepass={isPrepass}
           ssrContext={ssrContext}
-          ssrEnabled={opts.ssr}
         >
           <QueryClientProvider client={queryClient}>
             <Hydrate state={hydratedState}>

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -252,14 +252,8 @@ export function createReactQueryHooks<
       TError
     >,
   ): UseQueryResult<TQueryValues[TPath]['output'], TError> {
-    const {
-      client,
-      isPrepass,
-      queryClient,
-      prefetchQuery,
-      ssrReady,
-      ssrEnabled,
-    } = useContext();
+    const { client, isPrepass, queryClient, prefetchQuery, ssrReady } =
+      useContext();
 
     if (
       typeof window === 'undefined' &&
@@ -275,13 +269,12 @@ export function createReactQueryHooks<
      * Hack to make sure errors return `status`='error` when doing SSR
      * @link https://github.com/trpc/trpc/pull/1645
      */
-    const actualOpts =
-      ssrEnabled && !ssrReady
-        ? {
-            retryOnMount: false,
-            ...opts,
-          }
-        : opts;
+    const actualOpts = !ssrReady
+      ? {
+          retryOnMount: false,
+          ...opts,
+        }
+      : opts;
     return __useQuery(
       pathAndInput as any,
       () => (client as any).query(...getClientArgs(pathAndInput, actualOpts)),
@@ -372,14 +365,8 @@ export function createReactQueryHooks<
     >,
   ): UseInfiniteQueryResult<TQueryValues[TPath]['output'], TError> {
     const [path, input] = pathAndInput;
-    const {
-      client,
-      isPrepass,
-      prefetchInfiniteQuery,
-      queryClient,
-      ssrEnabled,
-      ssrReady,
-    } = useContext();
+    const { client, isPrepass, prefetchInfiniteQuery, queryClient, ssrReady } =
+      useContext();
 
     if (
       typeof window === 'undefined' &&
@@ -395,13 +382,12 @@ export function createReactQueryHooks<
      * Hack to make sure errors return `status`='error` when doing SSR
      * @link https://github.com/trpc/trpc/pull/1645
      */
-    const actualOpts =
-      ssrEnabled && !ssrReady
-        ? {
-            retryOnMount: false,
-            ...opts,
-          }
-        : opts;
+    const actualOpts = !ssrReady
+      ? {
+          retryOnMount: false,
+          ...opts,
+        }
+      : opts;
 
     return __useInfiniteQuery(
       pathAndInput as any,

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -256,6 +256,7 @@ export function createReactQueryHooks<
   ): TQuery {
     const { queryClient, ssrEnabled } = useContext();
     const isMounted = useIsMounted();
+
     if (
       isMounted ||
       !query.error ||
@@ -264,8 +265,8 @@ export function createReactQueryHooks<
     ) {
       return query;
     }
-    query.status = 'error';
-    return query;
+
+    return { ...query, status: 'error' };
   }
   function useQuery<TPath extends keyof TQueryValues & string>(
     pathAndInput: [path: TPath, ...args: inferHandlerInput<TQueries[TPath]>],

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -270,7 +270,9 @@ export function createReactQueryHooks<
      * @link https://github.com/trpc/trpc/pull/1645
      */
     const actualOpts =
-      ssrState && ssrState !== 'mounted'
+      ssrState &&
+      ssrState !== 'mounted' &&
+      queryClient.getQueryCache().find(pathAndInput)?.state.status === 'error'
         ? {
             retryOnMount: false,
             ...opts,
@@ -384,7 +386,9 @@ export function createReactQueryHooks<
      * @link https://github.com/trpc/trpc/pull/1645
      */
     const actualOpts =
-      ssrState && ssrState !== 'mounted'
+      ssrState &&
+      ssrState !== 'mounted' &&
+      queryClient.getQueryCache().find(pathAndInput)?.state.status == 'error'
         ? {
             retryOnMount: false,
             ...opts,

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -259,11 +259,11 @@ export function createReactQueryHooks<
     // Checking if the hook is mounted ensures we are not getting hydration errors
     const isMounted = useIsMounted();
 
-    // Check that this query is
-    // - Isn't mounted on the client
-    // - Is an actual error
+    // Check that that the query:
+    // - isn't mounted yet on the client
+    // - has an error
     // - SSR is enabled
-    // - The query originated from a SSR prepass
+    // - it originated from a SSR prepass
     if (
       !isMounted &&
       query.error &&

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -124,14 +124,12 @@ export function createReactQueryHooks<
     children,
     isPrepass = false,
     ssrContext,
-    ssrEnabled = false,
   }: {
     queryClient: QueryClient;
     client: TRPCClient<TRouter>;
     children: ReactNode;
     isPrepass?: boolean;
     ssrContext?: TSSRContext | null;
-    ssrEnabled?: boolean;
   }) {
     return (
       <Context.Provider
@@ -140,7 +138,7 @@ export function createReactQueryHooks<
           client,
           isPrepass,
           ssrContext: ssrContext || null,
-          ssrEnabled,
+
           fetchQuery: useCallback(
             (pathAndInput, opts) => {
               return queryClient.fetchQuery(

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -126,7 +126,7 @@ export function createReactQueryHooks<
     ssrContext?: TSSRContext | null;
     ssrEnabled?: boolean;
   }) {
-    const [ssrReady, setSSRReady] = useState(() => !ssrEnabled);
+    const [ssrReady, setSSRReady] = useState(!ssrEnabled);
     useEffect(() => {
       setSSRReady(true);
     }, []);

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -127,6 +127,8 @@ export function createReactQueryHooks<
       props.ssrState || (props.isPrepass ? 'prepass' : false),
     );
     useEffect(() => {
+      // Only updating state to `mounted` if we are using SSR.
+      // This makes it so we don't have an unnecessary re-render when opting out of SSR.
       setSSRState((state) => (state ? 'mounted' : false));
     }, []);
     return (

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -273,13 +273,7 @@ export function createReactQueryHooks<
       opts?.enabled !== false &&
       !queryClient.getQueryCache().find(pathAndInput)
     ) {
-      prefetchQuery(pathAndInput as any, {
-        ...(opts as any),
-        meta: {
-          _trpcSSR: 1,
-          ...opts?.meta,
-        },
-      });
+      prefetchQuery(pathAndInput as any, opts as any);
     }
 
     /**
@@ -400,13 +394,7 @@ export function createReactQueryHooks<
       opts?.enabled !== false &&
       !queryClient.getQueryCache().find(pathAndInput)
     ) {
-      prefetchInfiniteQuery(pathAndInput as any, {
-        ...(opts as any),
-        meta: {
-          _trpcSSR: 1,
-          ...opts?.meta,
-        },
-      });
+      prefetchInfiniteQuery(pathAndInput as any, opts as any);
     }
 
     /**

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -126,9 +126,9 @@ export function createReactQueryHooks<
     ssrContext?: TSSRContext | null;
     ssrEnabled?: boolean;
   }) {
-    const [ssrReady, setssrReady] = useState(() => !ssrEnabled);
+    const [ssrReady, setSSRReady] = useState(() => !ssrEnabled);
     useEffect(() => {
-      setssrReady(true);
+      setSSRReady(true);
     }, []);
     return (
       <Context.Provider

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -90,14 +90,6 @@ type inferProcedures<TObj extends ProcedureRecord<any, any, any, any>> = {
   };
 };
 
-function useIsMounted() {
-  const [state, setState] = useState(false);
-  useEffect(() => {
-    setState(true);
-  }, []);
-  return state;
-}
-
 export function createReactQueryHooks<
   TRouter extends AnyRouter,
   TSSRContext = unknown,
@@ -134,7 +126,10 @@ export function createReactQueryHooks<
     ssrContext?: TSSRContext | null;
     ssrEnabled?: boolean;
   }) {
-    const isMounted = useIsMounted();
+    const [ssrReady, setssrReady] = useState(() => !ssrEnabled);
+    useEffect(() => {
+      setssrReady(true);
+    }, []);
     return (
       <Context.Provider
         value={{
@@ -143,7 +138,7 @@ export function createReactQueryHooks<
           isPrepass,
           ssrContext: ssrContext || null,
           ssrEnabled,
-          isMounted,
+          ssrReady,
           fetchQuery: useCallback(
             (pathAndInput, opts) => {
               return queryClient.fetchQuery(
@@ -262,7 +257,7 @@ export function createReactQueryHooks<
       isPrepass,
       queryClient,
       prefetchQuery,
-      isMounted,
+      ssrReady,
       ssrEnabled,
     } = useContext();
 
@@ -281,7 +276,7 @@ export function createReactQueryHooks<
      * @link https://github.com/trpc/trpc/pull/1645
      */
     const actualOpts =
-      ssrEnabled && !isMounted
+      ssrEnabled && !ssrReady
         ? {
             retryOnMount: false,
             ...opts,
@@ -383,7 +378,7 @@ export function createReactQueryHooks<
       prefetchInfiniteQuery,
       queryClient,
       ssrEnabled,
-      isMounted,
+      ssrReady,
     } = useContext();
 
     if (
@@ -401,7 +396,7 @@ export function createReactQueryHooks<
      * @link https://github.com/trpc/trpc/pull/1645
      */
     const actualOpts =
-      ssrEnabled && !isMounted
+      ssrEnabled && !ssrReady
         ? {
             retryOnMount: false,
             ...opts,

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -18,7 +18,6 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
-  useRef,
   useState,
 } from 'react';
 import {
@@ -284,9 +283,8 @@ export function createReactQueryHooks<
     const actualOpts =
       ssrEnabled && !isMounted
         ? {
-            ...opts,
-            retry: false,
             retryOnMount: false,
+            ...opts,
           }
         : opts;
     return __useQuery(

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -19,6 +19,7 @@ import React, {
   useEffect,
   useMemo,
   useRef,
+  useState,
 } from 'react';
 import {
   hashQueryKey,
@@ -91,11 +92,11 @@ type inferProcedures<TObj extends ProcedureRecord<any, any, any, any>> = {
 };
 
 function useIsMounted() {
-  const ref = useRef(false);
+  const [state, setState] = useState(false);
   useEffect(() => {
-    ref.current = true;
+    setState(true);
   }, []);
-  return ref.current;
+  return state;
 }
 
 export function createReactQueryHooks<

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -403,9 +403,8 @@ export function createReactQueryHooks<
     const actualOpts =
       ssrEnabled && !isMounted
         ? {
-            ...opts,
-            retry: false,
             retryOnMount: false,
+            ...opts,
           }
         : opts;
 

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -125,12 +125,14 @@ export function createReactQueryHooks<
     children,
     isPrepass = false,
     ssrContext,
+    ssrEnabled = false,
   }: {
     queryClient: QueryClient;
     client: TRPCClient<TRouter>;
     children: ReactNode;
     isPrepass?: boolean;
     ssrContext?: TSSRContext | null;
+    ssrEnabled?: boolean;
   }) {
     return (
       <Context.Provider
@@ -139,7 +141,7 @@ export function createReactQueryHooks<
           client,
           isPrepass,
           ssrContext: ssrContext || null,
-
+          ssrEnabled,
           fetchQuery: useCallback(
             (pathAndInput, opts) => {
               return queryClient.fetchQuery(
@@ -252,11 +254,12 @@ export function createReactQueryHooks<
     queryKey: unknown[],
     query: TQuery,
   ): TQuery {
-    const { queryClient } = useContext();
+    const { queryClient, ssrEnabled } = useContext();
     const isMounted = useIsMounted();
     if (
       isMounted ||
       !query.error ||
+      !ssrEnabled ||
       !queryClient.getQueryCache().find(queryKey)?.meta?._trpcSSR
     ) {
       return query;

--- a/packages/react/src/internals/context.tsx
+++ b/packages/react/src/internals/context.tsx
@@ -36,7 +36,6 @@ export interface TRPCContextState<
   client: TRPCClient<TRouter>;
   isPrepass: boolean;
   ssrContext: TSSRContext | null;
-  ssrEnabled: boolean;
 
   /**
    * @link https://react-query.tanstack.com/guides/prefetching

--- a/packages/react/src/internals/context.tsx
+++ b/packages/react/src/internals/context.tsx
@@ -41,8 +41,8 @@ export interface TRPCContextState<
   isPrepass: boolean;
   ssrContext: TSSRContext | null;
   /**
-   * State of SSR.
-   * - `false` if not using ssr.
+   * State of SSR hydration.
+   * - `false` if not using SSR.
    * - `prepass` when doing a prepass to fetch queries' data
    * - `mounting` before TRPCProvider has been rendered on the client
    * - `mounted` when the TRPCProvider has been rendered on the client

--- a/packages/react/src/internals/context.tsx
+++ b/packages/react/src/internals/context.tsx
@@ -41,7 +41,11 @@ export interface TRPCContextState<
   isPrepass: boolean;
   ssrContext: TSSRContext | null;
   /**
-   * State of SSR. `false` if not using ssr.
+   * State of SSR.
+   * - `false` if not using ssr.
+   * - `prepass` when doing a prepass to fetch queries' data
+   * - `mounting` before TRPCProvider has been rendered on the client
+   * - `mounted` when the TRPCProvider has been rendered on the client
    */
   ssrState: SSRState;
 

--- a/packages/react/src/internals/context.tsx
+++ b/packages/react/src/internals/context.tsx
@@ -28,20 +28,19 @@ interface TRPCFetchInfiniteQueryOptions<TInput, TError, TOutput>
   extends FetchInfiniteQueryOptions<TInput, TError, TOutput>,
     TRPCRequestOptions {}
 
+export type SSRState = false | 'prepass' | 'mounting' | 'mounted';
 export interface TRPCContextState<
   TRouter extends AnyRouter,
   TSSRContext = undefined,
 > {
   queryClient: QueryClient;
   client: TRPCClient<TRouter>;
+  /**
+   * @deprecated use `ssrState === 'prepass'`
+   */
   isPrepass: boolean;
   ssrContext: TSSRContext | null;
-  ssrEnabled: boolean;
-  /**
-   * Is SSR mounted & dehydrated?
-   * Will always be `true` if `ssrEnabled` isn't set to `true`.
-   */
-  ssrReady: boolean;
+  ssrState: SSRState;
 
   /**
    * @link https://react-query.tanstack.com/guides/prefetching

--- a/packages/react/src/internals/context.tsx
+++ b/packages/react/src/internals/context.tsx
@@ -40,6 +40,9 @@ export interface TRPCContextState<
    */
   isPrepass: boolean;
   ssrContext: TSSRContext | null;
+  /**
+   * State of SSR. `false` if not using ssr.
+   */
   ssrState: SSRState;
 
   /**

--- a/packages/react/src/internals/context.tsx
+++ b/packages/react/src/internals/context.tsx
@@ -37,7 +37,10 @@ export interface TRPCContextState<
   isPrepass: boolean;
   ssrContext: TSSRContext | null;
   ssrEnabled: boolean;
-  isMounted: boolean;
+  /**
+   * Is SSR mounted & dehydrated? Unlesss `ssrEnabled:` is true, this will always be `true`
+   */
+  ssrReady: boolean;
 
   /**
    * @link https://react-query.tanstack.com/guides/prefetching

--- a/packages/react/src/internals/context.tsx
+++ b/packages/react/src/internals/context.tsx
@@ -36,6 +36,7 @@ export interface TRPCContextState<
   client: TRPCClient<TRouter>;
   isPrepass: boolean;
   ssrContext: TSSRContext | null;
+  ssrEnabled: boolean;
 
   /**
    * @link https://react-query.tanstack.com/guides/prefetching

--- a/packages/react/src/internals/context.tsx
+++ b/packages/react/src/internals/context.tsx
@@ -38,7 +38,8 @@ export interface TRPCContextState<
   ssrContext: TSSRContext | null;
   ssrEnabled: boolean;
   /**
-   * Is SSR mounted & dehydrated? Unlesss `ssrEnabled:` is true, this will always be `true`
+   * Is SSR mounted & dehydrated?
+   * Will always be `true` if `ssrEnabled` isn't set to `true`.
    */
   ssrReady: boolean;
 

--- a/packages/react/src/internals/context.tsx
+++ b/packages/react/src/internals/context.tsx
@@ -37,6 +37,7 @@ export interface TRPCContextState<
   isPrepass: boolean;
   ssrContext: TSSRContext | null;
   ssrEnabled: boolean;
+  isMounted: boolean;
 
   /**
    * @link https://react-query.tanstack.com/guides/prefetching

--- a/packages/server/test/react.test.tsx
+++ b/packages/server/test/react.test.tsx
@@ -2030,7 +2030,7 @@ describe('setInfiniteQueryData()', () => {
 /**
  * @link https://github.com/trpc/trpc/pull/1645
  */
-test.only('regression ssr with error sets `status`=`error`', async () => {
+test('regression ssr with error sets `status`=`error`', async () => {
   // @ts-ignore
   const { window } = global;
 

--- a/packages/server/test/react.test.tsx
+++ b/packages/server/test/react.test.tsx
@@ -2039,16 +2039,19 @@ test('regression: SSR with error sets `status`=`error`', async () => {
   delete global.window;
   const { trpc, trpcClientOptions } = factory;
   const App: AppType = () => {
-    const query = trpc.useQuery(['bad-query'] as any, {
-      retry() {
-        return false;
-      },
-    });
+    const query1 = trpc.useQuery(['bad-useQuery'] as any);
+    const query2 = trpc.useInfiniteQuery(['bad-useInfiniteQuery'] as any);
     queryState = {
-      status: query.status,
-      error: query.error,
+      query1: {
+        status: query1.status,
+        error: query1.error,
+      },
+      query2: {
+        status: query2.status,
+        error: query2.error,
+      },
     };
-    return <>{JSON.stringify(query.data || null)}</>;
+    return <>{JSON.stringify(query1.data || null)}</>;
   };
 
   const Wrapped = withTRPC({
@@ -2063,8 +2066,12 @@ test('regression: SSR with error sets `status`=`error`', async () => {
 
   // @ts-ignore
   global.window = window;
-  expect(queryState.error).toMatchInlineSnapshot(
-    `[TRPCClientError: No "query"-procedure on path "bad-query"]`,
+  expect(queryState.query1.error).toMatchInlineSnapshot(
+    `[TRPCClientError: No "query"-procedure on path "bad-useQuery"]`,
   );
-  expect(queryState.status).toBe('error');
+  expect(queryState.query2.error).toMatchInlineSnapshot(
+    `[TRPCClientError: No "query"-procedure on path "bad-useInfiniteQuery"]`,
+  );
+  expect(queryState.query1.status).toBe('error');
+  expect(queryState.query2.status).toBe('error');
 });

--- a/packages/server/test/react.test.tsx
+++ b/packages/server/test/react.test.tsx
@@ -2030,7 +2030,7 @@ describe('setInfiniteQueryData()', () => {
 /**
  * @link https://github.com/trpc/trpc/pull/1645
  */
-test('regression ssr with error sets `status`=`error`', async () => {
+test('regression: SSR with error sets `status`=`error`', async () => {
   // @ts-ignore
   const { window } = global;
 

--- a/packages/server/test/react.test.tsx
+++ b/packages/server/test/react.test.tsx
@@ -1475,6 +1475,45 @@ describe('withTRPC()', () => {
     expect(utils.container).toHaveTextContent('first post');
   });
 
+  test('ssr with error sets `status`=`error`', async () => {
+    // @ts-ignore
+    const { window } = global;
+
+    let queryState: any;
+    // @ts-ignore
+    delete global.window;
+    const { trpc, trpcClientOptions } = factory;
+    const App: AppType = () => {
+      const query = trpc.useQuery(['bad-query'] as any, {
+        retry() {
+          return false;
+        },
+      });
+      queryState = {
+        status: query.status,
+        error: query.error,
+      };
+      return <>{JSON.stringify(query.data || null)}</>;
+    };
+
+    const Wrapped = withTRPC({
+      config: () => trpcClientOptions,
+      ssr: true,
+    })(App);
+
+    await Wrapped.getInitialProps!({
+      AppTree: Wrapped,
+      Component: <div />,
+    } as any);
+
+    // @ts-ignore
+    global.window = window;
+    expect(queryState.error).toMatchInlineSnapshot(
+      `[TRPCClientError: No "query"-procedure on path "bad-query"]`,
+    );
+    expect(queryState.status).toBe('error');
+  });
+
   test('useInfiniteQuery', async () => {
     const { window } = global;
 

--- a/packages/server/test/react.test.tsx
+++ b/packages/server/test/react.test.tsx
@@ -1475,45 +1475,6 @@ describe('withTRPC()', () => {
     expect(utils.container).toHaveTextContent('first post');
   });
 
-  test('ssr with error sets `status`=`error`', async () => {
-    // @ts-ignore
-    const { window } = global;
-
-    let queryState: any;
-    // @ts-ignore
-    delete global.window;
-    const { trpc, trpcClientOptions } = factory;
-    const App: AppType = () => {
-      const query = trpc.useQuery(['bad-query'] as any, {
-        retry() {
-          return false;
-        },
-      });
-      queryState = {
-        status: query.status,
-        error: query.error,
-      };
-      return <>{JSON.stringify(query.data || null)}</>;
-    };
-
-    const Wrapped = withTRPC({
-      config: () => trpcClientOptions,
-      ssr: true,
-    })(App);
-
-    await Wrapped.getInitialProps!({
-      AppTree: Wrapped,
-      Component: <div />,
-    } as any);
-
-    // @ts-ignore
-    global.window = window;
-    expect(queryState.error).toMatchInlineSnapshot(
-      `[TRPCClientError: No "query"-procedure on path "bad-query"]`,
-    );
-    expect(queryState.status).toBe('error');
-  });
-
   test('useInfiniteQuery', async () => {
     const { window } = global;
 
@@ -2064,4 +2025,46 @@ describe('setInfiniteQueryData()', () => {
       expect(utils.container).toHaveTextContent('infinitePosts.title2');
     });
   });
+});
+
+/**
+ * @link https://github.com/trpc/trpc/pull/1645
+ */
+test.only('regression ssr with error sets `status`=`error`', async () => {
+  // @ts-ignore
+  const { window } = global;
+
+  let queryState: any;
+  // @ts-ignore
+  delete global.window;
+  const { trpc, trpcClientOptions } = factory;
+  const App: AppType = () => {
+    const query = trpc.useQuery(['bad-query'] as any, {
+      retry() {
+        return false;
+      },
+    });
+    queryState = {
+      status: query.status,
+      error: query.error,
+    };
+    return <>{JSON.stringify(query.data || null)}</>;
+  };
+
+  const Wrapped = withTRPC({
+    config: () => trpcClientOptions,
+    ssr: true,
+  })(App);
+
+  await Wrapped.getInitialProps!({
+    AppTree: Wrapped,
+    Component: <div />,
+  } as any);
+
+  // @ts-ignore
+  global.window = window;
+  expect(queryState.error).toMatchInlineSnapshot(
+    `[TRPCClientError: No "query"-procedure on path "bad-query"]`,
+  );
+  expect(queryState.status).toBe('error');
 });


### PR DESCRIPTION
When server-side-rendering the status stays at `loading` even when the query fails.

Here's an awful hack because I'm unsure what else to do. Any other thing I can think of will lead to hydration warnings.. I could also dive into the `optimisticResults`-property of `react-query` to see if there's a way to trick it to become `error`.

### This PR:

- Adds a new `SSRState`-property
- Bypasses default options and defaults to `refetchOnMount: false` when hydrating SSR until it's been mounted on the client

### For more context

How we do the SSR prepass to enable SSR:

1. Run through the app tree until there are no pending queries: https://github.com/trpc/trpc/blob/f27680fe9ccc444da6282f3e118ba82c3b0b2095/packages/next/src/withTRPC.tsx#L173-L192
2. In each query hook, we call `prefetchQuery` when doing the prepass in order to fetch it on the server: https://github.com/trpc/trpc/blob/f27680fe9ccc444da6282f3e118ba82c3b0b2095/packages/react/src/createReactQueryHooks.tsx#L243-L251