### PR TITLE
Honor type when useQuery select fn is used

### DIFF
--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -48,8 +48,8 @@ export interface TRPCUseQueryBaseOptions extends TRPCRequestOptions {
   ssr?: boolean;
 }
 
-export interface UseTRPCQueryOptions<TPath, TInput, TOutput, TError>
-  extends UseQueryOptions<TOutput, TError, TOutput, [TPath, TInput]>,
+export interface UseTRPCQueryOptions<TPath, TInput, TOutput, TData, TError>
+  extends UseQueryOptions<TOutput, TError, TData, [TPath, TInput]>,
     TRPCUseQueryBaseOptions {}
 
 export interface UseTRPCInfiniteQueryOptions<TPath, TInput, TOutput, TError>
@@ -264,15 +264,20 @@ export function createReactQueryHooks<
       : opts;
   }
 
-  function useQuery<TPath extends keyof TQueryValues & string>(
+  function useQuery<
+    TPath extends keyof TQueryValues & string,
+    TQueryFnData = TQueryValues[TPath]['output'],
+    TData = TQueryValues[TPath]['output'],
+  >(
     pathAndInput: [path: TPath, ...args: inferHandlerInput<TQueries[TPath]>],
     opts?: UseTRPCQueryOptions<
       TPath,
       TQueryValues[TPath]['input'],
-      TQueryValues[TPath]['output'],
+      TQueryFnData,
+      TData,
       TError
     >,
-  ): UseQueryResult<TQueryValues[TPath]['output'], TError> {
+  ): UseQueryResult<TData, TError> {
     const { client, isPrepass, queryClient, prefetchQuery } = useContext();
 
     if (

--- a/packages/server/test/react.test.tsx
+++ b/packages/server/test/react.test.tsx
@@ -358,6 +358,35 @@ describe('useQuery()', () => {
     });
     expect(utils.container).not.toHaveTextContent('second post');
   });
+
+  test('select fn', async () => {
+    const { trpc, client } = factory;
+    function MyComponent() {
+      const allPostsQuery = trpc.useQuery(['paginatedPosts', { limit: 1 }], {
+        select: () => ({
+          hello: 'world' as const,
+        }),
+      });
+      expectTypeOf(allPostsQuery.data!).toMatchTypeOf<{ hello: 'world' }>();
+
+      return <pre>{JSON.stringify(allPostsQuery.data ?? 'n/a', null, 4)}</pre>;
+    }
+    function App() {
+      const [queryClient] = useState(() => new QueryClient());
+      return (
+        <trpc.Provider {...{ queryClient, client }}>
+          <QueryClientProvider client={queryClient}>
+            <MyComponent />
+          </QueryClientProvider>
+        </trpc.Provider>
+      );
+    }
+
+    const utils = render(<App />);
+    await waitFor(() => {
+      expect(utils.container).toHaveTextContent('"hello": "world"');
+    });
+  });
 });
 
 test('mutation on mount + subscribe for it', async () => {


### PR DESCRIPTION
This will fix the issue specifically defined in the issue linked, but a thorough investigation to make sure typing is being done in a way that honors the patterns behind react-query would be a good idea. At the moment the infinite queries are actually broken (I have a PR there to resolve it), so those are probably less important to investigate until that PR is merged.

closes https://github.com/trpc/trpc/issues/1779
original PR: #1943