### PR TITLE
replace children with nested routers

### DIFF
--- a/examples/next-prisma-starter/src/server/routers/_app.ts
+++ b/examples/next-prisma-starter/src/server/routers/_app.ts
@@ -2,14 +2,28 @@
  * This file contains the root router of your tRPC-backend
  */
 import { t } from '../trpc';
-import { healthRouter } from './health';
-import { postRouter } from './post';
+import { createTRPCClient } from '@trpc/client';
+import { z } from 'zod';
+
+// import { healthRouter } from './health';
+// import { postRouter } from './post';
 
 export const appRouter = t.router({
-  children: {
-    post: postRouter,
-    health: healthRouter,
+  procedures: {
+    post: t.procedure.query(() => 1),
+    health: {
+      a: t.procedure.query(() => 5),
+      b: t.procedure.query(() => 6),
+      c: {
+        d: t.procedure.input(z.string().nullish()).query(() => 7),
+      },
+    },
   },
 });
 
+console.log(appRouter._def.procedures);
 export type AppRouter = typeof appRouter;
+
+const client = createTRPCClient<AppRouter>({ url: '' });
+
+client.health.c.d.query();

--- a/examples/standalone-server/src/server.ts
+++ b/examples/standalone-server/src/server.ts
@@ -22,50 +22,54 @@ type Context = inferAsyncReturnType<typeof createContext>;
 
 const t = initTRPC<{ ctx: Context }>()();
 
-const greetingProcedures = {
-  greeting: t.procedure
-    .input(
-      z.object({
-        name: z.string(),
-      }),
-    )
-    .query(({ input }) => `Hello, ${input.name}!`),
-};
+const greetingRouter = t.router({
+  procedures: {
+    greeting: t.procedure
+      .input(
+        z.object({
+          name: z.string(),
+        }),
+      )
+      .query(({ input }) => `Hello, ${input.name}!`),
+  },
+});
 
-const postProcedures = {
-  createPost: t.procedure
-    .input(
-      z.object({
-        title: z.string(),
-        text: z.string(),
+const postRouter = t.router({
+  procedures: {
+    createPost: t.procedure
+      .input(
+        z.object({
+          title: z.string(),
+          text: z.string(),
+        }),
+      )
+      .mutation(({ input }) => {
+        // imagine db call here
+        return {
+          id: `${Math.random()}`,
+          ...input,
+        };
       }),
-    )
-    .mutation(({ input }) => {
-      // imagine db call here
-      return {
-        id: `${Math.random()}`,
-        ...input,
-      };
+    randomNumber: t.procedure.subscription(() => {
+      return observable<{ randomNumber: number }>((emit) => {
+        const timer = setInterval(() => {
+          // emits a number every second
+          emit.next({ randomNumber: Math.random() });
+        }, 200);
+
+        return () => {
+          clearInterval(timer);
+        };
+      });
     }),
-  randomNumber: t.procedure.subscription(() => {
-    return observable<{ randomNumber: number }>((emit) => {
-      const timer = setInterval(() => {
-        // emits a number every second
-        emit.next({ randomNumber: Math.random() });
-      }, 200);
-
-      return () => {
-        clearInterval(timer);
-      };
-    });
-  }),
-};
+  },
+});
 
 // Merge routers together
 const appRouter = t.router({
   procedures: {
-    greeting: greetingProcedures,
-    post: postProcedures,
+    greeting: greetingRouter,
+    post: postRouter,
   },
 });
 

--- a/examples/standalone-server/src/server.ts
+++ b/examples/standalone-server/src/server.ts
@@ -22,54 +22,50 @@ type Context = inferAsyncReturnType<typeof createContext>;
 
 const t = initTRPC<{ ctx: Context }>()();
 
-const greetingRouter = t.router({
-  procedures: {
-    greeting: t.procedure
-      .input(
-        z.object({
-          name: z.string(),
-        }),
-      )
-      .query(({ input }) => `Hello, ${input.name}!`),
-  },
-});
-
-const postRouter = t.router({
-  procedures: {
-    createPost: t.procedure
-      .input(
-        z.object({
-          title: z.string(),
-          text: z.string(),
-        }),
-      )
-      .mutation(({ input }) => {
-        // imagine db call here
-        return {
-          id: `${Math.random()}`,
-          ...input,
-        };
+const greetingProcedures = {
+  greeting: t.procedure
+    .input(
+      z.object({
+        name: z.string(),
       }),
-    randomNumber: t.procedure.subscription(() => {
-      return observable<{ randomNumber: number }>((emit) => {
-        const timer = setInterval(() => {
-          // emits a number every second
-          emit.next({ randomNumber: Math.random() });
-        }, 200);
+    )
+    .query(({ input }) => `Hello, ${input.name}!`),
+};
 
-        return () => {
-          clearInterval(timer);
-        };
-      });
+const postProcedures = {
+  createPost: t.procedure
+    .input(
+      z.object({
+        title: z.string(),
+        text: z.string(),
+      }),
+    )
+    .mutation(({ input }) => {
+      // imagine db call here
+      return {
+        id: `${Math.random()}`,
+        ...input,
+      };
     }),
-  },
-});
+  randomNumber: t.procedure.subscription(() => {
+    return observable<{ randomNumber: number }>((emit) => {
+      const timer = setInterval(() => {
+        // emits a number every second
+        emit.next({ randomNumber: Math.random() });
+      }, 200);
+
+      return () => {
+        clearInterval(timer);
+      };
+    });
+  }),
+};
 
 // Merge routers together
 const appRouter = t.router({
-  children: {
-    greeting: greetingRouter,
-    post: postRouter,
+  procedures: {
+    greeting: greetingProcedures,
+    post: postProcedures,
   },
 });
 

--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -11,13 +11,6 @@ export type EnsureRecord<T> = T extends Record<string, any>
   ? T
   : Record<string, never>;
 
-type FlattenRouter<TRouter extends AnyRouter> =
-  TRouter['_def']['procedures'] & {
-    [TKey in keyof TRouter['_def']['children']]: FlattenRouter<
-      TRouter['_def']['children'][TKey]
-    >;
-  };
-
 function makeProxy<TRouter extends AnyRouter>(
   client: Client<TRouter>,
   ...path: string[]
@@ -55,7 +48,7 @@ function makeProxy<TRouter extends AnyRouter>(
     },
   );
 
-  return proxy as typeof client & FlattenRouter<TRouter>;
+  return proxy as typeof client & TRouter['_def']['procedures'];
 }
 export function createTRPCClient<TRouter extends AnyRouter>(
   opts: CreateTRPCClientOptions<TRouter>,

--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -11,6 +11,12 @@ export type EnsureRecord<T> = T extends Record<string, any>
   ? T
   : Record<string, never>;
 
+type FlattenRouter<TRouter extends AnyRouter> = {
+  [Key in keyof TRouter['_def']['procedures']]: TRouter['_def']['procedures'][Key] extends AnyRouter
+    ? FlattenRouter<TRouter['_def']['procedures'][Key]>
+    : TRouter['_def']['procedures'][Key];
+};
+
 function makeProxy<TRouter extends AnyRouter>(
   client: Client<TRouter>,
   ...path: string[]
@@ -48,7 +54,7 @@ function makeProxy<TRouter extends AnyRouter>(
     },
   );
 
-  return proxy as typeof client & TRouter['_def']['procedures'];
+  return proxy as typeof client & FlattenRouter<TRouter>;
 }
 export function createTRPCClient<TRouter extends AnyRouter>(
   opts: CreateTRPCClientOptions<TRouter>,

--- a/packages/react/src/createReactQueryProxy.tsx
+++ b/packages/react/src/createReactQueryProxy.tsx
@@ -94,14 +94,14 @@ type assertProcedure<T> = T extends Procedure<any> ? T : never;
 type DecoratedProcedureRecord<
   TProcedures extends RecursiveProcedureRecord,
   TPath extends string = '',
-> = OmitNeverKeys<{
+> = {
   [TKey in keyof TProcedures]: TProcedures[TKey] extends RecursiveProcedureRecord
     ? DecoratedProcedureRecord<TProcedures[TKey], `${TPath}${TKey & string}.`>
     : DecorateProcedure<
         assertProcedure<TProcedures[TKey & string]>,
         `${TPath}${TKey & string}`
       >;
-}>;
+};
 
 function makeProxy<
   TRouter extends AnyRouter,
@@ -117,8 +117,7 @@ function makeProxy<
           return client[name as keyof typeof client];
         }
         if (typeof name === 'string') {
-          // @ts-expect-error "excessively infinite"
-          return makeProxy(client, ...path, name) as any;
+          return makeProxy(client, ...path, name);
         }
 
         return client;

--- a/packages/react/src/createReactQueryProxy.tsx
+++ b/packages/react/src/createReactQueryProxy.tsx
@@ -1,7 +1,7 @@
 import {
   AnyRouter,
   Procedure,
-  RecursiveProcedureRecord,
+  ProcedureRouterRecord,
   inferProcedureInput,
   inferProcedureOutput,
 } from '@trpc/server';
@@ -92,11 +92,14 @@ type DecorateProcedure<
 type assertProcedure<T> = T extends Procedure<any> ? T : never;
 
 type DecoratedProcedureRecord<
-  TProcedures extends RecursiveProcedureRecord,
+  TProcedures extends ProcedureRouterRecord,
   TPath extends string = '',
 > = {
-  [TKey in keyof TProcedures]: TProcedures[TKey] extends RecursiveProcedureRecord
-    ? DecoratedProcedureRecord<TProcedures[TKey], `${TPath}${TKey & string}.`>
+  [TKey in keyof TProcedures]: TProcedures[TKey] extends AnyRouter
+    ? DecoratedProcedureRecord<
+        TProcedures[TKey]['_def']['procedures'],
+        `${TPath}${TKey & string}.`
+      >
     : DecorateProcedure<
         assertProcedure<TProcedures[TKey & string]>,
         `${TPath}${TKey & string}`

--- a/packages/server/src/core/index.ts
+++ b/packages/server/src/core/index.ts
@@ -1,4 +1,4 @@
-export type { AnyRouter } from './router';
+export type { AnyRouter, RecursiveProcedureRecord } from './router';
 export type { Procedure, ProcedureParams } from './procedure';
 
 export { initTRPC } from './initTRPC';

--- a/packages/server/src/core/index.ts
+++ b/packages/server/src/core/index.ts
@@ -1,4 +1,4 @@
-export type { AnyRouter, RecursiveProcedureRecord } from './router';
+export type { AnyRouter, ProcedureRouterRecord } from './router';
 export type { Procedure, ProcedureParams } from './procedure';
 
 export { initTRPC } from './initTRPC';

--- a/packages/server/src/core/router.ts
+++ b/packages/server/src/core/router.ts
@@ -199,29 +199,17 @@ export function createRouterFactory<TConfig extends RootConfig>(
       EnsureRecord<TProcedures['procedures']>
     >
   > {
-    // const prefixedChildren = Object.entries(opts.children ?? {}).map(
-    //   ([key, childRouter]) => {
-    //     const procedures = prefixObjectKeys(
-    //       (childRouter as any)._def.procedures,
-    //       `${key}.`,
-    //     );
-
-    //     return {
-    //       procedures,
-    //     };
-    //   },
-    // );
-
     const routerProcedures: Record<string, Procedure<any>> = omitPrototype({});
     function recursiveGetPaths(procedures: Record<string, any>, path = '') {
-      for (const [key, procedure] of Object.entries(procedures)) {
+      for (const [key, procedureOrObject] of Object.entries(procedures ?? {})) {
         const newPath = `${path}${key}`;
-        if (typeof procedure === 'object') {
-          recursiveGetPaths(procedure, `${newPath}.`);
-          return;
+
+        if (typeof procedureOrObject === 'object') {
+          recursiveGetPaths(procedureOrObject, `${newPath}.`);
+          continue;
         }
 
-        routerProcedures[newPath] = procedure;
+        routerProcedures[newPath] = procedureOrObject;
       }
     }
 

--- a/packages/server/src/core/router.ts
+++ b/packages/server/src/core/router.ts
@@ -44,7 +44,7 @@ export interface RouterDef<
   TContext,
   TErrorShape extends TRPCErrorShape<number>,
   TMeta extends Record<string, unknown>,
-  TProcedures extends RecursiveRecord<Procedure<any>>,
+  TProcedures extends RecursiveProcedureRecord,
 > {
   /**
    * @internal

--- a/packages/server/src/deprecated/interop.ts
+++ b/packages/server/src/deprecated/interop.ts
@@ -104,7 +104,6 @@ export type MigrateRouter<
     TInputContext,
     TErrorShape,
     TMeta,
-    Record<string, never>,
     MigrateProcedureRecord<TQueries, 'query'> &
       MigrateProcedureRecord<TMutations, 'mutation'> &
       MigrateProcedureRecord<TSubscriptions, 'subscription'>

--- a/packages/server/test/___testHelpers.ts
+++ b/packages/server/test/___testHelpers.ts
@@ -74,6 +74,7 @@ export function routerToServerAndClientNew<TRouter extends AnyNewRouter>(
         : opts.client
       : {}),
   };
+
   const client = createTRPCClient<typeof router>(trpcClientOptions);
   return {
     wsClient,

--- a/packages/server/test/children.test.ts
+++ b/packages/server/test/children.test.ts
@@ -8,21 +8,13 @@ test('children', async () => {
   const router = t.router({
     procedures: {
       foo: t.procedure.query(() => 'bar'),
-    },
-    children: {
-      child: t.router({
-        procedures: {
-          childQuery: t.procedure.query(() => 'asd'),
+      child: {
+        childQuery: t.procedure.query(() => 'asd'),
+        grandchild: {
+          foo: t.procedure.query(() => 'grandchild' as const),
+          mut: t.procedure.mutation(() => 'mut'),
         },
-        children: {
-          grandchild: t.router({
-            procedures: {
-              foo: t.procedure.query(() => 'grandchild' as const),
-              mut: t.procedure.mutation(() => 'mut'),
-            },
-          }),
-        },
-      }),
+      },
     },
   });
 
@@ -71,9 +63,6 @@ test('w/o children', async () => {
       foo,
     },
   });
-  const children = router._def.children;
-  //     ^?
-  expectTypeOf(children).toEqualTypeOf<Record<string, never>>();
 
   expectTypeOf(router._def.procedures.foo).toMatchTypeOf(foo);
 });

--- a/packages/server/test/children.test.ts
+++ b/packages/server/test/children.test.ts
@@ -8,13 +8,17 @@ test('children', async () => {
   const router = t.router({
     procedures: {
       foo: t.procedure.query(() => 'bar'),
-      child: {
-        childQuery: t.procedure.query(() => 'asd'),
-        grandchild: {
-          foo: t.procedure.query(() => 'grandchild' as const),
-          mut: t.procedure.mutation(() => 'mut'),
+      child: t.router({
+        procedures: {
+          childQuery: t.procedure.query(() => 'asd'),
+          grandchild: t.router({
+            procedures: {
+              foo: t.procedure.query(() => 'grandchild' as const),
+              mut: t.procedure.mutation(() => 'mut'),
+            },
+          }),
         },
-      },
+      }),
     },
   });
 
@@ -48,6 +52,7 @@ test('children', async () => {
 
   expect(await client.foo.query()).toBe('bar');
 
+  client.child.grandchild;
   expect(await client.child.grandchild.foo.query()).toBe('grandchild');
   expect(await client.child.grandchild.mut.mutate()).toBe('mut');
 

--- a/packages/server/test/useQuery.test.tsx
+++ b/packages/server/test/useQuery.test.tsx
@@ -14,41 +14,31 @@ const ctx = konn()
     const t = initTRPC()();
     const appRouter = t.router({
       procedures: {
-        post: {
-          byId: t.procedure
-            .input(
-              z.object({
-                id: z.string(),
-              }),
-            )
-            .query(() => '__result' as const),
-          list: t.procedure
-            .input(
-              z.object({
-                cursor: z.string().optional(),
-              }),
-            )
-            .query(() => '__infResult' as const),
-          create: t.procedure
-            .input(
-              z.object({
-                text: z.string(),
-              }),
-            )
-            .mutation(() => `__mutationResult` as const),
-        },
-        item: {
-          one: {
-            two: {
-              hello: t.procedure.query(() => '__result' as const),
-              three: {
-                four: t.procedure.query(() => '__result' as const),
-                five: t.procedure.query(() => '__result' as const),
-              },
-              nine: t.procedure.mutation(() => `__mutationResult` as const),
-            },
+        post: t.router({
+          procedures: {
+            byId: t.procedure
+              .input(
+                z.object({
+                  id: z.string(),
+                }),
+              )
+              .query(() => '__result' as const),
+            list: t.procedure
+              .input(
+                z.object({
+                  cursor: z.string().optional(),
+                }),
+              )
+              .query(() => '__infResult' as const),
+            create: t.procedure
+              .input(
+                z.object({
+                  text: z.string(),
+                }),
+              )
+              .mutation(() => `__mutationResult` as const),
           },
-        },
+        }),
       },
     });
     const opts = routerToServerAndClientNew(appRouter);

--- a/packages/server/test/useQuery.test.tsx
+++ b/packages/server/test/useQuery.test.tsx
@@ -13,35 +13,42 @@ const ctx = konn()
   .beforeEach(() => {
     const t = initTRPC()();
     const appRouter = t.router({
-      children: {
-        post: t.router({
-          procedures: {
-            byId: t.procedure
-              .input(
-                z.object({
-                  id: z.string(),
-                }),
-              )
-              .query(() => '__result' as const),
-            list: t.procedure
-              .input(
-                z.object({
-                  cursor: z.string().optional(),
-                }),
-              )
-              .query(() => '__infResult' as const),
-            /**
-             * @deprecated
-             */
-            create: t.procedure
-              .input(
-                z.object({
-                  text: z.string(),
-                }),
-              )
-              .mutation(() => `__mutationResult` as const),
+      procedures: {
+        post: {
+          byId: t.procedure
+            .input(
+              z.object({
+                id: z.string(),
+              }),
+            )
+            .query(() => '__result' as const),
+          list: t.procedure
+            .input(
+              z.object({
+                cursor: z.string().optional(),
+              }),
+            )
+            .query(() => '__infResult' as const),
+          create: t.procedure
+            .input(
+              z.object({
+                text: z.string(),
+              }),
+            )
+            .mutation(() => `__mutationResult` as const),
+        },
+        item: {
+          one: {
+            two: {
+              hello: t.procedure.query(() => '__result' as const),
+              three: {
+                four: t.procedure.query(() => '__result' as const),
+                five: t.procedure.query(() => '__result' as const),
+              },
+              nine: t.procedure.mutation(() => `__mutationResult` as const),
+            },
           },
-        }),
+        },
       },
     });
     const opts = routerToServerAndClientNew(appRouter);

--- a/scripts/generateBigBoi.ts
+++ b/scripts/generateBigBoi.ts
@@ -1,15 +1,30 @@
 import fs from 'fs';
 
-const NUM_ROUTERS = 500;
+const NUM_PROCEDURE_OBJECTS = 500;
 
-function createRouter(routerName: string) {
+function createProcedureObject(procedureObjectName: string) {
   return `
   import { z } from 'zod';
   import { t } from './_trpc';
   
-  export const ${routerName} = t.router({
-    procedures: {
-      greeting: t
+  export const ${procedureObjectName} = {
+    greeting: t
+      .procedure
+      .input(
+        z.object({
+          who: z.string()
+        })
+      )
+      .query(({input}) => \`hello \${input.who}\`),
+    greeting2: t
+      .procedure
+      .input(
+        z.object({
+          who: z.string()
+        })
+      )
+      .query(({input}) => \`hello \${input.who}\`),
+      greeting3: t
         .procedure
         .input(
           z.object({
@@ -17,7 +32,7 @@ function createRouter(routerName: string) {
           })
         )
         .query(({input}) => \`hello \${input.who}\`),
-      greeting2: t
+      greeting4: t
         .procedure
         .input(
           z.object({
@@ -25,50 +40,32 @@ function createRouter(routerName: string) {
           })
         )
         .query(({input}) => \`hello \${input.who}\`),
-        greeting3: t
-          .procedure
-          .input(
-            z.object({
-              who: z.string()
-            })
-          )
-          .query(({input}) => \`hello \${input.who}\`),
-        greeting4: t
-          .procedure
-          .input(
-            z.object({
-              who: z.string()
-            })
-          )
-          .query(({input}) => \`hello \${input.who}\`),
-        greeting5: t
-          .procedure
-          .input(
-            z.object({
-              who: z.string()
-            })
-          )
-          .query(({input}) => \`hello \${input.who}\`),
-    },
-    children: {
-      grandchild: t.router({
-        procedures: {
-          grandChildQuery: t.procedure.query(() => 'grandChildQuery'),
-          grandChildMutation: t.procedure.mutation(() => 'grandChildMutation'),
-        },
-      }),
-    },
-  })`.trim();
+      greeting5: t
+        .procedure
+        .input(
+          z.object({
+            who: z.string()
+          })
+        )
+        .query(({input}) => \`hello \${input.who}\`),
+      grandchild: {
+        grandChildQuery: t.procedure.query(() => 'grandChildQuery'),
+        grandChildMutation: t.procedure.mutation(() => 'grandChildMutation'),
+      }
+  }`.trim();
 }
 
 const SERVER_DIR = __dirname + '/../packages/server/test/__generated__/bigBoi';
 fs.mkdirSync(SERVER_DIR, { recursive: true });
 
 const indexBuf: string[] = [];
-for (let i = 0; i < NUM_ROUTERS; i++) {
-  const routerName = `r${i}`;
-  indexBuf.push(routerName);
-  fs.writeFileSync(`${SERVER_DIR}/${routerName}.ts`, createRouter(routerName));
+for (let i = 0; i < NUM_PROCEDURE_OBJECTS; i++) {
+  const procedureObjectName = `r${i}`;
+  indexBuf.push(procedureObjectName);
+  fs.writeFileSync(
+    `${SERVER_DIR}/${procedureObjectName}.ts`,
+    createProcedureObject(procedureObjectName),
+  );
 }
 
 const trpcFile = `
@@ -82,7 +79,7 @@ import { t } from './_trpc';
 ${indexBuf.map((name) => `import { ${name} } from './${name}';`).join('\n')}
 
 export const appRouter = t.router({
-  children: {
+  procedures: {
     ${indexBuf.join(',\n    ')}
   }
 })

--- a/scripts/generateBigBoi.ts
+++ b/scripts/generateBigBoi.ts
@@ -7,7 +7,8 @@ function createProcedureObject(procedureObjectName: string) {
   import { z } from 'zod';
   import { t } from './_trpc';
   
-  export const ${procedureObjectName} = {
+  export const ${procedureObjectName} = t.router({
+    procedures: {
     greeting: t
       .procedure
       .input(
@@ -48,11 +49,14 @@ function createProcedureObject(procedureObjectName: string) {
           })
         )
         .query(({input}) => \`hello \${input.who}\`),
-      grandchild: {
-        grandChildQuery: t.procedure.query(() => 'grandChildQuery'),
-        grandChildMutation: t.procedure.mutation(() => 'grandChildMutation'),
-      }
-  }`.trim();
+      grandchild: t.router({
+        procedures: {
+          grandChildQuery: t.procedure.query(() => 'grandChildQuery'),
+          grandChildMutation: t.procedure.mutation(() => 'grandChildMutation'),
+        }
+      })
+    }
+  })`.trim();
 }
 
 const SERVER_DIR = __dirname + '/../packages/server/test/__generated__/bigBoi';


### PR DESCRIPTION
Replace the `children` property/api with nested/recursive procedures:
```ts
const router = t.router({
    procedures: {
      foo: t.procedure.query(() => 'bar'),
      child: t.router({
        procedures: {
          childQuery: t.procedure.query(() => 'asd'),
          grandchild: t.router({
            procedures: {
              foo: t.procedure.query(() => 'grandchild' as const),
              mut: t.procedure.mutation(() => 'mut'),
            },
          }),
        },
      }),
    },
  });
```