### PR TITLE
add proxy ssg helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "@changesets/cli": "^2.17.0",
     "@manypkg/cli": "^0.19.0",
     "@rollup/plugin-node-resolve": "^13.1.3",
-    "@rollup/plugin-typescript": "^8.3.4",
     "@swc/core": "^1.2.224",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.1.1",
@@ -105,6 +104,7 @@
     "rollup-plugin-multi-input": "^1.3.1",
     "rollup-plugin-node-externals": "^4.1.1",
     "rollup-plugin-swc3": "^0.3.0",
+    "rollup-plugin-typescript2": "^0.32.1",
     "ts-jest": "^27.0.5",
     "typescript": "4.7.4"
   }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,9 +23,9 @@
       "default": "./dist/index.js"
     },
     "./ssg": {
-      "import": "./dist/ssg.mjs",
-      "require": "./dist/ssg.js",
-      "default": "./dist/ssg.js"
+      "import": "./dist/ssg/index.mjs",
+      "require": "./dist/ssg/index.js",
+      "default": "./dist/ssg/index.js"
     }
   },
   "files": [

--- a/packages/react/src/ssg/index.ts
+++ b/packages/react/src/ssg/index.ts
@@ -1,0 +1,4 @@
+export { createSSGHelpers } from './ssg';
+export type { CreateSSGHelpersOptions, CreateSSGHelpers } from './ssg';
+export { createProxySSGHelpers } from './ssgProxy';
+export type { DecoratedProcedureSSGRecord } from './ssgProxy';

--- a/packages/react/src/ssg/ssg.ts
+++ b/packages/react/src/ssg/ssg.ts
@@ -134,3 +134,5 @@ export function createSSGHelpers<TRouter extends AnyRouter>({
     queryClient,
   };
 }
+
+export type CreateSSGHelpers = ReturnType<typeof createSSGHelpers>;

--- a/packages/react/src/ssg/ssgProxy.ts
+++ b/packages/react/src/ssg/ssgProxy.ts
@@ -1,0 +1,117 @@
+import { InfiniteData } from '@tanstack/react-query';
+import {
+  AnyRouter,
+  OmitNeverKeys,
+  Procedure,
+  QueryProcedure,
+  inferHandlerInput,
+  inferProcedureOutput,
+} from '@trpc/server';
+import { createProxy } from '@trpc/server/shared';
+import {
+  CreateSSGHelpers,
+  CreateSSGHelpersOptions,
+  createSSGHelpers,
+} from './ssg';
+
+type DecorateProcedure<TProcedure extends Procedure<any>> = {
+  /**
+   * @link https://react-query.tanstack.com/guides/prefetching
+   */
+  fetch(
+    ...args: inferHandlerInput<TProcedure>
+  ): Promise<inferProcedureOutput<TProcedure>>;
+
+  /**
+   * @link https://react-query.tanstack.com/guides/prefetching
+   */
+  fetchInfinite(
+    ...args: inferHandlerInput<TProcedure>
+  ): Promise<InfiniteData<inferProcedureOutput<TProcedure>>>;
+
+  /**
+   * @link https://react-query.tanstack.com/guides/prefetching
+   */
+  prefetch(...args: inferHandlerInput<TProcedure>): Promise<void>;
+
+  /**
+   * @link https://react-query.tanstack.com/guides/prefetching
+   */
+  prefetchInfinite(...args: inferHandlerInput<TProcedure>): Promise<void>;
+};
+
+/**
+ * @internal
+ */
+export type DecoratedProcedureSSGRecord<TRouter extends AnyRouter> =
+  OmitNeverKeys<{
+    [TKey in keyof TRouter['_def']['record']]: TRouter['_def']['record'][TKey] extends AnyRouter
+      ? DecoratedProcedureSSGRecord<TRouter['_def']['record'][TKey]>
+      : // utils only apply to queries
+      TRouter['_def']['record'][TKey] extends QueryProcedure<any>
+      ? DecorateProcedure<TRouter['_def']['record'][TKey]>
+      : never;
+  }>;
+
+type AnyDecoratedProcedure = DecorateProcedure<any>;
+
+/**
+ * Create functions you can use for server-side rendering / static generation
+ */
+export function createProxySSGHelpers<TRouter extends AnyRouter>(
+  opts: CreateSSGHelpersOptions<TRouter>,
+) {
+  const helpers = createSSGHelpers(opts);
+
+  const proxy: unknown = new Proxy(
+    () => {
+      // noop
+    },
+    {
+      get(_obj, name) {
+        if (name === 'queryClient') {
+          return helpers.queryClient;
+        }
+
+        if (name === 'dehydrate') {
+          return helpers.dehydrate;
+        }
+
+        if (typeof name === 'string') {
+          return createProxy((opts) => {
+            const args = opts.args;
+
+            const pathCopy = [name, ...opts.path];
+
+            const utilName = pathCopy.pop() as keyof AnyDecoratedProcedure;
+
+            const fullPath = pathCopy.join('.');
+
+            switch (utilName) {
+              case 'fetch': {
+                return helpers.fetchQuery(fullPath, ...(args as any));
+              }
+              case 'fetchInfinite': {
+                return helpers.fetchInfiniteQuery(fullPath, ...(args as any));
+              }
+              case 'prefetch': {
+                return helpers.prefetchQuery(fullPath, ...(args as any));
+              }
+              case 'prefetchInfinite': {
+                return helpers.prefetchInfiniteQuery(
+                  fullPath,
+                  ...(args as any),
+                );
+              }
+            }
+          });
+        }
+
+        throw new Error('Not supported');
+      },
+    },
+  );
+
+  return proxy as Pick<CreateSSGHelpers, 'queryClient' | 'dehydrate'> &
+    DecoratedProcedureSSGRecord<TRouter>;
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -110,6 +110,7 @@
     "@cloudflare/workers-types": "^3.14.1",
     "@fastify/websocket": "^5.0.0",
     "@miniflare/core": "^2.4.0",
+    "@tanstack/react-query": "^4.0.10",
     "@types/aws-lambda": "^8.10.97",
     "@types/express": "^4.17.12",
     "@types/hash-sum": "^1.0.0",

--- a/packages/server/test/react/ssg.test.ts
+++ b/packages/server/test/react/ssg.test.ts
@@ -1,0 +1,58 @@
+import { InfiniteData } from '@tanstack/react-query';
+import { expectTypeOf } from 'expect-type';
+import { z } from 'zod';
+import { createProxySSGHelpers } from '../../../react/src/ssg/ssgProxy';
+import { initTRPC } from '../../src';
+
+const t = initTRPC()();
+
+const appRouter = t.router({
+  post: t.router({
+    byId: t.procedure
+      .input(
+        z.object({
+          id: z.string(),
+        }),
+      )
+      .query(() => '__result' as const),
+    list: t.procedure
+      .input(
+        z.object({
+          cursor: z.string().optional(),
+        }),
+      )
+      .query(() => '__infResult' as const),
+  }),
+});
+
+test('fetch', async () => {
+  const ssg = createProxySSGHelpers({ router: appRouter, ctx: {} });
+
+  const post = await ssg.post.byId.fetch({ id: '1' });
+  expectTypeOf<'__result'>(post);
+});
+
+test('fetchInfinite', async () => {
+  const ssg = createProxySSGHelpers({ router: appRouter, ctx: {} });
+
+  const post = await ssg.post.list.fetchInfinite({});
+  expectTypeOf<InfiniteData<'__infResult'>>(post);
+
+  expect(post.pages).toStrictEqual(['__infResult']);
+});
+
+test('prefetch and dehydrate', async () => {
+  const ssg = createProxySSGHelpers({ router: appRouter, ctx: {} });
+  await ssg.post.byId.prefetch({ id: '1' });
+
+  const data = JSON.stringify(ssg.dehydrate());
+  expect(data).toContain('__result');
+});
+
+test('prefetchInfinite and dehydrate', async () => {
+  const ssg = createProxySSGHelpers({ router: appRouter, ctx: {} });
+  await ssg.post.list.prefetchInfinite({});
+
+  const data = JSON.stringify(ssg.dehydrate());
+  expect(data).toContain('__infResult');
+});

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,5 +1,4 @@
 import nodeResolve from '@rollup/plugin-node-resolve';
-import typescript from '@rollup/plugin-typescript';
 import path from 'path';
 import { RollupOptions } from 'rollup';
 import del from 'rollup-plugin-delete';
@@ -7,6 +6,7 @@ import del from 'rollup-plugin-delete';
 import multiInput from 'rollup-plugin-multi-input';
 import externals from 'rollup-plugin-node-externals';
 import { swc } from 'rollup-plugin-swc3';
+import typescript from 'rollup-plugin-typescript2';
 
 const isWatchMode = process.argv.includes('--watch');
 const extensions = ['.ts', '.tsx'];
@@ -38,7 +38,7 @@ export const INPUTS: Record<typeof PACKAGES[number], string[]> = {
     'src/links/loggerLink.ts',
     'src/links/wsLink.ts',
   ],
-  react: ['src/index.ts', 'src/ssg.ts'],
+  react: ['src/index.ts', 'src/ssg/index.ts'],
   next: ['src/index.ts'],
 };
 
@@ -95,8 +95,8 @@ function types({ input, packageDir }: Options): RollupOptions {
       }),
       typescript({
         tsconfig: path.resolve(packageDir, 'tsconfig.build.json'),
-        outDir: path.resolve(packageDir, 'dist'),
-        noEmitOnError: !isWatchMode,
+        tsconfigOverride: { emitDeclarationOnly: true },
+        abortOnError: !isWatchMode,
       }),
     ],
   };

