### PR TITLE
Fix hydration issue with Date.prototype.toLocaleDateString

### DIFF
--- a/examples/next-prisma-starter/src/pages/post/[id].tsx
+++ b/examples/next-prisma-starter/src/pages/post/[id].tsx
@@ -23,7 +23,7 @@ const PostViewPage: NextPageWithLayout = () => {
   return (
     <>
       <h1>{data.title}</h1>
-      <em>Created {data.createdAt.toLocaleDateString()}</em>
+      <em>Created {data.createdAt.toLocaleDateString('en-us')}</em>
 
       <p>{data.text}</p>
 

--- a/www/docs/nextjs/ssg.md
+++ b/www/docs/nextjs/ssg.md
@@ -81,7 +81,7 @@ export default function PostViewPage(
   return (
     <>
       <h1>{data.title}</h1>
-      <em>Created {data.createdAt.toLocaleDateString()}</em>
+      <em>Created {data.createdAt.toLocaleDateString('en-us')}</em>
 
       <p>{data.text}</p>
 


### PR DESCRIPTION
See #1911 we get some hydration errors with the NextJS starter example.
This fixes the hydration by setting a locale in options. Was probably different between server and client.