### PR TITLE
Fixing docs responsiveness of features section

### DIFF
--- a/www/src/pages/index.tsx
+++ b/www/src/pages/index.tsx
@@ -43,7 +43,7 @@ const features = [
 
 function Feature({ title, description }) {
   return (
-    <div className={'col col-4 p-4'}>
+    <div className={'col col-4 p-4 basis-0'}>
       <h3 className="font-semibold text-xl pb-6">{title}</h3>
       <p>{description}</p>
     </div>
@@ -111,7 +111,7 @@ function Home() {
       </header>
       <main>
         {features && features.length > 0 && (
-          <section className="flex items-center py-8 px-0 w-full max-w-[var(--ifm-container-width-xl)] mx-auto">
+          <section className="flex flex-col md:flex-row items-center py-8 px-8 md:px-0 w-full max-w-[var(--ifm-container-width-xl)] mx-auto">
             {features.map((props, idx) => (
               <Feature key={idx} {...props} />
             ))}
@@ -119,7 +119,7 @@ function Home() {
         )}
       </main>
       <footer
-        className={`container w-full max-w-[var(--ifm-container-width)] mx-auto`}
+        className={`container px-8 md:px-0 w-full max-w-[var(--ifm-container-width)] mx-auto`}
       >
         <ol className="footnotes list-decimal">
           <li id="zero">

--- a/www/src/pages/index.tsx
+++ b/www/src/pages/index.tsx
@@ -43,7 +43,7 @@ const features = [
 
 function Feature({ title, description }) {
   return (
-    <div className={'col col-4 p-4 basis-0'}>
+    <div className={'col col-4 p-4'}>
       <h3 className="font-semibold text-xl pb-6">{title}</h3>
       <p>{description}</p>
     </div>


### PR DESCRIPTION
A tiny styling fix that is currently causing a side scroll on the index page of the site on mobile devices, as can be seen below. Although phones are obviously not the main demographic of a documentation website, it's an easy fix! I've changed the flex-direction to column for small devices, avoiding the side scroll. Keep up the good work! 🙌

**Before:**
![trpc-bug](https://user-images.githubusercontent.com/33397397/177011562-7462c298-8ba5-4d06-92bd-0b4300b5af8c.png)

**After:**
![trpc-fix](https://user-images.githubusercontent.com/33397397/177011592-ba45923d-ac71-4277-b676-76949c30b4e4.png)

