### PR TITLE
chore(deps): upgrade to TypeScript 4.6.4

### DIFF
--- a/examples/express-server/package.json
+++ b/examples/express-server/package.json
@@ -18,7 +18,7 @@
     "abort-controller": "^3.0.0",
     "express": "^4.17.1",
     "node-fetch": "^2.6.1",
-    "typescript": "4.4.4",
+    "typescript": "4.6.4",
     "zod": "^3.0.0"
   },
   "alias": {

--- a/examples/fastify-server/package.json
+++ b/examples/fastify-server/package.json
@@ -32,7 +32,7 @@
     "npm-run-all": "^4.1.5",
     "start-server-and-test": "^1.12.0",
     "ts-node": "^10.3.0",
-    "typescript": "4.4.4",
+    "typescript": "4.6.4",
     "wait-on": "^6.0.0"
   },
   "publishConfig": {

--- a/examples/lambda-api-gateway/package.json
+++ b/examples/lambda-api-gateway/package.json
@@ -9,7 +9,7 @@
     "@trpc/server": "^9.25.3",
     "node-fetch": "^2.6.1",
     "ts-node": "^10.3.0",
-    "typescript": "4.4.4"
+    "typescript": "4.6.4"
   },
   "devDependencies": {
     "serverless": "^3.18.1",

--- a/examples/next-prisma-starter-websockets/package.json
+++ b/examples/next-prisma-starter-websockets/package.json
@@ -83,7 +83,7 @@
     "prisma": "^3.7.0",
     "tailwindcss": "^3.0.23",
     "ts-jest": "^27.0.5",
-    "typescript": "4.4.4"
+    "typescript": "4.6.4"
   },
   "publishConfig": {
     "access": "restricted"

--- a/examples/next-prisma-starter/package.json
+++ b/examples/next-prisma-starter/package.json
@@ -66,7 +66,7 @@
     "prisma": "^3.7.0",
     "ts-jest": "^27.0.5",
     "ts-node": "^10.3.0",
-    "typescript": "4.4.4"
+    "typescript": "4.6.4"
   },
   "publishConfig": {
     "access": "restricted"

--- a/examples/next-prisma-todomvc/package.json
+++ b/examples/next-prisma-todomvc/package.json
@@ -50,7 +50,7 @@
     "npm-run-all": "^4.1.5",
     "playwright": "^1.19.1",
     "ts-jest": "^27.0.5",
-    "typescript": "4.4.4"
+    "typescript": "4.6.4"
   },
   "publishConfig": {
     "access": "restricted"

--- a/examples/standalone-server/package.json
+++ b/examples/standalone-server/package.json
@@ -17,7 +17,7 @@
     "@trpc/server": "^9.25.3",
     "abort-controller": "^3.0.0",
     "node-fetch": "^2.6.1",
-    "typescript": "4.4.4",
+    "typescript": "4.6.4",
     "ws": "^8.0.0",
     "zod": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -104,6 +104,6 @@
     "react-dom": "^18.1.0",
     "react-query-4": "npm:react-query@^4.0.0-alpha.4",
     "ts-jest": "^27.0.5",
-    "typescript": "4.4.4"
+    "typescript": "4.6.4"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -65,7 +65,7 @@
     "next": "^12.1.6",
     "node-fetch": "^2.6.1",
     "superstruct": "^0.15.2",
-    "typescript": "4.4.4",
+    "typescript": "4.6.4",
     "ws": "^8.0.0",
     "yup": "^0.32.8",
     "zod": "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14384,10 +14384,10 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.4.4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
-  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
+typescript@4.6.4:
+  version "4.6.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
+  integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
 
 uglify-js@^3.1.4:
   version "3.14.1"


### PR DESCRIPTION
## Description

This PR updates all any `/packages` or `/examples` using `typescript` `4.4.4` => `4.6.4`.

Fixes #1600 

## Notes

<details>
<summary>Click to toggle</summary>

I'm not experienced with `lerna` and had a hard time understanding their docs. 

I finally figured it out with: `yarn lerna add typescript@4.6.4 examples/next-prisma-starter-websockets --dev`

I noticed in the notes for the original issue that there could be issues with the build. I ran `yarn build` and didn't see any issues. I also ran `yarn test` and didn't have any issues. I couldn't get `yarn test-examples` to work.


```typescript
@examples/express-server: Error: Cannot find module '/Users/jp/dev/oss/trpc/examples/express-server/dist/server'
@examples/express-server:     at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
@examples/express-server:     at Function.Module._load (node:internal/modules/cjs/loader:778:27)
@examples/express-server:     at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:77:12)
@examples/express-server:     at node:internal/main/run_main_module:17:47 {
@examples/express-server:   code: 'MODULE_NOT_FOUND',
@examples/express-server:   requireStack: []
@examples/express-server: }
```

I thought maybe running `yarn build-examples` but no luck with that either.
```typescript
@examples/next-starter: Error: P1001: Can't reach database server at `localhost`:`5832`
@examples/next-starter: Please make sure your database server is running at `localhost`:`5832`.
@examples/next-starter: error Command failed with exit code 1.
@examples/next-starter: info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
@examples/next-starter: ERROR: "build:1-migrate" exited with 1.
@examples/next-starter: error Command failed with exit code 1.
```

If someone can help with this, I'm happy to open a separate PR for updating `CONTRIBUTING.md`.
</details>