### PR TITLE
Expose various socket and subscriptions lifecycle methods

### DIFF
--- a/packages/client/src/links/wsLink.ts
+++ b/packages/client/src/links/wsLink.ts
@@ -15,12 +15,16 @@ export interface WebSocketClientOptions {
   url: string;
   WebSocket?: typeof WebSocket;
   retryDelayMs?: typeof retryDelay;
+  onOpen?: () => void;
+  onClose?: () => void;
 }
 export function createWSClient(opts: WebSocketClientOptions) {
   const {
     url,
     WebSocket: WebSocketImpl = WebSocket,
     retryDelayMs: retryDelayFn = retryDelay,
+    onOpen,
+    onClose,
   } = opts;
   /* istanbul ignore next */
   if (!WebSocketImpl) {
@@ -123,6 +127,7 @@ export function createWSClient(opts: WebSocketClientOptions) {
       }
       connectAttempt = 0;
       state = 'open';
+      onOpen?.();
       dispatch();
     });
     conn.addEventListener('error', () => {
@@ -180,6 +185,7 @@ export function createWSClient(opts: WebSocketClientOptions) {
 
     conn.addEventListener('close', () => {
       if (activeConnection === conn) {
+        onClose?.();
         // connection might have been replaced already
         tryReconnect();
       }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,5 +1,6 @@
 export * from './assertNotBrowser';
 export * from './http';
+export * from './rpc';
 export * from './transformer';
 export * from './error/TRPCError';
 export * from './types';


### PR DESCRIPTION
Superseed #1999 

I'm implementing the api from https://github.com/trpc/trpc/pull/1999#issuecomment-1159030370

I'm still open to rollback to `next/error` but the `on` is less a breaking compare to v9 and feels a lot more natural for the the React dev that I am.

Edit: I'm waiting for the choice of API to fix tests