### PR TITLE
fix(PR-Template): Update Contributing guide link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,6 @@ What changes are made in this PR? Is it a feature or a bug fix?
 
 ## ✅ Checklist
 
-- [ ] I have followed the steps listed in the [Contributing guide](/CONTRIBUTING.md).
+- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
 - [ ] If necessary, I have added documentation related to the changes made.
 - [ ] I have added or updated the tests related to the changes made.


### PR DESCRIPTION
Closes #

## 🎯 Changes

Contribution guide link works fine in the [template itself](https://github.com/trpc/trpc/blob/main/.github/pull_request_template.md), But when creating a PR it leads to Github's root url
```
https://github.com/CONTRIBUTING.md => https://github.com/about/careers
```

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.