### PR TITLE
examples: Add a more minimal express example

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -20,6 +20,7 @@ jobs:
         dir: [
             express-server,
             .interop/express-server,
+            express-minimal,
             .interop/next-prisma-starter,
             .interop/next-prisma-starter-websockets,
             .interop/next-prisma-todomvc,

--- a/examples/express-minimal/README.md
+++ b/examples/express-minimal/README.md
@@ -1,6 +1,19 @@
+# Express Minimal Example
+
+## Includes
 
 - Express server
-- Vanilla TRPCClient in node
+- Vanilla TRPCClient in Node
+
+## Usage
+
+Run the server and client:
+
+```bash
+yarn start
+```
+
+Tip: Try changing either the procedure name or it's input on the server and see the client type-erroring.
 
 ---
 

--- a/examples/express-minimal/README.md
+++ b/examples/express-minimal/README.md
@@ -1,0 +1,7 @@
+
+- Express server
+- Vanilla TRPCClient in node
+
+---
+
+Created by [Julius](https://github.com/juliusmarminge).

--- a/examples/express-minimal/package.json
+++ b/examples/express-minimal/package.json
@@ -4,12 +4,12 @@
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server",
-    "dev:client": "nodemon -e ts -w . -x 'wait-on tcp:2021 && ts-node ./src/client'",
+    "dev:client": "nodemon -e ts -w . -x 'wait-on tcp:3000 && ts-node ./src/client'",
     "dev": "run-p dev:* --print-label",
     "build": "tsc",
     "start": "yarn dev",
-    "test-dev": "start-server-and-test 'ts-node src/server' 2021 'ts-node src/client'",
-    "test-start": "start-server-and-test 'node dist/server' 2021 'node dist/client'"
+    "test-dev": "start-server-and-test 'ts-node src/server' 3000 'ts-node src/client'",
+    "test-start": "start-server-and-test 'node dist/server' 3000 'node dist/client'"
   },
   "dependencies": {
     "@trpc/client": "^10.0.0-alpha.41",

--- a/examples/express-minimal/package.json
+++ b/examples/express-minimal/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@examples/express-minimal",
+  "version": "10.0.0-alpha.41",
+  "private": true,
+  "scripts": {
+    "dev:server": "nodemon -e ts -w . -x ts-node ./src/server",
+    "dev:client": "nodemon -e ts -w . -x 'wait-on tcp:2021 && ts-node ./src/client'",
+    "dev": "run-p dev:* --print-label",
+    "build": "tsc",
+    "start": "yarn dev",
+    "test-dev": "start-server-and-test 'ts-node src/server' 2021 'ts-node src/client'",
+    "test-start": "start-server-and-test 'node dist/server' 2021 'node dist/client'"
+  },
+  "dependencies": {
+    "@trpc/client": "^10.0.0-alpha.41",
+    "@trpc/react": "^10.0.0-alpha.41",
+    "@trpc/server": "^10.0.0-alpha.41",
+    "@types/node-fetch": "^2.5.11",
+    "express": "^4.17.1",
+    "node-fetch": "^2.6.1",
+    "zod": "^3.0.0"
+  },
+  "alias": {
+    "scheduler/tracing": "../../node_modules/scheduler/tracing-profiling"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.12",
+    "@types/react": "^18.0.9",
+    "nodemon": "^2.0.12",
+    "npm-run-all": "^4.1.5",
+    "start-server-and-test": "^1.12.0",
+    "ts-node": "^10.3.0",
+    "typescript": "4.7.4",
+    "wait-on": "^6.0.0"
+  },
+  "publishConfig": {
+    "access": "restricted"
+  }
+}

--- a/examples/express-minimal/src/client.ts
+++ b/examples/express-minimal/src/client.ts
@@ -1,0 +1,21 @@
+import { createTRPCClient, createTRPCClientProxy } from '@trpc/client';
+import fetch from 'node-fetch';
+import type { AppRouter } from './router';
+
+// polyfill
+global.fetch = fetch as any;
+
+async function main() {
+  const client = createTRPCClient<AppRouter>({
+    url: 'http://localhost:2021/trpc',
+  });
+  const proxy = createTRPCClientProxy(client);
+
+  const withoutInputQuery = await proxy.hello.greeting.query();
+  console.log(withoutInputQuery);
+
+  const withInputQuery = await proxy.hello.greeting.query({ name: 'Alex' });
+  console.log(withInputQuery);
+}
+
+main();

--- a/examples/express-minimal/src/client.ts
+++ b/examples/express-minimal/src/client.ts
@@ -7,7 +7,7 @@ global.fetch = fetch as any;
 
 async function main() {
   const client = createTRPCClient<AppRouter>({
-    url: 'http://localhost:2021/trpc',
+    url: 'http://localhost:3000/trpc',
   });
   const proxy = createTRPCClientProxy(client);
 

--- a/examples/express-minimal/src/router.ts
+++ b/examples/express-minimal/src/router.ts
@@ -1,0 +1,18 @@
+import { initTRPC } from '@trpc/server';
+import { z } from 'zod';
+
+const t = initTRPC()();
+
+const helloRouter = t.router({
+  greeting: t.procedure
+    .input(z.object({ name: z.string() }).nullish())
+    .query(({ input }) => {
+      return `Hello ${input?.name ?? 'World'}`;
+    }),
+});
+
+export const appRouter = t.router({
+  hello: helloRouter,
+});
+
+export type AppRouter = typeof appRouter;

--- a/examples/express-minimal/src/server.ts
+++ b/examples/express-minimal/src/server.ts
@@ -1,0 +1,19 @@
+import { createExpressMiddleware } from '@trpc/server/adapters/express';
+import express from 'express';
+import { appRouter } from './router';
+
+async function main() {
+  // express implementation
+  const app = express();
+
+  app.use(
+    '/trpc',
+    createExpressMiddleware({
+      router: appRouter,
+      createContext: () => ({}),
+    }),
+  );
+  app.listen(2021);
+}
+
+main();

--- a/examples/express-minimal/src/server.ts
+++ b/examples/express-minimal/src/server.ts
@@ -6,6 +6,9 @@ async function main() {
   // express implementation
   const app = express();
 
+  // For testing purposes, wait-on requests '/'
+  app.get('/', (_req, res) => res.send('Server is running!'));
+
   app.use(
     '/trpc',
     createExpressMiddleware({
@@ -13,7 +16,7 @@ async function main() {
       createContext: () => ({}),
     }),
   );
-  app.listen(2021);
+  app.listen(3000);
 }
 
 main();

--- a/examples/express-minimal/tsconfig.json
+++ b/examples/express-minimal/tsconfig.json
@@ -1,0 +1,34 @@
+{
+  "compilerOptions": {
+    "lib": ["es5", "es6", "es7", "esnext", "dom"],
+    "target": "es5",
+    "module": "commonjs",
+    "declaration": true,
+    // "moduleResolution": "node",
+    "outDir": "./dist",
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "esModuleInterop": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    /* Strict Type-Checking Options */
+    "strict": true /* Enable all strict type-checking options. */,
+    "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
+    "strictNullChecks": true /* Enable strict null checks. */,
+    "noImplicitThis": true /* Raise error on 'this' expressions with an implied 'any' type. */,
+    "alwaysStrict": true /* Parse in strict mode and emit "use strict" for each source file. */,
+    // "strictPropertyInitialization": false,
+    /* Additional Checks */
+    "noUnusedLocals": true /* Report errors on unused locals. */,
+    "noUnusedParameters": true /* Report errors on unused parameters. */,
+    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
+    "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */
+  },
+  "include": ["src"],
+  "exclude": [
+    "node_modules"
+    // "**/__tests__/"
+  ]
+}


### PR DESCRIPTION
Related discussion: #2325 

As pointed out in that discussion, there isn't really a minimal example that "follows the docs" (For usage with Next there is #2169). This implements just that:
`A simple router without any of the fancy functions exposed by a single express endpoint and consumed by the vanilla trpc client.`


