### PR TITLE
Remove undefined HTTP headers from TRPCClient

### DIFF
--- a/packages/client/src/internals/httpRequest.ts
+++ b/packages/client/src/internals/httpRequest.ts
@@ -59,12 +59,13 @@ export function httpRequest<TResponseShape = TRPCResponse>(
     const url = getUrl();
 
     Promise.resolve(rt.headers())
-      .then((headers) => {
-        Object.keys(headers).forEach((key) => {
-          if (headers[key] === undefined) {
-            delete headers[key];
+      .then((rawHeaders) => {
+        const headers = Object.keys(rawHeaders).reduce((acc, key) => {
+          if (rawHeaders[key] !== undefined) {
+            return { ...acc, [key]: rawHeaders[key] };
           }
-        });
+          return acc;
+        }, {});
 
         return rt.fetch(url, {
           method: method[type],

--- a/packages/client/src/internals/httpRequest.ts
+++ b/packages/client/src/internals/httpRequest.ts
@@ -62,11 +62,12 @@ export function httpRequest<TResponseShape = TRPCResponse>(
       .then((rawHeaders) => {
         const headers: HeadersInit = { 'content-type': 'application/json' };
         for (const key in rawHeaders) {
-          if (rawHeaders[key] !== undefined) {
-            if (Array.isArray(rawHeaders[key])) {
-              headers[key] = (rawHeaders[key] as string[]).join(',');
+          const header = rawHeaders[key];
+          if (header !== undefined) {
+            if (Array.isArray(header)) {
+              headers[key] = header.join(',');
             } else {
-              headers[key] = rawHeaders[key] as string;
+              headers[key] = header;
             }
           }
         }

--- a/packages/client/src/internals/httpRequest.ts
+++ b/packages/client/src/internals/httpRequest.ts
@@ -59,8 +59,14 @@ export function httpRequest<TResponseShape = TRPCResponse>(
     const url = getUrl();
 
     Promise.resolve(rt.headers())
-      .then((headers) =>
-        rt.fetch(url, {
+      .then((headers) => {
+        Object.keys(headers).forEach((key) => {
+          if (headers[key] === undefined) {
+            delete headers[key];
+          }
+        });
+
+        return rt.fetch(url, {
           method: method[type],
           signal: ac?.signal,
           body: getBody(),
@@ -68,8 +74,8 @@ export function httpRequest<TResponseShape = TRPCResponse>(
             'content-type': 'application/json',
             ...headers,
           },
-        }),
-      )
+        });
+      })
       .then((res) => {
         return res.json();
       })

--- a/packages/client/src/internals/httpRequest.ts
+++ b/packages/client/src/internals/httpRequest.ts
@@ -60,21 +60,22 @@ export function httpRequest<TResponseShape = TRPCResponse>(
 
     Promise.resolve(rt.headers())
       .then((rawHeaders) => {
-        const headers = Object.keys(rawHeaders).reduce((acc, key) => {
+        const headers: HeadersInit = { 'content-type': 'application/json' };
+        for (const key in rawHeaders) {
           if (rawHeaders[key] !== undefined) {
-            return { ...acc, [key]: rawHeaders[key] };
+            if (Array.isArray(rawHeaders[key])) {
+              headers[key] = (rawHeaders[key] as string[]).join(',');
+            } else {
+              headers[key] = rawHeaders[key] as string;
+            }
           }
-          return acc;
-        }, {});
+        }
 
         return rt.fetch(url, {
           method: method[type],
           signal: ac?.signal,
           body: getBody(),
-          headers: {
-            'content-type': 'application/json',
-            ...headers,
-          },
+          headers,
         });
       })
       .then((res) => {

--- a/packages/server/test/headers.test.tsx
+++ b/packages/server/test/headers.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/ban-types */
-import { createTRPCClient } from '@trpc/client';
+import { createTRPCClient } from '../../client/src';
 import * as trpc from '../src';
 import { Dict } from '../src';
 import { routerToServerAndClient } from './_testHelpers';

--- a/packages/server/test/websockets.test.ts
+++ b/packages/server/test/websockets.test.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 // import WebSocket from 'ws';
 import { waitFor } from '@testing-library/react';
-import { TRPCClientError } from '@trpc/client';
+import { TRPCClientError } from '../../client/src';
 import { EventEmitter } from 'events';
 import { expectTypeOf } from 'expect-type';
 import { default as WebSocket, default as ws } from 'ws';


### PR DESCRIPTION
Closes: https://github.com/trpc/trpc/issues/1712

## Remove undefined HTTP headers from TRPCClient

Added a transform to delete headers with `undefined` values before HTTP requests are sent by the `TRPCClient`.

```javascript
{ "x-defined": "xyz", "x-undefined": undefined } 
// is transformed to
{ "x-defined": "xyz" }
```

### Changes
* Added headers transformer to `httpRequest` method
* Removed `undefined` typing from `HTTPHeaders` record
* Added test case for removing undefined headers 
* Updated @trpc/client imports to relative path in tests
 