### PR TITLE
fix: Handle WebSocket errors to avoid Node.js crashes

### DIFF
--- a/packages/server/src/adapters/ws.ts
+++ b/packages/server/src/adapters/ws.ts
@@ -248,6 +248,12 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
       }
     });
 
+    // WebSocket errors should be handled, as otherwise unhandled exceptions will crash Node.js.
+    // This line was introduced after the following error brought down production systems:
+    // "RangeError: Invalid WebSocket frame: RSV2 and RSV3 must be clear"
+    // Here is the relevant discussion: https://github.com/websockets/ws/issues/1354#issuecomment-774616962
+    client.on('error', console.error);
+
     client.once('close', () => {
       for (const sub of clientSubscriptions.values()) {
         sub.destroy();


### PR DESCRIPTION
## 🎯 Changes

We caught the following error on our production:

![image](https://user-images.githubusercontent.com/304265/186275512-1279e27e-ec73-44d7-ad88-05454cb96144.png)

I believe those malformed requests come from some vulnerability scanners. In either case, such requests should not crash the instance. During the investigation I found this discussion: https://github.com/websockets/ws/issues/1354#issuecomment-774616962, and started to look into the way of handling the error. It seems there is no other way to inject this handler, so here is the PR. I have tested it already and it prevents the crash of the nodejs process.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made. - I have no idea how to add the test here