### PR TITLE
docs: add version-tag to react-query in installation snippets

### DIFF
--- a/www/docs/main/quickstart.mdx
+++ b/www/docs/main/quickstart.mdx
@@ -24,7 +24,7 @@ For implementing tRPC endpoints and routers. Install in your server codebase.
 
 For making typesafe API calls from your client. Install in your client codebase (`@trpc/server` is a peer dependency of `@trpc/client`).
 
-`npm install @trpc/react react-query`
+`npm install @trpc/react react-query@3`
 
 For generating a powerful set of React hooks for querying your tRPC API. Powered by [react-query](https://react-query.tanstack.com/).
 
@@ -37,13 +37,13 @@ A set of utilies for integrating tRPC with [Next.js](https://nextjs.org/).
 **npm:**
 
 ```bash
-npm install @trpc/server @trpc/client @trpc/react react-query @trpc/next
+npm install @trpc/server @trpc/client @trpc/react react-query@3 @trpc/next
 ```
 
 **yarn:**
 
 ```bash
-yarn add @trpc/server @trpc/client @trpc/react react-query @trpc/next
+yarn add @trpc/server @trpc/client @trpc/react react-query@3 @trpc/next
 ```
 
 ## Defining a router

--- a/www/docs/nextjs/introduction.md
+++ b/www/docs/nextjs/introduction.md
@@ -45,7 +45,7 @@ Recommended but not enforced file structure. This is what you get when starting 
 ### 1. Install deps
 
 ```bash
-yarn add @trpc/client @trpc/server @trpc/react @trpc/next zod react-query
+yarn add @trpc/client @trpc/server @trpc/react @trpc/next zod react-query@3
 ```
 
 - React Query: `@trpc/react` provides a thin wrapper over [react-query](https://react-query.tanstack.com/overview). It is required as a peer dependency.

--- a/www/docs/reactjs/introduction.md
+++ b/www/docs/reactjs/introduction.md
@@ -62,7 +62,7 @@ Follow the [Quickstart](/docs/quickstart) and read the [`@trpc/server` docs](/do
 #### 1. Install dependencies
 
 ```bash
-yarn add @trpc/client @trpc/server @trpc/react react-query
+yarn add @trpc/client @trpc/server @trpc/react react-query@3
 ```
 - @trpc/server: This is a peer dependency of `@trpc/client` so you have to install it again!
 - React Query: @trpc/react provides a thin wrapper over react-query. It is required as a peer dependency.


### PR DESCRIPTION
Update installation snippets since react-query have tagged v4 as stable and it is not currently compatible.