### PR TITLE
update example link for `trpc-openapi`

### DIFF
--- a/examples/trpc-openapi/README.md
+++ b/examples/trpc-openapi/README.md
@@ -2,8 +2,8 @@
 
 ### Next.js
 
-**Go to https://github.com/jlalmes/trpc-openapi/tree/master/examples/with-nextjs**
+**Go to https://github.com/jlalmes/trpc-openapi/tree/v0.1.0/examples/with-nextjs**
 
 ### Express
 
-**Go to https://github.com/jlalmes/trpc-openapi/tree/master/examples/with-express**
+**Go to https://github.com/jlalmes/trpc-openapi/tree/v0.1.0/examples/with-express**


### PR DESCRIPTION
The examples have been moved to another branch,.