### PR TITLE
Doc page for sending cookies cross-origin by editing fetch's arguments

### DIFF
--- a/www/docs/client/cors.md
+++ b/www/docs/client/cors.md
@@ -13,7 +13,7 @@ The arguments provided to the fetch function used by tRPC can be modified as fol
 import { createTRPCClient } from '@trpc/client';
 
 const client = createTRPCClient<AppRouter>({
-  url: 'http://localhost:5000/trpc',
+  url: 'YOUR_SERVER_URL',
   fetch(url, options) {
     return fetch(url, {
       ...options,

--- a/www/docs/client/cors.md
+++ b/www/docs/client/cors.md
@@ -1,0 +1,24 @@
+---
+id: cors
+title: Send cookies cross-origin
+sidebar_label: CORS & Cookies
+slug: /cors
+---
+
+If your API reside on a different origin than your front-end and wish to send cookies to it, you will need to enable [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) on your server and send cookies with your requests by providing the option `{credentials: "include"}` to fetch.
+
+The arguments provided to the fetch function used by tRPC can be modified as follow.
+
+```ts title='app.ts'
+import { createTRPCClient } from '@trpc/client';
+
+const client = createTRPCClient<AppRouter>({
+  url: 'http://localhost:5000/trpc',
+  fetch(url, options) {
+    return fetch(url, {
+      ...options,
+      credentials: "include"
+    }
+  }
+});
+```

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -42,9 +42,13 @@ module.exports = {
       type: 'category',
       label: '@trpc/client',
       collapsed: false,
-      items: ['client/vanilla', 'client/links', 'client/header'],
+      items: [
+        'client/vanilla',
+        'client/links',
+        'client/header',
+        'client/cors'
+      ],
     },
-
     {
       type: 'category',
       label: '@trpc/react',
@@ -61,7 +65,11 @@ module.exports = {
       type: 'category',
       label: '@trpc/next',
       collapsed: false,
-      items: ['nextjs/ssr', 'nextjs/ssg', 'nextjs/starter-projects'],
+      items: [
+        'nextjs/ssr',
+        'nextjs/ssg',
+        'nextjs/starter-projects'
+      ],
     },
     {
       type: 'category',


### PR DESCRIPTION
I feel like other people might be interested in having a simple example of setting the fetch's "credentials" option to "include" in the client's documentation.