### PR TITLE
Move imports from react-query/hydration to react-query

### DIFF
--- a/packages/next/src/withTRPC.tsx
+++ b/packages/next/src/withTRPC.tsx
@@ -18,8 +18,13 @@ import {
   NextPageContext,
 } from 'next/dist/shared/lib/utils';
 import React, { createElement, useState } from 'react';
-import { QueryClient, QueryClientProvider } from 'react-query';
-import { DehydratedState, Hydrate, dehydrate } from 'react-query/hydration';
+import {
+  DehydratedState,
+  Hydrate,
+  QueryClient,
+  QueryClientProvider,
+  dehydrate,
+} from 'react-query';
 import ssrPrepass from 'react-ssr-prepass';
 
 type QueryClientConfig = ConstructorParameters<typeof QueryClient>[0];


### PR DESCRIPTION
This entrypoint will be removed in `react-query@4` and currently breaks `react-query@beta` because of the missing entry in the export map. See https://react-query-beta.tanstack.com/guides/migrating-to-react-query-4#separate-hydration-exports-have-been-removed