### PR TITLE
[RFC] Call procedures w/o ending `.query()`

### DIFF
--- a/packages/client/src/internals/TRPCClient.ts
+++ b/packages/client/src/internals/TRPCClient.ts
@@ -256,17 +256,20 @@ export class TRPCClient<TRouter extends AnyRouter> {
     });
   }
 
-  public procedureCall(opts: {
+  public procedureCall(params: {
     path: string;
     input: unknown;
-    context: unknown;
+    opts: unknown;
   }) {
-    const type = this.runtime.operationTypeSwitch(opts);
+    const type = this.runtime.operationTypeSwitch(params);
+    if (type === 'subscription') {
+      return (this.subscription as any)(params.path, params.input, params.opts);
+    }
     return this.requestAsPromise({
+      ...(params.path as any),
       type,
-      path: opts.path as any,
-      input: opts.input,
-      context: opts.context as any,
+      path: params.path as any,
+      input: params.input,
     });
   }
   public subscription<

--- a/packages/client/src/internals/defaultProcedureTypeSwitch.ts
+++ b/packages/client/src/internals/defaultProcedureTypeSwitch.ts
@@ -1,0 +1,13 @@
+import { ProcedureTypeSwitch } from '..';
+
+const subscriptionPaths = /\b(on)/;
+const mutationPaths = /\b(edit|create|add|delete|remove|do)/;
+export const defaultProcedureTypeSwitch: ProcedureTypeSwitch = (op) => {
+  if (mutationPaths.test(op.path)) {
+    return 'mutation';
+  }
+  if (subscriptionPaths.test(op.path)) {
+    return 'subscription';
+  }
+  return 'query';
+};

--- a/packages/client/src/internals/defaultProcedureTypeSwitch.ts
+++ b/packages/client/src/internals/defaultProcedureTypeSwitch.ts
@@ -1,7 +1,7 @@
 import { ProcedureTypeSwitch } from '..';
 
 const subscriptionPaths = /\b(on)/;
-const mutationPaths = /\b(edit|create|add|delete|remove|do)/;
+const mutationPaths = /(edit|create|add|delete|remove|mutation)|\b(do)/i;
 export const defaultProcedureTypeSwitch: ProcedureTypeSwitch = (op) => {
   if (mutationPaths.test(op.path)) {
     return 'mutation';

--- a/packages/client/src/links/types.ts
+++ b/packages/client/src/links/types.ts
@@ -1,4 +1,4 @@
-import { AnyRouter, DataTransformer } from '@trpc/server';
+import { AnyRouter, DataTransformer, ProcedureType } from '@trpc/server';
 import { Observable, Observer } from '@trpc/server/observable';
 import { TRPCResultMessage, TRPCSuccessResponse } from '@trpc/server/rpc';
 import { TRPCClientError } from '../TRPCClientError';
@@ -13,7 +13,7 @@ export type PromiseAndCancel<TValue> = {
 export type OperationContext = Record<string, unknown>;
 export type Operation<TInput = unknown> = {
   id: number;
-  type: 'query' | 'mutation' | 'subscription';
+  type: ProcedureType;
   input: TInput;
   path: string;
   context: OperationContext;
@@ -30,11 +30,14 @@ export type TRPCFetch = (
   options?: RequestInit,
 ) => Promise<Response>;
 
+export type ProcedureTypeSwitch = (op: { path: string }) => ProcedureType;
+
 export interface TRPCClientRuntime {
   fetch: TRPCFetch;
   AbortController?: typeof AbortController;
   headers: () => HTTPHeaders | Promise<HTTPHeaders>;
   transformer: DataTransformer;
+  operationTypeSwitch: ProcedureTypeSwitch;
 }
 
 export interface OperationResultEnvelope<TOutput> {

--- a/packages/server/src/core/router.ts
+++ b/packages/server/src/core/router.ts
@@ -1,4 +1,4 @@
-import { inferProcedureOutput } from '.';
+import { ProcedureTypeOrUnknown, inferProcedureOutput } from '.';
 import { Filter } from '..';
 import { TRPCError } from '../error/TRPCError';
 import {
@@ -154,7 +154,7 @@ export interface Router<TDef extends AnyRouterDef> {
   // FIXME rename me and deprecate
   getErrorShape(opts: {
     error: TRPCError;
-    type: ProcedureType | 'unknown';
+    type: ProcedureTypeOrUnknown;
     path: string | undefined;
     input: unknown;
     ctx: undefined | TDef['_ctx'];

--- a/packages/server/src/core/types.ts
+++ b/packages/server/src/core/types.ts
@@ -23,6 +23,11 @@ export const procedureTypes = ['query', 'mutation', 'subscription'] as const;
  */
 export type ProcedureType = typeof procedureTypes[number];
 
+/**
+ * @public
+ */
+export type ProcedureTypeOrUnknown = ProcedureType | 'unknown';
+
 export type inferHandlerInput<TProcedure extends Procedure<any>> =
   ProcedureArgs<inferProcedureParams<TProcedure>>;
 

--- a/packages/server/src/error/formatter.ts
+++ b/packages/server/src/error/formatter.ts
@@ -1,4 +1,4 @@
-import { ProcedureType } from '../core';
+import { ProcedureTypeOrUnknown } from '..';
 import {
   TRPCErrorShape,
   TRPC_ERROR_CODE_KEY,
@@ -13,7 +13,7 @@ export type ErrorFormatter<TContext, TShape extends TRPCErrorShape<number>> = ({
   error,
 }: {
   error: TRPCError;
-  type: ProcedureType | 'unknown';
+  type: ProcedureTypeOrUnknown;
   path: string | undefined;
   input: unknown;
   ctx: undefined | TContext;

--- a/packages/server/src/http/internals/types.ts
+++ b/packages/server/src/http/internals/types.ts
@@ -1,4 +1,4 @@
-import { AnyRouter, ProcedureType, inferRouterDef } from '../../core';
+import { AnyRouter, ProcedureTypeOrUnknown, inferRouterDef } from '../../core';
 import { TRPCError } from '../../error/TRPCError';
 import { BaseHandlerOptions } from '../../internals/types';
 import { TRPCResponse } from '../../rpc';
@@ -30,7 +30,7 @@ export type ResponseMetaFn<TRouter extends AnyRouter> = (opts: {
    * The different tRPC paths requested
    **/
   paths?: string[];
-  type: ProcedureType | 'unknown';
+  type: ProcedureTypeOrUnknown;
   errors: TRPCError[];
 }) => ResponseMeta;
 

--- a/packages/server/src/internals/types.ts
+++ b/packages/server/src/internals/types.ts
@@ -1,5 +1,5 @@
 import { inferRouterDef } from '../core';
-import { ProcedureType } from '../core';
+import { ProcedureTypeOrUnknown } from '../core';
 import { AnyRouter } from '../core/router';
 import { TRPCError } from '../error/TRPCError';
 
@@ -16,7 +16,7 @@ export interface BaseHandlerOptions<TRouter extends AnyRouter, TRequest> {
 
 export type OnErrorFunction<TRouter extends AnyRouter, TRequest> = (opts: {
   error: TRPCError;
-  type: ProcedureType | 'unknown';
+  type: ProcedureTypeOrUnknown;
   path: string | undefined;
   req: TRequest;
   input: unknown;

--- a/packages/server/src/rpc/envelopes.ts
+++ b/packages/server/src/rpc/envelopes.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-import { ProcedureType } from '../deprecated/router';
+import { ProcedureType } from '..';
 import { TRPC_ERROR_CODE_NUMBER } from './codes';
 
 /**

--- a/packages/server/test/children.test.ts
+++ b/packages/server/test/children.test.ts
@@ -10,8 +10,8 @@ test('children', async () => {
     child: t.router({
       childQuery: t.procedure.query(() => 'asd'),
       grandchild: t.router({
-        foo: t.procedure.query(() => 'grandchild' as const),
-        mut: t.procedure.mutation(() => 'mut'),
+        getSomething: t.procedure.query(() => 'grandchild' as const),
+        doSomething: t.procedure.mutation(() => 'mut'),
       }),
     }),
   });
@@ -25,17 +25,17 @@ test('children', async () => {
   }).toMatchInlineSnapshot(`
     Object {
       "mutations": Object {
-        "child.grandchild.mut": [Function],
+        "child.grandchild.doSomething": [Function],
       },
       "procedures": Object {
         "child.childQuery": [Function],
-        "child.grandchild.foo": [Function],
-        "child.grandchild.mut": [Function],
+        "child.grandchild.doSomething": [Function],
+        "child.grandchild.getSomething": [Function],
         "foo": [Function],
       },
       "queries": Object {
         "child.childQuery": [Function],
-        "child.grandchild.foo": [Function],
+        "child.grandchild.getSomething": [Function],
         "foo": [Function],
       },
       "subscriptions": Object {},
@@ -44,10 +44,10 @@ test('children', async () => {
 
   const { close, proxy } = routerToServerAndClientNew(router);
 
-  expect(await proxy.foo.query()).toBe('bar');
+  expect(await proxy.foo()).toBe('bar');
 
-  expect(await proxy.child.grandchild.foo.query()).toBe('grandchild');
-  expect(await proxy.child.grandchild.mut.mutate()).toBe('mut');
+  expect(await proxy.child.grandchild.getSomething()).toBe('grandchild');
+  expect(await proxy.child.grandchild.doSomething()).toBe('mut');
 
   return close();
 });

--- a/packages/server/test/concat.test.ts
+++ b/packages/server/test/concat.test.ts
@@ -46,7 +46,7 @@ const ctx = konn()
     const combined = t.procedure.unstable_concat(proc1).unstable_concat(proc2);
 
     const appRouter = t.router({
-      getContext: combined.mutation(({ ctx }) => {
+      getContext: combined.query(({ ctx }) => {
         return ctx;
       }),
     });
@@ -74,7 +74,7 @@ const ctx = konn()
   .done();
 
 test('decorate independently', async () => {
-  const result = await ctx.proxy.getContext.mutate();
+  const result = await ctx.proxy.getContext();
   // This is correct
   expect(result).toEqual({
     user: mockUser,

--- a/packages/server/test/interop/links.test.ts
+++ b/packages/server/test/interop/links.test.ts
@@ -15,6 +15,7 @@ import {
   loggerLink,
   retryLink,
 } from '../../../client/src';
+import { defaultProcedureTypeSwitch } from '../../../client/src/internals/defaultProcedureTypeSwitch';
 import * as trpc from '../../src';
 import { AnyRouter } from '../../src';
 import { observable, observableToPromise } from '../../src/observable';
@@ -27,6 +28,7 @@ const mockRuntime: TRPCClientRuntime = {
     serialize: (v) => v,
     deserialize: (v) => v,
   },
+  operationTypeSwitch: defaultProcedureTypeSwitch,
 };
 test('chainer', async () => {
   let attempt = 0;

--- a/packages/server/test/react/bigBoi.test.tsx
+++ b/packages/server/test/react/bigBoi.test.tsx
@@ -19,19 +19,19 @@ test('vanilla', async () => {
   const { proxy } = opts;
 
   {
-    const result = await proxy.r0.greeting.query({ who: 'KATT' });
+    const result = await proxy.r0.greeting({ who: 'KATT' });
 
     expect(result).toBe('hello KATT');
     expectTypeOf(result).not.toBeAny();
     expectTypeOf(result).toMatchTypeOf<string>();
   }
   {
-    const result = await proxy.r10.grandchild.grandChildMutation.mutate();
+    const result = await proxy.r10.grandchild.grandChildMutation();
     expect(result).toBe('grandChildMutation');
   }
 
   {
-    const result = await proxy.r499.greeting.query({ who: 'KATT' });
+    const result = await proxy.r499.greeting({ who: 'KATT' });
 
     expect(result).toBe('hello KATT');
     expectTypeOf(result).not.toBeAny();

--- a/packages/server/test/react/interop-basic.test.tsx
+++ b/packages/server/test/react/interop-basic.test.tsx
@@ -58,14 +58,12 @@ test('interop inference', async () => {
   );
 
   // FIXME // @ts-expect-error we can't call oldProcedure with proxy
-  expect(await opts.proxy.oldProcedure.query()).toBe(
-    'oldProcedureOutput__input:n/a',
-  );
+  expect(await opts.proxy.oldProcedure()).toBe('oldProcedureOutput__input:n/a');
 
   // @ts-expect-error we can't call new procedures without proxy
   expect(await opts.client.query('newProcedure')).toBe('newProcedureOutput');
 
-  expect(await opts.proxy.newProcedure.query()).toBe('newProcedureOutput');
+  expect(await opts.proxy.newProcedure()).toBe('newProcedureOutput');
 });
 
 test('useQuery()', async () => {

--- a/packages/server/test/smoke.test.ts
+++ b/packages/server/test/smoke.test.ts
@@ -73,7 +73,7 @@ test('very happy path', async () => {
     expectTypeOf<TError['data']['foo']>().toMatchTypeOf<'bar'>();
   }
   const { proxy, close } = routerToServerAndClientNew(router);
-  expect(await proxy.greeting.query('KATT')).toBe('hello KATT');
+  expect(await proxy.greeting('KATT')).toBe('hello KATT');
   close();
 });
 
@@ -97,7 +97,7 @@ test('middleware', async () => {
       .query(({ ctx }) => `${ctx.prefix} ${ctx.user}`),
   });
   const { proxy, close } = routerToServerAndClientNew(router);
-  expect(await proxy.greeting.query()).toBe('hello KATT');
+  expect(await proxy.greeting()).toBe('hello KATT');
   close();
 });
 
@@ -108,7 +108,7 @@ test('sad path', async () => {
   const { proxy, close } = routerToServerAndClientNew(router);
 
   // @ts-expect-error this procedure does not exist
-  const result = await waitError(proxy.not.found.query(), TRPCClientError);
+  const result = await waitError(proxy.not.found(), TRPCClientError);
   expect(result).toMatchInlineSnapshot(
     `[TRPCClientError: No "query"-procedure on path "not.found"]`,
   );
@@ -117,12 +117,12 @@ test('sad path', async () => {
 
 test('call a mutation as a query', async () => {
   const router = t.router({
-    hello: procedure.query(() => 'world'),
+    editWorld: procedure.query(() => 'world'),
   });
   const { proxy, close } = routerToServerAndClientNew(router);
 
-  await expect((proxy.hello as any).mutate()).rejects.toMatchInlineSnapshot(
-    `[TRPCClientError: No "mutation"-procedure on path "hello"]`,
+  await expect((proxy.editWorld as any)()).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: No "mutation"-procedure on path "editWorld"]`,
   );
 
   close();

--- a/packages/server/test/smoke.test.ts
+++ b/packages/server/test/smoke.test.ts
@@ -184,7 +184,7 @@ test('subscriptions', async () => {
     }),
   });
 
-  const subscription = proxy.onEvent.subscribe(10, {
+  const subscription = proxy.onEvent(10, {
     onStarted: onStartedMock,
     onData: onDataMock,
     onComplete: onCompleteMock,


### PR DESCRIPTION
Client calls deciding if a procedure is a query or a mutation based on **naming conventions**.

## Summary

### How the code changes

```diff
- await proxy.postById.query('1')
+ await proxy.postById('1')
- await proxy.editPost.mutation({ id: '1', data: { title: 'Hello tRPC' }})
+ await proxy.editPost({ id: '1', data: { title: 'Hello tRPC' }})
```

### What it requires

Uses a mapper & **naming conventions** to decide if something is a query or mutation:

https://github.com/trpc/trpc/blob/76f69e96c2c015c96589dbc69740a8506427b231/packages/client/src/internals/defaultProcedureTypeSwitch.ts#L3-L13

This mapper is configurable.

### Notes

- This approach _could_ also be used on the backend to get replace of `.query()`/`.mutation()` at the end of a procedure builder with a `.resolve()`
- A lint plugin would be preferable to help devs write things according to a specific structure
- Related conversations:
  - #2270
  - https://github.com/trpc/trpc/issues/887#issuecomment-1200828262
  - #2316 
- Could allow environments where one doesn't ever care about HTTP caching `GET` to map everything as a `POST` procedure

## I want your input

- Is it worth exploring this direction or does it make the behavior too implicit?
