### PR TITLE
docs: add stackblitz links  for some example apps

### DIFF
--- a/www/docs/main/example-apps.md
+++ b/www/docs/main/example-apps.md
@@ -92,7 +92,7 @@ Here's some example apps:
       <td>
         <ul>
           <li><a href="https://githubbox.com/trpc/trpc/tree/main/examples/standalone-server">CodeSandbox</a></li>
-          <li><a href="https://stackblitz.com/edit/trpc-standalone-server?file=README.md">StackBlitz</a></li>
+          <li><a href="https://stackblitz.com/edit/trpc-standalone-server">StackBlitz</a></li>
           <li><a href="https://github.com/trpc/trpc/tree/main/examples/standalone-server">Source</a></li>
         </ul>
       </td>
@@ -103,7 +103,7 @@ Here's some example apps:
       <td>
         <ul>
           <li><a href="https://githubbox.com/trpc/trpc/tree/main/examples/express-server">CodeSandbox</a></li>
-          <li><a href="https://stackblitz.com/edit/trpc-express-server?file=README.md">StackBlitz</a></li>
+          <li><a href="https://stackblitz.com/edit/trpc-express-server">StackBlitz</a></li>
           <li><a href="https://github.com/trpc/trpc/tree/main/examples/express-server">Source</a></li>
         </ul>
       </td>
@@ -114,7 +114,7 @@ Here's some example apps:
       <td>
         <ul>
           <li><a href="https://codesandbox.io/s/github/trpc/trpc/tree/main/examples/fastify-server">CodeSandbox</a></li>
-          <li><a href="https://stackblitz.com/edit/trpc-fastify-server?file=README.md">StackBlitz</a></li>
+          <li><a href="https://stackblitz.com/edit/trpc-fastify-server">StackBlitz</a></li>
           <li><a href="https://github.com/trpc/trpc/tree/main/examples/fastify-server">Source</a></li>
         </ul>
       </td>

--- a/www/docs/main/example-apps.md
+++ b/www/docs/main/example-apps.md
@@ -92,6 +92,7 @@ Here's some example apps:
       <td>
         <ul>
           <li><a href="https://githubbox.com/trpc/trpc/tree/main/examples/standalone-server">CodeSandbox</a></li>
+          <li><a href="https://stackblitz.com/edit/trpc-standalone-server?file=README.md">StackBlitz</a></li>
           <li><a href="https://github.com/trpc/trpc/tree/main/examples/standalone-server">Source</a></li>
         </ul>
       </td>
@@ -102,6 +103,7 @@ Here's some example apps:
       <td>
         <ul>
           <li><a href="https://githubbox.com/trpc/trpc/tree/main/examples/express-server">CodeSandbox</a></li>
+          <li><a href="https://stackblitz.com/edit/trpc-express-server?file=README.md">StackBlitz</a></li>
           <li><a href="https://github.com/trpc/trpc/tree/main/examples/express-server">Source</a></li>
         </ul>
       </td>
@@ -112,6 +114,7 @@ Here's some example apps:
       <td>
         <ul>
           <li><a href="https://codesandbox.io/s/github/trpc/trpc/tree/main/examples/fastify-server">CodeSandbox</a></li>
+          <li><a href="https://stackblitz.com/edit/trpc-fastify-server?file=README.md">StackBlitz</a></li>
           <li><a href="https://github.com/trpc/trpc/tree/main/examples/fastify-server">Source</a></li>
         </ul>
       </td>


### PR DESCRIPTION
Following #1720 , I've added some StackBlitz links for  `bare node`, `expressjs` and `fastify` server examples. There is one issue with the bare node server example on StackBlitz which I'm unable to fix . If anyone can look into that it'd be a great help. Here is the link  https://stackblitz.com/edit/trpc-standalone-server?file=README.md . Thx