### PR TITLE
Fix parsing input-less mutation on resolveHTTPResponse

### DIFF
--- a/packages/server/src/http/resolveHTTPResponse.ts
+++ b/packages/server/src/http/resolveHTTPResponse.ts
@@ -35,7 +35,11 @@ function getRawProcedureInputOrThrow(req: HTTPRequest) {
       const raw = req.query.get('input');
       return JSON.parse(raw!);
     }
-    return typeof req.body === 'string' ? JSON.parse(req.body) : req.body;
+    if (typeof req.body === 'string') {
+      // A mutation with no inputs will have req.body === ''
+      return req.body.length === 0 ? undefined : JSON.parse(req.body)
+    }
+    return req.body;
   } catch (err) {
     throw new TRPCError({
       code: 'PARSE_ERROR',

--- a/packages/server/src/http/resolveHTTPResponse.ts
+++ b/packages/server/src/http/resolveHTTPResponse.ts
@@ -37,7 +37,7 @@ function getRawProcedureInputOrThrow(req: HTTPRequest) {
     }
     if (typeof req.body === 'string') {
       // A mutation with no inputs will have req.body === ''
-      return req.body.length === 0 ? undefined : JSON.parse(req.body)
+      return req.body.length === 0 ? undefined : JSON.parse(req.body);
     }
     return req.body;
   } catch (err) {


### PR DESCRIPTION
Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

Fixes input-less mutation procedures.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.