### PR TITLE
docs: add note about fastify param length limit

### DIFF
--- a/www/docs/server/fastify.md
+++ b/www/docs/server/fastify.md
@@ -121,7 +121,7 @@ export type Context = inferAsyncReturnType<typeof createContext>;
 
 ### Create Fastify server
 
-tRPC includes an adapter for [Fastify](https://www.fastify.io/) out of the box. This adapter lets you convert your tRPC router into an [Fastify plugin](https://www.fastify.io/docs/latest/Reference/Plugins/).
+tRPC includes an adapter for [Fastify](https://www.fastify.io/) out of the box. This adapter lets you convert your tRPC router into an [Fastify plugin](https://www.fastify.io/docs/latest/Reference/Plugins/). In order to prevent errors during large batch requests, make sure to set the `maxParamLength` Fastify option to a suitable value, as shown.
 
 ```ts title='server.ts'
 import fastify from 'fastify';
@@ -129,7 +129,9 @@ import { fastifyTRPCPlugin } from '@trpc/server/adapters/fastify';
 import { createContext } from './context';
 import { appRouter } from './router';
 
-const server = fastify();
+const server = fastify({
+  maxParamLength: 5000
+});
 
 server.register(fastifyTRPCPlugin, {
   prefix: '/trpc',


### PR DESCRIPTION
This adds a note to prevent people from encountering an error when tRPC batches too many queries, which generates long HTTP request URI queries, which Fastify will reject by default.