### PR TITLE
fix(docs): double slash comment was misaligned

### DIFF
--- a/www/docs/server/infer-types.md
+++ b/www/docs/server/infer-types.md
@@ -46,5 +46,5 @@ export type User = inferProcedureOutput<AppRouter['user']['me']>;
 //           ^? { id: number, name: string }}
 
 export type PostInput = inferProcedureInput<AppRouter['post']>;
-//            ^? string
+//           ^? string
 ```


### PR DESCRIPTION
Sorry, OCD was killing me about this..

<img width="245" alt="CleanShot 2022-07-23 at 12 58 17@2x" src="https://user-images.githubusercontent.com/51714798/180602334-7745e746-ef6d-446a-b49a-755842f4e203.png">

so i fixed the indentation...

<img width="248" alt="CleanShot 2022-07-23 at 13 03 39@2x" src="https://user-images.githubusercontent.com/51714798/180602402-24265642-cd3e-426b-804f-7f8fbf181dca.png">
