### PR TITLE
Fix createTRPCClient

### DIFF
--- a/packages/client/src/createTRPCClientProxy.ts
+++ b/packages/client/src/createTRPCClientProxy.ts
@@ -4,7 +4,7 @@
 import type { AnyRouter } from '@trpc/server';
 import { TRPCClient as Client } from './internals/TRPCClient';
 
-type FlattenRouter<TRouter extends AnyRouter> = {
+export type FlattenRouter<TRouter extends AnyRouter> = {
   [Key in keyof TRouter['_def']['record']]: TRouter['_def']['record'][Key] extends AnyRouter
     ? FlattenRouter<TRouter['_def']['record'][Key]>
     : TRouter['_def']['record'][Key];


### PR DESCRIPTION
If we don't export `FlattenRouter` TS does some weird stuff to get the return type of `createTRPCClient`. See [this](https://pastebin.com/AuwLRu66) for what it had produced in the `.d.ts` before.