### PR TITLE
fix node-http type errors

### DIFF
--- a/packages/server/src/adapters/node-http/types.ts
+++ b/packages/server/src/adapters/node-http/types.ts
@@ -1,12 +1,14 @@
 import http from 'http';
-import qs from 'qs';
 import { inferRouterContext } from '../..';
 import { HTTPBaseHandlerOptions } from '../../http/internals/types';
 import { AnyRouter } from '../../router';
 
+interface ParsedQs {
+  [key: string]: undefined | string | string[] | ParsedQs | ParsedQs[];
+}
+
 export type NodeHTTPRequest = http.IncomingMessage & {
-  method?: string;
-  query?: qs.ParsedQs;
+  query?: ParsedQs;
   body?: unknown;
 };
 export type NodeHTTPResponse = http.ServerResponse;


### PR DESCRIPTION
fix #1904

Remove use of `@types/qs`. Change `NodeHTTPRequest` to use `http.IncomingMessage`'s type for `method`.