### PR TITLE
Add output response parser

### DIFF
--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -74,16 +74,19 @@ function getClientArgs<TPathAndInput extends unknown[], TOptions>(
   return [path, input, opts] as const;
 }
 
-type inferInfiniteQueryNames<TObj extends ProcedureRecord<any, any, any, any>> =
-  {
-    [TPath in keyof TObj]: inferProcedureInput<TObj[TPath]> extends {
-      cursor?: any;
-    }
-      ? TPath
-      : never;
-  }[keyof TObj];
+type inferInfiniteQueryNames<
+  TObj extends ProcedureRecord<any, any, any, any, any, any>,
+> = {
+  [TPath in keyof TObj]: inferProcedureInput<TObj[TPath]> extends {
+    cursor?: any;
+  }
+    ? TPath
+    : never;
+}[keyof TObj];
 
-type inferProcedures<TObj extends ProcedureRecord<any, any, any, any>> = {
+type inferProcedures<
+  TObj extends ProcedureRecord<any, any, any, any, any, any>,
+> = {
   [TPath in keyof TObj]: {
     input: inferProcedureInput<TObj[TPath]>;
     output: inferProcedureOutput<TObj[TPath]>;

--- a/packages/server/src/internals/procedure.ts
+++ b/packages/server/src/internals/procedure.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { TRPCError } from '../TRPCError';
 import { assertNotBrowser } from '../assertNotBrowser';
 import { ProcedureType } from '../router';
-import { TRPCError } from '../TRPCError';
 import { getErrorFromUnknown } from './errors';
 import { MiddlewareFunction, middlewareMarker } from './middlewares';
 import { wrapCallSafe } from './wrapCallSafe';
+
 assertNotBrowser();
 
 export type ProcedureParserZodEsque<TInput, TOutput> = {
@@ -136,9 +137,6 @@ export class Procedure<
 
   private async parseOutput(rawOutput: TOutput): Promise<TFinalOutput> {
     try {
-      if (process.env.TRPC_SKIP_OUTPUT_VALIDATION) {
-        return rawOutput as any;
-      }
       return await this.parseOutputFn(rawOutput);
     } catch (cause) {
       throw new TRPCError({

--- a/packages/server/src/internals/procedure.ts
+++ b/packages/server/src/internals/procedure.ts
@@ -7,8 +7,8 @@ import { MiddlewareFunction, middlewareMarker } from './middlewares';
 import { wrapCallSafe } from './wrapCallSafe';
 assertNotBrowser();
 
-export type ProcedureParserZodEsque<TInput, TParsed> = {
-  _input: TInput;
+export type ProcedureParserZodEsque<T, TParsed> = {
+  _input: T;
   _output: TParsed;
 };
 
@@ -235,12 +235,11 @@ export class Procedure<
   }
 }
 
-export type CreateProcedureWithInput<TContext, TInput, TParsedInput, TOutput> =
-  {
-    input: ProcedureParser<TInput>;
-    output?: ProcedureParser<TOutput>;
-    resolve: ProcedureResolver<TContext, TParsedInput, TOutput>;
-  };
+export type CreateProcedureWithInput<TContext, TInput, TOutput> = {
+  input: ProcedureParser<TInput>;
+  output?: ProcedureParser<TOutput>;
+  resolve: ProcedureResolver<TContext, TInput, TOutput>;
+};
 
 export type CreateProcedureWithInputOutputParser<
   TContext,
@@ -281,7 +280,7 @@ export type CreateProcedureOptions<
       TOutput,
       TParsedOutput
     >
-  | CreateProcedureWithInput<TContext, TInput, TParsedInput, TOutput>
+  | CreateProcedureWithInput<TContext, TInput, TOutput>
   | CreateProcedureWithoutInput<TContext, TOutput, TParsedOutput>;
 
 export function createProcedure<

--- a/packages/server/src/internals/procedure.ts
+++ b/packages/server/src/internals/procedure.ts
@@ -7,9 +7,9 @@ import { MiddlewareFunction, middlewareMarker } from './middlewares';
 import { wrapCallSafe } from './wrapCallSafe';
 assertNotBrowser();
 
-export type ProcedureParserZodEsque<T, TParsed> = {
-  _input: T;
-  _output: TParsed;
+export type ProcedureParserZodEsque<TInput, TOutput> = {
+  _input: TInput;
+  _output: TOutput;
 };
 
 export type ProcedureParserMyZodEsque<T> = {
@@ -27,14 +27,15 @@ export type ProcedureParserCustomValidatorEsque<T> = (
 export type ProcedureParserYupEsque<T> = {
   validateSync: (input: unknown) => T;
 };
+
 export type ProcedureParser<T> =
   | ProcedureParserYupEsque<T>
   | ProcedureParserSuperstructEsque<T>
   | ProcedureParserCustomValidatorEsque<T>
   | ProcedureParserMyZodEsque<T>;
 
-export type ProcedureParserWithInputOutput<T, TParsed> =
-  ProcedureParserZodEsque<T, TParsed>;
+export type ProcedureParserWithInputOutput<TInput, TOutput> =
+  ProcedureParserZodEsque<TInput, TOutput>;
 
 export type ProcedureResolver<TContext, TParsedInput, TOutput> = (opts: {
   ctx: TContext;
@@ -249,7 +250,7 @@ export type CreateProcedureWithInputOutputParser<
   TParsedOutput,
 > = {
   input: ProcedureParserWithInputOutput<TInput, TParsedInput>;
-  output?: ProcedureParserWithInputOutput<TOutput, TParsedOutput>;
+  output?: ProcedureParserWithInputOutput<TParsedOutput, TOutput>;
   resolve: ProcedureResolver<
     TContext,
     TParsedInput,
@@ -258,7 +259,9 @@ export type CreateProcedureWithInputOutputParser<
 };
 
 export type CreateProcedureWithoutInput<TContext, TOutput, TParsedOutput> = {
-  output?: ProcedureParserWithInputOutput<TOutput, TParsedOutput>;
+  output?:
+    | ProcedureParserWithInputOutput<TParsedOutput, TOutput>
+    | ProcedureParser<TOutput>;
   resolve: ProcedureResolver<
     TContext,
     undefined,

--- a/packages/server/src/internals/procedure.ts
+++ b/packages/server/src/internals/procedure.ts
@@ -7,34 +7,34 @@ import { MiddlewareFunction, middlewareMarker } from './middlewares';
 import { wrapCallSafe } from './wrapCallSafe';
 assertNotBrowser();
 
-export type ProcedureInputParserZodEsque<TInput, TParsedInput> = {
+export type ProcedureParserZodEsque<TInput, TParsed> = {
   _input: TInput;
-  _output: TParsedInput;
+  _output: TParsed;
 };
 
-export type ProcedureInputParserMyZodEsque<TInput> = {
-  parse: (input: any) => TInput;
+export type ProcedureParserMyZodEsque<T> = {
+  parse: (input: any) => T;
 };
 
-export type ProcedureInputParserSuperstructEsque<TInput> = {
-  create: (input: unknown) => TInput;
+export type ProcedureParserSuperstructEsque<T> = {
+  create: (input: unknown) => T;
 };
 
-export type ProcedureInputParserCustomValidatorEsque<TInput> = (
+export type ProcedureParserCustomValidatorEsque<T> = (
   input: unknown,
-) => TInput | Promise<TInput>;
+) => T | Promise<T>;
 
-export type ProcedureInputParserYupEsque<TInput> = {
-  validateSync: (input: unknown) => TInput;
+export type ProcedureParserYupEsque<T> = {
+  validateSync: (input: unknown) => T;
 };
-export type ProcedureInputParser<TInput> =
-  | ProcedureInputParserYupEsque<TInput>
-  | ProcedureInputParserSuperstructEsque<TInput>
-  | ProcedureInputParserCustomValidatorEsque<TInput>
-  | ProcedureInputParserMyZodEsque<TInput>;
+export type ProcedureParser<T> =
+  | ProcedureParserYupEsque<T>
+  | ProcedureParserSuperstructEsque<T>
+  | ProcedureParserCustomValidatorEsque<T>
+  | ProcedureParserMyZodEsque<T>;
 
-export type ProcedureInputParserWithInputOutput<TInput, TParsedInput> =
-  ProcedureInputParserZodEsque<TInput, TParsedInput>;
+export type ProcedureParserWithInputOutput<T, TParsed> =
+  ProcedureParserZodEsque<T, TParsed>;
 
 export type ProcedureResolver<TContext, TParsedInput, TOutput> = (opts: {
   ctx: TContext;
@@ -45,7 +45,8 @@ export type ProcedureResolver<TContext, TParsedInput, TOutput> = (opts: {
 interface ProcedureOptions<TContext, TParsedInput, TOutput> {
   middlewares: Array<MiddlewareFunction<any, any>>;
   resolver: ProcedureResolver<TContext, TParsedInput, TOutput>;
-  inputParser: ProcedureInputParser<TParsedInput>;
+  inputParser: ProcedureParser<TParsedInput>;
+  outputParser: ProcedureParser<TOutput>;
 }
 
 /**
@@ -58,36 +59,33 @@ export interface ProcedureCallOptions<TContext> {
   type: ProcedureType;
 }
 
-type ParseFn<TParsedInput> = (
-  value: unknown,
-) => TParsedInput | Promise<TParsedInput>;
-function getParseFn<TParsedInput>(
-  inputParser: ProcedureInputParser<TParsedInput>,
-): ParseFn<TParsedInput> {
-  const parser = inputParser as any;
+type ParseFn<T> = (value: unknown) => T | Promise<T>;
+
+function getParseFn<T>(procedureParser: ProcedureParser<T>): ParseFn<T> {
+  const parser = procedureParser as any;
 
   if (typeof parser === 'function') {
-    // ProcedureInputParserCustomValidatorEsque
+    // ProcedureParserCustomValidatorEsque
     return parser;
   }
 
   if (typeof parser.parseAsync === 'function') {
-    // ProcedureInputParserZodEsque
+    // ProcedureParserZodEsque
     return parser.parseAsync.bind(parser);
   }
 
   if (typeof parser.parse === 'function') {
-    // ProcedureInputParserZodEsque
+    // ProcedureParserZodEsque
     return parser.parse.bind(parser);
   }
 
   if (typeof parser.validateSync === 'function') {
-    // ProcedureInputParserYupEsque
+    // ProcedureParserYupEsque
     return parser.validateSync.bind(parser);
   }
 
   if (typeof parser.create === 'function') {
-    // ProcedureInputParserSuperstructEsque
+    // ProcedureParserSuperstructEsque
     return parser.create.bind(parser);
   }
 
@@ -97,22 +95,33 @@ function getParseFn<TParsedInput>(
 /**
  * @internal
  */
-export class Procedure<TInputContext, TContext, TInput, TParsedInput, TOutput> {
+export class Procedure<
+  TInputContext,
+  TContext,
+  TInput,
+  TParsedInput,
+  TOutput,
+  TParsedOutput,
+> {
   private middlewares: Readonly<Array<MiddlewareFunction<any, any>>>;
   private resolver: ProcedureResolver<TContext, TParsedInput, TOutput>;
-  private readonly inputParser: ProcedureInputParser<TParsedInput>;
-  private parse: ParseFn<TParsedInput>;
+  private readonly inputParser: ProcedureParser<TParsedInput>;
+  private parseInputFn: ParseFn<TParsedInput>;
+  private readonly outputParser: ProcedureParser<TOutput>;
+  private parseOutputFn: ParseFn<TOutput>;
 
   constructor(opts: ProcedureOptions<TContext, TParsedInput, TOutput>) {
     this.middlewares = opts.middlewares;
     this.resolver = opts.resolver;
     this.inputParser = opts.inputParser;
-    this.parse = getParseFn(this.inputParser);
+    this.parseInputFn = getParseFn(this.inputParser);
+    this.outputParser = opts.outputParser;
+    this.parseOutputFn = getParseFn(this.outputParser);
   }
 
   private async parseInput(rawInput: unknown): Promise<TParsedInput> {
     try {
-      return await this.parse(rawInput);
+      return await this.parseInputFn(rawInput);
     } catch (cause) {
       throw new TRPCError({
         code: 'BAD_REQUEST',
@@ -121,8 +130,23 @@ export class Procedure<TInputContext, TContext, TInput, TParsedInput, TOutput> {
     }
   }
 
+  private async parseOutput(rawOutput: unknown): Promise<TOutput> {
+    try {
+      if (process.env.TRPC_SKIP_OUTPUT_VALIDATION) {
+        return rawOutput as TOutput;
+      }
+      return await this.parseOutputFn(rawOutput);
+    } catch (cause) {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        cause,
+        message: 'Output validation failed',
+      });
+    }
+  }
+
   /**
-   * Trigger middlewares in order, parse raw input & call resolver
+   * Trigger middlewares in order, parse raw input, call resolver & parse raw output
    * @internal
    */
   public async call(
@@ -132,7 +156,8 @@ export class Procedure<TInputContext, TContext, TInput, TParsedInput, TOutput> {
     const middlewaresWithResolver = this.middlewares.concat([
       async ({ ctx }: { ctx: TContext }) => {
         const input = await this.parseInput(opts.rawInput);
-        const data = await this.resolver({ ...opts, ctx, input });
+        const rawOutput = await this.resolver({ ...opts, ctx, input });
+        const data = await this.parseOutput(rawOutput);
         return {
           marker: middlewareMarker,
           ok: true,
@@ -194,7 +219,8 @@ export class Procedure<TInputContext, TContext, TInput, TParsedInput, TOutput> {
         TContext,
         TInput,
         TParsedInput,
-        TOutput
+        TOutput,
+        TParsedOutput
       >;
     } = (this as any).constructor;
 
@@ -202,6 +228,7 @@ export class Procedure<TInputContext, TContext, TInput, TParsedInput, TOutput> {
       middlewares: [...middlewares, ...this.middlewares],
       resolver: this.resolver,
       inputParser: this.inputParser,
+      outputParser: this.outputParser,
     });
 
     return instance as any;
@@ -210,20 +237,34 @@ export class Procedure<TInputContext, TContext, TInput, TParsedInput, TOutput> {
 
 export type CreateProcedureWithInput<TContext, TInput, TParsedInput, TOutput> =
   {
-    input: ProcedureInputParser<TInput>;
+    input: ProcedureParser<TInput>;
+    output?: ProcedureParser<TOutput>;
     resolve: ProcedureResolver<TContext, TParsedInput, TOutput>;
   };
+
 export type CreateProcedureWithInputOutputParser<
   TContext,
   TInput,
   TParsedInput,
   TOutput,
+  TParsedOutput,
 > = {
-  input: ProcedureInputParserWithInputOutput<TInput, TParsedInput>;
-  resolve: ProcedureResolver<TContext, TParsedInput, TOutput>;
+  input: ProcedureParserWithInputOutput<TInput, TParsedInput>;
+  output?: ProcedureParserWithInputOutput<TOutput, TParsedOutput>;
+  resolve: ProcedureResolver<
+    TContext,
+    TParsedInput,
+    unknown extends TParsedOutput ? TOutput : TParsedOutput
+  >;
 };
-export type CreateProcedureWithoutInput<TContext, TOutput> = {
-  resolve: ProcedureResolver<TContext, undefined, TOutput>;
+
+export type CreateProcedureWithoutInput<TContext, TOutput, TParsedOutput> = {
+  output?: ProcedureParserWithInputOutput<TOutput, TParsedOutput>;
+  resolve: ProcedureResolver<
+    TContext,
+    undefined,
+    unknown extends TParsedOutput ? TOutput : TParsedOutput
+  >;
 };
 
 export type CreateProcedureOptions<
@@ -231,19 +272,33 @@ export type CreateProcedureOptions<
   TInput = undefined,
   TParsedInput = undefined,
   TOutput = undefined,
+  TParsedOutput = undefined,
 > =
-  | CreateProcedureWithInput<TContext, TInput, TParsedInput, TOutput>
   | CreateProcedureWithInputOutputParser<
       TContext,
       TInput,
       TParsedInput,
-      TOutput
+      TOutput,
+      TParsedOutput
     >
-  | CreateProcedureWithoutInput<TContext, TOutput>;
+  | CreateProcedureWithInput<TContext, TInput, TParsedInput, TOutput>
+  | CreateProcedureWithoutInput<TContext, TOutput, TParsedOutput>;
 
-export function createProcedure<TContext, TInput, TParsedInput, TOutput>(
-  opts: CreateProcedureOptions<TContext, TInput, TParsedInput, TOutput>,
-): Procedure<unknown, TContext, TInput, TParsedInput, TOutput> {
+export function createProcedure<
+  TContext,
+  TInput,
+  TParsedInput,
+  TOutput,
+  TParsedOutput,
+>(
+  opts: CreateProcedureOptions<
+    TContext,
+    TInput,
+    TParsedInput,
+    TOutput,
+    TParsedOutput
+  >,
+): Procedure<unknown, TContext, TInput, TParsedInput, TOutput, TParsedOutput> {
   const inputParser =
     'input' in opts
       ? opts.input
@@ -257,27 +312,35 @@ export function createProcedure<TContext, TInput, TParsedInput, TOutput>(
           return undefined;
         };
 
+  const outputParser =
+    'output' in opts && opts.output
+      ? opts.output
+      : (output: unknown) => output as TOutput;
+
   return new Procedure({
     inputParser: inputParser as any,
     resolver: opts.resolve as any,
     middlewares: [],
+    outputParser: outputParser as any,
   });
 }
 
 export type inferProcedureFromOptions<
   TInputContext,
-  TOptions extends CreateProcedureOptions<any, any, any, any>,
+  TOptions extends CreateProcedureOptions<any, any, any, any, any>,
 > = TOptions extends CreateProcedureOptions<
   infer TContext,
   infer TInput,
   infer TParsedInput,
-  infer TOutput
+  infer TOutput,
+  infer TParsedOutput
 >
   ? Procedure<
       TInputContext,
       TContext,
       unknown extends TInput ? undefined : TInput,
       unknown extends TParsedInput ? undefined : TParsedInput,
-      TOutput
+      TOutput,
+      TParsedOutput
     >
   : never;

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -331,7 +331,7 @@ export class Router<
 
   public query<TPath extends string, TInput, TOutput>(
     path: TPath,
-    procedure: CreateProcedureWithInput<TContext, TInput, TInput, TOutput>,
+    procedure: CreateProcedureWithInput<TContext, TInput, TOutput>,
   ): Router<
     TInputContext,
     TContext,
@@ -395,7 +395,7 @@ export class Router<
 
   public mutation<TPath extends string, TInput, TOutput>(
     path: TPath,
-    procedure: CreateProcedureWithInput<TContext, TInput, TInput, TOutput>,
+    procedure: CreateProcedureWithInput<TContext, TInput, TOutput>,
   ): Router<
     TInputContext,
     TContext,
@@ -440,15 +440,17 @@ export class Router<
     TInput,
     TParsedInput,
     TOutput extends Subscription<unknown>,
-    TParsedOutput,
   >(
     path: TPath,
-    procedure: CreateProcedureWithInputOutputParser<
-      TContext,
-      TInput,
-      TParsedInput,
-      TOutput,
-      TParsedOutput
+    procedure: Omit<
+      CreateProcedureWithInputOutputParser<
+        TContext,
+        TInput,
+        TParsedInput,
+        TOutput,
+        unknown
+      >,
+      'output'
     >,
   ): Router<
     TInputContext,
@@ -469,7 +471,10 @@ export class Router<
     TOutput extends Subscription<unknown>,
   >(
     path: TPath,
-    procedure: CreateProcedureWithInput<TContext, TInput, TInput, TOutput>,
+    procedure: Omit<
+      CreateProcedureWithInput<TContext, TInput, TOutput>,
+      'output'
+    >,
   ): Router<
     TInputContext,
     TContext,
@@ -486,10 +491,12 @@ export class Router<
   public subscription<
     TPath extends string,
     TOutput extends Subscription<unknown>,
-    TParsedOutput,
   >(
     path: TPath,
-    procedure: CreateProcedureWithoutInput<TContext, TOutput, TParsedOutput>,
+    procedure: Omit<
+      CreateProcedureWithoutInput<TContext, TOutput, unknown>,
+      'output'
+    >,
   ): Router<
     TInputContext,
     TContext,
@@ -502,7 +509,10 @@ export class Router<
 
   public subscription(
     path: string,
-    procedure: CreateProcedureOptions<TContext, any, any, any, any>, // TODO: omit "output"
+    procedure: Omit<
+      CreateProcedureOptions<TContext, any, any, any, any>,
+      'output'
+    >,
   ) {
     const router = new Router<TContext, TContext, {}, {}, any, any>({
       subscriptions: safeObject({

--- a/packages/server/test/inference.test.ts
+++ b/packages/server/test/inference.test.ts
@@ -6,18 +6,45 @@ import { inferProcedureInput, inferProcedureOutput } from '../src';
 test('infer input & output', async () => {
   const router = trpc
     .router()
-    .query('withInput', {
-      input: z.string(),
+    .query('noInput', {
       async resolve({ input }) {
         return { input };
       },
     })
-    .query('noInput', {
+    .query('withInput', {
+      input: z.string(),
+      output: z.object({
+        input: z.string(),
+      }),
+      async resolve({ input }) {
+        return { input };
+      },
+    })
+    .query('withOutput', {
+      output: z.object({
+        input: z.string(),
+      }),
+      // @ts-expect-error - ensure type inferred from "output" is expected as resolve fn return type
+      async resolve({ input }) {
+        return { input };
+      },
+    })
+    .query('withInputOutput', {
+      input: z.string(),
+      output: z.object({
+        input: z.string(),
+      }),
       async resolve({ input }) {
         return { input };
       },
     });
   type TQueries = typeof router['_def']['queries'];
+  {
+    const input: inferProcedureInput<TQueries['noInput']> = null as any;
+    const output: inferProcedureOutput<TQueries['noInput']> = null as any;
+    expectTypeOf(input).toMatchTypeOf<undefined | null | void>();
+    expectTypeOf(output).toMatchTypeOf<{ input: undefined }>();
+  }
   {
     const input: inferProcedureInput<TQueries['withInput']> = null as any;
     const output: inferProcedureOutput<TQueries['withInput']> = null as any;
@@ -25,9 +52,16 @@ test('infer input & output', async () => {
     expectTypeOf(output).toMatchTypeOf<{ input: string }>();
   }
   {
-    const input: inferProcedureInput<TQueries['noInput']> = null as any;
-    const output: inferProcedureOutput<TQueries['noInput']> = null as any;
+    const input: inferProcedureInput<TQueries['withOutput']> = null as any;
+    const output: inferProcedureOutput<TQueries['withOutput']> = null as any;
     expectTypeOf(input).toMatchTypeOf<undefined | null | void>();
-    expectTypeOf(output).toMatchTypeOf<{ input: undefined }>();
+    expectTypeOf(output).toMatchTypeOf<{ input: string }>();
+  }
+  {
+    const input: inferProcedureInput<TQueries['withInputOutput']> = null as any;
+    const output: inferProcedureOutput<TQueries['withInputOutput']> =
+      null as any;
+    expectTypeOf(input).toMatchTypeOf<string>();
+    expectTypeOf(output).toMatchTypeOf<{ input: string }>();
   }
 });

--- a/packages/server/test/inference.test.ts
+++ b/packages/server/test/inference.test.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import * as trpc from '../src';
 import { inferProcedureInput, inferProcedureOutput } from '../src';
 
-test('infer input & output', async () => {
+test('infer query input & output', async () => {
   const router = trpc
     .router()
     .query('noInput', {
@@ -24,7 +24,7 @@ test('infer input & output', async () => {
       output: z.object({
         input: z.string(),
       }),
-      // @ts-expect-error - ensure type inferred from "output" is expected as resolve fn return type
+      // @ts-expect-error - ensure type inferred from "output" is expected as "resolve" fn return type
       async resolve({ input }) {
         return { input };
       },
@@ -63,5 +63,119 @@ test('infer input & output', async () => {
       null as any;
     expectTypeOf(input).toMatchTypeOf<string>();
     expectTypeOf(output).toMatchTypeOf<{ input: string }>();
+  }
+});
+
+test('infer mutation input & output', async () => {
+  const router = trpc
+    .router()
+    .mutation('noInput', {
+      async resolve({ input }) {
+        return { input };
+      },
+    })
+    .mutation('withInput', {
+      input: z.string(),
+      output: z.object({
+        input: z.string(),
+      }),
+      async resolve({ input }) {
+        return { input };
+      },
+    })
+    .mutation('withOutput', {
+      output: z.object({
+        input: z.string(),
+      }),
+      // @ts-expect-error - ensure type inferred from "output" is expected as "resolve" fn return type
+      async resolve({ input }) {
+        return { input };
+      },
+    })
+    .mutation('withInputOutput', {
+      input: z.string(),
+      output: z.object({
+        input: z.string(),
+      }),
+      async resolve({ input }) {
+        return { input };
+      },
+    });
+  type TMutations = typeof router['_def']['mutations'];
+  {
+    const input: inferProcedureInput<TMutations['noInput']> = null as any;
+    const output: inferProcedureOutput<TMutations['noInput']> = null as any;
+    expectTypeOf(input).toMatchTypeOf<undefined | null | void>();
+    expectTypeOf(output).toMatchTypeOf<{ input: undefined }>();
+  }
+  {
+    const input: inferProcedureInput<TMutations['withInput']> = null as any;
+    const output: inferProcedureOutput<TMutations['withInput']> = null as any;
+    expectTypeOf(input).toMatchTypeOf<string>();
+    expectTypeOf(output).toMatchTypeOf<{ input: string }>();
+  }
+  {
+    const input: inferProcedureInput<TMutations['withOutput']> = null as any;
+    const output: inferProcedureOutput<TMutations['withOutput']> = null as any;
+    expectTypeOf(input).toMatchTypeOf<undefined | null | void>();
+    expectTypeOf(output).toMatchTypeOf<{ input: string }>();
+  }
+  {
+    const input: inferProcedureInput<TMutations['withInputOutput']> =
+      null as any;
+    const output: inferProcedureOutput<TMutations['withInputOutput']> =
+      null as any;
+    expectTypeOf(input).toMatchTypeOf<string>();
+    expectTypeOf(output).toMatchTypeOf<{ input: string }>();
+  }
+});
+
+test('infer subscription input & output', async () => {
+  // @ts-expect-error - ensure "output" is omitted in subscription procedure
+  const router = trpc
+    .router()
+    .subscription('noSubscription', {
+      // @ts-expect-error - ensure Subscription is expected as "resolve" fn return type
+      async resolve({ input }) {
+        return { input };
+      },
+    })
+    .subscription('noInput', {
+      async resolve({ input }) {
+        return new trpc.Subscription(() => () => null);
+      },
+    })
+    .subscription('withInput', {
+      input: z.string(),
+      async resolve({ input }) {
+        return new trpc.Subscription<typeof input>((emit) => {
+          emit.data(input);
+          return () => null;
+        });
+      },
+    })
+    .subscription('withOutput', {
+      input: z.string(),
+      output: z.null(),
+      async resolve({ input }) {
+        return new trpc.Subscription<typeof input>((emit) => {
+          emit.data(input);
+          return () => null;
+        });
+      },
+    });
+  type TSubscriptions = typeof router['_def']['subscriptions'];
+  {
+    const input: inferProcedureInput<TSubscriptions['noInput']> = null as any;
+    const output: inferProcedureOutput<TSubscriptions['noInput']> = null as any;
+    expectTypeOf(input).toMatchTypeOf<undefined | null | void>();
+    expectTypeOf(output).toMatchTypeOf<trpc.Subscription<unknown>>();
+  }
+  {
+    const input: inferProcedureInput<TSubscriptions['withInput']> = null as any;
+    const output: inferProcedureOutput<TSubscriptions['withInput']> =
+      null as any;
+    expectTypeOf(input).toMatchTypeOf<string>();
+    expectTypeOf(output).toMatchTypeOf<trpc.Subscription<string>>();
   }
 });

--- a/packages/server/test/inference.test.ts
+++ b/packages/server/test/inference.test.ts
@@ -141,7 +141,7 @@ test('infer subscription input & output', async () => {
       },
     })
     .subscription('noInput', {
-      async resolve({ input }) {
+      async resolve() {
         return new trpc.Subscription(() => () => null);
       },
     })

--- a/packages/server/test/outputParser.test.ts
+++ b/packages/server/test/outputParser.test.ts
@@ -26,6 +26,7 @@ test('zod', async () => {
       "input": "foobar",
     }
   `);
+
   await expect(client.query('q', 1234)).rejects.toMatchInlineSnapshot(
     `[TRPCClientError: Output validation failed]`,
   );
@@ -54,6 +55,7 @@ test('zod async', async () => {
       "input": "foobar",
     }
   `);
+
   await expect(client.query('q', 1234)).rejects.toMatchInlineSnapshot(
     `[TRPCClientError: Output validation failed]`,
   );
@@ -80,6 +82,7 @@ test('zod transform', async () => {
       "input": 6,
     }
   `);
+
   await expect(client.query('q', 1234)).rejects.toMatchInlineSnapshot(
     `[TRPCClientError: Output validation failed]`,
   );
@@ -106,6 +109,7 @@ test('superstruct', async () => {
       "input": "foobar",
     }
   `);
+
   await expect(client.query('q', 1234)).rejects.toMatchInlineSnapshot(
     `[TRPCClientError: Output validation failed]`,
   );
@@ -143,6 +147,7 @@ test('yup', async () => {
       "input": "foobar",
     }
   `);
+
   await expect(client.query('q', 1234)).rejects.toMatchInlineSnapshot(
     `[TRPCClientError: Output validation failed]`,
   );
@@ -169,6 +174,7 @@ test('myzod', async () => {
       "input": "foobar",
     }
   `);
+
   await expect(client.query('q', 1234)).rejects.toMatchInlineSnapshot(
     `[TRPCClientError: Output validation failed]`,
   );
@@ -198,6 +204,7 @@ test('validator fn', async () => {
       "input": "foobar",
     }
   `);
+
   await expect(client.query('q', 1234)).rejects.toMatchInlineSnapshot(
     `[TRPCClientError: Output validation failed]`,
   );
@@ -208,9 +215,9 @@ test('validator fn', async () => {
 test('async validator fn', async () => {
   const router = trpc.router().query('q', {
     input: (value: unknown) => value as string | number,
-    output: async (value: unknown): Promise<{ input: string }> => {
-      if (typeof (value as any).input === 'string') {
-        return value as any;
+    output: async (value: any): Promise<{ input: string }> => {
+      if (value && typeof value.input === 'string') {
+        return { input: value.input };
       }
       throw new Error('Fail');
     },
@@ -227,6 +234,7 @@ test('async validator fn', async () => {
       "input": "foobar",
     }
   `);
+
   await expect(client.query('q', 1234)).rejects.toMatchInlineSnapshot(
     `[TRPCClientError: Output validation failed]`,
   );

--- a/packages/server/test/outputParser.test.ts
+++ b/packages/server/test/outputParser.test.ts
@@ -1,5 +1,17 @@
-describe('output parser', () => {
-  describe('inference', () => {});
-  describe('validators', () => {});
-  describe('transformer', () => {});
+describe('output response parser', () => {
+  describe('inference', () => {
+    test('todo', () => {
+      expect(true).toBe(true);
+    });
+  });
+  describe('validators', () => {
+    test('todo', () => {
+      expect(true).toBe(true);
+    });
+  });
+  describe('transformer', () => {
+    test('todo', () => {
+      expect(true).toBe(true);
+    });
+  });
 });

--- a/packages/server/test/outputParser.test.ts
+++ b/packages/server/test/outputParser.test.ts
@@ -1,0 +1,5 @@
+describe('output parser', () => {
+  describe('inference', () => {});
+  describe('validators', () => {});
+  describe('transformer', () => {});
+});

--- a/packages/server/test/outputParser.test.ts
+++ b/packages/server/test/outputParser.test.ts
@@ -1,17 +1,235 @@
-describe('output response parser', () => {
-  describe('inference', () => {
-    test('todo', () => {
-      expect(true).toBe(true);
-    });
+import '@testing-library/jest-dom';
+import { expectTypeOf } from 'expect-type';
+import myzod from 'myzod';
+import * as yup from 'yup';
+import * as t from 'superstruct';
+import { z } from 'zod';
+import * as trpc from '../src';
+import { routerToServerAndClient } from './_testHelpers';
+
+test('zod', async () => {
+  const router = trpc.router().query('q', {
+    input: z.string().or(z.number()),
+    output: z.object({
+      input: z.string(),
+    }),
+    resolve({ input }) {
+      return { input: input as string };
+    },
   });
-  describe('validators', () => {
-    test('todo', () => {
-      expect(true).toBe(true);
-    });
+  const { client, close } = routerToServerAndClient(router);
+
+  const output = await client.query('q', 'foobar');
+  expectTypeOf(output.input).toBeString();
+  expect(output).toMatchInlineSnapshot(`
+    Object {
+      "input": "foobar",
+    }
+  `);
+  await expect(client.query('q', 1234)).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: Output validation failed]`,
+  );
+
+  close();
+});
+
+test('zod async', async () => {
+  const router = trpc.router().query('q', {
+    input: z.string().or(z.number()),
+    output: z
+      .object({
+        input: z.string(),
+      })
+      .refine(async (value) => !!value),
+    resolve({ input }) {
+      return { input: input as string };
+    },
   });
-  describe('transformer', () => {
-    test('todo', () => {
-      expect(true).toBe(true);
-    });
+  const { client, close } = routerToServerAndClient(router);
+
+  const output = await client.query('q', 'foobar');
+  expectTypeOf(output.input).toBeString();
+  expect(output).toMatchInlineSnapshot(`
+    Object {
+      "input": "foobar",
+    }
+  `);
+  await expect(client.query('q', 1234)).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: Output validation failed]`,
+  );
+
+  close();
+});
+
+test('zod transform', async () => {
+  const router = trpc.router().query('q', {
+    input: z.string().or(z.number()),
+    output: z.object({
+      input: z.string().transform((s) => s.length),
+    }),
+    resolve({ input }) {
+      return { input: input as string };
+    },
   });
+  const { client, close } = routerToServerAndClient(router);
+
+  const output = await client.query('q', 'foobar');
+  expectTypeOf(output.input).toBeNumber();
+  expect(output).toMatchInlineSnapshot(`
+    Object {
+      "input": 6,
+    }
+  `);
+  await expect(client.query('q', 1234)).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: Output validation failed]`,
+  );
+
+  close();
+});
+
+test('superstruct', async () => {
+  const router = trpc.router().query('q', {
+    input: t.union([t.string(), t.number()]),
+    output: t.object({
+      input: t.string(),
+    }),
+    resolve({ input }) {
+      return { input: input as string };
+    },
+  });
+  const { client, close } = routerToServerAndClient(router);
+
+  const output = await client.query('q', 'foobar');
+  expectTypeOf(output.input).toBeString();
+  expect(output).toMatchInlineSnapshot(`
+    Object {
+      "input": "foobar",
+    }
+  `);
+  await expect(client.query('q', 1234)).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: Output validation failed]`,
+  );
+
+  close();
+});
+
+test('yup', async () => {
+  const yupStringOrNumber = (value: unknown) => {
+    switch (typeof value) {
+      case 'number':
+        return yup.number().required();
+      case 'string':
+        return yup.string().required();
+      default:
+        throw new Error('Fail');
+    }
+  };
+
+  const router = trpc.router().query('q', {
+    input: yup.lazy(yupStringOrNumber),
+    output: yup.object({
+      input: yup.string().strict().required(),
+    }),
+    resolve({ input }) {
+      return { input: input as string };
+    },
+  });
+  const { client, close } = routerToServerAndClient(router);
+
+  const output = await client.query('q', 'foobar');
+  expectTypeOf(output.input).toBeString();
+  expect(output).toMatchInlineSnapshot(`
+    Object {
+      "input": "foobar",
+    }
+  `);
+  await expect(client.query('q', 1234)).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: Output validation failed]`,
+  );
+
+  close();
+});
+
+test('myzod', async () => {
+  const router = trpc.router().query('q', {
+    input: myzod.string().or(myzod.number()),
+    output: myzod.object({
+      input: myzod.string(),
+    }),
+    resolve({ input }) {
+      return { input: input as string };
+    },
+  });
+  const { client, close } = routerToServerAndClient(router);
+
+  const output = await client.query('q', 'foobar');
+  expectTypeOf(output.input).toBeString();
+  expect(output).toMatchInlineSnapshot(`
+    Object {
+      "input": "foobar",
+    }
+  `);
+  await expect(client.query('q', 1234)).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: Output validation failed]`,
+  );
+
+  close();
+});
+
+test('validator fn', async () => {
+  const router = trpc.router().query('q', {
+    input: (value: unknown) => value as string | number,
+    output: (value: unknown) => {
+      if (typeof (value as any).input === 'string') {
+        return value as { input: string };
+      }
+      throw new Error('Fail');
+    },
+    resolve({ input }) {
+      return { input: input as string };
+    },
+  });
+  const { client, close } = routerToServerAndClient(router);
+
+  const output = await client.query('q', 'foobar');
+  expectTypeOf(output.input).toBeString();
+  expect(output).toMatchInlineSnapshot(`
+    Object {
+      "input": "foobar",
+    }
+  `);
+  await expect(client.query('q', 1234)).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: Output validation failed]`,
+  );
+
+  close();
+});
+
+test('async validator fn', async () => {
+  const router = trpc.router().query('q', {
+    input: (value: unknown) => value as string | number,
+    output: async (value: unknown): Promise<{ input: string }> => {
+      if (typeof (value as any).input === 'string') {
+        return value as any;
+      }
+      throw new Error('Fail');
+    },
+    resolve({ input }) {
+      return { input: input as string };
+    },
+  });
+  const { client, close } = routerToServerAndClient(router);
+
+  const output = await client.query('q', 'foobar');
+  expectTypeOf(output.input).toBeString();
+  expect(output).toMatchInlineSnapshot(`
+    Object {
+      "input": "foobar",
+    }
+  `);
+  await expect(client.query('q', 1234)).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: Output validation failed]`,
+  );
+
+  close();
 });

--- a/packages/server/test/validators.test.ts
+++ b/packages/server/test/validators.test.ts
@@ -128,51 +128,6 @@ test('zod transform mixed input/output', async () => {
   close();
 });
 
-test('zod transform output mixed input/output', async () => {
-  const input = z.object({
-    length: z.string().transform((s) => s.length),
-  });
-
-  const router = trpc.router().query('num', {
-    input: input,
-    resolve({ input }) {
-      expectTypeOf(input.length).toBeNumber();
-      return {
-        input,
-      };
-    },
-  });
-  const { client, close } = routerToServerAndClient(router);
-
-  await expect(client.query('num', { length: '123' })).resolves
-    .toMatchInlineSnapshot(`
-          Object {
-            "input": Object {
-              "length": 3,
-            },
-          }
-        `);
-
-  await expect(
-    // @ts-expect-error this should only accept a string
-    client.query('num', { length: 123 }),
-  ).rejects.toMatchInlineSnapshot(`
-          [TRPCClientError: [
-            {
-              "code": "invalid_type",
-              "expected": "string",
-              "received": "number",
-              "path": [
-                "length"
-              ],
-              "message": "Expected string, received number"
-            }
-          ]]
-        `);
-
-  close();
-});
-
 test('superstruct', async () => {
   const router = trpc.router().query('num', {
     input: t.number(),

--- a/packages/server/test/validators.test.ts
+++ b/packages/server/test/validators.test.ts
@@ -128,6 +128,51 @@ test('zod transform mixed input/output', async () => {
   close();
 });
 
+test('zod transform output mixed input/output', async () => {
+  const input = z.object({
+    length: z.string().transform((s) => s.length),
+  });
+
+  const router = trpc.router().query('num', {
+    input: input,
+    resolve({ input }) {
+      expectTypeOf(input.length).toBeNumber();
+      return {
+        input,
+      };
+    },
+  });
+  const { client, close } = routerToServerAndClient(router);
+
+  await expect(client.query('num', { length: '123' })).resolves
+    .toMatchInlineSnapshot(`
+          Object {
+            "input": Object {
+              "length": 3,
+            },
+          }
+        `);
+
+  await expect(
+    // @ts-expect-error this should only accept a string
+    client.query('num', { length: 123 }),
+  ).rejects.toMatchInlineSnapshot(`
+          [TRPCClientError: [
+            {
+              "code": "invalid_type",
+              "expected": "string",
+              "received": "number",
+              "path": [
+                "length"
+              ],
+              "message": "Expected string, received number"
+            }
+          ]]
+        `);
+
+  close();
+});
+
 test('superstruct', async () => {
   const router = trpc.router().query('num', {
     input: t.number(),

--- a/www/docs/server/output-validation.md
+++ b/www/docs/server/output-validation.md
@@ -1,0 +1,109 @@
+---
+id: output-validation
+title: Output Validation
+sidebar_label: Output Validation
+slug: /output-validation
+---
+
+You are able to add an output validation to the `query()` and `mutation()` router methods. The output validator is invoked with the payload returned by the `resolve()` function.
+
+When an `output` validator is defined, its inferred type is expected as the return type of the `resolve()` function.
+
+:::info
+
+- If output validation fails, the server will respond with a `INTERNAL_SERVER_ERROR`.
+- Output validation can be skipped by setting the environment variable: `TRPC_SKIP_OUTPUT_VALIDATION=true`
+
+:::
+
+## Examples
+
+tRPC works out-of-the-box with yup/superstruct/zod/myzod/custom validators/[..] - [see test suite](https://github.com/trpc/trpc/blob/feature/output-parser-oas/packages/server/test/outputParser.test.ts)
+
+### With [Zod](https://github.com/colinhacks/zod)
+
+```tsx
+import * as trpc from '@trpc/server';
+import { z } from 'zod';
+
+// [...]
+
+export const appRouter = trpc.router<Context>().query('hello', {
+  output: z.object({
+    greeting: z.string(),
+  }),
+  // expects return type of { greeting: string }
+  resolve() {
+    return {
+      greeting: 'hello!',
+    };
+  },
+});
+
+export type AppRouter = typeof appRouter;
+```
+
+### With [Yup](https://github.com/jquense/yup)
+
+```tsx
+import * as trpc from '@trpc/server';
+import * as yup from 'yup';
+
+// [...]
+
+export const appRouter = trpc.router<Context>().query('hello', {
+  output: yup.object({
+    greeting: yup.string().required(),
+  }),
+  resolve() {
+    return { greeting: 'hello!' };
+  },
+});
+
+export type AppRouter = typeof appRouter;
+```
+
+### With [Superstruct](https://github.com/ianstormtaylor/superstruct)
+
+```tsx
+import * as trpc from '@trpc/server';
+import * as t from 'superstruct';
+
+// [...]
+
+export const appRouter = trpc.router<Context>().query('hello', {
+  input: t.string(),
+  output: t.object({
+    greeting: t.string(),
+  }),
+  resolve({ input }) {
+    return { greeting: input };
+  },
+});
+
+export type AppRouter = typeof appRouter;
+```
+
+### With custom validator
+
+```tsx
+import * as trpc from '@trpc/server';
+import * as t from 'superstruct';
+
+// [...]
+
+export const appRouter = trpc.router<Context>().query('hello', {
+  output: (value: any) => {
+    if (value && typeof value.greeting === 'string') {
+      return { greeting: value.greeting };
+    }
+    throw new Error('Greeting not found');
+  },
+  // expects return type of { greeting: string }
+  resolve() {
+    return { greeting: 'hello!' };
+  },
+});
+
+export type AppRouter = typeof appRouter;
+```

--- a/www/docs/server/output-validation.md
+++ b/www/docs/server/output-validation.md
@@ -5,15 +5,15 @@ sidebar_label: Output Validation
 slug: /output-validation
 ---
 
-You are able to add an output validation to the `query()` and `mutation()` router methods. The output validator is invoked with the payload returned by the `resolve()` function.
+tRPC gives you automatic type-safety of outputs without the need of adding a validator; however, it can be useful at times to strictly define the output type in order to prevent sensitive data of being leaked.
+
+Similarily to `input:`, an `output:` validation to the `query()` and `mutation()` router methods. The output validator is invoked with the payload returned by the `resolve()` function.
 
 When an `output` validator is defined, its inferred type is expected as the return type of the `resolve()` function.
 
 :::info
-
+- This is entirely optional and only if you want to ensure you don't accidentally leak anything e
 - If output validation fails, the server will respond with a `INTERNAL_SERVER_ERROR`.
-- Output validation can be skipped by setting the environment variable: `TRPC_SKIP_OUTPUT_VALIDATION=true`
-
 :::
 
 ## Examples

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -25,6 +25,7 @@ module.exports = {
         'server/context',
         'server/middlewares',
         'server/authorization',
+        'server/output-validation',
         'server/infer-types',
         'server/error-handling',
         'server/error-formatting',


### PR DESCRIPTION
### 🚧 Work in progress

## Added output validation to router queries & mutations

I have a goal to try and auto-generate OpenAPI docs for a TRPC router (cc. https://github.com/trpc/trpc/issues/755). The feature in this PR will enable us to generate JSON schemas for request and response payloads. This output parser is **opt-in only** and should not introduce any breaking changes.

### API
```
const appRouter = new trpc.router<Context>()
  .query({
    input: z.string(),
    output: z.object({
      input: z.string(),
    }),
    resolve: ({ input }) => {
      return { input };
    }
  });
```

- Added a new optional `output` property.
- When `output` is provided, the `resolve` function will expect a return type inferred from the `output` parser.
- The response data will be validated against the `output` parser, unless `NODE_ENV` is `production`. 
- If the response data fails validation a `TRPCError INTERNAL_SERVER_ERROR` error will be thrown.

### Todo
- Get some feedback (cc. @KATT)
- Write some comprehensive output parser tests.
- Update documentation.