### PR TITLE
fix labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,13 +1,23 @@
 '📚 documentation / examples':
-  - www/docs/**
-  - examples/**
+  - any:
+      [
+        'www/docs/**',
+        '!www/docs/**/package.json',
+        'examples/**',
+        '!examples/**/package.json',
+      ]
+
 '🕸 www':
-  - www/**
+  - any: ['www/**', '!www/**/package.json']
+
 '@trpc/server':
-  - packages/server/**
+  - any: ['packages/server/**', '!packages/server/package.json']
+
 '@trpc/client':
-  - packages/client/**
+  - any: ['packages/client/**', '!packages/client/package.json']
+
 '@trpc/next':
-  - packages/next/**
+  - any: ['packages/next/**', '!packages/next/package.json']
+
 '@trpc/react':
-  - packages/react/**
+  - any: ['packages/react/**', '!packages/react/package.json']


### PR DESCRIPTION
Closes #

## 🎯 Changes

- excluded `package.json` from labeler. PRs got littered with every single label cause of the version syncing when updating one package. this fixes that. see example run here: [juliusmarminge/trpc#1](https://github.com/juliusmarminge/trpc/pull/1). now only the relevant label is assigned

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.