--- a/www/docs/nextjs/ssg.md
+++ b/www/docs/nextjs/ssg.md
@@ -28,7 +28,7 @@ import { trpc } from 'utils/trpc';
 export async function getStaticProps(
   context: GetStaticPropsContext<{ id: string }>,
 ) {
-  const ssg = await createSSGHelpers({
+  const ssg = await createProxySSGHelpers({
     router: appRouter,
     ctx: {},
     transformer: superjson, // optional - adds superjson serialization
@@ -36,9 +36,7 @@ export async function getStaticProps(
   const id = context.params?.id as string;
 
   // prefetch `post.byId`
-  await ssg.fetchQuery('post.byId', {
-    id,
-  });
+  await ssg.post.byId.fetch({ id });
 
   return {
     props: {

--- a/www/docs/reactjs/ssg-helpers.md
+++ b/www/docs/reactjs/ssg-helpers.md
@@ -5,19 +5,12 @@ sidebar_label: SSG Helpers
 slug: /ssg-helpers
 ---
 
-`createSSGHelpers` providers you a set of helper functions that you can use to prefetch queries on the server.
+`createProxySSGHelpers` providers you a set of helper functions that you can use to prefetch queries on the server.
 
 ```ts
-import { createSSGHelpers } from '@trpc/react/ssg';
+import { createProxySSGHelpers } from '@trpc/react/ssg';
 
-const {
-  prefetchQuery,
-  prefetchInfiniteQuery,
-  fetchQuery,
-  fetchInfiniteQuery,
-  dehydrate,
-  queryClient,
-} = await createSSGHelpers({
+const ssg = await createProxySSGHelpers({
   router: appRouter,
   ctx: createContext,
   transformer: superjson, // optional - adds superjson serialization
@@ -29,7 +22,7 @@ The returned functions are all wrappers around react-query functions. Please che
 ## Next.js Example
 
 ```ts title='pages/posts/[id].tsx'
-import { createSSGHelpers } from '@trpc/react/ssg';
+import { createProxySSGHelpers } from '@trpc/react/ssg';
 import { GetServerSidePropsContext, InferGetServerSidePropsType } from 'next';
 import { prisma } from 'server/context';
 import { appRouter } from 'server/routers/_app';
@@ -39,7 +32,7 @@ import superjson from 'superjson';
 export async function getServerSideProps(
   context: GetServerSidePropsContext<{ id: string }>,
 ) {
-  const ssg = await createSSGHelpers({
+  const ssg = await createProxySSGHelpers({
     router: appRouter,
     ctx: {},
     transformer: superjson,
@@ -47,9 +40,7 @@ export async function getServerSideProps(
   const id = context.params?.id as string;
 
   // Prefetch `post.byId`
-  await ssg.fetchQuery('post.byId', {
-    id,
-  });
+  await ssg.post.ById.fetch({ id });
 
   // Make sure to return { props: { trpcState: ssg.dehydrate() } }
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2896,14 +2896,6 @@
     is-module "^1.0.0"
     resolve "^1.19.0"
 
-"@rollup/plugin-typescript@^8.3.4":
-  version "8.3.4"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-typescript/-/plugin-typescript-8.3.4.tgz#45cdc0787b658b37d0362c705d8de86bc8bc040e"
-  integrity sha512-wt7JnYE9antX6BOXtsxGoeVSu4dZfw0dU3xykfOQ4hC3EddxRbVG/K0xiY1Wup7QOHJcjLYXWAn0Kx9Z1SBHHg==
-  dependencies:
-    "@rollup/pluginutils" "^3.1.0"
-    resolve "^1.17.0"
-
 "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
@@ -2913,7 +2905,7 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@rollup/pluginutils@^4.2.1":
+"@rollup/pluginutils@^4.1.2", "@rollup/pluginutils@^4.2.1":
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.2.1.tgz#e6c6c3aba0744edce3fb2074922d3776c0af2a6d"
   integrity sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==
@@ -7206,7 +7198,7 @@ finalhandler@1.2.0:
     statuses "2.0.1"
     unpipe "~1.0.0"
 
-find-cache-dir@^3.2.0:
+find-cache-dir@^3.2.0, find-cache-dir@^3.3.2:
   version "3.3.2"
   resolved "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz#b30c5b6eff0730731aea9bbd9dbecbd80256d64b"
   integrity sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==
@@ -7444,7 +7436,7 @@ fs-exists-sync@^0.1.0:
   resolved "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
   integrity sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=
 
-fs-extra@^10.1.0:
+fs-extra@^10.0.0, fs-extra@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
   integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
@@ -8499,13 +8491,6 @@ is-core-module@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211"
   integrity sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
-  dependencies:
-    has "^1.0.3"
-
-is-core-module@^2.9.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.10.0.tgz#9012ede0a91c69587e647514e1d5277019e728ed"
-  integrity sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==
   dependencies:
     has "^1.0.3"
 
@@ -12805,15 +12790,6 @@ resolve@^1.10.0, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.0:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
-resolve@^1.17.0:
-  version "1.22.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
-  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
-  dependencies:
-    is-core-module "^2.9.0"
-    path-parse "^1.0.7"
-    supports-preserve-symlinks-flag "^1.0.0"
-
 resolve@^2.0.0-next.3:
   version "2.0.0-next.3"
   resolved "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.3.tgz#d41016293d4a8586a39ca5d9b5f15cbea1f55e46"
@@ -12937,6 +12913,17 @@ rollup-plugin-swc3@^0.3.0:
     joycon "^3.1.1"
     jsonc-parser "^3.0.0"
     typedoc "^0.22.15"
+
+rollup-plugin-typescript2@^0.32.1:
+  version "0.32.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.32.1.tgz#470ded8e1965efac02043cc0ef4a7fa36bed83b9"
+  integrity sha512-RanO8bp1WbeMv0bVlgcbsFNCn+Y3rX7wF97SQLDxf0fMLsg0B/QFF005t4AsGUcDgF3aKJHoqt4JF2xVaABeKw==
+  dependencies:
+    "@rollup/pluginutils" "^4.1.2"
+    find-cache-dir "^3.3.2"
+    fs-extra "^10.0.0"
+    resolve "^1.20.0"
+    tslib "^2.4.0"
 
 rollup-pluginutils@^2.8.1:
   version "2.8.2"


### PR DESCRIPTION
Closes #2450

cc @juliusmarminge

## 🎯 Changes
```ts
import { createProxySSGHelpers } from '@trpc/react/ssg'
const ssg = createProxySSGHelpers({
    router: appRouter,
    ctx: {},
})

await ssg.post.list.prefetch()
```

I also switched back to `rollup-plugin-typescript2` because the `@rollup/plugin-typescript` was erroring that there was an excessively deep type when there wasn't.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.