### PR TITLE
Replace example project links with template links

### DIFF
--- a/examples/next-prisma-starter-websockets/src/pages/index.tsx
+++ b/examples/next-prisma-starter-websockets/src/pages/index.tsx
@@ -198,7 +198,7 @@ export default function IndexPage() {
                   <br />
                   <a
                     className="text-gray-100 underline"
-                    href="https://github.com/trpc/trpc/tree/main/examples/next-prisma-starter-websockets"
+                    href="https://github.com/trpc/examples-next-prisma-starter-websockets"
                     target="_blank"
                     rel="noreferrer"
                   >

--- a/examples/next-prisma-todomvc/src/pages/[filter].tsx
+++ b/examples/next-prisma-todomvc/src/pages/[filter].tsx
@@ -322,7 +322,7 @@ export default function TodosPage({
           <a href="https://twitter.com/alexdotjs">alexdotjs / KATT</a>.
         </p>
         <p>
-          <a href="https://github.com/trpc/trpc/tree/main/examples/next-prisma-todomvc">
+          <a href="https://github.com/trpc/examples-next-prisma-todomvc">
             Source code
           </a>{' '}
           -{' '}

--- a/www/docs/further/subscriptions.md
+++ b/www/docs/further/subscriptions.md
@@ -12,7 +12,7 @@ Subscriptions & WebSockets are in beta, alpha & might change without a major ver
 ## Using Subscriptions
 
 :::tip
-- For a full-stack example have a look at [/examples/next-prisma-starter-websockets](https://github.com/trpc/trpc/tree/main/examples/next-prisma-starter-websockets).
+- For a full-stack example have a look at [/examples/next-prisma-starter-websockets](https://github.com/trpc/examples-next-prisma-starter-websockets).
 - For a bare-minumum Node.js example see [/examples/standalone-server](https://github.com/trpc/trpc/tree/main/examples/standalone-server).
 
 :::
@@ -124,7 +124,7 @@ const client = createTRPCClient<AppRouter>({
 
 ### Using React
 
-See [/examples/next-prisma-starter-websockets](https://github.com/trpc/trpc/tree/main/examples/next-prisma-starter-websockets).
+See [/examples/next-prisma-starter-websockets](https://github.com/trpc/examples-next-prisma-starter-websockets).
 
 ## WebSockets RPC Specification
 

--- a/www/docs/main/example-apps.md
+++ b/www/docs/main/example-apps.md
@@ -30,7 +30,7 @@ Here's some example apps:
       <td><a href="https://nextjs.trpc.io">nextjs.trpc.io</a></td>
       <td>
         <ul>
-          <li><a href="https://github.com/trpc/trpc/tree/main/examples/next-prisma-starter">Source</a></li>
+          <li><a href="https://github.com/trpc/examples-next-prisma-starter">Source</a></li>
         </ul>
       </td>
     </tr>
@@ -65,7 +65,7 @@ Here's some example apps:
       <td>
         <ul>
           <li><a href="https://codesandbox.io/s/github/trpc/trpc/tree/main/examples/next-prisma-starter-websockets?file=/src/pages/index.tsx">CodeSandbox</a></li>
-          <li><a href="https://github.com/trpc/trpc/tree/main/examples/next-prisma-starter-websockets">Source</a></li>
+          <li><a href="https://github.com/trpc/examples-next-prisma-starter-websockets">Source</a></li>
         </ul>
       </td>
     </tr>
@@ -82,7 +82,7 @@ Here's some example apps:
       <td>
         <ul>
           <li><a href="https://codesandbox.io/s/github/trpc/trpc/tree/main/examples/next-prisma-todomvc?file=/pages/%5Bfilter%5D.tsx">CodeSandbox</a></li>
-          <li><a href="https://github.com/trpc/trpc/tree/main/examples/next-prisma-todomvc">Source</a></li>
+          <li><a href="https://github.com/trpc/examples-next-prisma-todomvc">Source</a></li>
         </ul>
       </td>
     </tr>

--- a/www/docs/nextjs/ssg.md
+++ b/www/docs/nextjs/ssg.md
@@ -6,7 +6,7 @@ slug: /ssg
 ---
 
 :::tip
-Reference project: https://github.com/trpc/trpc/tree/main/examples/next-prisma-todomvc
+Reference project: https://github.com/trpc/examples-next-prisma-todomvc
 :::
 
 Static site generation requires executing tRPC queries inside `getStaticProps` on each page.

--- a/www/docs/nextjs/starter-projects.md
+++ b/www/docs/nextjs/starter-projects.md
@@ -29,7 +29,7 @@ Get started quickly with one of the sample projects! Copy the snippet from _Quic
       <td>
         <ul>
           <li><a href="https://codesandbox.io/s/github/trpc/trpc/tree/main/examples/next-prisma-starter?file=/src/pages/index.tsx">CodeSandbox</a></li>
-          <li><a href="https://github.com/trpc/trpc/tree/main/examples/next-prisma-starter">Source</a></li>
+          <li><a href="https://github.com/trpc/examples-next-prisma-starter">Source</a></li>
         </ul>
       </td>
     </tr>
@@ -64,7 +64,7 @@ Get started quickly with one of the sample projects! Copy the snippet from _Quic
       <td>
         <ul>
           <li><a href="https://codesandbox.io/s/github/trpc/trpc/tree/main/examples/next-prisma-todomvc?file=/pages/%5Bfilter%5D.tsx">CodeSandbox</a></li>
-          <li><a href="https://github.com/trpc/trpc/tree/main/examples/next-prisma-todomvc">Source</a></li>
+          <li><a href="https://github.com/trpc/examples-next-prisma-todomvc">Source</a></li>
         </ul>
       </td>
     </tr>


### PR DESCRIPTION
See: #1720

Other links that could be converted into template repo:
- https://github.com/trpc/trpc/tree/main/examples/standalone-server
- https://github.com/trpc/trpc/tree/main/examples/fastify-server
- https://github.com/trpc/trpc/tree/main/examples/express-server