### PR TITLE
Fix Websockets example layout on mobile

### DIFF
--- a/examples/next-prisma-starter-websockets/src/pages/index.tsx
+++ b/examples/next-prisma-starter-websockets/src/pages/index.tsx
@@ -58,7 +58,7 @@ function AddMessageForm({ onMessagePost }: { onMessagePost: () => void }) {
           await postMessage();
         }}
       >
-        <fieldset disabled={addPost.isLoading}>
+        <fieldset disabled={addPost.isLoading} className="min-w-0">
           <div className="flex rounded bg-gray-500 px-3 py-2 text-lg text-gray-200 w-full items-end">
             <textarea
               value={message}


### PR DESCRIPTION
I think that cause of #1691 is `fieldset` tag min-width is setted to [min-content](https://developer.mozilla.org/en-US/docs/Web/CSS/min-width) by browser default.

So, I tried to resolve it to set min-width to 0.