### PR TITLE
remove tslib and "gitHead" field

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -41,6 +41,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "82bf01f8759b04f2ade69c9047e28f74f889d547"
+  }
 }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -56,6 +56,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "9ea5c1f180e83867c1dadf2d66b0212da2679f66"
+  }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -54,6 +54,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "gitHead": "9ea5c1f180e83867c1dadf2d66b0212da2679f66"
+  }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -70,8 +70,5 @@
     "yup": "^0.32.8",
     "zod": "^3.0.0"
   },
-  "gitHead": "82bf01f8759b04f2ade69c9047e28f74f889d547",
-  "dependencies": {
-    "tslib": "^2.1.0"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
`tslib` is an unused dependency (even in the `dist`) and `"gitHead"` is a property that is supposed to be temporary, created by lerna during the publish process (see lerna/lerna#1880).