### PR TITLE
Feat: Add `X-Powered-By` header

### DIFF
--- a/packages/server/src/core/initTRPC.ts
+++ b/packages/server/src/core/initTRPC.ts
@@ -10,6 +10,7 @@ import {
   CombinedDataTransformer,
   DataTransformerOptions,
   DefaultDataTransformer,
+  defaultPoweredByHeader,
   defaultTransformer,
   getDataTransformer,
 } from '../transformer';
@@ -47,21 +48,25 @@ export function initTRPC<TParams extends Partial<InitGenerics> = {}>() {
         : DefaultDataTransformer
       : DefaultDataTransformer;
     type $ErrorShape = ErrorFormatterShape<$Formatter>;
+    type $PoweredByHeader = NonNullable<$Options['poweredByHeader']>;
 
     type $Config = CreateRootConfig<{
       ctx: $Context;
       meta: $Meta;
       errorShape: $ErrorShape;
       transformer: $Transformer;
+      poweredByHeader: $PoweredByHeader;
     }>;
 
     const errorFormatter = options?.errorFormatter ?? defaultFormatter;
     const transformer = getDataTransformer(
       options?.transformer ?? defaultTransformer,
     ) as $Transformer;
+    const poweredByHeader = options?.poweredByHeader ?? defaultPoweredByHeader;
     const _config: $Config = {
       transformer,
       errorShape: null as any,
+      poweredByHeader,
       ctx: null as any,
       meta: null as any,
     };
@@ -85,6 +90,7 @@ export function initTRPC<TParams extends Partial<InitGenerics> = {}>() {
       router: createRouterFactory<$Config>({
         errorFormatter,
         transformer,
+        poweredByHeader,
       }),
       /**
        * Merge Routers

--- a/packages/server/src/core/internals/config.ts
+++ b/packages/server/src/core/internals/config.ts
@@ -2,6 +2,7 @@ import { ErrorFormatter } from '../../error/formatter';
 import {
   CombinedDataTransformer,
   DataTransformerOptions,
+  PoweredByHeader,
 } from '../../transformer';
 
 /**
@@ -19,6 +20,7 @@ export interface InitGenerics {
 export interface InitOptions<T extends InitGenerics> {
   transformer: DataTransformerOptions;
   errorFormatter: ErrorFormatter<T['ctx'], any>;
+  poweredByHeader: PoweredByHeader;
 }
 
 /**
@@ -35,6 +37,7 @@ export interface RootConfig extends InitGenerics {
   transformer: CombinedDataTransformer;
   // FIXME this should probably be restricted
   errorShape: any;
+  poweredByHeader: PoweredByHeader;
 }
 
 /**

--- a/packages/server/src/core/internals/mergeRouters.ts
+++ b/packages/server/src/core/internals/mergeRouters.ts
@@ -37,9 +37,14 @@ export function mergeRouters(...routerList: AnyRouter[]): AnyRouter {
     return prev;
   }, defaultTransformer as CombinedDataTransformer);
 
+  const poweredByHeader = !routerList.some(
+    (router) => !router._def.poweredByHeader,
+  );
+
   const router = createRouterFactory({
     errorFormatter,
     transformer,
+    poweredByHeader,
   })(record);
   return router;
 }

--- a/packages/server/src/core/router.ts
+++ b/packages/server/src/core/router.ts
@@ -9,7 +9,12 @@ import {
 } from '../error/formatter';
 import { getHTTPStatusCodeFromError } from '../http/internals/getHTTPStatusCode';
 import { TRPCErrorShape, TRPC_ERROR_CODES_BY_KEY } from '../rpc';
-import { CombinedDataTransformer, defaultTransformer } from '../transformer';
+import {
+  CombinedDataTransformer,
+  PoweredByHeader,
+  defaultPoweredByHeader,
+  defaultTransformer,
+} from '../transformer';
 import { RootConfig } from './internals/config';
 import {
   InternalProcedure,
@@ -80,6 +85,7 @@ export interface RouterDef<
   _meta: TMeta;
   errorFormatter: ErrorFormatter<TContext, TErrorShape>;
   transformer: CombinedDataTransformer;
+  poweredByHeader: PoweredByHeader;
   // FIXME this is slow
   procedures: Filter<TRecord, Procedure<any>> &
     SimpleFlatten<PrefixedProcedures<TRecord>>;
@@ -153,6 +159,8 @@ export interface Router<TDef extends AnyRouterDef> {
   errorFormatter: TDef['errorFormatter'];
   /** @deprecated **/
   transformer: TDef['transformer'];
+  /** @deprecated **/
+  poweredByHeader: TDef['poweredByHeader'];
 
   // FIXME rename me and deprecate
   createCaller: RouterCaller<TDef>;
@@ -171,7 +179,7 @@ export interface Router<TDef extends AnyRouterDef> {
  */
 export type RouterDefaultOptions<TContext> = Pick<
   AnyRouterDef<TContext>,
-  'transformer' | 'errorFormatter'
+  'transformer' | 'errorFormatter' | 'poweredByHeader'
 >;
 
 /**
@@ -199,6 +207,7 @@ const emptyRouter = {
   subscriptions: {},
   errorFormatter: defaultFormatter,
   transformer: defaultTransformer,
+  poweredByHeader: defaultPoweredByHeader,
 };
 
 /**
@@ -244,6 +253,7 @@ export function createRouterFactory<TConfig extends RootConfig>(
       {
         transformer: defaults?.transformer ?? defaultTransformer,
         errorFormatter: defaults?.errorFormatter ?? defaultFormatter,
+        poweredByHeader: defaults?.poweredByHeader ?? defaultPoweredByHeader,
       },
       { procedures: routerProcedures },
     );
@@ -287,6 +297,7 @@ export function createRouterFactory<TConfig extends RootConfig>(
       _def,
       transformer: _def.transformer,
       errorFormatter: _def.errorFormatter,
+      poweredByHeader: _def.poweredByHeader,
       createCaller(ctx) {
         return {
           query: (path, ...args) =>

--- a/packages/server/src/deprecated/interop.ts
+++ b/packages/server/src/deprecated/interop.ts
@@ -1,4 +1,3 @@
-import { CombinedDataTransformer, ProcedureParams, ProcedureType } from '..';
 import { CreateRootConfig, RootConfig } from '../core/internals/config';
 import { getParseFnOrPassThrough } from '../core/internals/getParseFn';
 import {
@@ -22,6 +21,13 @@ import {
   AnyRouter as AnyOldRouter,
   Router as OldRouter,
 } from '../deprecated/router';
+import {
+  CombinedDataTransformer,
+  PoweredByHeader,
+  ProcedureParams,
+  ProcedureType,
+  defaultPoweredByHeader,
+} from '../index';
 import { TRPCErrorShape } from '../rpc';
 import { Procedure as OldProcedure } from './internals/procedure';
 import { ProcedureRecord } from './router';
@@ -116,6 +122,7 @@ export type MigrateRouter<
         errorShape: TErrorShape;
         meta: TMeta;
         transformer: CombinedDataTransformer;
+        poweredByHeader: PoweredByHeader;
       }>,
       TQueries,
       'query'
@@ -126,6 +133,7 @@ export type MigrateRouter<
           errorShape: TErrorShape;
           meta: TMeta;
           transformer: CombinedDataTransformer;
+          poweredByHeader: PoweredByHeader;
         }>,
         TMutations,
         'mutation'
@@ -136,6 +144,7 @@ export type MigrateRouter<
           errorShape: TErrorShape;
           meta: TMeta;
           transformer: CombinedDataTransformer;
+          poweredByHeader: PoweredByHeader;
         }>,
         TSubscriptions,
         'subscription'
@@ -198,6 +207,7 @@ export function migrateRouter<TOldRouter extends AnyOldRouter>(
 ): MigrateOldRouter<TOldRouter> {
   const errorFormatter = oldRouter._def.errorFormatter;
   const transformer = oldRouter._def.transformer;
+  const poweredByHeader = defaultPoweredByHeader;
 
   type ProcRecord = Record<string, NewProcedure<any>>;
 
@@ -223,6 +233,7 @@ export function migrateRouter<TOldRouter extends AnyOldRouter>(
   const newRouter = createRouterFactory<any>({
     transformer,
     errorFormatter,
+    poweredByHeader,
   })(procedures);
 
   return newRouter as any;

--- a/packages/server/src/http/resolveHTTPResponse.ts
+++ b/packages/server/src/http/resolveHTTPResponse.ts
@@ -82,6 +82,7 @@ export async function resolveHTTPResponse<
     let status = getHTTPStatusCode(untransformedJSON);
     const headers: HTTPHeaders = {
       'Content-Type': 'application/json',
+      ...(router._def.poweredByHeader && { 'X-Powered-By': 'tRPC <trpc.io>' }),
     };
 
     const meta =

--- a/packages/server/src/transformer.ts
+++ b/packages/server/src/transformer.ts
@@ -63,3 +63,12 @@ export const defaultTransformer: DefaultDataTransformer = {
   input: { serialize: (obj) => obj, deserialize: (obj) => obj },
   output: { serialize: (obj) => obj, deserialize: (obj) => obj },
 };
+
+/**
+ * @internal
+ */
+export type PoweredByHeader = boolean;
+/**
+ * @internal
+ */
+export const defaultPoweredByHeader = true;

--- a/packages/server/test/adapters/awsLambda.test.tsx
+++ b/packages/server/test/adapters/awsLambda.test.tsx
@@ -78,6 +78,7 @@ test('basic test', async () => {
     Object {
       "headers": Object {
         "Content-Type": "application/json",
+        "X-Powered-By": "tRPC <trpc.io>",
       },
       "statusCode": 200,
     }
@@ -108,6 +109,7 @@ test('bad type', async () => {
     Object {
       "headers": Object {
         "Content-Type": "application/json",
+        "X-Powered-By": "tRPC <trpc.io>",
       },
       "statusCode": 400,
     }
@@ -164,6 +166,7 @@ test('test v2 format', async () => {
     Object {
       "headers": Object {
         "Content-Type": "application/json",
+        "X-Powered-By": "tRPC <trpc.io>",
       },
       "statusCode": 200,
     }
@@ -200,6 +203,7 @@ test('router with no context', async () => {
     Object {
       "headers": Object {
         "Content-Type": "application/json",
+        "X-Powered-By": "tRPC <trpc.io>",
       },
       "statusCode": 200,
     }

--- a/packages/server/test/adapters/lambda.test.tsx
+++ b/packages/server/test/adapters/lambda.test.tsx
@@ -84,6 +84,7 @@ test('basic test', async () => {
     Object {
       "headers": Object {
         "Content-Type": "application/json",
+        "X-Powered-By": "tRPC <trpc.io>",
       },
       "statusCode": 200,
     }
@@ -114,6 +115,7 @@ test('bad type', async () => {
     Object {
       "headers": Object {
         "Content-Type": "application/json",
+        "X-Powered-By": "tRPC <trpc.io>",
       },
       "statusCode": 400,
     }
@@ -170,6 +172,7 @@ test('test v2 format', async () => {
     Object {
       "headers": Object {
         "Content-Type": "application/json",
+        "X-Powered-By": "tRPC <trpc.io>",
       },
       "statusCode": 200,
     }
@@ -206,6 +209,7 @@ test('router with no context', async () => {
     Object {
       "headers": Object {
         "Content-Type": "application/json",
+        "X-Powered-By": "tRPC <trpc.io>",
       },
       "statusCode": 200,
     }

--- a/packages/server/test/poweredBy.test.ts
+++ b/packages/server/test/poweredBy.test.ts
@@ -1,0 +1,58 @@
+import { routerToServerAndClientNew } from './___testHelpers';
+import { initTRPC, router } from '../src';
+
+test('with enabled header (default)', async () => {
+  const t = initTRPC()({});
+
+  const appRouter = t.router({ ping: t.procedure.query(() => 'pong') });
+  const { httpUrl, close } = routerToServerAndClientNew(appRouter);
+
+  const res = await fetch(`${httpUrl}/ping`);
+  expect(res.headers.get('x-powered-by')?.includes('tRPC <trpc.io>')).toBe(
+    true,
+  );
+
+  close();
+});
+
+test('with disabled header', async () => {
+  const t = initTRPC()({ poweredByHeader: false });
+
+  const appRouter = t.router({ ping: t.procedure.query(() => 'pong') });
+  const { httpUrl, close } = routerToServerAndClientNew(appRouter);
+
+  const res = await fetch(`${httpUrl}/ping`);
+  expect(res.headers.get('x-powered-by')).toBe(null);
+
+  close();
+});
+
+test('with merged routers', async () => {
+  const t = initTRPC()({ poweredByHeader: false });
+
+  const routerOne = t.router({ ping1: t.procedure.query(() => 'pong1') });
+  const routerTwo = t.router({ ping2: t.procedure.query(() => 'pong2') });
+  const appRouter = t.mergeRouters(routerOne, routerTwo);
+
+  const { httpUrl, close } = routerToServerAndClientNew(appRouter);
+
+  const res = await fetch(`${httpUrl}/ping`);
+  expect(res.headers.get('x-powered-by')).toBe(null);
+
+  close();
+});
+
+test('with interop router', async () => {
+  const appRouter = router()
+    .query('ping', { resolve: () => 'pong' })
+    .interop();
+
+  const { httpUrl, close } = routerToServerAndClientNew(appRouter);
+
+  const res = await fetch(`${httpUrl}/ping`);
+  expect(res.headers.get('x-powered-by')?.includes('tRPC <trpc.io>')).toBe(
+    true,
+  );
+
+  close();
+});

--- a/scripts/generateMergeRouters.ts
+++ b/scripts/generateMergeRouters.ts
@@ -26,6 +26,7 @@ const TEMPLATE = `
   _meta: RP0['_meta'];
   transformer: RP0['transformer'];
   errorFormatter: RP0['errorFormatter'];
+  poweredByHeader: RP0['poweredByHeader'];
   queries: __queries__;
   mutations: __mutations__;
   subscriptions: __subscriptions__;


### PR DESCRIPTION
> @KATT: I'd like to get a better picture of number of apps used in production, right now we can only do wild guesses based on npm downloads

## Feat: Add `X-Powered-By` header

```
X-Powered-By: tRPC <trpc.io>
```

This header will be useful for analytics, so that tools like [BuiltWith](https://builtwith.com), [Wappalyzer](https://www.wappalyzer.com/) etc. can track tRPC trends over time.

The `X-Powered-By` is enabled by default, it can be explicitly enabled/disabled with the `poweredByHeader`. 

```ts
const t = initTRPC()({
  ...,
  poweredByHeader: false,
});
```

We should add a reference on how to disable this into `API Reference` page of the new docs. 