### PR TITLE
docs: added @h4ad/serverless-adapter to collection of resources

### DIFF
--- a/www/docs/main/awesome-trpc.mdx
+++ b/www/docs/main/awesome-trpc.mdx
@@ -11,16 +11,17 @@ slug: /awesome-trpc
 
 > Please make and add!
 
-| Description                                                                        | Link                                                  |
-| ---------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| tRPC Playground - sandbox for testing tRPC queries in the browser                  | https://github.com/sachinraja/trpc-playground         |
-| tRPC-SvelteKit - SvelteKit tRPC extension                                          | https://github.com/icflorescu/trpc-sveltekit          |
-| tRPC-OpenAPI - OpenAPI & REST support for your tRPC routers                        | https://github.com/jlalmes/trpc-openapi               |
-| Create tRPC App - Create tRPC-powered apps with one command                        | https://github.com/omar-dulaimi/create-trpc-app       |
-| Prisma tRPC Generator - Prisma 2+ generator to emit fully implemented tRPC routers | https://github.com/omar-dulaimi/prisma-trpc-generator |
-| tRPC-nuxt - Nuxt 3 module                                                          | https://github.com/wobsoriano/trpc-nuxt               |
-| tRPC-SWR - SWR wrapper                                                             | https://github.com/sachinraja/trpc-swr                |
-| tRPC Shield - tRPC permissions as another layer of abstraction!                    | https://github.com/omar-dulaimi/trpc-shield           |
+| Description                                                                                        | Link                                                                  |
+|----------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------|
+| tRPC Playground - sandbox for testing tRPC queries in the browser                                  | https://github.com/sachinraja/trpc-playground                         |
+| tRPC-SvelteKit - SvelteKit tRPC extension                                                          | https://github.com/icflorescu/trpc-sveltekit                          |
+| tRPC-OpenAPI - OpenAPI & REST support for your tRPC routers                                        | https://github.com/jlalmes/trpc-openapi                               |
+| Create tRPC App - Create tRPC-powered apps with one command                                        | https://github.com/omar-dulaimi/create-trpc-app                       |
+| Prisma tRPC Generator - Prisma 2+ generator to emit fully implemented tRPC routers                 | https://github.com/omar-dulaimi/prisma-trpc-generator                 |
+| tRPC-nuxt - Nuxt 3 module                                                                          | https://github.com/wobsoriano/trpc-nuxt                               |
+| tRPC-SWR - SWR wrapper                                                                             | https://github.com/sachinraja/trpc-swr                                |
+| tRPC Shield - tRPC permissions as another layer of abstraction!                                    | https://github.com/omar-dulaimi/trpc-shield                           |
+| @h4ad/serverless-adapter - Connect tRPC with AWS SQS, AWS API Gateway and many more event sources. | https://viniciusl.com.br/serverless-adapter/docs/main/frameworks/trpc |
 
 ## 🍀 Starting points, example projects, etc
 


### PR DESCRIPTION
I am the maintainer of the [@h4ad/serverless-adapter](https://github.com/H4ad/serverless-adapter) library which is a library for connecting APIs with serverless environments like AWS, Huawei and many others.

This PR adds my library to the resource list for anyone who wants to connect APIs built with tRPC with event sources like AWS SQS, AWS API Gateway or even with FunctionGraph on Huawei.

In theory my library removes the need for `@trpc/server/adapters/aws-lambda` but I don't know what plans you have for your internal integrations, what do you think?