### PR TITLE
reset `./interop/examples` according to `main`

### DIFF
--- a/examples/.interop/next-prisma-starter-websockets/package.json
+++ b/examples/.interop/next-prisma-starter-websockets/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@examples/interop-next-starter-websockets",
+  "name": "@examples/legacy-trpc-next-starter-websockets",
   "version": "10.0.0-alpha.36",
   "private": true,
   "scripts": {

--- a/examples/.interop/next-prisma-starter-websockets/package.json
+++ b/examples/.interop/next-prisma-starter-websockets/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@examples/legacy-trpc-next-starter-websockets",
+  "name": "@examples/interop-next-starter-websockets",
   "version": "10.0.0-alpha.36",
   "private": true,
   "scripts": {

--- a/examples/.interop/next-prisma-starter-websockets/src/pages/_app.tsx
+++ b/examples/.interop/next-prisma-starter-websockets/src/pages/_app.tsx
@@ -1,7 +1,17 @@
 import '../styles/global.css';
+import { httpBatchLink } from '@trpc/client/links/httpBatchLink';
+import { loggerLink } from '@trpc/client/links/loggerLink';
+import { wsLink, createWSClient } from '@trpc/client/links/wsLink';
+import { withTRPC } from '@trpc/next';
 import { getSession, SessionProvider } from 'next-auth/react';
+import getConfig from 'next/config';
 import { AppType } from 'next/dist/shared/lib/utils';
-import { trpc } from 'utils/trpc';
+import type { AppRouter } from 'server/routers/_app';
+import superjson from 'superjson';
+
+const { publicRuntimeConfig } = getConfig();
+
+const { APP_URL, WS_URL } = publicRuntimeConfig;
 
 const MyApp: AppType = ({ Component, pageProps }) => {
   return (
@@ -19,4 +29,63 @@ MyApp.getInitialProps = async ({ ctx }) => {
   };
 };
 
-export default trpc.withTRPC(MyApp);
+function getEndingLink() {
+  if (typeof window === 'undefined') {
+    return httpBatchLink({
+      url: `${APP_URL}/api/trpc`,
+    });
+  }
+  const client = createWSClient({
+    url: WS_URL,
+  });
+  return wsLink<AppRouter>({
+    client,
+  });
+}
+
+export default withTRPC<AppRouter>({
+  config({ ctx }) {
+    /**
+     * If you want to use SSR, you need to use the server's full URL
+     * @link https://trpc.io/docs/ssr
+     */
+
+    return {
+      /**
+       * @link https://trpc.io/docs/links
+       */
+      links: [
+        // adds pretty logs to your console in development and logs errors in production
+        loggerLink({
+          enabled: (opts) =>
+            (process.env.NODE_ENV === 'development' &&
+              typeof window !== 'undefined') ||
+            (opts.direction === 'down' && opts.result instanceof Error),
+        }),
+        getEndingLink(),
+      ],
+      /**
+       * @link https://trpc.io/docs/data-transformers
+       */
+      transformer: superjson,
+      /**
+       * @link https://react-query.tanstack.com/reference/QueryClient
+       */
+      queryClientConfig: { defaultOptions: { queries: { staleTime: 60 } } },
+      headers: () => {
+        if (ctx?.req) {
+          // on ssr, forward client's headers to the server
+          return {
+            ...ctx.req.headers,
+            'x-ssr': '1',
+          };
+        }
+        return {};
+      },
+    };
+  },
+  /**
+   * @link https://trpc.io/docs/ssr
+   */
+  ssr: true,
+})(MyApp);

--- a/examples/.interop/next-prisma-starter-websockets/src/utils/trpc.ts
+++ b/examples/.interop/next-prisma-starter-websockets/src/utils/trpc.ts
@@ -1,90 +1,18 @@
-import {
-  createWSClient,
-  httpBatchLink,
-  loggerLink,
-  wsLink,
-} from '@trpc/client';
-import { setupTRPC } from '@trpc/next';
-import type { inferProcedureInput, inferProcedureOutput } from '@trpc/server';
-import getConfig from 'next/config';
+import { createReactQueryHooks } from '@trpc/react';
+import type { inferProcedureOutput } from '@trpc/server';
+import { AppRouter } from 'server/routers/_app';
+
+// import superjson from 'superjson';
 // ℹ️ Type-only import:
 // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export
-import type { AppRouter } from 'server/routers/_app';
-import superjson from 'superjson';
-
-const { publicRuntimeConfig } = getConfig();
-
-const { APP_URL, WS_URL } = publicRuntimeConfig;
-
-function getEndingLink() {
-  if (!process.browser) {
-    return httpBatchLink({
-      url: `${APP_URL}/api/trpc`,
-    });
-  }
-  const client = createWSClient({
-    url: WS_URL,
-  });
-  return wsLink<AppRouter>({
-    client,
-  });
-}
 
 /**
  * A set of strongly-typed React hooks from your `AppRouter` type signature with `createReactQueryHooks`.
  * @link https://trpc.io/docs/react#3-create-trpc-hooks
  */
-export const trpc = setupTRPC<AppRouter>({
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  config() {
-    /**
-     * If you want to use SSR, you need to use the server's full URL
-     * @link https://trpc.io/docs/ssr
-     */
-    return {
-      /**
-       * @link https://trpc.io/docs/data-transformers
-       */
-      transformer: superjson,
-      /**
-       * @link https://trpc.io/docs/links
-       */
-      links: [
-        // adds pretty logs to your console in development and logs errors in production
-        loggerLink({
-          enabled: (opts) =>
-            process.env.NODE_ENV === 'development' ||
-            (opts.direction === 'down' && opts.result instanceof Error),
-        }),
-        getEndingLink(),
-      ],
-      /**
-       * @link https://react-query.tanstack.com/reference/QueryClient
-       */
-      // queryClientConfig: { defaultOptions: { queries: { staleTime: 60 } } },
-    };
-  },
-  /**
-   * @link https://trpc.io/docs/ssr
-   */
-  ssr: true,
-  /**
-   * Set headers or status code when doing SSR
-   */
-  responseMeta({ clientErrors }) {
-    if (clientErrors.length) {
-      // propagate http first error from API calls
-      return {
-        status: clientErrors[0].data?.httpStatus ?? 500,
-      };
-    }
+export const trpc = createReactQueryHooks<AppRouter>();
 
-    // for app caching with SSR see https://trpc.io/docs/caching
-
-    return {};
-  },
-});
-
+// export const transformer = superjson;
 /**
  * This is a helper method to infer the output of a query resolver
  * @example type HelloOutput = inferQueryOutput<'hello'>
@@ -92,15 +20,3 @@ export const trpc = setupTRPC<AppRouter>({
 export type inferQueryOutput<
   TRouteKey extends keyof AppRouter['_def']['queries'],
 > = inferProcedureOutput<AppRouter['_def']['queries'][TRouteKey]>;
-
-export type inferQueryInput<
-  TRouteKey extends keyof AppRouter['_def']['queries'],
-> = inferProcedureInput<AppRouter['_def']['queries'][TRouteKey]>;
-
-export type inferMutationInput<
-  TRouteKey extends keyof AppRouter['_def']['mutations'],
-> = inferProcedureInput<AppRouter['_def']['mutations'][TRouteKey]>;
-
-export type inferMutationOutput<
-  TRouteKey extends keyof AppRouter['_def']['mutations'],
-> = inferProcedureOutput<AppRouter['_def']['mutations'][TRouteKey]>;


### PR DESCRIPTION
Get rid of `setupNext`, etc