### PR TITLE
Update isTRPCClientError type guard example

### DIFF
--- a/www/docs/server/infer-types.md
+++ b/www/docs/server/infer-types.md
@@ -58,13 +58,10 @@ import type {
 import { TRPCClientError } from '@trpc/client';
 import { proxy } from './trpc';
 
-export function isTRPCClientError(
+export function isTRPCClientError<TRouter extends AnyRouter>(
   cause: unknown,
 ): cause is TRPCClientError<TRouter> {
-  if (cause instanceof TRPCClientError) {
-    return true;
-  }
-  return false;
+  return cause instanceof TRPCClientError;
 }
 
 async function main() {


### PR DESCRIPTION
## 🎯 Changes

- Added missing generic for isTRPCClientError for TRouter in the documentation.
- Simplified return.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.