### PR TITLE
feat(www): adjusts spacing and colors of landing page

### DIFF
--- a/www/src/components/Features.tsx
+++ b/www/src/components/Features.tsx
@@ -7,27 +7,29 @@ const features = [
     description:
       'Automatic typesafety & autocompletion inferred from your API-paths, their input data, & outputs.',
     icon: <FiLock size={20} />,
-    color: 'bg-indigo-200 text-indigo-500',
+    color:
+      'dark:bg-indigo-900/50 bg-indigo-200 dark:text-indigo-300 text-indigo-600',
   },
   {
     title: 'Light & Snappy DX',
     description:
       'No code generation, run-time bloat, or build pipeline. Zero dependencies & a tiny client-side footprint.',
     icon: <FiZap size={20} />,
-    color: 'bg-amber-200 text-amber-500',
+    color:
+      'dark:bg-amber-900/50 bg-amber-200 dark:text-amber-300 text-amber-600',
   },
   {
     title: 'Add to existing brownfield project',
     description:
       'Easy to add to your existing brownfield project with adapters for Connect/Express/Next.js.',
     icon: <FiBriefcase size={20} />,
-    color: 'bg-pink-200 text-pink-500',
+    color: 'dark:bg-pink-900/50 bg-pink-200 dark:text-pink-300 text-pink-600',
   },
 ];
 
 export const Features: FC = () => {
   return (
-    <div className="container grid grid-cols-1 gap-6 pt-12 mx-auto lg:grid-cols-3">
+    <div className="container grid grid-cols-1 gap-6 pt-36 mx-auto lg:grid-cols-3">
       {features.map((feature) => {
         return (
           <div key={feature.title}>

--- a/www/src/components/GithubStarCountButton.tsx
+++ b/www/src/components/GithubStarCountButton.tsx
@@ -21,21 +21,23 @@ export const GithubStarCountButton = () => {
     ? new Intl.NumberFormat().format(starCount)
     : null;
 
+  const starCountStyles = starCountStr
+    ? 'w-[58px] opacity-100'
+    : 'w-0 opacity-0';
+
   return (
     <a
       href="https://github.com/trpc/trpc/stargazers"
       target="_blank"
       rel="noopener noreferrer"
-      className="flex items-center gap-[5px] px-4 text-sm font-bold text-black transition rounded-lg md:text-base hover:no-underline py-2 hover:text-black bg-gradient-to-r from-cyan-100 via-cyan-200 to-cyan-300 hover:from-cyan-300 hover:via-cyan-300 hover:to-cyan-300"
+      className="flex items-center gap-[5px] px-4 text-sm font-bold transition rounded-lg md:text-base hover:no-underline py-2 dark:bg-zinc-800 bg-zinc-200 dark:text-zinc-300 text-zinc-800 dark:hover:text-zinc-300 dark:hover:bg-zinc-800/75 hover:text-zinc-900 hover:bg-zinc-300 shadow-xl"
     >
       <div className="flex items-center gap-2">
         <FiStar strokeWidth={3} /> Star
       </div>
 
       <div
-        className={`transition-all duration-1000 inline-block overflow-hidden font-mono whitespace-nowrap ${
-          starCountStr ? 'w-[58px] opacity-100' : 'w-0 opacity-0'
-        }`}
+        className={`transition-all duration-1000 inline-block overflow-hidden font-mono whitespace-nowrap ${starCountStyles}`}
       >
         {starCountStr}
       </div>

--- a/www/src/css/custom.css
+++ b/www/src/css/custom.css
@@ -11,13 +11,13 @@
 
 /* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary: #2596be;
-  --ifm-color-primary-dark: #0c7da5;
-  --ifm-color-primary-darker: #00638b;
-  --ifm-color-primary-darkest: #004a72;
-  --ifm-color-primary-light: #3fb0d8;
-  --ifm-color-primary-lighter: #58c9f1;
-  --ifm-color-primary-lightest: #72e3ff;
+  --ifm-color-primary: #398ccb;
+  --ifm-color-primary-dark: #317eb9;
+  --ifm-color-primary-darker: #2e77af;
+  --ifm-color-primary-darkest: #266290;
+  --ifm-color-primary-light: #4e98d0;
+  --ifm-color-primary-lighter: #589ed3;
+  --ifm-color-primary-lightest: #77b0db;
   --ifm-code-font-size: 95%;
   --ifm-container-width: 1140px;
   --ifm-container-width-xl: 1320px;

--- a/www/src/pages/index.tsx
+++ b/www/src/pages/index.tsx
@@ -25,7 +25,7 @@ function Home() {
           charSet="utf-8"
         />
       </Head>
-      <main className="container px-6 mx-auto py-28 md:py-40 lg:py-48 xl:py-64 space-y-28">
+      <main className="container px-6 mx-auto pt-28 md:pt-40 lg:pt-48 xl:pt-64 space-y-28">
         <header className="flex flex-col lg:flex-row">
           <div className="flex-1">
             <h1 className="pb-3 text-2xl font-bold whitespace-pre-wrap lg:text-3xl">
@@ -39,7 +39,7 @@ function Home() {
             <div className="flex items-center gap-4 mt-6">
               <Link
                 href="/docs/quickstart"
-                className="inline-block px-4 py-2 text-sm font-bold text-black transition-colors rounded-lg md:text-base hover:bg-cyan-600 hover:no-underline hover:text-black bg-cyan-500"
+                className="inline-block px-4 py-2 text-sm font-bold text-black transition-colors rounded-lg md:text-base hover:bg-primary-darker hover:no-underline hover:text-black bg-primary shadow-xl"
               >
                 Quickstart
               </Link>
@@ -50,22 +50,12 @@ function Home() {
         </header>
 
         <section>
-          {/* <SectionTitle
-          title="The easy way to build typesafe APIs"
-          description={
-            <>
-              If your project is built with TypeScript end-to-end, you can share
-              types directly between your client and server, without relying on
-              code generation.
-            </>
-          }
-        /> */}
           <Features />
         </section>
         <section className="max-w-[80ch] px-6 mx-auto md:px-0">
-          <blockquote cite="https://twitter.com/alexdotjs">
-            <SectionTitle title={<>You may not need a traditional API</>} />
-            <p className="pt-3 text-sm text-gray-600 md:text-base dark:text-gray-400">
+          <SectionTitle title={<>You may not need a traditional API</>} />
+          <blockquote cite="https://twitter.com/alexdotjs" className="mt-6">
+            <p className="text-sm text-gray-600 md:text-base dark:text-gray-400">
               If we have a project that is built with the same language
               end-to-end, why should we need to bring in <em>another</em>{' '}
               language into the mix, like <code>.yaml</code> or{' '}
@@ -106,11 +96,29 @@ function Home() {
           <SectionTitle title="Don't take our word for it!" />
           <TwitterWall />
         </section>
-        <div className="px-4 mx-auto lg:max-w-screen-lg">
-          <div className="aspect-square">
-            <Sponsors />
+        <section className="pb-12">
+          <SectionTitle
+            title="Sponsors"
+            description={
+              <>
+                We couldn&apos;t have done it without all of our amazing{' '}
+                <a
+                  href="https://github.com/sponsors/KATT"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                >
+                  sponsors
+                </a>
+                , who help us to keep tRPC alive and well-funded.
+              </>
+            }
+          />
+          <div className="max-w-screen-md mx-auto">
+            <div className="aspect-square mt-3">
+              <Sponsors />
+            </div>
           </div>
-        </div>
+        </section>
       </main>
     </Layout>
   );


### PR DESCRIPTION
this commit brings the following changes:

- Adjusts some spacings between sections.
- Gives the sponsor section a title and a description with a link to sponsoring.
- Makes the sponsors smaller.
- Moves the Alex quote title outside of the blockquote.
- Changes the website primary colour to be that of the new logo.
- Changes the colour of the github star count button to be more minimal.
- Changes the colours of the feature section icons.