### PR TITLE
hide noisy shiki

### DIFF
--- a/www/src/css/custom.css
+++ b/www/src/css/custom.css
@@ -214,3 +214,13 @@ h5 {
 .markdown ol {
   @apply list-decimal list-inside;
 }
+
+/** Hide noisy shiki stuff */
+
+data-lsp {
+  border-bottom: 0 !important;
+}
+
+data-lsp::before {
+  display: none;
+}

--- a/www/src/css/custom.css
+++ b/www/src/css/custom.css
@@ -217,10 +217,10 @@ h5 {
 
 /** Hide noisy shiki stuff */
 
-data-lsp {
+.shiki data-lsp {
   border-bottom: 0 !important;
 }
 
-data-lsp::before {
+.shiki data-lsp::before {
   display: none;
 }


### PR DESCRIPTION
Closes #2499 

## 🎯 Changes

"Disables" hover tooltips for Shiki Twoslash. Now only what we explicitly show is displayed.

![CleanShot 2022-08-22 at 16 43 06](https://user-images.githubusercontent.com/51714798/185949509-f0f41b07-da6b-48a3-b9c8-03f825950157.png)

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.