### PR TITLE
fix(types): export internals for types definitions generation

### DIFF
--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -11,9 +11,8 @@ export function createTRPCClient<TRouter extends AnyRouter>(
   return new Client<TRouter>(opts);
 }
 
-export type TRPCClient<TRouter extends AnyRouter> = Client<TRouter>;
-
 export type {
   TRPCRequestOptions,
   CreateTRPCClientOptions,
+  TRPCClient,
 } from './internals/TRPCClient';

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -27,6 +27,8 @@ import { Prefixer, ThenArg, flatten } from './types';
 
 assertNotBrowser();
 
+export type { Procedure } from './internals/procedure';
+
 /**
  * @public
  */


### PR DESCRIPTION
This is a follow-up of this [PR](https://github.com/trpc/trpc/pull/1958#issue-1261776224), on the right origin this time. 👍 