### PR TITLE
Documentation fix: useInfiniteQuery

### DIFF
--- a/www/docs/reactjs/useInfiniteQuery.md
+++ b/www/docs/reactjs/useInfiniteQuery.md
@@ -42,7 +42,7 @@ export const appRouter = trpc.router<Context>()
           myCursor: 'asc',
         },
       })
-      let nextCursor: typeof cursor | null = null;
+      let nextCursor: typeof cursor | undefined = undefined;
       if (items.length > limit) {
         const nextItem = items.pop()
         nextCursor = nextItem!.myCursor;


### PR DESCRIPTION
Hello, I was reading the docs and found a slight problem.

According to the [React Query docs](https://react-query-v3.tanstack.com/guides/infinite-queries), react query knows if an infinite query is over if it receives undefined in getNextPageParam :

>A hasNextPage boolean is now available and is true if getNextPageParam returns a value other than ***undefined***

In the example in the docs the cursor instead returns `null`, causing React Query to repeat the results.

`let nextCursor: typeof cursor | null = null;`

` getNextPageParam: (lastPage) => lastPage.nextCursor,`


This confused me so I'm proposing this fix.

## 🎯 Changes

Change null to undefined in the useInfiniteQuery.md example
`let nextCursor: typeof cursor | undefined = undefined;`

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
