### PR TITLE
Chores: Examples TypeScript as devDependency

### DIFF
--- a/examples/express-server/package.json
+++ b/examples/express-server/package.json
@@ -18,7 +18,6 @@
     "abort-controller": "^3.0.0",
     "express": "^4.17.1",
     "node-fetch": "^2.6.1",
-    "typescript": "4.4.4",
     "zod": "^3.0.0"
   },
   "alias": {
@@ -32,6 +31,7 @@
     "npm-run-all": "^4.1.5",
     "start-server-and-test": "^1.12.0",
     "ts-node": "^10.3.0",
+    "typescript": "4.4.4",
     "wait-on": "^6.0.0"
   },
   "publishConfig": {

--- a/examples/lambda-api-gateway/package.json
+++ b/examples/lambda-api-gateway/package.json
@@ -8,13 +8,13 @@
     "@trpc/client": "^9.25.3",
     "@trpc/server": "^9.25.3",
     "node-fetch": "^2.6.1",
-    "ts-node": "^10.3.0",
-    "typescript": "4.4.4"
+    "ts-node": "^10.3.0"
   },
   "devDependencies": {
     "serverless": "^3.18.1",
     "serverless-offline": "^8.8.0",
-    "serverless-plugin-typescript": "^2.1.2"
+    "serverless-plugin-typescript": "^2.1.2",
+    "typescript": "4.4.4"
   },
   "scripts": {
     "build": "yarn tsc",

--- a/examples/standalone-server/package.json
+++ b/examples/standalone-server/package.json
@@ -17,7 +17,6 @@
     "@trpc/server": "^9.25.3",
     "abort-controller": "^3.0.0",
     "node-fetch": "^2.6.1",
-    "typescript": "4.4.4",
     "ws": "^8.0.0",
     "zod": "^3.0.0"
   },
@@ -31,6 +30,7 @@
     "npm-run-all": "^4.1.5",
     "start-server-and-test": "^1.12.0",
     "ts-node": "^10.3.0",
+    "typescript": "4.4.4",
     "wait-port": "^0.2.9"
   },
   "publishConfig": {


### PR DESCRIPTION
Changing the `package.json` files in examples.

Closes #2073 