### PR TITLE
Use the OnErrorFunction type for AWS Lambda adapter's onError method

### DIFF
--- a/packages/server/src/adapters/aws-lambda/utils.ts
+++ b/packages/server/src/adapters/aws-lambda/utils.ts
@@ -6,6 +6,7 @@ import type {
   APIGatewayProxyStructuredResultV2,
 } from 'aws-lambda';
 import type { ResponseMetaFn } from '../../http/internals/types';
+import type { OnErrorFunction } from '../../internals/onErrorFunction';
 import type { AnyRouter, inferRouterContext } from '../../router';
 
 export type APIGatewayEvent = APIGatewayProxyEvent | APIGatewayProxyEventV2;
@@ -36,7 +37,7 @@ export type AWSLambdaOptions<
       batching?: {
         enabled: boolean;
       };
-      onError?: (options: Record<string, unknown>) => void;
+      onError?: OnErrorFunction<TRouter, TEvent>;
       responseMeta?: ResponseMetaFn<TRouter>;
     } & (
       | {


### PR DESCRIPTION
👋 Hey tRPC folks!
Currently the arguments to `onError` in AWS Lambda adapter are typed as a record of `unknown` which is cumbersome to work with. The more helpful type already exists, so I've just used it here. Let me know if I'm missing something.