### PR TITLE
Bugfix `output` type inference priority

### DIFF
--- a/packages/server/src/internals/procedure.ts
+++ b/packages/server/src/internals/procedure.ts
@@ -2,6 +2,7 @@
 import { TRPCError } from '../TRPCError';
 import { assertNotBrowser } from '../assertNotBrowser';
 import { ProcedureType } from '../router';
+import { InferLast } from '../types';
 import { getErrorFromUnknown } from './errors';
 import { MiddlewareFunction, middlewareMarker } from './middlewares';
 import { wrapCallSafe } from './wrapCallSafe';
@@ -266,7 +267,7 @@ export type CreateProcedureWithInput<TContext, TMeta, TInput, TOutput> = {
   input: ProcedureParser<TInput>;
   output?: ProcedureParser<TOutput>;
   meta?: TMeta;
-  resolve: ProcedureResolver<TContext, TInput, TOutput>;
+  resolve: ProcedureResolver<TContext, TInput, InferLast<TOutput>>;
 };
 
 export type CreateProcedureWithInputOutputParser<
@@ -280,7 +281,7 @@ export type CreateProcedureWithInputOutputParser<
   input: ProcedureParserWithInputOutput<TInput, TParsedInput>;
   output?: ProcedureParserWithInputOutput<TOutput, TParsedOutput>;
   meta?: TMeta;
-  resolve: ProcedureResolver<TContext, TParsedInput, TOutput>;
+  resolve: ProcedureResolver<TContext, TParsedInput, InferLast<TOutput>>;
 };
 
 export type CreateProcedureWithoutInput<
@@ -293,7 +294,7 @@ export type CreateProcedureWithoutInput<
     | ProcedureParserWithInputOutput<TOutput, TParsedOutput>
     | ProcedureParser<TOutput>;
   meta?: TMeta;
-  resolve: ProcedureResolver<TContext, undefined, TOutput>;
+  resolve: ProcedureResolver<TContext, undefined, InferLast<TOutput>>;
 };
 
 export type CreateProcedureOptions<

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -59,6 +59,6 @@ export type Dict<T> = Record<string, T | undefined>;
 /**
  * @internal
  * Creates a "lower-priority" type inference.
- * https://github.com/microsoft/TypeScript/issues/14829#issuecomment-320754731
+ * https://github.com/microsoft/TypeScript/issues/14829#issuecomment-322267089
  */
-export type InferLast<T> = T & {};
+export type InferLast<T> = T & { [K in keyof T]: T[K] };

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -55,3 +55,10 @@ export type ThenArg<T> = T extends PromiseLike<infer U> ? ThenArg<U> : T;
  * @public
  */
 export type Dict<T> = Record<string, T | undefined>;
+
+/**
+ * @internal
+ * Creates a "lower-priority" type inference.
+ * https://github.com/microsoft/TypeScript/issues/14829#issuecomment-320754731
+ */
+export type InferLast<T> = T & {};

--- a/packages/server/test/inference.test.ts
+++ b/packages/server/test/inference.test.ts
@@ -33,7 +33,6 @@ test('infer query input & output', async () => {
       output: z.object({
         input: z.string(),
       }),
-      // https://github.com/trpc/trpc/discussions/1817
       // @ts-expect-error - ensure type inferred from "output" is higher priority than "resolve" fn return type
       resolve() {
         return {};
@@ -114,7 +113,6 @@ test('infer mutation input & output', async () => {
       output: z.object({
         input: z.string(),
       }),
-      // https://github.com/trpc/trpc/discussions/1817
       // @ts-expect-error - ensure type inferred from "output" is higher priority than "resolve" fn return type
       resolve() {
         return {};

--- a/packages/server/test/inference.test.ts
+++ b/packages/server/test/inference.test.ts
@@ -29,6 +29,16 @@ test('infer query input & output', async () => {
         return { input };
       },
     })
+    .query('withOutputEmptyObject', {
+      output: z.object({
+        input: z.string(),
+      }),
+      // https://github.com/trpc/trpc/discussions/1817
+      // @ts-expect-error - ensure type inferred from "output" is higher priority than "resolve" fn return type
+      resolve() {
+        return {};
+      },
+    })
     .query('withInputOutput', {
       input: z.string(),
       output: z.object({
@@ -54,6 +64,14 @@ test('infer query input & output', async () => {
   {
     const input: inferProcedureInput<TQueries['withOutput']> = null as any;
     const output: inferProcedureOutput<TQueries['withOutput']> = null as any;
+    expectTypeOf(input).toMatchTypeOf<undefined | null | void>();
+    expectTypeOf(output).toMatchTypeOf<{ input: string }>();
+  }
+  {
+    const input: inferProcedureInput<TQueries['withOutputEmptyObject']> =
+      null as any;
+    const output: inferProcedureOutput<TQueries['withOutputEmptyObject']> =
+      null as any;
     expectTypeOf(input).toMatchTypeOf<undefined | null | void>();
     expectTypeOf(output).toMatchTypeOf<{ input: string }>();
   }
@@ -92,6 +110,16 @@ test('infer mutation input & output', async () => {
         return { input };
       },
     })
+    .mutation('withOutputEmptyObject', {
+      output: z.object({
+        input: z.string(),
+      }),
+      // https://github.com/trpc/trpc/discussions/1817
+      // @ts-expect-error - ensure type inferred from "output" is higher priority than "resolve" fn return type
+      resolve() {
+        return {};
+      },
+    })
     .mutation('withInputOutput', {
       input: z.string(),
       output: z.object({
@@ -117,6 +145,14 @@ test('infer mutation input & output', async () => {
   {
     const input: inferProcedureInput<TMutations['withOutput']> = null as any;
     const output: inferProcedureOutput<TMutations['withOutput']> = null as any;
+    expectTypeOf(input).toMatchTypeOf<undefined | null | void>();
+    expectTypeOf(output).toMatchTypeOf<{ input: string }>();
+  }
+  {
+    const input: inferProcedureInput<TMutations['withOutputEmptyObject']> =
+      null as any;
+    const output: inferProcedureOutput<TMutations['withOutputEmptyObject']> =
+      null as any;
     expectTypeOf(input).toMatchTypeOf<undefined | null | void>();
     expectTypeOf(output).toMatchTypeOf<{ input: string }>();
   }


### PR DESCRIPTION
Closes #1817 

## Bugfix `output` type inference priority

`resolve` is not throwing a TS error when returning an empty object. This is because TS is inferring the returned `{}` type from `resolve` as `TOutput` with higher priority than the supplied `output` type.

See inference priority reproduction: https://stackblitz.com/edit/typescript-qnjchh?file=index.ts
See real world issue reproduction: https://stackblitz.com/edit/typescript-5j9cvu?file=index.ts

Requires new patch release: `v9.22.1` @KATT? 