### PR TITLE
refactor using globals and fix misc type errors

### DIFF
--- a/packages/client/src/links/internals/httpUtils.ts
+++ b/packages/client/src/links/internals/httpUtils.ts
@@ -40,17 +40,15 @@ export function httpRequest(
   const input = 'input' in props ? props.input : arrayToDict(props.inputs);
 
   function getUrl() {
-    let url = props.url + '/' + path;
-    const queryParts: string[] = [];
+    const url = new URL(props.url + '/' + path);
+
     if ('inputs' in props) {
-      queryParts.push('batch=1');
+      url.searchParams.set('batch', '1');
     }
     if (type === 'query' && input !== undefined) {
-      queryParts.push(`input=${encodeURIComponent(JSON.stringify(input))}`);
+      url.searchParams.set('input', JSON.stringify(input));
     }
-    if (queryParts.length) {
-      url += '?' + queryParts.join('&');
-    }
+
     return url;
   }
   function getBody() {
@@ -66,7 +64,7 @@ export function httpRequest(
     const meta = {} as any as ResponseShape['meta'];
     Promise.resolve(rt.headers())
       .then((headers) =>
-        rt.fetch(url, {
+        rt.fetch(url.href, {
           method: METHOD[type],
           signal: ac?.signal,
           body: getBody(),

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@trpc/server",
-  "version": "10.0.0-alpha.20",
+  "name": "@sachinraja/trpc-server",
+  "version": "10.0.0-decouple.4",
   "description": "tRPC Server",
   "author": "KATT",
   "license": "MIT",

--- a/packages/server/src/TRPCError.ts
+++ b/packages/server/src/TRPCError.ts
@@ -2,13 +2,13 @@ import { getMessageFromUnkownError } from './internals/errors';
 import { TRPC_ERROR_CODE_KEY } from './rpc/codes';
 
 export class TRPCError extends Error {
-  public readonly cause?: unknown;
+  public cause?: Error | undefined;
   public readonly code;
 
   constructor(opts: {
     message?: string;
     code: TRPC_ERROR_CODE_KEY;
-    cause?: unknown;
+    cause?: Error;
   }) {
     const cause = opts.cause;
     const code = opts.code;

--- a/packages/server/src/adapters/fastify/fastifyRequestHandler.ts
+++ b/packages/server/src/adapters/fastify/fastifyRequestHandler.ts
@@ -1,5 +1,4 @@
 import { FastifyReply, FastifyRequest } from 'fastify';
-import { URLSearchParams } from 'url';
 import { assertNotBrowser } from '../../assertNotBrowser';
 import {
   HTTPBaseHandlerOptions,

--- a/packages/server/src/adapters/node-http/nodeHTTPRequestHandler.ts
+++ b/packages/server/src/adapters/node-http/nodeHTTPRequestHandler.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { URLSearchParams } from 'url';
 import { assertNotBrowser } from '../../assertNotBrowser';
 import { HTTPRequest } from '../../http/internals/types';
 import { resolveHTTPResponse } from '../../http/resolveHTTPResponse';

--- a/packages/server/src/adapters/node-http/types.ts
+++ b/packages/server/src/adapters/node-http/types.ts
@@ -1,15 +1,15 @@
-import http from 'http';
+import { IncomingMessage, ServerResponse } from 'http';
 import qs from 'qs';
 import { inferRouterContext } from '../..';
 import { HTTPBaseHandlerOptions } from '../../http/internals/types';
 import { AnyRouter } from '../../router';
 
-export type NodeHTTPRequest = http.IncomingMessage & {
+export type NodeHTTPRequest = IncomingMessage & {
   method?: string;
   query?: qs.ParsedQs;
   body?: unknown;
 };
-export type NodeHTTPResponse = http.ServerResponse;
+export type NodeHTTPResponse = ServerResponse;
 
 export type NodeHTTPCreateContextOption<
   TRouter extends AnyRouter,

--- a/packages/server/src/adapters/standalone.ts
+++ b/packages/server/src/adapters/standalone.ts
@@ -2,7 +2,6 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import http from 'http';
-import url from 'url';
 import { AnyRouter } from '../router';
 import {
   NodeHTTPCreateContextFnOptions,
@@ -22,7 +21,8 @@ export function createHTTPHandler<TRouter extends AnyRouter>(
   opts: CreateHTTPHandlerOptions<TRouter>,
 ) {
   return async (req: http.IncomingMessage, res: http.ServerResponse) => {
-    const endpoint = url.parse(req.url!).pathname!.slice(1);
+    const endpoint = new URL(req.url!).pathname.slice(1);
+
     await nodeHTTPRequestHandler({
       ...opts,
       req,

--- a/packages/server/src/adapters/ws.ts
+++ b/packages/server/src/adapters/ws.ts
@@ -1,9 +1,9 @@
-import http from 'http';
+import { IncomingMessage } from 'http';
 import ws from 'ws';
 import { TRPCError } from '../TRPCError';
 import { BaseHandlerOptions } from '../internals/BaseHandlerOptions';
 import { callProcedure } from '../internals/callProcedure';
-import { getErrorFromUnknown } from '../internals/errors';
+import { getCauseFromUnknown, getErrorFromUnknown } from '../internals/errors';
 import { transformTRPCResponse } from '../internals/transformTRPCResponse';
 import { AnyRouter, ProcedureType, inferRouterContext } from '../router';
 import {
@@ -84,11 +84,11 @@ function parseMessage(
  */
 export type WSSHandlerOptions<TRouter extends AnyRouter> = BaseHandlerOptions<
   TRouter,
-  http.IncomingMessage
+  IncomingMessage
 > & {
   wss: ws.Server;
   process?: NodeJS.Process;
-} & NodeHTTPCreateContextOption<TRouter, http.IncomingMessage, ws>;
+} & NodeHTTPCreateContextOption<TRouter, IncomingMessage, ws>;
 
 export function applyWSSHandler<TRouter extends AnyRouter>(
   opts: WSSHandlerOptions<TRouter>,
@@ -232,7 +232,7 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
       } catch (cause) {
         const error = new TRPCError({
           code: 'PARSE_ERROR',
-          cause,
+          cause: getCauseFromUnknown(cause),
         });
 
         respond({

--- a/packages/server/src/assertNotBrowser.ts
+++ b/packages/server/src/assertNotBrowser.ts
@@ -3,6 +3,7 @@
 export function assertNotBrowser() {
   if (
     typeof window !== 'undefined' &&
+    !('Deno' in window) &&
     process.env.NODE_ENV !== 'test' &&
     process.env.JEST_WORKER_ID === undefined
   ) {

--- a/packages/server/src/http/internals/types.ts
+++ b/packages/server/src/http/internals/types.ts
@@ -1,15 +1,14 @@
+import { TRPCError } from '../../TRPCError';
+import { BaseHandlerOptions } from '../../internals/BaseHandlerOptions';
 import {
   AnyRouter,
-  Dict,
   ProcedureType,
-  ResponseMeta,
-  TRPCError,
   inferRouterContext,
   inferRouterError,
-} from '@trpc/server';
-import { URLSearchParams } from 'url';
-import { BaseHandlerOptions } from '../../internals/BaseHandlerOptions';
+} from '../../router';
 import { TRPCResponse } from '../../rpc';
+import { Dict } from '../../types';
+import { ResponseMeta } from '../ResponseMeta';
 
 export type HTTPHeaders = Dict<string | string[]>;
 

--- a/packages/server/src/http/resolveHTTPResponse.ts
+++ b/packages/server/src/http/resolveHTTPResponse.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { Maybe } from '@trpc/server';
 import { TRPCError } from '../TRPCError';
 import { callProcedure } from '../internals/callProcedure';
 import { getErrorFromUnknown } from '../internals/errors';
@@ -11,6 +10,7 @@ import {
   inferRouterError,
 } from '../router';
 import { TRPCErrorResponse, TRPCResponse, TRPCResultResponse } from '../rpc';
+import { Maybe } from '../types';
 import { getHTTPStatusCode } from './internals/getHTTPStatusCode';
 import {
   HTTPBaseHandlerOptions,
@@ -37,11 +37,13 @@ function getRawProcedureInputOrThrow(req: HTTPRequest) {
       return JSON.parse(raw!);
     }
     return typeof req.body === 'string' ? JSON.parse(req.body) : req.body;
-  } catch (cause) {
-    throw new TRPCError({
+  } catch (err) {
+    const trpcError = new TRPCError({
       code: 'PARSE_ERROR',
-      cause,
     });
+    if (err instanceof Error) {
+      trpcError.cause = err;
+    }
   }
 }
 

--- a/packages/server/src/internals/errors.ts
+++ b/packages/server/src/internals/errors.ts
@@ -20,14 +20,23 @@ export function getErrorFromUnknown(cause: unknown): TRPCError {
   if (cause instanceof Error && cause.name === 'TRPCError') {
     return cause as TRPCError;
   }
+
   const err = new TRPCError({
     code: 'INTERNAL_SERVER_ERROR',
-    cause,
   });
 
   // take stack trace from cause
   if (cause instanceof Error) {
+    err.cause = cause;
     err.stack = cause.stack;
   }
   return err;
+}
+
+export function getCauseFromUnknown(cause: unknown) {
+  if (cause instanceof Error) {
+    return cause;
+  }
+
+  return undefined;
 }

--- a/packages/server/src/internals/procedure.ts
+++ b/packages/server/src/internals/procedure.ts
@@ -2,7 +2,7 @@
 import { TRPCError } from '../TRPCError';
 import { assertNotBrowser } from '../assertNotBrowser';
 import { ProcedureType } from '../router';
-import { getErrorFromUnknown } from './errors';
+import { getCauseFromUnknown, getErrorFromUnknown } from './errors';
 import { MiddlewareFunction, middlewareMarker } from './middlewares';
 import { wrapCallSafe } from './wrapCallSafe';
 
@@ -130,7 +130,7 @@ export class Procedure<
     } catch (cause) {
       throw new TRPCError({
         code: 'BAD_REQUEST',
-        cause,
+        cause: getCauseFromUnknown(cause),
       });
     }
   }
@@ -141,7 +141,7 @@ export class Procedure<
     } catch (cause) {
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',
-        cause,
+        cause: getCauseFromUnknown(cause),
         message: 'Output validation failed',
       });
     }

--- a/packages/server/test/react.test.tsx
+++ b/packages/server/test/react.test.tsx
@@ -34,7 +34,7 @@ import {
 import { observable } from '../../client/src/observable';
 import { withTRPC } from '../../next/src';
 import { OutputWithCursor, createReactQueryHooks } from '../../react/src';
-import { createSSGHelpers } from '../../react/ssg';
+import { createSSGHelpers } from '../../react/src/ssg';
 import { DefaultErrorShape } from '../src';
 import { TRPCError } from '../src/TRPCError';
 

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "../../tsconfig.json",
   "include": ["src", "test"],
   "compilerOptions": {
-    "lib": ["ES2020"],
-    "target": "ES2020"
+    "lib": ["ES2020", "DOM"],
+    "target": "ES2020",
+    "noEmit": true,
+    "emitDeclarationOnly": false
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2924,6 +2924,13 @@
     javascript-natural-sort "0.7.1"
     lodash "4.17.21"
 
+"@trpc/server@^10.0.0-alpha.20":
+  version "10.0.0-alpha.20"
+  resolved "https://registry.yarnpkg.com/@trpc/server/-/server-10.0.0-alpha.20.tgz#08f94f5000f6b8977cf3f2d1d33bfcd7efdbbcac"
+  integrity sha512-T2LG3Ak9QR0pzXHuenBl0izxeNoBj1q9kONb6rPNndtkDF0UmjM4qdnFK0bBQ27hqiOTAesb95m4wLcR0Hd0Uw==
+  dependencies:
+    tslib "^2.1.0"
+
 "@ts-type/package-dts@^1.0.58":
   version "1.0.58"
   resolved "https://registry.yarnpkg.com/@ts-type/package-dts/-/package-dts-1.0.58.tgz#75f6fdf5f1e8f262a5081b90346439b4c4bc8d01"
@@ -3254,7 +3261,7 @@
 
 "@typescript-eslint/eslint-plugin@^4.11.1", "@typescript-eslint/eslint-plugin@^4.30.0":
   version "4.33.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz#c24dc7c8069c7706bc40d99f6fa87edcb2005276"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz#c24dc7c8069c7706bc40d99f6fa87edcb2005276"
   integrity sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==
   dependencies:
     "@typescript-eslint/experimental-utils" "4.33.0"
@@ -3280,7 +3287,7 @@
 
 "@typescript-eslint/parser@^4.11.1", "@typescript-eslint/parser@^5.0.0", "@typescript-eslint/parser@^5.14.0":
   version "4.33.0"
-  resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz#dfe797570d9694e560528d18eecad86c8c744899"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.33.0.tgz#dfe797570d9694e560528d18eecad86c8c744899"
   integrity sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==
   dependencies:
     "@typescript-eslint/scope-manager" "4.33.0"


### PR DESCRIPTION
closes #1597
closes #1588

Refactor globals:
  - use `URL` and `URLSearchParams` global instead of importing from `url`

Type errors:
  - update the `cause` property to conform to https://github.com/tc39/proposal-error-cause
  - fix various type errors in tests

This could have been two separate PRs but both are needed for Deno support.
