### PR TITLE
Update SSG helpers docs

### DIFF
--- a/www/docs/reactjs/ssg-helpers.md
+++ b/www/docs/reactjs/ssg-helpers.md
@@ -53,7 +53,7 @@ export async function getServerSideProps(
    */
   await ssg.prefetchQuery('post.byId', {
     id,
-  })
+  });
 
   // Make sure to return { props: { trpcState: ssg.dehydrate() } }
   return {

--- a/www/docs/reactjs/ssg-helpers.md
+++ b/www/docs/reactjs/ssg-helpers.md
@@ -32,6 +32,7 @@ The returned functions are all wrappers around react-query functions. Please che
 import { createSSGHelpers } from '@trpc/react/ssg';
 import { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next';
 import { prisma } from 'server/context';
+import { createContext } from 'server/context';
 import { appRouter } from 'server/routers/_app';
 import { trpc } from 'utils/trpc';
 import superjson from 'superjson';
@@ -41,7 +42,7 @@ export async function getServerSideProps(
 ) {
   const ssg = await createSSGHelpers({
     router: appRouter,
-    ctx: {},
+    ctx: await createContext(),
     transformer: superjson,
   });
   const id = context.params?.id as string;

--- a/www/docs/reactjs/ssg-helpers.md
+++ b/www/docs/reactjs/ssg-helpers.md
@@ -40,7 +40,7 @@ import superjson from 'superjson';
 export async function getServerSideProps(
   context: GetServerSidePropsContext<{ id: string }>,
 ) {
-  const ssg = await createSSGHelpers({
+  const ssg = createSSGHelpers({
     router: appRouter,
     ctx: await createContext(),
     transformer: superjson,

--- a/www/docs/reactjs/ssg-helpers.md
+++ b/www/docs/reactjs/ssg-helpers.md
@@ -31,8 +31,7 @@ The returned functions are all wrappers around react-query functions. Please che
 ```ts title='pages/posts/[id].tsx'
 import { createSSGHelpers } from '@trpc/react/ssg';
 import { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next';
-import { prisma } from 'server/context';
-import { createContext } from 'server/context';
+import { createContext, prisma } from 'server/context';
 import { appRouter } from 'server/routers/_app';
 import { trpc } from 'utils/trpc';
 import superjson from 'superjson';

--- a/www/docs/reactjs/ssg-helpers.md
+++ b/www/docs/reactjs/ssg-helpers.md
@@ -47,10 +47,13 @@ export async function getServerSideProps(
   });
   const id = context.params?.id as string;
 
-  // Prefetch `post.byId`
-  await ssg.fetchQuery('post.byId', {
+  /*
+   * Prefetching the `post.byId` query here.
+   * `prefetchQuery` does not return the result - if you need that, use `fetchQuery` instead.
+   */
+  await ssg.prefetchQuery('post.byId', {
     id,
-  });
+  })
 
   // Make sure to return { props: { trpcState: ssg.dehydrate() } }
   return {


### PR DESCRIPTION

## 🎯 Changes

Here are three updates for the SSG helpers docs.

- Use a real example of filling the `ctx` field via `await createContext()`.
- Remove `await` when calling `createSSGHelpers`, as it is not async.
- Replace `fetchQuery` with `prefetchQuery` and add a comment to mention their use cases.

