### PR TITLE
Docs formatting

### DIFF
--- a/www/docs/main/introduction.md
+++ b/www/docs/main/introduction.md
@@ -1,6 +1,7 @@
 ---
 id: introduction
 title: tRPC
+hide_title: true
 sidebar_label: Introduction
 slug: /
 author: Alex / KATT 🐱
@@ -30,7 +31,7 @@ author_image_url: https://avatars1.githubusercontent.com/u/459267?s=460&v=4
 
 ## Introduction
 
-<abbr title="TypeScript Remote Procedure Call">tRPC</abbr> allows you to easily build & consume fully typesafe APIs, without schemas or code generation.
+<p><abbr title="TypeScript Remote Procedure Call">tRPC</abbr> allows you to easily build & consume fully typesafe APIs, without schemas or code generation.</p>
 
 As TypeScript and static typing increasingly becomes a best practice in web programming, the API presents a major pain point. We need better ways to **statically type** our API endpoints and **share those types** between our client and server (or server-to-server). We set out to build a simple library for building typesafe APIs that leverages the full power of modern TypeScript. Introducing tRPC!
 

--- a/www/src/css/custom.css
+++ b/www/src/css/custom.css
@@ -87,3 +87,21 @@ article {
 .footnotes :target {
   background: yellow;
 }
+
+.docs-wrapper main > .container > .row {
+  justify-content: center;
+}
+.docs-wrapper main > .container > .row > .col:first-child {
+  max-width: 650px !important;
+}
+@media only screen and (min-width: 997px) {
+  .docs-wrapper main > .container > .row > .col:first-child {
+    max-width: min(75%, 650px) !important;
+  }
+}
+
+@media only screen and (min-width: 1496px) {
+  .docs-wrapper main > .container > .row > .col:first-child {
+    max-width: min(75%, 750px) !important;
+  }
+}

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -76,7 +76,7 @@ function Home() {
         />
       </Head>
       <header className={clsx('hero hero--primary', styles.heroBanner)}>
-        <div className="container">
+        <div className="container main-container">
           <h1 className="hero__title">{siteConfig.title}</h1>
           <p className="hero__subtitle">{siteConfig.tagline}</p>
           <p>
@@ -97,14 +97,14 @@ function Home() {
               alt="Server/client example"
             />
             <figcaption>
-              The client above is <strong>not</strong> importing any code from
-              the server, only its type declarations. <code>import type</code>{' '}
-              only imports declarations to be used annotations and declarations.
-              It{' '}
+              The client doesn't import <em>any code</em> from the server, only
+              a single TypeScript type. The <code>import type</code> declaration
+              is{' '}
               <a href="https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export">
-                always gets fully erased
-              </a>
-              , so there’s no remnant of it at runtime.
+                fully erased
+              </a>{' '}
+              at runtime. tRPC transforms this type into a fully typesafe
+              client.
             </figcaption>
           </figure>
           <p>

--- a/www/src/pages/styles.module.css
+++ b/www/src/pages/styles.module.css
@@ -16,7 +16,6 @@
   padding-top: 15px;
   max-width: 600px;
   margin: auto;
-  font-size: 90%;
 }
 .heroBanner figcaption a {
   color: var(--ifm-hero-text-color);
@@ -27,8 +26,11 @@
 }
 
 .heroBanner figcaption code {
-  background-color: var(--ifm-color-darkest);
-  color: #222;
+  background-color: #ffffff20;
+  border-color: var(--ifm-color-darkest);
+  border-radius: 5px;
+  border-width: 1px;
+  color: var(--ifm-color-darkest);
 }
 
 @media screen and (max-width: 966px) {
@@ -38,17 +40,17 @@
 }
 .getStarted {
   display: inline-block;
-  color: white;
-  background: --ifm-color-primary;
-  border: 2px solid white;
+  color: var(--ifm-navbar-background-color);
+  background: transparent;
+  border: 2px solid var(--ifm-navbar-background-color);
   border-radius: 4px;
   padding: 10px 25px;
   margin: 50px 0px 0px 0px;
   font-size: 14pt;
 }
 .getStarted:hover {
-  background: white;
-  color: --ifm-color-primary;
+  background: var(--ifm-navbar-background-color);
+  color: var(--ifm-color-primary);
   text-decoration: none;
 }
 

--- a/www/src/pages/styles.module.css
+++ b/www/src/pages/styles.module.css
@@ -18,11 +18,13 @@
   margin: auto;
 }
 .heroBanner figcaption a {
-  color: var(--ifm-hero-text-color);
-
-  /* font-size: 0.8rem;
-  font-style: italic; */
+  color: var(--ifm-color-gray-200);
   text-decoration: underline;
+}
+
+[data-theme='dark'] .heroBanner {
+  background-color: var(--ifm-color-primary-darkest);
+  color: var(--ifm-color-gray-200);
 }
 
 .heroBanner figcaption code {
@@ -40,16 +42,16 @@
 }
 .getStarted {
   display: inline-block;
-  color: var(--ifm-navbar-background-color);
+  color: var(--ifm-color-gray-200);
   background: transparent;
-  border: 2px solid var(--ifm-navbar-background-color);
+  border: 2px solid var(--ifm-color-gray-200);
   border-radius: 4px;
   padding: 10px 25px;
   margin: 50px 0px 0px 0px;
   font-size: 14pt;
 }
 .getStarted:hover {
-  background: var(--ifm-navbar-background-color);
+  background: var(--ifm-color-gray-200);
   color: var(--ifm-color-primary);
   text-decoration: none;
 }


### PR DESCRIPTION
Probably the easiest win in terms of docs readability. The fact that docusaurus doesn't apply a max-width on the main content column is bizarre. This makes the tRPC docs feel intimidating, like a wall of text. I think this helps dramatically.

Before
<img width="911" alt="Screen Shot 2022-03-26 at 5 13 28 PM" src="https://user-images.githubusercontent.com/3084745/160261263-ad61132b-f278-4d2d-b77b-2043cee0434d.png">

After
<img width="912" alt="Screen Shot 2022-03-26 at 5 13 12 PM" src="https://user-images.githubusercontent.com/3084745/160261267-dad0d19d-dfcf-4d43-add0-b9799614f761.png">

