### PR TITLE
fix: fastify adapter using fastify-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ tRPC allows you to easily build & consume fully typesafe APIs, without schemas o
 - 🐎&nbsp; Snappy DX - No code generation, run-time bloat, or build pipeline.
 - 🍃&nbsp; Light - tRPC has zero deps and a tiny client-side footprint.
 - 🐻&nbsp; Easy to add to your existing brownfield project.
-- 🔋&nbsp; Batteries included - React.js/Next.js/Express.js adapters. _(But tRPC is not tied to React - [reach out](https://twitter.com/alexdotjs) if you want to make a Svelte/Vue/... adapter)_
+- 🔋&nbsp; Batteries included - React.js/Next.js/Express.js/Fastify adapters. _(But tRPC is not tied to React - [reach out](https://twitter.com/alexdotjs) if you want to make a Svelte/Vue/... adapter)_
 - 🥃&nbsp; Subscriptions support.
 - ⚡️&nbsp; Request batching - requests made at the same time can be automatically combined into one
 - 👀&nbsp; Quite a few examples in the [./examples](./examples)-folder

--- a/examples/fastify-server/package.json
+++ b/examples/fastify-server/package.json
@@ -19,7 +19,6 @@
     "@trpc/server": "^9.20.3",
     "abort-controller": "^3.0.0",
     "fastify": "^3.27.1",
-    "fastify-plugin": "^3.0.1",
     "fastify-websocket": "^4.0.0",
     "node-fetch": "^2.6.1",
     "tslib": "^2.1.0",

--- a/examples/fastify-server/src/client/index.ts
+++ b/examples/fastify-server/src/client/index.ts
@@ -10,6 +10,23 @@ async function start() {
     headers: { username: 'nyan' },
   });
 
+  const getHello = await fetch(`http://localhost:${port}/hello`);
+  const getHelloJSON = await getHello.json();
+
+  console.log('>>> fetch:get:hello:', getHelloJSON);
+
+  const postHello = await fetch(`http://localhost:${port}/hello`, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ text: 'life', life: 42 }),
+  });
+
+  const postHelloJSON = await postHello.json();
+  console.log('>>> fetch:post:hello:', postHelloJSON);
+
   const version = await anon.client.query('version');
   console.log('>>> anon:version:', version);
 

--- a/examples/fastify-server/src/server/server.ts
+++ b/examples/fastify-server/src/server/server.ts
@@ -1,5 +1,5 @@
 import fastify from 'fastify';
-// import fp from 'fastify-plugin';
+import fp from 'fastify-plugin';
 import ws from 'fastify-websocket';
 import { fastifyTRPCPlugin } from '@trpc/server/adapters/fastify';
 import { createContext } from './router/context';
