### PR TITLE
Fix typo in documentation

### DIFF
--- a/www/docs/server/error-handling.md
+++ b/www/docs/server/error-handling.md
@@ -57,7 +57,7 @@ const appRouter = trpc.router().query('hello', {
     throw new trpc.TRPCError({
       code: 'INTERNAL_SERVER_ERROR',
       message: 'An unexpected error occurred, please try again later.',
-      // optional: pass the oroginal error to retain stack trace
+      // optional: pass the original error to retain stack trace
       cause: theError,
     });
   },


### PR DESCRIPTION
![SCR-20220702-llc](https://user-images.githubusercontent.com/57513430/177016792-b1479a36-e812-4a42-a936-daab02937f1e.png)

"oroginal" → "original"