### PR TITLE
[idea] path proxy

### DIFF
--- a/examples/.interop/next-prisma-starter/src/pages/index.tsx
+++ b/examples/.interop/next-prisma-starter/src/pages/index.tsx
@@ -4,7 +4,8 @@ import Link from 'next/link';
 
 const IndexPage: NextPageWithLayout = () => {
   const utils = trpc.useContext();
-  const postsQuery = trpc.useQuery(['post.all']);
+  const postsQuery = trpc.useQuery([trpc.paths.post.all]);
+  const singlePostQuery = trpc.useQuery([trpc.paths.post.byId, {id: 'foo'}])
   const addPost = trpc.useMutation('post.add', {
     async onSuccess() {
       // refetches posts after a post is added

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -112,7 +112,7 @@ type Stringable<S> = S | { toString: () => S };
 /**
  * e.g. `StringBuilder<['a', 'b', 'c']`
  *
- * => `{ a: { b: { c: {toString: () => 'c'} } } }`
+ * => `{ a: { b: { c: {toString: () => 'a.b.c'} } } }`
  */
 type StringBuilder<
   Segments extends string[],
@@ -341,7 +341,7 @@ export function createReactQueryHooks<
   >(
     _pathAndInput: [
       path: Stringable<TPath>,
-      ...args: inferHandlerInput<TQueries[TPath]>
+      ...args: inferHandlerInput<TQueries[TPath]>,
     ],
     opts?: UseTRPCQueryOptions<
       TPath,
@@ -412,7 +412,7 @@ export function createReactQueryHooks<
   >(
     pathAndInput: [
       path: TPath,
-      ...args: inferHandlerInput<TSubscriptions[TPath]>
+      ...args: inferHandlerInput<TSubscriptions[TPath]>,
     ],
     opts: {
       enabled?: boolean;

--- a/packages/server/test/interop/react/useMutation.test.tsx
+++ b/packages/server/test/interop/react/useMutation.test.tsx
@@ -87,8 +87,8 @@ describe('useMutation()', () => {
     const { trpc, client } = factory;
 
     function MyComponent() {
-      const allPostsQuery = trpc.useQuery(['allPosts']);
-      const deletePostsMutation = trpc.useMutation('deletePosts');
+      const allPostsQuery = trpc.useQuery([trpc.paths.allPosts]);
+      const deletePostsMutation = trpc.useMutation(trpc.paths.deletePosts);
 
       useEffect(() => {
         allPostsQuery.refetch().then(async (allPosts) => {


### PR DESCRIPTION
This _isn't_ ready to be merged as-is. It's just the easiest way I could come up with for communicating an idea.

Basically, this is an alternative to the Proxy-is-love-Proxy-is-life API that's upcoming in v10 - if it were up to me, it would be a replacement, but there's no reason they can't both co-exist.

Basically, this more-or-less keeps the "v9" way of invoking clients, but instead of typing `'` then writing what _looks_ like a plain string (although of course it's type-checked), you can type `trpc.paths.` and build a string dynamically, using a similar `Proxy` method that `next` currently does for invocable functions.

Demo using an existing example:

https://user-images.githubusercontent.com/15040698/180673363-ad694102-7ec4-44f3-93e4-abd1ab707b74.mov

Implementation wise, it's done too "late" - I semi-arbitrarily put it in the `createReactQueryHooks.tsx` file, meaning it's taking a string in the format `a.b.c` (i.e. which has already been "glued together",  so has to be split apart again). This is unnecessary, but I want to show the POC to see what people thought.

Here are the benefits, in my mind:

1. Go to definition in IDEs, like the existing Proxy API
2. Easy-to-understand usage - it's closer to being "honest". `proxy.mutations.deleteById(...)` feels to me like it's _lying_ to the user, by pretending that you're actually calling a delete function. `client.query(...)`, `trpc.useQuery(...)` etc. much more closely correspond to what happens in reality. trpc now just provides a helper for constructor paths.
3. Reusable for _all_ clients, including ones not in this repo. React and Next.js will be dethroned some day, maybe even soon. This technique doesn't require a new `Proxy`-based implementation for every client. They'll all need strings!
4. Clients that can't support proxies could much more easily write a code transformer plugin which swaps these path-builder-proxies for literal strings, instead of being totally out in the cold.

Downside(s) vs the existing Proxy API:

1. Slightly more verbose. `trpc.proxy.queries.getById({ id: 1 })` vs `trpc.query(trpc.paths.getById, { id: 1 })`: 37 vs 41 (although obviously both forms can be "golfed" plenty).
2. Less magical-seeming. I think this is a good thing, but some people seem to want to make it feel like you can literally call server-side functions from the client. I guess the clue's in the name!
3. Might be killed by https://github.com/trpc/trpc/issues/2311 (?)

Also related #2270 

I wanted to open this up early to enable discussion, and because with #2311 it seems time-sensitive.