### PR TITLE
Return errors to links correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "codegen:entrypoints": "yarn ts-node scripts/entrypoints.ts",
     "codegen:generateMergeRouters": "yarn ts-node scripts/generateMergeRouters.ts",
     "codegen": "run-p codegen:*",
-    "ts-node": "ts-node --compiler-options '{\"module\":\"commonjs\"}'",
+    "ts-node": "ts-node --compiler-options {\\\"module\\\":\\\"commonjs\\\"}",
     "postinstall": "yarn codegen",
     "build": "lerna run build --scope=\"@trpc/*\" --stream",
     "watch": "lerna run build --scope \"@trpc/*\" --stream --parallel -- --watch",


### PR DESCRIPTION
A fix for `TRPCError`s thrown on the server arriving in `next` instead of `error` in links.

I think this is clearer that the text above:
```ts
const customLink: TRPCLink<AppRouter> = (runtime) => {
  return ({ next, op }) => {
    return observable((observer) => {
      const unsubscribe = next(op).subscribe({
        next(value) {
          // `TRPCError`s from the server are sent here
          observer.next(value);
        },
        error(value) {
          // instead of here
          observer.error(value);
        },
        complete() {
          observer.complete();
        }
      });
      return unsubscribe;
    });
  };
};

export const client = createTRPCClient<AppRouter>({
  fetch(url, options) {
    return fetch(url, { ...options, credentials: 'include' });
  },
  transformer: superjson,
  links: [
    customLink,
    httpBatchLink({
      url: '/trpc'
    })
  ]
});

export const proxy = createTRPCClientProxy(client);
```

I'm pretty sure I got the fix working for `httpBatchLink` and `httpLink`, but not 100% sure what I did for `wsLink` actually works.