### PR TITLE
Add docs announcement bar

### DIFF
--- a/www/docusaurus.config.js
+++ b/www/docusaurus.config.js
@@ -23,6 +23,11 @@ module.exports = {
       // contextualSearch: true,
       // searchParameters: {},
     },
+		announcementBar: {
+			content: "<b>🚀 Hey, we just released v10 update, read <a href='/docs/quickstart'>the documentation guide</a></b>",
+			backgroundColor: 'var(--ifm-color-primary-dark)',
+			textColor: 'var(--ifm-color-light)',
+		},
     navbar: {
       title: 'tRPC',
       logo: {

--- a/www/docusaurus.config.js
+++ b/www/docusaurus.config.js
@@ -23,11 +23,12 @@ module.exports = {
       // contextualSearch: true,
       // searchParameters: {},
     },
-		announcementBar: {
-			content: "<b>🚀 Hey, we just released v10 update, read <a href='/docs/quickstart'>the documentation guide</a></b>",
-			backgroundColor: 'var(--ifm-color-primary-dark)',
-			textColor: 'var(--ifm-color-light)',
-		},
+    // announcementBar: {
+    //   content:
+    //     "<b>🚀 Hey, we just released v10 update, read <a href='/docs/quickstart'>the documentation guide</a></b>",
+    //   backgroundColor: 'var(--ifm-color-primary-dark)',
+    //   textColor: 'var(--ifm-color-light)',
+    // },
     navbar: {
       title: 'tRPC',
       logo: {


### PR DESCRIPTION
As per issue #2203 , adding support to docausurus config file, that will render pretty minimal shy announcement bar.
Now the default announce bar is, like I said, pretty shy, so I'd be up for customizing it a bit to make it a bit more fancy and dancy, but that's of course only if you think it'd be cool.
For this I can swizzle the component and customize it further.
Without customization it looks like so
<img width="1171" alt="image" src="https://user-images.githubusercontent.com/43781031/179270265-389d376b-d04f-4df2-8671-ac144fcd94ce.png">

Background and font color are cusotmizable, and for this PR are taken from tailwind config.
You can render `html` inside the announcement bar `content` property.