### PR TITLE
Prevent @server test memory leaks due to improper teardown.

### DIFF
--- a/packages/server/test/_testHelpers.ts
+++ b/packages/server/test/_testHelpers.ts
@@ -79,7 +79,10 @@ export function routerToServerAndClient<TRouter extends AnyRouter>(
     close: async () => {
       await Promise.all([
         new Promise((resolve) => httpServer.server.close(resolve)),
-        new Promise((resolve) => wss.close(resolve)),
+        new Promise((resolve) => {
+          wss.clients.forEach((ws) => ws.close());
+          wss.close(resolve);
+        }),
       ]);
     },
     router,

--- a/packages/server/test/websockets.test.ts
+++ b/packages/server/test/websockets.test.ts
@@ -205,7 +205,7 @@ test('$subscription()', async () => {
   close();
 });
 
-test.skip('$subscription() - server randomly stop and restart (this test might be flaky, try re-running)', async () => {
+test('$subscription() - server randomly stop and restart', async () => {
   const { client, close, ee, wssPort, applyWSSHandlerOpts } = factory();
   ee.once('subscription:created', () => {
     setTimeout(() => {


### PR DESCRIPTION
### Issue: 
When running `yarn test` we generate the following warning due our wss clients not being closed before the server is closed. This is also causing some flakey tests.
```
A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them.
```
### Changes: 
* `_testHelpers.ts` - Close all clients before closing websocket server after each test
* `websockets.test.ts` - Enabled flakey websocket subscription test