### PR TITLE
chore(deps): use packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "engines": {
     "node": "^16.0.0"
   },
+  "packageManager": "yarn@1.22.19",
   "scripts": {
     "lerna": "lerna",
     "start": "yarn watch",


### PR DESCRIPTION
When [corepack](https://nodejs.org/dist/latest-v16.x/docs/api/corepack.html) is enabled, using `packageManager` will transparently download and install the expected yarn version to run the project.

It will also display an error if we try to use another package manager (as I did):
![image](https://user-images.githubusercontent.com/1443499/178772765-7ff0fa1d-4195-4b8c-8021-f544434dbae2.png)
