### PR TITLE
Correct import in API Gateway documentation

### DIFF
--- a/www/docs/server/api-gateway.md
+++ b/www/docs/server/api-gateway.md
@@ -66,7 +66,7 @@ export type AppRouter = typeof appRouter;
 tRPC includes an adapter for API Gateway out of the box. This adapter lets you run your routes through the API Gateway handler.
 
 ```ts title='server.ts'
-import * as trpcAPIGW from '@trpc/server/adapters/api-gateway';
+import { CreateLambdaContextOptions, lambdaRequestHandler } from '@trpc/server/adapters/lambda';
 
 const appRouter = /* ... */;
 
@@ -74,10 +74,10 @@ const appRouter = /* ... */;
 const createContext = ({
   event,
   context,
-}: trpcAPIGW.CreateLambdaContextOptions) => ({}) // no context
+}: CreateLambdaContextOptions) => ({}) // no context
 type Context = trpc.inferAsyncReturnType<typeof createContext>;
 
-export const handler = trpcAPIGW.lambdaRequestHandler({
+export const handler = lambdaRequestHandler({
   router: appRouter,
   createContext,
 })


### PR DESCRIPTION
The new documentation for the API Gateway adapter includes an invalid import. Note that 9.25.0 actually includes a folder `adapters/api-gateway` but it seems like some left over that should have been cleaned before 9.25.0 was released.

Before people start using the adapter it could be worth considering if it should be called `aws-lambda` or `aws-api-gateway` instead. Prefixing with `aws` makes it clear where this adapter can be used. Note that the documentation consistency calls this an Amazon API Gateway adapter, but the code mainly calls it `lambda`. 

FYI @Lilja