### PR TITLE
`typeof window !== 'undefined'` to test for client

### DIFF
--- a/examples/next-prisma-starter-websockets/src/pages/_app.tsx
+++ b/examples/next-prisma-starter-websockets/src/pages/_app.tsx
@@ -30,7 +30,7 @@ MyApp.getInitialProps = async ({ ctx }) => {
 };
 
 function getEndingLink() {
-  if (!process.browser) {
+  if (typeof window === 'undefined') {
     return httpBatchLink({
       url: `${APP_URL}/api/trpc`,
     });
@@ -58,7 +58,8 @@ export default withTRPC<AppRouter>({
         // adds pretty logs to your console in development and logs errors in production
         loggerLink({
           enabled: (opts) =>
-            (process.env.NODE_ENV === 'development' && process.browser) ||
+            (process.env.NODE_ENV === 'development' &&
+              typeof window !== 'undefined') ||
             (opts.direction === 'down' && opts.result instanceof Error),
         }),
         getEndingLink(),

--- a/examples/next-prisma-starter/src/pages/_app.tsx
+++ b/examples/next-prisma-starter/src/pages/_app.tsx
@@ -25,7 +25,7 @@ const MyApp = (({ Component, pageProps }: AppPropsWithLayout) => {
 }) as AppType;
 
 function getBaseUrl() {
-  if (process.browser) {
+  if (typeof window !== 'undefined') {
     return '';
   }
   // reference for vercel.com

--- a/www/docs/nextjs/ssr.md
+++ b/www/docs/nextjs/ssr.md
@@ -21,7 +21,7 @@ const MyApp: AppType = ({ Component, pageProps }) => {
 
 export default withTRPC<AppRouter>({
   config({ ctx }) {
-    if (process.browser) {
+    if (typeof window !== 'undefined') {
       // during client requests
       return {
         url: '/api/trpc',

--- a/www/docs/server/caching.md
+++ b/www/docs/server/caching.md
@@ -27,7 +27,7 @@ If you turn on SSR in your app you might discover that your app loads slow on fo
 // in _app.tsx
 export default withTRPC({
   config({ ctx }) {
-    if (process.browser) {
+    if (typeof window !== 'undefined') {
       return {
         url: '/api/trpc',
       };


### PR DESCRIPTION
Since `process.browser` is deprecated, the recommended workaround for determining if we are on the client or server on nextjs is `typeof window !== 'undefined'`: 
https://github.com/zeit/next.js/issues/5354#issuecomment-520305040

Thanks for quickly accepting this @KATT!  🙏 