### PR TITLE
docs(awesome-trpc): add create-t3-app to awesome trpc

### DIFF
--- a/www/docs/main/awesome-trpc.mdx
+++ b/www/docs/main/awesome-trpc.mdx
@@ -12,7 +12,7 @@ slug: /awesome-trpc
 > Please make and add!
 
 | Description                                                                                        | Link                                                                  |
-|----------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------|
+| -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
 | tRPC Playground - sandbox for testing tRPC queries in the browser                                  | https://github.com/sachinraja/trpc-playground                         |
 | tRPC-SvelteKit - SvelteKit tRPC extension                                                          | https://github.com/icflorescu/trpc-sveltekit                          |
 | tRPC-OpenAPI - OpenAPI & REST support for your tRPC routers                                        | https://github.com/jlalmes/trpc-openapi                               |
@@ -22,6 +22,7 @@ slug: /awesome-trpc
 | tRPC-SWR - SWR wrapper                                                                             | https://github.com/sachinraja/trpc-swr                                |
 | tRPC Shield - tRPC permissions as another layer of abstraction!                                    | https://github.com/omar-dulaimi/trpc-shield                           |
 | @h4ad/serverless-adapter - Connect tRPC with AWS SQS, AWS API Gateway and many more event sources. | https://viniciusl.com.br/serverless-adapter/docs/main/frameworks/trpc |
+| create-t3-app - Scaffold a starter project using the t3 stack (Next.js, tRPC, TailwindCSS, Primsa) | https://create.t3.gg                                                  |
 
 ## 🍀 Starting points, example projects, etc
 


### PR DESCRIPTION
Added [create-t3-app](https://github.com/nexxeln/create-t3-app) to awesome-trpc section.

Should I put the GitHub repo link or is the landing page link fine?