### PR TITLE
Add `inferRouterProxyClient` type to `@trpc/client`

### DIFF
--- a/packages/client/src/createTRPCClientProxy.ts
+++ b/packages/client/src/createTRPCClientProxy.ts
@@ -23,6 +23,9 @@ import {
   TRPCSubscriptionObserver,
 } from './internals/TRPCClient';
 
+export type inferRouterProxyClient<TRouter extends AnyRouter> =
+  DecoratedProcedureRecord<TRouter['_def']['record'], TRouter>;
+
 type Resolver<TProcedure extends Procedure<any>> = (
   ...args: ProcedureArgs<TProcedure['_def']>
 ) => Promise<inferProcedureOutput<TProcedure>>;
@@ -101,7 +104,7 @@ export function createTRPCClientProxy<TRouter extends AnyRouter>(
     const fullPath = pathCopy.join('.');
     return (client as any)[procedureType](fullPath, ...args);
   });
-  return proxy as DecoratedProcedureRecord<TRouter['_def']['record'], TRouter>;
+  return proxy as inferRouterProxyClient<TRouter>;
 }
 
 export function createTRPCProxyClient<TRouter extends AnyRouter>(


### PR DESCRIPTION
I want this so I can build things with my own wrappers around the created proxy client.

## 🎯 Changes

Feature adds `export inferRouterProxyClient<TRouter>`

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.