### PR TITLE
chore: add react-query instead of @tanstack/react-query

### DIFF
--- a/www/versioned_docs/version-9.x/nextjs/introduction.md
+++ b/www/versioned_docs/version-9.x/nextjs/introduction.md
@@ -45,7 +45,7 @@ Recommended but not enforced file structure. This is what you get when starting 
 ### 1. Install deps
 
 ```bash
-yarn add @trpc/client @trpc/server @trpc/react @trpc/next zod @tanstack/react-query
+yarn add @trpc/client @trpc/server @trpc/react @trpc/next zod react-query
 ```
 
 - React Query: `@trpc/react` provides a thin wrapper over [@tanstack/react-query](https://react-query.tanstack.com/overview). It is required as a peer dependency.


### PR DESCRIPTION
Closes #

## 🎯 Changes

To learn trpc, I tried to create trpc with the next.js application. But I get the following error: ``` error - ./node_modules/@trpc/next/dist/trpc-next.esm.js:8:0
Module not found: cannot resolve 'react-query' ```. Only when I installed `react-query` did it starts working without any problems. I opened this PR because I thought this would be useful for other developers.

![Screen Shot 2022-08-27 at 2 56 23 AM](https://user-images.githubusercontent.com/63788958/187005234-3f7ff460-78da-4f79-a2a0-6b58c7a38139.png)


## ✅ Checklist

- [ x ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ x ] If necessary, I have added documentation related to the changes made.
- [ x ] I have added or updated the tests related to the changes made.