### PR TITLE
docs: Create Next.js custom App as function

### DIFF
--- a/www/docs/nextjs/introduction.md
+++ b/www/docs/nextjs/introduction.md
@@ -135,12 +135,12 @@ The `createReactQueryHooks` function expects certain parameters to be passed via
 
 ```tsx title='pages/_app.tsx'
 import { withTRPC } from '@trpc/next';
-import { AppType } from 'next/dist/shared/lib/utils';
+import type { AppProps } from 'next/app';
 import { AppRouter } from './api/trpc/[trpc]';
 
-const MyApp: AppType = ({ Component, pageProps }) => {
+function MyApp({ Component, pageProps }: AppProps) {
   return <Component {...pageProps} />;
-};
+}
 
 function getBaseUrl() {
   if (typeof window !== 'undefined') {


### PR DESCRIPTION
## 🎯 Changes

- Modifies code example for generating the Next.js custom App component
  - Uses `function` instead of typed `const` which follows the example from the official [Next.js documentation](https://nextjs.org/docs/basic-features/typescript)
  - Get rid of the `next/dist/shared/lib/utils` import which could look somewhat hacky / suspicious for new users. 

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.