@@ -18,7 +18,7 @@ export function createServer(opts: ServerOptions) {
   const server = fastify({ logger: dev });
 
   server.register(ws);
-  server.register(fastifyTRPCPlugin, {
+  server.register(fp(fastifyTRPCPlugin), {
     prefix,
     useWSS: true,
     trpcOptions: { router: appRouter, createContext },

--- a/examples/fastify-server/src/server/server.ts
+++ b/examples/fastify-server/src/server/server.ts
@@ -23,6 +23,10 @@ export function createServer(opts: ServerOptions) {
     trpcOptions: { router: appRouter, createContext },
   });
 
+  server.get('/', async () => {
+    return { hello: 'wait-on 💨' };
+  });
+
   server.get('/hello', async () => {
     return { hello: 'GET' };
   });

--- a/examples/fastify-server/src/server/server.ts
+++ b/examples/fastify-server/src/server/server.ts
@@ -1,5 +1,4 @@
 import fastify from 'fastify';
-import fp from 'fastify-plugin';
 import ws from 'fastify-websocket';
 import { fastifyTRPCPlugin } from '@trpc/server/adapters/fastify';
 import { createContext } from './router/context';
@@ -18,7 +17,7 @@ export function createServer(opts: ServerOptions) {
   const server = fastify({ logger: dev });
 
   server.register(ws);
-  server.register(fp(fastifyTRPCPlugin), {
+  server.register(fastifyTRPCPlugin, {
     prefix,
     useWSS: true,
     trpcOptions: { router: appRouter, createContext },

--- a/examples/fastify-server/src/server/server.ts
+++ b/examples/fastify-server/src/server/server.ts
@@ -1,5 +1,5 @@
 import fastify from 'fastify';
-import fp from 'fastify-plugin';
+// import fp from 'fastify-plugin';
 import ws from 'fastify-websocket';
 import { fastifyTRPCPlugin } from '@trpc/server/adapters/fastify';
 import { createContext } from './router/context';
@@ -18,15 +18,23 @@ export function createServer(opts: ServerOptions) {
   const server = fastify({ logger: dev });
 
   server.register(ws);
-  server.register(fp(fastifyTRPCPlugin), {
+  server.register(fastifyTRPCPlugin, {
     prefix,
     useWSS: true,
     trpcOptions: { router: appRouter, createContext },
   });
 
-  server.get('/', async () => {
-    return { hello: 'world' };
+  server.get('/hello', async () => {
+    return { hello: 'GET' };
   });
+
+  server.post<{ Body: { text: string; life: number } }>(
+    '/hello',
+    async ({ body }) => {
+      console.log('BODY:', typeof body, body);
+      return { hello: 'POST', body };
+    },
+  );
 
   const stop = () => server.close();
   const start = async () => {

--- a/packages/server/src/adapters/fastify/fastifyTRPCPlugin.ts
+++ b/packages/server/src/adapters/fastify/fastifyTRPCPlugin.ts
@@ -30,7 +30,7 @@ export function fastifyTRPCPlugin<TRouter extends AnyRouter>(
     },
   );
 
-  fastify.all(`${opts.prefix ?? ''}/:path`, async (req, res) => {
+  fastify.all(`/:path`, async (req, res) => {
     const path = (req.params as any).path;
     await fastifyRequestHandler({ ...opts.trpcOptions, req, res, path });
   });
@@ -41,7 +41,7 @@ export function fastifyTRPCPlugin<TRouter extends AnyRouter>(
       wss: fastify.websocketServer,
     });
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    fastify.get(opts.prefix ?? '/', { websocket: true }, () => {});
+    fastify.get('/', { websocket: true }, () => {});
   }
 
   done();

--- a/packages/server/src/adapters/fastify/fastifyTRPCPlugin.ts
+++ b/packages/server/src/adapters/fastify/fastifyTRPCPlugin.ts
@@ -30,7 +30,15 @@ export function fastifyTRPCPlugin<TRouter extends AnyRouter>(
     },
   );
 
-  fastify.all(`/:path`, async (req, res) => {
+  let prefix = opts.prefix ?? '';
+
+  // https://github.com/fastify/fastify-plugin/blob/fe079bef6557a83794bf437e14b9b9edb8a74104/plugin.js#L11
+  // @ts-expect-error property 'default' does not exists on type ...
+  if (typeof fastifyTRPCPlugin.default !== 'function') {
+    prefix = ''; // handled by fastify internally
+  }
+
+  fastify.all(`${prefix}/:path`, async (req, res) => {
     const path = (req.params as any).path;
     await fastifyRequestHandler({ ...opts.trpcOptions, req, res, path });
   });
@@ -41,7 +49,7 @@ export function fastifyTRPCPlugin<TRouter extends AnyRouter>(
       wss: fastify.websocketServer,
     });
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    fastify.get('/', { websocket: true }, () => {});
+    fastify.get(prefix ?? '/', { websocket: true }, () => {});
   }
 
   done();

--- a/www/docs/further/awesome-trpc.mdx
+++ b/www/docs/further/awesome-trpc.mdx
@@ -14,7 +14,7 @@ slug: /awesome-trpc
 | Description                                                       | Link                                          |
 | ----------------------------------------------------------------- | --------------------------------------------- |
 | tRPC Playground - sandbox for testing tRPC queries in the browser | https://github.com/sachinraja/trpc-playground |
-| tRPC-SvelteKit  - SvelteKit tRPC extension                        | https://github.com/icflorescu/trpc-sveltekit  |
+| tRPC-SvelteKit - SvelteKit tRPC extension                         | https://github.com/icflorescu/trpc-sveltekit  |
 
 ## 🍀 Starting points, example projects, etc
 
@@ -28,6 +28,7 @@ slug: /awesome-trpc
 | tRPC in a Cloudflare Worker                                                                      | https://github.com/esamattis/trpc-cloudflare-worker                     |
 | tRPC on Commerce Cloud Managed Runtime                                                           | https://github.com/danechitoaie/commerce-cloud-managed-runtime-trpc-poc |
 | tRPC-SvelteKit Example Application                                                               | https://github.com/icflorescu/trpc-sveltekit-example                    |
+| tRPC + Rakkas (Vite framework)                                                                   | https://github.com/sachinraja/trpc-rakkas                               |
 
 ## 🏁 Open-source projects using tRPC
 

--- a/www/docs/main/example-apps.md
+++ b/www/docs/main/example-apps.md
@@ -107,6 +107,16 @@ Here's some example apps:
       </td>
     </tr>
     <tr>
+      <td>Fastify server with WebSocket &amp; procedure calls with node.js.</td>
+      <td><em>n/a</em></td>
+      <td>
+        <ul>
+          <li><a href="https://codesandbox.io/s/github/trpc/trpc/tree/main/examples/fastify-server">CodeSandbox</a></li>
+          <li><a href="https://github.com/trpc/trpc/tree/main/examples/fastify-server">Source</a></li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
       <td>SvelteKit Example Application with Prisma.</td>
       <td><em>n/a</em></td>
       <td>

--- a/www/docs/main/introduction.md
+++ b/www/docs/main/introduction.md
@@ -48,7 +48,7 @@ If your project is built with full-stack TypeScript, you can share types **direc
 - 🐎&nbsp; Snappy DX - No code generation, run-time bloat, or build pipeline.
 - 🍃&nbsp; Light - tRPC has zero deps and a tiny client-side footprint.
 - 🐻&nbsp; Easy to add to your existing brownfield project.
-- 🔋&nbsp; Batteries included - React.js/Next.js/Express.js adapters. _(But tRPC is not tied to React - [reach out](https://twitter.com/alexdotjs) if you want to make a Svelte/Vue/... adapter)_
+- 🔋&nbsp; Batteries included - React.js/Next.js/Express.js/Fastify adapters. _(But tRPC is not tied to React - [reach out](https://twitter.com/alexdotjs) if you want to make a Svelte/Vue/... adapter)_
 - 🥃&nbsp; Subscriptions support.
 - ⚡️&nbsp; Request batching - requests made at the same time can be automatically combined into one.
 - 👀&nbsp; Quite a few [examples](example-apps.md) that you can use for reference or as a starting point.

--- a/www/docs/server/fastify.md
+++ b/www/docs/server/fastify.md
@@ -39,7 +39,7 @@ The best way to start with the Fastify adapter is to take a look at the example 
 ### Install dependencies
 
 ```bash
-yarn add @trpc/server fastify fastify-plugin zod
+yarn add @trpc/server fastify zod
 ```
 
 > [Zod](https://github.com/colinhacks/zod) isn't a required dependency, but it's used in the sample router below.
@@ -121,18 +121,17 @@ export type Context = inferAsyncReturnType<typeof createContext>;
 
 ### Create Fastify server
 
-tRPC includes an adapter for [Fastify](https://www.fastify.io/) out of the box. This adapter lets you convert your tRPC router into an [Fastify plugin](https://www.npmjs.com/package/fastify-plugin).
+tRPC includes an adapter for [Fastify](https://www.fastify.io/) out of the box. This adapter lets you convert your tRPC router into an [Fastify plugin](https://www.fastify.io/docs/latest/Reference/Plugins/).
 
 ```ts
 import fastify from 'fastify';
-import fp from 'fastify-plugin';
 import { fastifyTRPCPlugin } from '@trpc/server/adapters/fastify';
 import { createContext } from './context';
 import { appRouter } from './router';
 
 const server = fastify();
 
-server.register(fp(fastifyTRPCPlugin), {
+server.register(fastifyTRPCPlugin, {
   prefix: '/trpc',
   trpcOptions: { router: appRouter, createContext },
 });
@@ -198,7 +197,7 @@ export const appRouter = trpc
 ### Activate the `useWSS` option
 
 ```ts
-server.register(fp(fastifyTRPCPlugin), {
+server.register(fastifyTRPCPlugin, {
   useWSS: true,
   // ...
 });


### PR DESCRIPTION
Fixes #1715, allows the use of the fastify adapter with or without the `fastify-plugin`.

With fp: the response body will be a string for all requests (as before). 
Without fp: the response body will not be modified by the adapter.