### PR TITLE
Fix incorrect imports in vanilla client setup docs

### DIFF
--- a/www/docs/client/vanilla.md
+++ b/www/docs/client/vanilla.md
@@ -10,7 +10,7 @@ The magic of tRPC is making _strongly typed_ API calls without relying on code g
 Import the `AppRouter` type into your client from the file your root tRPC router is defined. This single type represents the type signature of your entire API.
 
 ```ts title='client.ts'
-import type { AppRouter } from '../path/to/server/trpc.ts';
+import type { AppRouter } from '../path/to/server/trpc';
 ```
 
 The `import type` keywords let you import from _any TypeScript file_ on your filesystem. Plus `import type` can only import types, **NOT** code. So there's no danger of accidentally importing server-side code into your client. All calls to `import type` are _always fully erased_ from your compiled JavaScript bundle ([source](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export)).
@@ -21,7 +21,7 @@ Create a typesafe client with the `createTRPCClient` method from `@trpc/client`:
 
 ```ts title='client.ts'
 // pages/index.tsx
-import type { AppRouter } from '../path/to/server/trpc.ts';
+import type { AppRouter } from '../path/to/server/trpc';
 import { createTRPCClient } from '@trpc/client';
 
 const client = createTRPCClient<AppRouter>({


### PR DESCRIPTION
Hey, great project you have there!

The TS imports should probably go without the `.ts` at the end. (ts2691)

<img width="437" alt="image" src="https://user-images.githubusercontent.com/13211347/177008065-79698f39-79eb-44fd-93c5-6d8f84e0f0df.png">



Kind regards,
Niklas