### PR TITLE
chore: update cloudflare-workers example to v10

### DIFF
--- a/examples/cloudflare-workers/.gitignore
+++ b/examples/cloudflare-workers/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/examples/cloudflare-workers/README.md
+++ b/examples/cloudflare-workers/README.md
@@ -1,0 +1,6 @@
+- [Cloudflare Workers](https://workers.cloudflare.com)
+- Vanilla TRPCClient in node
+
+---
+
+Created by [sachinraja](https://github.com/sachinraja).

--- a/examples/cloudflare-workers/package.json
+++ b/examples/cloudflare-workers/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@examples/cloudflare-workers",
+  "version": "10.0.0-alpha.36",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "test-dev": "start-server-and-test 'wrangler dev --local' 8787 'node --loader ts-node/esm src/client.ts'"
+  },
+  "dependencies": {
+    "@trpc/client": "^10.0.0-alpha.36",
+    "@trpc/server": "^10.0.0-alpha.36",
+    "zod": "^3.0.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^3.8.0",
+    "node-fetch": "^2.6.1",
+    "start-server-and-test": "^1.12.0",
+    "ts-node": "^10.3.0",
+    "typescript": "4.7.4",
+    "wrangler": "^0.0.27"
+  },
+  "publishConfig": {
+    "access": "restricted"
+  }
+}

--- a/examples/cloudflare-workers/src/client.ts
+++ b/examples/cloudflare-workers/src/client.ts
@@ -1,0 +1,47 @@
+import {
+  createTRPCClient,
+  createTRPCClientProxy,
+  httpBatchLink,
+  loggerLink,
+} from '@trpc/client';
+import fetch from 'node-fetch';
+import type { AppRouter } from './router';
+
+// polyfill
+global.fetch = fetch as any;
+
+const sleep = (ms = 100) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function main() {
+  const url = 'http://localhost:8787';
+
+  const client = createTRPCClient<AppRouter>({
+    links: [loggerLink(), httpBatchLink({ url })],
+  });
+
+  const proxy = createTRPCClientProxy(client);
+
+  await sleep();
+
+  // parallel queries
+  await Promise.all([
+    //
+    proxy.hello.query(),
+    proxy.hello.query('client'),
+  ]);
+  await sleep();
+
+  const postCreate = await proxy.post.createPost.mutate({
+    title: 'hello client',
+  });
+  console.log('created post', postCreate.title);
+  await sleep();
+
+  const postList = await proxy.post.listPosts.query();
+  console.log('has posts', postList, 'first:', postList[0].title);
+  await sleep();
+
+  console.log('👌 should be a clean exit if everything is working right');
+}
+
+main();

--- a/examples/cloudflare-workers/src/index.ts
+++ b/examples/cloudflare-workers/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Welcome to Cloudflare Workers!
+ *
+ * - Run `yarn dev` in your terminal to start a development server
+ * - Open a browser tab at http://localhost:8787/ to see your worker in action
+ * - Run `wrangler publish --name my-worker` to publish your worker
+ *
+ * Learn more at https://developers.cloudflare.com/workers/
+ */
+import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
+import { appRouter } from './router';
+
+export default {
+  async fetch(request: Request): Promise<Response> {
+    return fetchRequestHandler({
+      endpoint: '',
+      req: request,
+      router: appRouter,
+      createContext: ({ req }) => ({ req }),
+    });
+  },
+};

--- a/examples/cloudflare-workers/src/router.ts
+++ b/examples/cloudflare-workers/src/router.ts
@@ -1,0 +1,38 @@
+import { initTRPC } from '@trpc/server';
+import { z } from 'zod';
+
+let id = 0;
+
+const db = {
+  posts: [
+    {
+      id: ++id,
+      title: 'hello',
+    },
+  ],
+};
+
+const t = initTRPC()();
+
+const postRouter = t.router({
+  createPost: t.procedure
+    .input(z.object({ title: z.string() }))
+    .mutation(({ input }) => {
+      const post = {
+        id: ++id,
+        ...input,
+      };
+      db.posts.push(post);
+      return post;
+    }),
+  listPosts: t.procedure.query(() => db.posts),
+});
+
+export const appRouter = t.router({
+  post: postRouter,
+  hello: t.procedure.input(z.string().nullish()).query(({ input }) => {
+    return `hello ${input ?? 'world'}`;
+  }),
+});
+
+export type AppRouter = typeof appRouter;

--- a/examples/cloudflare-workers/tsconfig.json
+++ b/examples/cloudflare-workers/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/examples/cloudflare-workers/wrangler.toml
+++ b/examples/cloudflare-workers/wrangler.toml
@@ -1,0 +1,3 @@
+name = "cloudflare-workers"
+main = "src/index.ts"
+compatibility_date = "2022-05-01"


### PR DESCRIPTION
Updated the router and client to v10.

Have a problem though with the fetch-handler not finding the procedures:
![CleanShot 2022-07-11 at 19 11 48](https://user-images.githubusercontent.com/51714798/178320149-13323426-8ecb-421d-b8a6-0d4bf6c2e251.png)

Not sure if I need to do something else to make it compatible?