### PR TITLE
fix v9 docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ packages/*/*
 ## Dont ignore src or test
 !packages/*/src
 !packages/*/test
+.vercel

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,3 @@ packages/*/*
 ## Dont ignore src or test
 !packages/*/src
 !packages/*/test
-.vercel

--- a/.tmp/v10-docs.md
+++ b/.tmp/v10-docs.md
@@ -1,8 +1,15 @@
+# ⚠️ Potentially outdated doc
+
+See https://alpha.trpc.io/docs/v10/migrate-from-v9-to-v10
+
+
+
 # [tRPC](https://trpc.io) V10
 
 > How the the future [tRPC V10](https://trpc.io) will look like.
 
 
+- [⚠️ Potentially outdated doc](#️-potentially-outdated-doc)
 - [tRPC V10](#trpc-v10)
   - [Play with it!](#play-with-it)
   - [Goals & features](#goals--features)
@@ -638,4 +645,4 @@ https://alpha.trpc.io/docs/links#creating-a-custom-link
 
 ## Migration path & Interopability mode
 
-👉 Moved to [alpha.trpc.io/docs/migrate-from-v9-to-v10](https://alpha.trpc.io/docs/migrate-from-v9-to-v10)
+👉 Moved to [alpha.trpc.io/docs/migrate-from-v9-to-v10](https://alpha.trpc.io/docs/v10/migrate-from-v9-to-v10)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 > 
 > You might be looking for the [`main`](https://github.com/trpc/trpc/tree/main)-branch which is the stable v9-version. 
 >
-> See our [migration guide](https://alpha.trpc.io/docs/migrate-from-v9-to-v10) for a summary of what is changing or take a look at [the **v10 docs website**](https://alpha.trpc.io/).
+> See our [migration guide](https://alpha.trpc.io/docs/v10/migrate-from-v9-to-v10) for a summary of what is changing or take a look at [the **v10 docs website**](https://alpha.trpc.io/).
 > There is also [the `examples-v10-next-prisma-starter-sqlite` project](https://github.com/trpc/examples-v10-next-prisma-starter-sqlite) to try out a real project using this version.
 
 

--- a/www/.gitignore
+++ b/www/.gitignore
@@ -21,4 +21,3 @@ yarn-error.log*
 
 
 .env
-.vercel

--- a/www/.gitignore
+++ b/www/.gitignore
@@ -21,3 +21,4 @@ yarn-error.log*
 
 
 .env
+.vercel

--- a/www/docs/main/awesome-trpc.mdx
+++ b/www/docs/main/awesome-trpc.mdx
@@ -5,8 +5,8 @@ sidebar_label: Awesome tRPC Collection
 slug: /awesome-trpc
 ---
 
-:::caution
-Most of the examples on this page are out-of-date since V10. We'll update this soon.
+:::info
+Some of the examples on this page are out-of-date since V10. We'll update this soon.
 :::
 
 > Collection of resources on tRPC. **Please** edit this page and add your own links! 🙏
@@ -50,7 +50,7 @@ Most of the examples on this page are out-of-date since V10. We'll update this s
 | NX + tRPC + Prisma + NextJS + Expo                                                               | https://github.com/mwarger/tmdb-watchlist-prisma                        |
 | NX + tRPC + EdgeDB + NextJS + Expo                                                               | https://github.com/mwarger/tmdb-watchlist-edgedb                        |
 | tRPC + Fresh                                                                                     | https://github.com/LunaTK/fresh-trpc-example                            |
-| tRPC (w/ Fetch Adapter) + SvelteKit + Tailwind CSS                                               | https://github.com/austins/trpc-sveltekit-fetchadapter-example      |
+| tRPC (w/ Fetch Adapter) + SvelteKit + Tailwind CSS                                               | https://github.com/austins/trpc-sveltekit-fetchadapter-example          |
 
 ## 🏁 Open-source projects using tRPC
 

--- a/www/docs/main/example-apps.md
+++ b/www/docs/main/example-apps.md
@@ -6,8 +6,8 @@ slug: /example-apps
 ---
 
 
-:::caution
-Most of the examples on this page are out-of-date since V10. We'll update this soon.
+:::info
+Some of the examples on this page are out-of-date since V10. We'll update this soon.
 :::
 
 You can clone trpc and play with local examples, or play with them in the CodeSandbox link below.

--- a/www/docs/main/quickstart.mdx
+++ b/www/docs/main/quickstart.mdx
@@ -259,6 +259,6 @@ trpc.u;
 
 tRPC includes more sophisticated client-side tooling designed for React projects generally and Next.js specifically. Read the appropriate guide next:
 
-- [Usage with Next.js](/docs/nextjs)
-- [Usage with Express (server-side)](/docs/express)
-- [Usage with React (client-side)](/docs/react)
+- [Usage with Next.js](nextjs)
+- [Usage with Express (server-side)](express)
+- [Usage with React (client-side)](react)

--- a/www/docs/main/quickstart.mdx
+++ b/www/docs/main/quickstart.mdx
@@ -3,9 +3,6 @@ id: quickstart
 title: Quickstart
 sidebar_label: Quickstart
 slug: /quickstart
-author: colinhacks
-author_url: https://twitter.com/colinhacks
-author_image_url: https://avatars.githubusercontent.com/u/3084745?v=4
 ---
 
 import CodeBlock from '@theme/CodeBlock';

--- a/www/docs/migration/migrate-from-v9-to-v10.mdx
+++ b/www/docs/migration/migrate-from-v9-to-v10.mdx
@@ -19,10 +19,10 @@ In a gist, what has changed?
 
 The way you initialize tRPC on the server has been update, we now create a root `t` variable that contains the root information about your app:
 
-- [Context](/docs/context)
-- [Meta data](/docs/metadata)
-- [Error formatter](/docs/error-formatting)
-- [Data Transformer](/docs/error-formatting)
+- [Context](context)
+- [Meta data](metadata)
+- [Error formatter](error-formatting)
+- [Data Transformer](error-formatting)
 
 The way the `t` variable is defined is simply like this:
 
@@ -122,7 +122,7 @@ type GreetingOutput = inferProcedureOutput<AppRouter['greeting']>;
 
 ### Middlewares
 
-Middlewares are now reusable and can be chained, see [middleware](/docs/middlewares) docs.
+Middlewares are now reusable and can be chained, see [middleware](middlewares) docs.
 
 ```ts
 // OLD
@@ -257,7 +257,7 @@ Any procedures defined using `t.procedure` must be called on the client using th
 
 🚧
 
-### Custom [Links](/docs/links)
+### Custom [Links](links)
 
 🚧
 

--- a/www/docs/nextjs/introduction.md
+++ b/www/docs/nextjs/introduction.md
@@ -6,7 +6,7 @@ slug: /nextjs
 ---
 
 :::tip
-If you're using tRPC in a new project, consider using one of the example projects as a starting point or for reference: [tRPC Example Projects](/docs/example-apps)
+If you're using tRPC in a new project, consider using one of the example projects as a starting point or for reference: [tRPC Example Projects](example-apps)
 :::
 
 tRPC and Next.js are a match made in heaven! Next.js makes it easy for you to build your client and server together in one codebase. This makes it easy to share types between them.
@@ -88,7 +88,7 @@ If strict mode is too much, at least enable `strictNullChecks`:
 
 ### 3. Create a tRPC router
 
-Implement your tRPC router in `./pages/api/trpc/[trpc].ts`. If you need to split your router into several subrouters, implement them in a top-level `server` directory in your project root, then import them into `./pages/api/trpc/[trpc].ts` and [merge them](/docs/merging-routers) into a single root `appRouter`.
+Implement your tRPC router in `./pages/api/trpc/[trpc].ts`. If you need to split your router into several subrouters, implement them in a top-level `server` directory in your project root, then import them into `./pages/api/trpc/[trpc].ts` and [merge them](merging-routers) into a single root `appRouter`.
 
 <details><summary>View sample router</summary>
 
@@ -216,7 +216,7 @@ The `config`-argument is a function that returns an object that configures the t
 - Optional:
   - `queryClientConfig`: a configuration object for the React Query `QueryClient` used internally by the tRPC React hooks: [QueryClient docs](https://tanstack.com/query/v4/docs/reference/QueryClient)
   - `headers`: an object or a function that returns an object of outgoing tRPC requests
-  - `transformer`: a transformer applied to outgoing payloads. Read more about [Data Transformers](/docs/data-transformers)
+  - `transformer`: a transformer applied to outgoing payloads. Read more about [Data Transformers](data-transformers)
   - `fetch`: customize the implementation of `fetch` used by tRPC internally
   - `AbortController`: customize the implementation of `AbortController` used by tRPC internally
 
@@ -257,4 +257,4 @@ export const trpc = setupTRPC({
 
 ## Next steps
 
-Refer to the `@trpc/react` docs for additional information on executing [Queries](/docs/react-queries) and [Mutations](/docs/react-mutations) inside your components.
+Refer to the `@trpc/react` docs for additional information on executing [Queries](react-queries) and [Mutations](react-mutations) inside your components.

--- a/www/docs/nextjs/ssg.md
+++ b/www/docs/nextjs/ssg.md
@@ -90,4 +90,4 @@ export default function PostViewPage(
 }
 ```
 
-Check out [here](/docs/ssg-helpers) to learn more about `createSSGHelpers`.
+Check out [here](ssg-helpers) to learn more about `createSSGHelpers`.

--- a/www/docs/nextjs/ssr.md
+++ b/www/docs/nextjs/ssr.md
@@ -64,4 +64,4 @@ export default trpc.withTRPC(MyApp);
 
 ## Caveats
 
-When you enable SSR, tRPC will use `getInitialProps` to prefetch all queries on the server. That causes problems [like this](https://github.com/trpc/trpc/issues/596) when you use `getServerSideProps` in a page and solving it is out of our hands. Though, you can use [SSG Helpers](/docs/ssg-helpers) to prefetch queries in `getStaticProps` or `getServerSideProps`.
+When you enable SSR, tRPC will use `getInitialProps` to prefetch all queries on the server. That causes problems [like this](https://github.com/trpc/trpc/issues/596) when you use `getServerSideProps` in a page and solving it is out of our hands. Though, you can use [SSG Helpers](ssg-helpers) to prefetch queries in `getStaticProps` or `getServerSideProps`.

--- a/www/docs/reactjs/introduction.md
+++ b/www/docs/reactjs/introduction.md
@@ -7,7 +7,7 @@ slug: /react
 
 :::info
 
-- If you're using Next.js, read the [Usage with Next.js](/docs/nextjs) guide instead.
+- If you're using Next.js, read the [Usage with Next.js](nextjs) guide instead.
 - In order to infer types from your Node.js backend you should have the frontend & backend in the same monorepo.
   :::
 
@@ -59,7 +59,7 @@ If strict mode is too much, at least enable `strictNullChecks`:
 
 #### 3. Implement your `appRouter`
 
-Follow the [Quickstart](/docs/quickstart) and read the [`@trpc/server` docs](/docs/router) for guidance on this. Once you have your API implemented and listening via HTTP, continue to the next step.
+Follow the [Quickstart](quickstart) and read the [`@trpc/server` docs](router) for guidance on this. Once you have your API implemented and listening via HTTP, continue to the next step.
 
 ### Client Side
 

--- a/www/docs/server/express.md
+++ b/www/docs/server/express.md
@@ -68,7 +68,7 @@ export const appRouter = t.router({
 export type AppRouter = typeof appRouter;
 ```
 
-If your router file starts getting too big, split your router into several subrouters each implemented in its own file. Then [merge them](/docs/merging-routers) into a single root `appRouter`.
+If your router file starts getting too big, split your router into several subrouters each implemented in its own file. Then [merge them](merging-routers) into a single root `appRouter`.
 
 ### 3. Use the Express adapter
 

--- a/www/docs/server/fastify.md
+++ b/www/docs/server/fastify.md
@@ -92,7 +92,7 @@ export type AppRouter = typeof appRouter;
 
 </details>
 
-If your router file starts getting too big, split your router into several subrouters each implemented in its own file. Then [merge them](/docs/merging-routers) into a single root `appRouter`.
+If your router file starts getting too big, split your router into several subrouters each implemented in its own file. Then [merge them](merging-routers) into a single root `appRouter`.
 
 ### Create the context
 

--- a/www/docs/server/fetch.md
+++ b/www/docs/server/fetch.md
@@ -91,7 +91,7 @@ export type AppRouter = typeof appRouter;
 
 </details>
 
-If your router file starts getting too big, split your router into several subrouters each implemented in its own file. Then [merge them](/docs/merging-routers) into a single root `appRouter`.
+If your router file starts getting too big, split your router into several subrouters each implemented in its own file. Then [merge them](merging-routers) into a single root `appRouter`.
 
 ### Create the context
 

--- a/www/docs/server/output-validation.md
+++ b/www/docs/server/output-validation.md
@@ -7,7 +7,7 @@ slug: /output-validation
 
 tRPC gives you automatic type-safety of outputs without the need of adding a validator; however, it can be useful at times to strictly define the output type in order to prevent sensitive data of being leaked.
 
-Similarily to [`input`](/docs/router), an `output` validator can be added. The output validator is invoked with your payload.
+Similarily to [`input`](router), an `output` validator can be added. The output validator is invoked with your payload.
 
 When an `output` validator is defined, its inferred type is expected as the return type of your resolver (like `t.procedure.query()`).
 

--- a/www/docusaurus.config.js
+++ b/www/docusaurus.config.js
@@ -12,6 +12,9 @@ module.exports = {
   organizationName: 'trpc', // Usually your GitHub org/user name.
   projectName: 'trpc', // Usually your repo name.
   themeConfig: {
+    defaultMode: 'darkMode',
+    disableSwitch: false,
+    respectPrefersColorScheme: true,
     image: 'img/facebook_cover_photo_2.png',
     prism: {
       theme: require('prism-react-renderer/themes/vsDark'),
@@ -24,6 +27,7 @@ module.exports = {
       // searchParameters: {},
     },
     announcementBar: {
+      id: 'v10',
       content:
         "🚀 You are looking at a pre-release of tRPC v10! See <a href='https://alpha.trpc.io/docs/v10/migrate-from-v9-to-v10'>the migration guide</a> for a summary of what is changing &amp; <a href='https://github.com/trpc/examples-v10-next-prisma-starter-sqlite'>go here</a> to try out a real project using this version.",
       backgroundColor: 'var(--ifm-color-primary-dark)',

--- a/www/docusaurus.config.js
+++ b/www/docusaurus.config.js
@@ -25,9 +25,10 @@ module.exports = {
     },
     announcementBar: {
       content:
-        "🚀 You are looking at a pre-release of tRPC v10! See <a href='https://alpha.trpc.io/docs/migrate-from-v9-to-v10'>the migration guide</a> for a summary of what is changing &amp; <a href='https://github.com/trpc/examples-v10-next-prisma-starter-sqlite'>go here</a> to try out a real project using this version.",
+        "🚀 You are looking at a pre-release of tRPC v10! See <a href='https://alpha.trpc.io/docs/v10/migrate-from-v9-to-v10'>the migration guide</a> for a summary of what is changing &amp; <a href='https://github.com/trpc/examples-v10-next-prisma-starter-sqlite'>go here</a> to try out a real project using this version.",
       backgroundColor: 'var(--ifm-color-primary-dark)',
       textColor: '#ffffff',
+      isCloseable: false,
     },
     navbar: {
       title: 'tRPC',
@@ -37,20 +38,20 @@ module.exports = {
       },
       items: [
         {
-          to: 'docs',
+          to: 'docs/v9',
           label: 'Docs',
           activeBaseRegex: 'docs(/?)$',
         },
         {
-          to: 'docs/quickstart',
+          to: 'docs/v9/quickstart',
           label: 'Quickstart',
         },
         {
-          to: 'docs/awesome-trpc',
+          to: 'docs/v9/awesome-trpc',
           label: 'Awesome tRPC Collection',
         },
         {
-          to: 'docs/nextjs',
+          to: 'docs/v9/nextjs',
           label: 'Usage with Next.js',
         },
         {
@@ -85,11 +86,11 @@ module.exports = {
           items: [
             {
               label: 'Docs',
-              to: 'docs',
+              to: 'docs/v9',
             },
             {
               label: 'Usage with Next.js',
-              to: 'docs/nextjs',
+              to: 'docs/v9/nextjs',
             },
           ],
         },
@@ -151,14 +152,21 @@ module.exports = {
       '@docusaurus/preset-classic',
       {
         docs: {
-          lastVersion: 'current',
+          lastVersion: '9.x',
+          // disableVersioning: true,
+          // onlyIncludeVersions: ['9.x'],
           versions: {
             current: {
               label: '10.x',
-              // path: '1.0.0',
+              path: 'v10',
+              badge: true,
+            },
+            '9.x': {
+              label: '9.x',
+              path: 'v9',
             },
           },
-          includeCurrentVersion: false,
+          // includeCurrentVersion: false,
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
           editUrl: 'https://github.com/trpc/trpc/tree/next/www/',

--- a/www/docusaurus.config.js
+++ b/www/docusaurus.config.js
@@ -167,10 +167,12 @@ module.exports = {
               label: '10.x',
               path: 'v10',
               badge: true,
+              className: 'v10',
             },
             '9.x': {
               label: '9.x',
               path: 'v9',
+              className: 'v9',
             },
           },
           // includeCurrentVersion: false,

--- a/www/docusaurus.config.js
+++ b/www/docusaurus.config.js
@@ -42,20 +42,23 @@ module.exports = {
       },
       items: [
         {
-          to: 'docs/v9',
+          type: 'doc',
+          docId: 'main/introduction',
           label: 'Docs',
-          activeBaseRegex: 'docs(/?)$',
         },
         {
-          to: 'docs/v9/quickstart',
+          type: 'doc',
+          docId: 'main/quickstart',
           label: 'Quickstart',
         },
         {
-          to: 'docs/v9/awesome-trpc',
+          type: 'doc',
+          docId: 'main/awesome-trpc',
           label: 'Awesome tRPC Collection',
         },
         {
-          to: 'docs/v9/nextjs',
+          type: 'doc',
+          docId: 'nextjs/introduction',
           label: 'Usage with Next.js',
         },
         {

--- a/www/package.json
+++ b/www/package.json
@@ -19,8 +19,8 @@
     "postinstall": "cd .. && run-s postinstall build"
   },
   "dependencies": {
-    "@docusaurus/core": "^2.0.0-rc.1",
-    "@docusaurus/preset-classic": "^2.0.0-rc.1",
+    "@docusaurus/core": "^2.0.1",
+    "@docusaurus/preset-classic": "^2.0.1",
     "@mdx-js/react": "^1.6.22",
     "@trpc/client": "^10.0.0-proxy-alpha.54",
     "@trpc/next": "^10.0.0-proxy-alpha.54",
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@babel/core": "^7.18.6",
     "@babel/preset-env": "^7.18.6",
-    "@docusaurus/module-type-aliases": "^2.0.0-rc.1",
+    "@docusaurus/module-type-aliases": "^2.0.1",
     "@octokit/graphql": "^5.0.0",
     "@octokit/graphql-schema": "^10.74.2",
     "@tsconfig/docusaurus": "^1.0.6",

--- a/www/src/css/custom.css
+++ b/www/src/css/custom.css
@@ -233,7 +233,18 @@ h5 {
 }
 
 /* Hide announcement bar for v9 */
-html:not(.docs-version-current)
-  .announcementBar_---node_modules-\@docusaurus-theme-classic-lib-theme-AnnouncementBar-styles-module {
+html:not(.docs-version-current) [role='banner'] {
   display: none !important;
+}
+
+/* Toggle different gifs depending on version */
+.trpcgif {
+  display: none;
+}
+
+html.v10 .trpcgif--v10 {
+  display: block;
+}
+html.v9 .trpcgif--v9 {
+  display: block;
 }

--- a/www/src/css/custom.css
+++ b/www/src/css/custom.css
@@ -231,3 +231,9 @@ h5 {
 .theme-doc-version-badge {
   margin-bottom: 1rem;
 }
+
+/* Hide announcement bar for v9 */
+html:not(.docs-version-current)
+  .announcementBar_---node_modules-\@docusaurus-theme-classic-lib-theme-AnnouncementBar-styles-module {
+  display: none !important;
+}

--- a/www/src/pages/index.tsx
+++ b/www/src/pages/index.tsx
@@ -2,16 +2,28 @@ import Head from '@docusaurus/Head';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Features } from '../components/Features';
 import { GithubStarCountButton } from '../components/GithubStarCountButton';
 import { SectionTitle } from '../components/SectionTitle';
 import { TwitterWall } from '../components/TwitterWall';
 import { Sponsors } from '../components/sponsors';
 
+/**
+ * Hack to get the selected version of the page from local storage
+ */
+function getCurrentVersion() {
+  if (typeof window === 'undefined') {
+    return '9.x';
+  }
+  return window.localStorage.getItem('docs-preferred-version-default') || '9.x';
+}
+
 function Home() {
   const context = useDocusaurusContext();
   const { siteConfig } = context;
+
+  const activeVersion = getCurrentVersion();
 
   return (
     <Layout
@@ -20,6 +32,7 @@ function Home() {
     >
       <Head>
         <body className="homepage" />
+        <html className={activeVersion === 'current' ? 'v10' : 'v9'} />
         <script
           async
           src="https://platform.twitter.com/widgets.js"
@@ -47,11 +60,24 @@ function Home() {
               <GithubStarCountButton />
             </div>
           </div>
-          <div className="flex-1 py-4 lg:p-0">
-            <img
-              src="https://user-images.githubusercontent.com/51714798/186850605-7cb9f6b2-2230-4eb7-981b-0b90ee1f8ffa.gif"
-              alt="Demo"
-            />
+          <div className="flex-1 py-4 lg:p-0 group">
+            <figure>
+              {/* V10 */}
+              <img
+                src="https://user-images.githubusercontent.com/51714798/186850605-7cb9f6b2-2230-4eb7-981b-0b90ee1f8ffa.gif"
+                alt="Demo"
+                className="trpcgif trpcgif--v10"
+              />
+              <img
+                src="https://storage.googleapis.com/trpc/trpcgif.gif"
+                alt="Demo"
+                className="trpcgif trpcgif--v9"
+              />
+              <figcaption className="text-sm text-center text-gray-400 group-hover:text-gray-900 transition">
+                The client above is <strong>not</strong> importing any code from
+                the server, only its type declarations.
+              </figcaption>
+            </figure>
           </div>
         </header>
 

--- a/www/src/pages/index.tsx
+++ b/www/src/pages/index.tsx
@@ -1,29 +1,51 @@
 import Head from '@docusaurus/Head';
 import Link from '@docusaurus/Link';
+import { useLocation } from '@docusaurus/router';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Features } from '../components/Features';
 import { GithubStarCountButton } from '../components/GithubStarCountButton';
 import { SectionTitle } from '../components/SectionTitle';
 import { TwitterWall } from '../components/TwitterWall';
 import { Sponsors } from '../components/sponsors';
 
+type Version = 'current' | '9.x';
+
 /**
  * Hack to get the selected version of the page from local storage
  */
-function getCurrentVersion() {
-  if (typeof window === 'undefined') {
-    return '9.x';
-  }
-  return window.localStorage.getItem('docs-preferred-version-default') || '9.x';
+function useLocalStorageVersion() {
+  const [version, setVersion] = useState<Version>(() => {
+    if (typeof window === 'undefined') {
+      return '9.x';
+    }
+    return (window.localStorage.getItem('docs-preferred-version-default') ||
+      '9.x') as Version;
+  });
+
+  return {
+    active: version,
+    set(value: Version) {
+      setVersion(value as Version);
+      window.localStorage.setItem('docs-preferred-version-default', value);
+    },
+  };
 }
 
 function Home() {
   const context = useDocusaurusContext();
   const { siteConfig } = context;
 
-  const activeVersion = getCurrentVersion();
+  const version = useLocalStorageVersion();
+
+  const location = useLocation();
+  useEffect(() => {
+    if (location.search.includes('v10') && version.active !== 'current') {
+      version.set('current');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.search, version.active]);
 
   return (
     <Layout
@@ -32,7 +54,7 @@ function Home() {
     >
       <Head>
         <body className="homepage" />
-        <html className={activeVersion === 'current' ? 'v10' : 'v9'} />
+        <html className={version.active === 'current' ? 'v10' : 'v9'} />
         <script
           async
           src="https://platform.twitter.com/widgets.js"

--- a/www/src/pages/index.tsx
+++ b/www/src/pages/index.tsx
@@ -39,7 +39,7 @@ function Home() {
             </p>
             <div className="flex items-center gap-4 mt-6">
               <Link
-                href="/docs/quickstart"
+                href="/docs/v9/quickstart"
                 className="inline-block px-4 py-2 text-sm font-bold text-black transition-colors rounded-lg md:text-base hover:bg-primary-darker hover:no-underline hover:text-black bg-primary shadow-xl"
               >
                 Quickstart

--- a/www/vercel.json
+++ b/www/vercel.json
@@ -29,6 +29,10 @@
       "source": "/discord",
       "destination": "https://discord.gg/wzaMgEJkcf",
       "permanent": false
+    },
+    {
+      "source": "/docs/((?!v[0-9]+/).*)",
+      "destination": "/docs/v9/*"
     }
   ]
 }

--- a/www/vercel.json
+++ b/www/vercel.json
@@ -31,8 +31,8 @@
       "permanent": false
     },
     {
-      "source": "/docs/((?!v[0-9]+/).*)",
-      "destination": "/docs/v9/*"
+      "source": "/docs/:path((?!v[0-9]+/).*)",
+      "destination": "/docs/v9/:path*"
     }
   ]
 }

--- a/www/versioned_docs/version-9.x/main/quickstart.mdx
+++ b/www/versioned_docs/version-9.x/main/quickstart.mdx
@@ -3,9 +3,6 @@ id: quickstart
 title: Quickstart
 sidebar_label: Quickstart
 slug: /quickstart
-author: colinhacks
-author_url: https://twitter.com/colinhacks
-author_image_url: https://avatars.githubusercontent.com/u/3084745?v=4
 ---
 
 :::tip

--- a/www/versioned_docs/version-9.x/main/quickstart.mdx
+++ b/www/versioned_docs/version-9.x/main/quickstart.mdx
@@ -139,6 +139,6 @@ export type AppRouter = typeof appRouter;
 
 tRPC includes more sophisticated client-side tooling designed for React projects generally and Next.js specifically. Read the appropriate guide next:
 
-- [Usage with Next.js](/docs/nextjs)
-- [Usage with Express.js (server-side)](/docs/express)
-- [Usage with React (client-side)](/docs/react)
+- [Usage with Next.js](nextjs)
+- [Usage with Express.js (server-side)](express)
+- [Usage with React (client-side)](react)

--- a/www/versioned_docs/version-9.x/nextjs/introduction.md
+++ b/www/versioned_docs/version-9.x/nextjs/introduction.md
@@ -6,7 +6,7 @@ slug: /nextjs
 ---
 
 :::tip
-If you're using tRPC in a new project, consider using one of the example projects as a starting point or for reference: [tRPC Example Projects](/docs/example-apps)
+If you're using tRPC in a new project, consider using one of the example projects as a starting point or for reference: [tRPC Example Projects](example-apps)
 :::
 
 tRPC and Next.js are a match made in heaven! Next.js makes it easy for you to build your client and server together in one codebase. This makes it easy to share types between them.
@@ -81,7 +81,7 @@ If strict mode is too much, at least enable `strictNullChecks`:
 
 ### 3. Create a tRPC router
 
-Implement your tRPC router in `./pages/api/trpc/[trpc].ts`. If you need to split your router into several subrouters, implement them in a top-level `server` directory in your project root, then import them into `./pages/api/trpc/[trpc].ts` and [merge them](/docs/merging-routers) into a single root `appRouter`.
+Implement your tRPC router in `./pages/api/trpc/[trpc].ts`. If you need to split your router into several subrouters, implement them in a top-level `server` directory in your project root, then import them into `./pages/api/trpc/[trpc].ts` and [merge them](merging-routers) into a single root `appRouter`.
 
 <details><summary>View sample router</summary>
 
@@ -199,7 +199,7 @@ The `config`-argument is a function that returns an object that configures the t
 - Optional:
   - `queryClientConfig`: a configuration object for the React Query `QueryClient` used internally by the tRPC React hooks: [QueryClient docs](https://react-query.tanstack.com/reference/QueryClient)
   - `headers`: an object or a function that returns an object of outgoing tRPC requests
-  - `transformer`: a transformer applied to outgoing payloads. Read more about [Data Transformers](/docs/data-transformers)
+  - `transformer`: a transformer applied to outgoing payloads. Read more about [Data Transformers](data-transformers)
   - `fetch`: customize the implementation of `fetch` used by tRPC internally
   - `AbortController`: customize the implementation of `AbortController` used by tRPC internally
 
@@ -237,4 +237,4 @@ export default withTRPC<AppRouter>({
 
 ## Next steps
 
-Refer to the `@trpc/react` docs for additional information on executing [Queries](/docs/react-queries) and [Mutations](/docs/react-mutations) inside your components.
+Refer to the `@trpc/react` docs for additional information on executing [Queries](react-queries) and [Mutations](react-mutations) inside your components.

--- a/www/versioned_docs/version-9.x/nextjs/ssg.md
+++ b/www/versioned_docs/version-9.x/nextjs/ssg.md
@@ -92,4 +92,4 @@ export default function PostViewPage(
 }
 ```
 
-Check out [here](/docs/ssg-helpers) to learn more about `createSSGHelpers`.
+Check out [here](ssg-helpers) to learn more about `createSSGHelpers`.

--- a/www/versioned_docs/version-9.x/nextjs/ssr.md
+++ b/www/versioned_docs/version-9.x/nextjs/ssr.md
@@ -59,4 +59,4 @@ export default withTRPC<AppRouter>({
 
 ## Caveats
 
-When you enable SSR, tRPC will use `getInitialProps` to prefetch all queries on the server. That causes problems [like this](https://github.com/trpc/trpc/issues/596) when you use `getServerSideProps` in a page and solving it is out of our hands. Though, you can use [SSG Helpers](/docs/ssg-helpers) to prefetch queries in `getStaticProps` or `getServerSideProps`.
+When you enable SSR, tRPC will use `getInitialProps` to prefetch all queries on the server. That causes problems [like this](https://github.com/trpc/trpc/issues/596) when you use `getServerSideProps` in a page and solving it is out of our hands. Though, you can use [SSG Helpers](ssg-helpers) to prefetch queries in `getStaticProps` or `getServerSideProps`.

--- a/www/versioned_docs/version-9.x/reactjs/introduction.md
+++ b/www/versioned_docs/version-9.x/reactjs/introduction.md
@@ -7,7 +7,7 @@ slug: /react
 
 :::info
 
-- If you're using Next.js, read the [Usage with Next.js](/docs/nextjs) guide instead.
+- If you're using Next.js, read the [Usage with Next.js](nextjs) guide instead.
 - In order to infer types from your Node.js backend you should have the frontend & backend in the same monorepo.
 :::
 
@@ -53,7 +53,7 @@ If strict mode is too much, at least enable `strictNullChecks`:
 
 #### 3. Implement your `appRouter`
 
-Follow the [Quickstart](/docs/quickstart) and read the [`@trpc/server` docs](/docs/router) for guidance on this. Once you have your API implemented and listening via HTTP, continue to the next step.
+Follow the [Quickstart](quickstart) and read the [`@trpc/server` docs](router) for guidance on this. Once you have your API implemented and listening via HTTP, continue to the next step.
 
 ### Client Side
 

--- a/www/versioned_docs/version-9.x/server/express.md
+++ b/www/versioned_docs/version-9.x/server/express.md
@@ -74,7 +74,7 @@ const appRouter = trpc
 export type AppRouter = typeof appRouter;
 ```
 
-If your router file starts getting too big, split your router into several subrouters each implemented in its own file. Then [merge them](/docs/merging-routers) into a single root `appRouter`.
+If your router file starts getting too big, split your router into several subrouters each implemented in its own file. Then [merge them](merging-routers) into a single root `appRouter`.
 
 ### 3. Use the Express.js adapter
 

--- a/www/versioned_docs/version-9.x/server/fastify.md
+++ b/www/versioned_docs/version-9.x/server/fastify.md
@@ -93,7 +93,7 @@ export type AppRouter = typeof appRouter;
 
 </details>
 
-If your router file starts getting too big, split your router into several subrouters each implemented in its own file. Then [merge them](/docs/merging-routers) into a single root `appRouter`.
+If your router file starts getting too big, split your router into several subrouters each implemented in its own file. Then [merge them](merging-routers) into a single root `appRouter`.
 
 ### Create the context
 

--- a/www/versions.json
+++ b/www/versions.json
@@ -1,1 +1,1 @@
-["current", "9.x"]
+["9.x", "current"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1830,7 +1830,7 @@
     "@docsearch/css" "3.2.1"
     algoliasearch "^4.0.0"
 
-"@docusaurus/core@2.0.1", "@docusaurus/core@^2.0.0-rc.1":
+"@docusaurus/core@2.0.1", "@docusaurus/core@^2.0.1":
   version "2.0.1"
   resolved "https://registry.npmjs.org/@docusaurus/core/-/core-2.0.1.tgz#a2b0d653e8f18eacddda4778a46b638dd1f0f45c"
   integrity sha512-Prd46TtZdiixlTl8a+h9bI5HegkfREjSNkrX2rVEwJZeziSz4ya+l7QDnbnCB2XbxEG8cveFo/F9q5lixolDtQ==
@@ -1948,7 +1948,7 @@
     url-loader "^4.1.1"
     webpack "^5.73.0"
 
-"@docusaurus/module-type-aliases@2.0.1", "@docusaurus/module-type-aliases@^2.0.0-rc.1":
+"@docusaurus/module-type-aliases@2.0.1", "@docusaurus/module-type-aliases@^2.0.1":
   version "2.0.1"
   resolved "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.1.tgz#44d7132297bedae0890695b0e7ebbe14a73e26d1"
   integrity sha512-f888ylnxHAM/3T8p1lx08+lTc6/g7AweSRfRuZvrVhHXj3Tz/nTTxaP6gPTGkJK7WLqTagpar/IGP6/74IBbkg==
@@ -2067,7 +2067,7 @@
     sitemap "^7.1.1"
     tslib "^2.4.0"
 
-"@docusaurus/preset-classic@^2.0.0-rc.1":
+"@docusaurus/preset-classic@^2.0.1":
   version "2.0.1"
   resolved "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.0.1.tgz#21a806e16b61026d2a0efa6ca97e17397065d894"
   integrity sha512-nOoniTg46My1qdDlLWeFs55uEmxOJ+9WMF8KKG8KMCu5LAvpemMi7rQd4x8Tw+xiPHZ/sQzH9JmPTMPRE4QGPw==


### PR DESCRIPTION
Prepare for releasing v9 alpha.

## 🎯 Changes

- Make all routes on www prefixed
- Only show announcement bar if v10 is selected + make it non-dismissable
- Redirect `/docs/*` -> `/docs/v9/*`

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.