### PR TITLE
Fixed typo for function parameter

### DIFF
--- a/www/docs/main/quickstart.mdx
+++ b/www/docs/main/quickstart.mdx
@@ -102,7 +102,7 @@ export type AppRouter = typeof appRouter;
 Similarly to GraphQL, tRPC makes a distinction between query and mutation endpoints. Let's add a `createUser` mutation:
 
 ```ts
-createUser(payload: {name: string}) => {id: string; name: string};
+createUser(data: {name:string}) => { id: string; name: string; }
 ```
 
 ```ts title='server.ts'


### PR DESCRIPTION
Small typo fix for example consistency.