### PR TITLE
Simplify tRPC request/response/message interfaces

### DIFF
--- a/packages/client/src/internals/TRPCClient.ts
+++ b/packages/client/src/internals/TRPCClient.ts
@@ -5,7 +5,7 @@ import {
   inferProcedureOutput,
   inferSubscriptionOutput,
 } from '@trpc/server';
-import { TRPCResult } from '@trpc/server/rpc';
+import { TRPCResultMessage } from '@trpc/server/rpc';
 import { CancelFn } from '..';
 import { TRPCClientError } from '../TRPCClientError';
 import { getFetch } from '../getFetch';
@@ -212,7 +212,7 @@ export class TRPCClient<TRouter extends AnyRouter> {
     path: TPath,
     input: TInput,
     opts: TRPCRequestOptions &
-      Partial<Observer<TRPCResult<TOutput>, TRPCClientError<TRouter>>>,
+      Partial<Observer<TRPCResultMessage<TOutput>, TRPCClientError<TRouter>>>,
   ): Unsubscribable {
     const observable$ = this.$request<TInput, TOutput>({
       type: 'subscription',
@@ -230,7 +230,7 @@ export class TRPCClient<TRouter extends AnyRouter> {
           opts.error?.(err);
           return;
         }
-        opts.next?.(result.data.result);
+        opts.next?.(result.data.result as TRPCResultMessage<TOutput>);
       },
       error(err) {
         opts.error?.(err);

--- a/packages/client/src/links/transformerLink.ts
+++ b/packages/client/src/links/transformerLink.ts
@@ -22,19 +22,21 @@ function transformOperationResult<TResult extends OperationResult<any, any>>(
       },
     };
   }
-  if (result.data.result.type !== 'data') {
-    return result;
-  }
-  return {
-    ...result,
-    data: {
-      ...result.data,
-      result: {
-        ...result.data.result,
-        data: transformer.deserialize(result.data.result.data),
+
+  if ('data' in result.data.result) {
+    return {
+      ...result,
+      data: {
+        ...result.data,
+        result: {
+          ...result.data.result,
+          data: transformer.deserialize(result.data.result.data),
+        },
       },
-    },
-  };
+    };
+  }
+
+  return result;
 }
 export function transformerLink<TRouter extends AnyRouter = AnyRouter>(
   transformer: ClientDataTransformerOptions,

--- a/packages/client/src/links/types.ts
+++ b/packages/client/src/links/types.ts
@@ -1,5 +1,5 @@
 import { AnyRouter, inferRouterError } from '@trpc/server';
-import { TRPCResponse } from '@trpc/server/rpc';
+import { TRPCResponse, TRPCResponseMessage } from '@trpc/server/rpc';
 import { TRPCClientError } from '../TRPCClientError';
 import { Observable, Observer } from '../observable/types';
 
@@ -36,8 +36,12 @@ export interface LinkRuntime {
   AbortController?: typeof AbortController;
 }
 
+type OperationResultData<TRouter extends AnyRouter, TOutput> =
+  | TRPCResponse<TOutput, inferRouterError<TRouter>>
+  | TRPCResponseMessage<TOutput, inferRouterError<TRouter>>;
+
 export interface OperationResult<TRouter extends AnyRouter, TOutput> {
-  data: TRPCResponse<TOutput, inferRouterError<TRouter>>;
+  data: OperationResultData<TRouter, TOutput>;
   context?: OperationContext;
 }
 

--- a/packages/client/src/links/wsLink.ts
+++ b/packages/client/src/links/wsLink.ts
@@ -2,8 +2,9 @@ import { AnyRouter, ProcedureType } from '@trpc/server';
 import {
   TRPCClientIncomingMessage,
   TRPCClientIncomingRequest,
-  TRPCRequest,
-  TRPCResponse,
+  TRPCClientOutgoingMessage,
+  TRPCRequestMessage,
+  TRPCResponseMessage,
 } from '@trpc/server/rpc';
 import { TRPCClientError } from '../TRPCClientError';
 import { retryDelay } from '../internals/retryDelay';
@@ -30,7 +31,7 @@ export function createWSClient(opts: WebSocketClientOptions) {
   /**
    * outgoing messages buffer whilst not open
    */
-  let outgoing: TRPCRequest[] = [];
+  let outgoing: TRPCClientOutgoingMessage[] = [];
   /**
    * pending outgoing requests that are awaiting callback
    */
@@ -140,7 +141,7 @@ export function createWSClient(opts: WebSocketClientOptions) {
         }
       }
     };
-    const handleIncomingResponse = (data: TRPCResponse) => {
+    const handleIncomingResponse = (data: TRPCResponseMessage) => {
       const req = data.id !== null && pendingRequests[data.id];
       if (!req) {
         // do something?
@@ -207,7 +208,7 @@ export function createWSClient(opts: WebSocketClientOptions) {
 
   function request(op: Operation, callbacks: TCallbacks): UnsubscribeFn {
     const { type, input, path, id } = op;
-    const envelope: TRPCRequest = {
+    const envelope: TRPCRequestMessage = {
       id,
       method: type,
       params: {
@@ -236,7 +237,6 @@ export function createWSClient(opts: WebSocketClientOptions) {
         outgoing.push({
           id,
           method: 'subscription.stop',
-          params: undefined,
         });
         dispatch();
       }

--- a/packages/client/src/links/wsLink.ts
+++ b/packages/client/src/links/wsLink.ts
@@ -209,7 +209,6 @@ export function createWSClient(opts: WebSocketClientOptions) {
     const { type, input, path, id } = op;
     const envelope: TRPCRequest = {
       id,
-      jsonrpc: '2.0',
       method: type,
       params: {
         input,

--- a/packages/server/src/adapters/next.ts
+++ b/packages/server/src/adapters/next.ts
@@ -7,7 +7,6 @@ import type {
 } from 'next/types';
 import { TRPCError } from '../TRPCError';
 import { AnyRouter } from '../router';
-import { TRPCErrorResponse } from '../rpc';
 import { nodeHTTPRequestHandler } from './node-http';
 import {
   NodeHTTPCreateContextFnOptions,
@@ -46,12 +45,11 @@ export function createNextApiHandler<TRouter extends AnyRouter>(
         path: undefined,
         input: undefined,
       });
-      const json: TRPCErrorResponse = {
+      res.statusCode = 500;
+      res.json({
         id: -1,
         error,
-      };
-      res.statusCode = 500;
-      res.json(json);
+      });
       return;
     }
 

--- a/packages/server/src/adapters/ws.ts
+++ b/packages/server/src/adapters/ws.ts
@@ -7,10 +7,9 @@ import { getCauseFromUnknown, getErrorFromUnknown } from '../internals/errors';
 import { transformTRPCResponse } from '../internals/transformTRPCResponse';
 import { AnyRouter, ProcedureType, inferRouterContext } from '../router';
 import {
-  TRPCErrorResponse,
+  TRPCClientOutgoingMessage,
   TRPCReconnectNotification,
-  TRPCRequest,
-  TRPCResponse,
+  TRPCResponseMessage,
 } from '../rpc';
 import { Subscription } from '../subscription';
 import { CombinedDataTransformer } from '../transformer';
@@ -58,7 +57,7 @@ function assertIsJSONRPC2OrUndefined(
 function parseMessage(
   obj: unknown,
   transformer: CombinedDataTransformer,
-): TRPCRequest {
+): TRPCClientOutgoingMessage {
   assertIsObject(obj);
   const { method, params, id, jsonrpc } = obj;
   assertIsRequestId(id);
@@ -67,7 +66,6 @@ function parseMessage(
     return {
       id,
       method,
-      params: undefined,
     };
   }
   assertIsProcedureType(method);
@@ -76,7 +74,11 @@ function parseMessage(
   const { input: rawInput, path } = params;
   assertIsString(path);
   const input = transformer.input.deserialize(rawInput);
-  return { jsonrpc, id, method, params: { input, path } };
+  return {
+    id,
+    method,
+    params: { input, path },
+  };
 }
 
 /**
@@ -102,7 +104,7 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
       Subscription<TRouter>
     >();
 
-    function respond(untransformedJSON: TRPCResponse) {
+    function respond(untransformedJSON: TRPCResponseMessage) {
       client.send(
         JSON.stringify(transformTRPCResponse(router, untransformedJSON)),
       );
@@ -110,7 +112,7 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
     const ctxPromise = createContext?.({ req, res: client });
     let ctx: inferRouterContext<TRouter> | undefined = undefined;
 
-    async function handleRequest(msg: TRPCRequest) {
+    async function handleRequest(msg: TRPCClientOutgoingMessage) {
       const { id } = msg;
       /* istanbul ignore next */
       if (id === null) {
@@ -178,7 +180,8 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
         });
         sub.on('error', (_error: unknown) => {
           const error = getErrorFromUnknown(_error);
-          const json: TRPCErrorResponse = {
+          opts.onError?.({ error, path, type, ctx, req, input });
+          respond({
             id,
             error: router.getErrorShape({
               error,
@@ -187,9 +190,7 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
               input,
               ctx,
             }),
-          };
-          opts.onError?.({ error, path, type, ctx, req, input });
-          respond(json);
+          });
         });
         sub.on('destroy', () => {
           respond({
@@ -259,16 +260,6 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
         ctx = await ctxPromise;
       } catch (cause) {
         const error = getErrorFromUnknown(cause);
-        const json: TRPCErrorResponse = {
-          id: null,
-          error: router.getErrorShape({
-            error,
-            type: 'unknown',
-            path: undefined,
-            input: undefined,
-            ctx,
-          }),
-        };
         opts.onError?.({
           error,
           path: undefined,
@@ -277,7 +268,16 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
           req,
           input: undefined,
         });
-        respond(json);
+        respond({
+          id: null,
+          error: router.getErrorShape({
+            error,
+            type: 'unknown',
+            path: undefined,
+            input: undefined,
+            ctx,
+          }),
+        });
 
         // close in next tick
         (global.setImmediate ?? global.setTimeout)(() => {

--- a/packages/server/src/adapters/ws.ts
+++ b/packages/server/src/adapters/ws.ts
@@ -74,11 +74,7 @@ function parseMessage(
   const { input: rawInput, path } = params;
   assertIsString(path);
   const input = transformer.input.deserialize(rawInput);
-  return {
-    id,
-    method,
-    params: { input, path },
-  };
+  return { jsonrpc, id, method, params: { input, path } };
 }
 
 /**

--- a/packages/server/src/http/resolveHTTPResponse.ts
+++ b/packages/server/src/http/resolveHTTPResponse.ts
@@ -9,7 +9,7 @@ import {
   inferRouterContext,
   inferRouterError,
 } from '../router';
-import { TRPCErrorResponse, TRPCResponse, TRPCResultResponse } from '../rpc';
+import { TRPCResponse } from '../rpc';
 import { Maybe } from '../types';
 import { getHTTPStatusCode } from './internals/getHTTPStatusCode';
 import {
@@ -196,12 +196,11 @@ export async function resolveHTTPResponse<
       }),
     );
     const errors = rawResults.flatMap((obj) => (obj.error ? [obj.error] : []));
-    const resultEnvelopes = rawResults.map((obj) => {
+    const resultEnvelopes = rawResults.map((obj): TRouterResponse => {
       const { path, input } = obj;
 
       if (obj.error) {
-        const json: TRPCErrorResponse<TRouterError> = {
-          id: null,
+        return {
           error: router.getErrorShape({
             error: obj.error,
             type,
@@ -210,16 +209,12 @@ export async function resolveHTTPResponse<
             ctx,
           }),
         };
-        return json;
       } else {
-        const json: TRPCResultResponse<unknown> = {
-          id: null,
+        return {
           result: {
-            type: 'data',
             data: obj.data,
           },
         };
-        return json;
       }
     });
 
@@ -233,16 +228,6 @@ export async function resolveHTTPResponse<
     // - input deserialization fails
     const error = getErrorFromUnknown(cause);
 
-    const json: TRPCErrorResponse<TRouterError> = {
-      id: null,
-      error: router.getErrorShape({
-        error,
-        type,
-        path: undefined,
-        input: undefined,
-        ctx,
-      }),
-    };
     onError?.({
       error,
       path: undefined,
@@ -251,6 +236,17 @@ export async function resolveHTTPResponse<
       type: type,
       req,
     });
-    return endResponse(json, [error]);
+    return endResponse(
+      {
+        error: router.getErrorShape({
+          error,
+          type,
+          path: undefined,
+          input: undefined,
+          ctx,
+        }),
+      },
+      [error],
+    );
   }
 }

--- a/packages/server/src/internals/transformTRPCResponse.ts
+++ b/packages/server/src/internals/transformTRPCResponse.ts
@@ -1,33 +1,38 @@
 import { AnyRouter } from '../router';
-import { TRPCResponse } from '../rpc';
+import { TRPCResponse, TRPCResponseMessage } from '../rpc';
 
-function transformTRPCResponseItem(
-  router: AnyRouter,
-  item: TRPCResponse,
-): TRPCResponse {
+function transformTRPCResponseItem<
+  TResponseItem extends TRPCResponse | TRPCResponseMessage,
+>(router: AnyRouter, item: TResponseItem): TResponseItem {
   if ('error' in item) {
     return {
       ...item,
       error: router._def.transformer.output.serialize(item.error),
     };
   }
-  if (item.result.type !== 'data') {
-    return item;
+
+  if ('data' in item.result) {
+    return {
+      ...item,
+      result: {
+        ...item.result,
+        data: router._def.transformer.output.serialize(item.result.data),
+      },
+    };
   }
-  return {
-    ...item,
-    result: {
-      ...item.result,
-      data: router._def.transformer.output.serialize(item.result.data),
-    },
-  };
+
+  return item;
 }
 
 /**
  * Takes a unserialized `TRPCResponse` and serializes it with the router's transformers
  **/
 export function transformTRPCResponse<
-  TResponse extends TRPCResponse | TRPCResponse[],
+  TResponse extends
+    | TRPCResponse
+    | TRPCResponse[]
+    | TRPCResponseMessage
+    | TRPCResponseMessage[],
 >(router: AnyRouter, itemOrItems: TResponse) {
   return Array.isArray(itemOrItems)
     ? itemOrItems.map((item) => transformTRPCResponseItem(router, item))

--- a/packages/server/src/rpc/envelopes.ts
+++ b/packages/server/src/rpc/envelopes.ts
@@ -1,31 +1,10 @@
+/* eslint-disable @typescript-eslint/no-namespace */
 import { ProcedureType } from '../router';
 import { TRPC_ERROR_CODE_NUMBER } from './codes';
 
-type JSONRPC2RequestId = number | string | null;
-
 /**
- * All requests/responses extends this shape
+ * Error response
  */
-interface JSONRPC2BaseEnvelope {
-  id: JSONRPC2RequestId;
-  jsonrpc?: '2.0';
-}
-
-interface JSONRPC2BaseRequest<TMethod extends string = string>
-  extends JSONRPC2BaseEnvelope {
-  method: TMethod;
-}
-interface JSONRPC2Request<TMethod extends string = string, TParams = unknown>
-  extends JSONRPC2BaseRequest<TMethod> {
-  params: TParams;
-}
-
-interface JSONRPC2ResultResponse<TResult = unknown>
-  extends JSONRPC2BaseEnvelope {
-  result: TResult;
-}
-
-// inner types
 export interface TRPCErrorShape<
   TCode extends number = TRPC_ERROR_CODE_NUMBER,
   TData extends Record<string, unknown> = Record<string, unknown>,
@@ -36,74 +15,114 @@ export interface TRPCErrorShape<
 }
 
 /**
- * The result data wrapped
+ * JSON-RPC 2.0 Specification
  */
-export type TRPCResult<TData = unknown> =
-  | {
-      type: 'data';
-      data: TData;
-    }
-  | {
-      type: 'started';
-    }
-  | {
-      type: 'stopped';
-    };
+export namespace JSONRPC2 {
+  export type RequestId = number | string | null;
+
+  /**
+   * All requests/responses extends this shape
+   */
+  export interface BaseEnvelope {
+    id?: RequestId;
+    jsonrpc?: '2.0';
+  }
+
+  export interface BaseRequest<TMethod extends string = string>
+    extends BaseEnvelope {
+    method: TMethod;
+  }
+
+  export interface Request<TMethod extends string = string, TParams = unknown>
+    extends BaseRequest<TMethod> {
+    params: TParams;
+  }
+
+  export interface ResultResponse<TResult = unknown> extends BaseEnvelope {
+    result: TResult;
+  }
+
+  export interface ErrorResponse<TError extends TRPCErrorShape = TRPCErrorShape>
+    extends BaseEnvelope {
+    error: TError;
+  }
+}
 
 /**
- * Request envelope
+ * TRPC HTTP Envelopes
  */
-export type TRPCRequest =
-  | JSONRPC2Request<'subscription.stop'>
-  | JSONRPC2Request<
-      ProcedureType,
-      {
-        path: string;
-        input: unknown;
-      }
-    >;
 
-/**
- * OK response
- */
-export type TRPCResultResponse<TData = unknown> = JSONRPC2ResultResponse<
-  TRPCResult<TData>
+export type TRPCRequest = JSONRPC2.Request<
+  ProcedureType,
+  { path: string; input: unknown }
 >;
 
-/**
- * Generic response wrapper that is either a result or error
- */
+export type TRPCResult<TData = unknown> = { data: TData };
+
+export type TRPCErrorResponse<TError extends TRPCErrorShape = TRPCErrorShape> =
+  JSONRPC2.ErrorResponse<TError>;
+
 export type TRPCResponse<
-  TData = unknown,
+  TResult = unknown,
   TError extends TRPCErrorShape = TRPCErrorShape,
-> = TRPCResultResponse<TData> | TRPCErrorResponse<TError>;
+> = JSONRPC2.ResultResponse<TRPCResult<TResult>> | TRPCErrorResponse<TError>;
 
 /**
- * Error response
+ * HTTP WS Envelopes
  */
-export interface TRPCErrorResponse<
+
+export type TRPCRequestMessage = {
+  id: JSONRPC2.RequestId;
+} & TRPCRequest;
+
+/**
+ * The client asked the server to unsubscribe
+ */
+export type TRPCSubscriptionStopNotification = {
+  id: null;
+} & JSONRPC2.BaseRequest<'subscription.stop'>;
+
+/**
+ * The client's outgoing request types
+ */
+export type TRPCClientOutgoingRequest = TRPCSubscriptionStopNotification;
+
+/**
+ * The client's sent messages shape
+ */
+export type TRPCClientOutgoingMessage =
+  | TRPCRequestMessage
+  | ({ id: JSONRPC2.RequestId } & JSONRPC2.BaseRequest<'subscription.stop'>);
+
+export type TRPCResultMessage<TData = unknown> =
+  | ({ type: 'data' } & TRPCResult<TData>)
+  | { type: 'started' }
+  | { type: 'stopped' };
+
+export type TRPCResponseMessage<
+  TResult = unknown,
   TError extends TRPCErrorShape = TRPCErrorShape,
-> extends JSONRPC2BaseEnvelope {
-  error: TError;
-}
+> = { id: JSONRPC2.RequestId } & (
+  | JSONRPC2.ResultResponse<TRPCResultMessage<TResult>>
+  | TRPCErrorResponse<TError>
+);
 
 /**
  * The server asked the client to reconnect - useful when restarting/redeploying service
  */
-export interface TRPCReconnectNotification
-  extends JSONRPC2BaseRequest<'reconnect'> {
-  id: null;
-}
+export type TRPCReconnectNotification = {
+  id: JSONRPC2.RequestId;
+} & JSONRPC2.BaseRequest<'reconnect'>;
 
 /**
  * The client's incoming request types
  */
-export type TRPCClientIncomingRequest =
-  TRPCReconnectNotification /* could be extended in future */;
+export type TRPCClientIncomingRequest = TRPCReconnectNotification;
 
 /**
  * The client's received messages shape
  */
-export type TRPCClientIncomingMessage =
-  | TRPCResponse
-  | TRPCClientIncomingRequest;
+export type TRPCClientIncomingMessage<
+  TResult = unknown,
+  TError extends TRPCErrorShape = TRPCErrorShape,
+> = TRPCResponseMessage<TResult, TError> | TRPCClientIncomingRequest;

--- a/packages/server/test/adapters/fastify.test.ts
+++ b/packages/server/test/adapters/fastify.test.ts
@@ -16,7 +16,7 @@ import {
   CreateFastifyContextOptions,
   fastifyTRPCPlugin,
 } from '../../src/adapters/fastify';
-import { TRPCResult } from '../../src/rpc';
+import { TRPCResultMessage } from '../../src/rpc';
 
 const config = {
   port: 2022,
@@ -262,7 +262,7 @@ describe('anonymous user', () => {
     const sub = app.client.subscription('onMessage', undefined, {
       next(data) {
         expectTypeOf(data).not.toBeAny();
-        expectTypeOf(data).toMatchTypeOf<TRPCResult<Message>>();
+        expectTypeOf(data).toMatchTypeOf<TRPCResultMessage<Message>>();
         next(data);
       },
     });

--- a/packages/server/test/adapters/next.test.ts
+++ b/packages/server/test/adapters/next.test.ts
@@ -97,10 +97,8 @@ describe('ok request', () => {
     const json: any = JSON.parse((end.mock.calls[0] as any)[0]);
     expect(json).toMatchInlineSnapshot(`
       Object {
-        "id": null,
         "result": Object {
           "data": "world",
-          "type": "data",
         },
       }
     `);
@@ -120,10 +118,8 @@ describe('ok request', () => {
     const json: any = JSON.parse((end.mock.calls[0] as any)[0]);
     expect(json).toMatchInlineSnapshot(`
       Object {
-        "id": null,
         "result": Object {
           "data": "world",
-          "type": "data",
         },
       }
     `);

--- a/packages/server/test/links.test.ts
+++ b/packages/server/test/links.test.ts
@@ -66,10 +66,8 @@ test('chainer', async () => {
         "response": "[redacted]",
       },
       "data": Object {
-        "id": null,
         "result": Object {
           "data": "world",
-          "type": "data",
         },
       },
     }
@@ -169,10 +167,8 @@ describe('batching', () => {
             "response": "[redacted]",
           },
           "data": Object {
-            "id": null,
             "result": Object {
               "data": "hello world",
-              "type": "data",
             },
           },
         },
@@ -181,10 +177,8 @@ describe('batching', () => {
             "response": "[redacted]",
           },
           "data": Object {
-            "id": null,
             "result": Object {
               "data": "hello alexdotjs",
-              "type": "data",
             },
           },
         },

--- a/packages/server/test/rawFetch.test.tsx
+++ b/packages/server/test/rawFetch.test.tsx
@@ -47,7 +47,6 @@ test('batching with raw batch', async () => {
     expect(json[0].result).toMatchInlineSnapshot(`
 Object {
   "data": "alexdotjs",
-  "type": "data",
 }
 `);
   }

--- a/packages/server/test/responseMeta.test.ts
+++ b/packages/server/test/responseMeta.test.ts
@@ -52,10 +52,8 @@ test('set custom headers in beforeEnd', async () => {
 
     expect(await res.json()).toMatchInlineSnapshot(`
 Object {
-  "id": null,
   "result": Object {
     "data": "public endpoint",
-    "type": "data",
   },
 }
 `);
@@ -69,10 +67,8 @@ Object {
 
     expect(await res.json()).toMatchInlineSnapshot(`
 Object {
-  "id": null,
   "result": Object {
     "data": "not cached endpoint",
-    "type": "data",
   },
 }
 `);

--- a/packages/server/test/transformer.test.ts
+++ b/packages/server/test/transformer.test.ts
@@ -484,12 +484,10 @@ test('superjson - no input', async () => {
   expect(json).not.toHaveProperty('error');
   expect(json).toMatchInlineSnapshot(`
 Object {
-  "id": null,
   "result": Object {
     "data": Object {
       "json": "world",
     },
-    "type": "data",
   },
 }
 `);

--- a/packages/server/test/websockets.test.ts
+++ b/packages/server/test/websockets.test.ts
@@ -13,7 +13,7 @@ import { wsLink } from '../../client/src';
 import * as trpc from '../src';
 import { TRPCError } from '../src';
 import { applyWSSHandler } from '../src/adapters/ws';
-import { TRPCRequest, TRPCResult } from '../src/rpc';
+import { TRPCRequestMessage, TRPCResultMessage } from '../src/rpc';
 
 type Message = {
   id: string;
@@ -148,7 +148,7 @@ test('basic subscription test', async () => {
   const subscription = client.subscription('onMessage', undefined, {
     next(data) {
       expectTypeOf(data).not.toBeAny();
-      expectTypeOf(data).toMatchTypeOf<TRPCResult<Message>>();
+      expectTypeOf(data).toMatchTypeOf<TRPCResultMessage<Message>>();
       next(data);
     },
   });
@@ -480,7 +480,7 @@ describe('regression test - slow createContext', () => {
     });
     const rawClient = new WebSocket(t.wssUrl);
 
-    const msg: TRPCRequest = {
+    const msg: TRPCRequestMessage = {
       id: 1,
       method: 'query',
       params: {
@@ -522,7 +522,7 @@ describe('regression test - slow createContext', () => {
     t.wsClient.close();
     const rawClient = new WebSocket(t.wssUrl);
 
-    const msg: TRPCRequest = {
+    const msg: TRPCRequestMessage = {
       id: 1,
       method: 'query',
       params: {
@@ -633,7 +633,7 @@ test('regression - badly shaped request', async () => {
   const t = factory();
   const rawClient = new WebSocket(t.wssUrl);
 
-  const msg: TRPCRequest = {
+  const msg: TRPCRequestMessage = {
     id: null,
     method: 'query',
     params: {

--- a/www/docs/further/rpc.md
+++ b/www/docs/further/rpc.md
@@ -96,9 +96,7 @@ encodeURIComponent(
   [
     // result for `postById`
     {
-      "id": null,
       "result": {
-        "type": "data",
         "data": {
           "id": "1",
           "title": "Hello tRPC",
@@ -109,9 +107,7 @@ encodeURIComponent(
     },
     // result for `relatedPosts`
     {
-      "id": null,
       "result": {
-        "type": "data",
         "data": [
           /* ... */
         ]
@@ -133,9 +129,7 @@ In order to have a specification that works regardless of the transport layer we
 
 ```json
 {
-  "id": null,
   "result": {
-    "type": "data",
     "data": {
       "id": "1",
       "title": "Hello tRPC",
@@ -149,9 +143,7 @@ In order to have a specification that works regardless of the transport layer we
 
 ```ts
 {
-  id: null;
   result: {
-    type: 'data';
     data: TOutput; // output from procedure
   };
 }
@@ -166,7 +158,6 @@ In order to have a specification that works regardless of the transport layer we
 ```json
 [
   {
-    "id": null,
     "error": {
       "json": {
         "message": "Something went wrong",

--- a/www/docs/further/subscriptions.md
+++ b/www/docs/further/subscriptions.md
@@ -142,7 +142,7 @@ See [/examples/next-prisma-starter-websockets](https://github.com/trpc/trpc/tree
 ```ts
 {
   id: number | string;
-  jsonrpc?: '2.0';
+  jsonrpc?: '2.0'; // optional
   method: 'query' | 'mutation';
   params: {
     path: string;
@@ -158,7 +158,7 @@ _... below, or an error._
 ```ts
 {
   id: number | string;
-  jsonrpc: '2.0';
+  jsonrpc?: '2.0'; // only defined if included in request
   result: {
     type: 'data'; // always 'data' for mutation / queries
     data: TOutput; // output from procedure
@@ -201,17 +201,17 @@ _... below, or an error._
 ```ts
 {
   id: number | string;
-  jsonrpc: '2.0';
+  jsonrpc?: '2.0';
   result: (
     | {
-      type: 'data';
+        type: 'data';
         data: TData; // subscription emitted data
       }
     | {
-        type: 'started'; // sub started
+        type: 'started'; // subscription started
       }
     | {
-        type: 'stopped'; // sub stopped
+        type: 'stopped'; // subscription stopped
       }
   )
 }
@@ -225,6 +225,6 @@ See https://www.jsonrpc.org/specification#error_object or [Error Formatting](../
 ## Notifications from Server to Client
 
 
-### `{id: null, type: 'reconnect' }`
+### `{ id: null, type: 'reconnect' }`
 
 Tells clients to reconnect before shutting down server. Invoked by `wssHandler.broadcastReconnectNotification()`.

--- a/www/docs/server/output-validation.md
+++ b/www/docs/server/output-validation.md
@@ -7,12 +7,12 @@ slug: /output-validation
 
 tRPC gives you automatic type-safety of outputs without the need of adding a validator; however, it can be useful at times to strictly define the output type in order to prevent sensitive data of being leaked.
 
-Similarily to `input:`, an `output:` validation to the `query()` and `mutation()` router methods. The output validator is invoked with the payload returned by the `resolve()` function.
+Similarily to [`input`](/docs/router), an `output` validation can be added to the `query()` and `mutation()` router methods. The output validator is invoked with the payload returned by the `resolve()` function.
 
 When an `output` validator is defined, its inferred type is expected as the return type of the `resolve()` function.
 
 :::info
-- This is entirely optional and only if you want to ensure you don't accidentally leak anything e
+- This is entirely optional and only if you want to validate your output at runtime. This can be useful to ensure you do not accidentally leak any unexpected data.
 - If output validation fails, the server will respond with a `INTERNAL_SERVER_ERROR`.
 :::
 


### PR DESCRIPTION
Closes https://github.com/trpc/trpc/issues/1778

## Simplify tRPC request/response/message interfaces
 
  * Remove `"id": null` from HTTP response envelopes
  * Remove `"type": "data"` from HTTP response envelopes
  * Remove `"jsonrpc": "2.0"` from WS message envelopes