### PR TITLE
fix(types): expose Procedure

### DIFF
--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -11,9 +11,8 @@ export function createTRPCClient<TRouter extends AnyRouter>(
   return new Client<TRouter>(opts);
 }
 
-export type TRPCClient<TRouter extends AnyRouter> = Client<TRouter>;
-
 export type {
   TRPCRequestOptions,
   CreateTRPCClientOptions,
+  TRPCClient,
 } from './internals/TRPCClient';

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -27,6 +27,8 @@ import { Prefixer, ThenArg, flatten } from './types';
 
 assertNotBrowser();
 
+export type { Procedure } from './internals/procedure';
+
 /**
  * @public
  */


### PR DESCRIPTION
In ESM context, when generating types for my own package `@acme/api` and exposing the type `AppRouter`, TypeScript is unable to resolve the internal type `Procedure` because it's not explicitly exported in `exports` map:

```typescript
import * as trpc from "@trpc/server";
export declare const appRouter: trpc.Router<{}, {}, {}, Record<"hello", import("@trpc/server/dist/internals/procedure.js").Procedure<{}, {}, {}, {
    name?: string | undefined;
}, {
    name?: string | undefined;
}, {
    greeting: string;
}, unknown, {
    greeting: string;
}>>, {}, {}, trpc.DefaultErrorShape>;
export declare type AppRouter = typeof appRouter;
//# sourceMappingURL=router.d.ts.map
```

It results in `AppRouter` being incomplete, `Procedure` being replaced with `any`:
<img width="1212" alt="image" src="https://user-images.githubusercontent.com/1443499/172160436-c2c135e7-453c-47aa-972e-d5c619f50f18.png">

The fix is to export `Procedure` as part of `@trpc/server` public types.

If I didn't export it from the proper place, don't hesitate to move the statement. 👍 

**edit**: I spotted another type not exported resulting in a failure to generate types declaration, this time in `@trpc/client`:
```bash
> tsc --project tsconfig.build.json --emitDeclarationOnly --declaration --declarationMap

src/config/trpc.ts:5:14 - error TS2742: The inferred type of 'client' cannot be named without a reference to '../../../../node_modules/@trpc/client/dist/internals/TRPCClient.js'. This is likely not portable. A type annotation is necessary.

5 export const client = createTRPCClient<AppRouter>({
               ~~~~~~


Found 1 error in src/config/trpc.ts:5
```
`TRPCClient` from `./internals/TRPCClient` should be exported instead of redefining it [here](https://github.com/trpc/trpc/blob/a3ecf56d83dd9774aaf885e83e9ccfe363fbab48/packages/client/src/createTRPCClient.ts#L14).