### PR TITLE
feat(www): adds playsInline to mp4 previews

### DIFF
--- a/www/src/components/Preview.tsx
+++ b/www/src/components/Preview.tsx
@@ -8,6 +8,7 @@ export const Preview = () => {
           autoPlay
           loop
           muted
+          playsInline
           width="550px"
           className="rounded-md shadow-xl trpcgif trpcgif--v10-dark"
         >
@@ -21,6 +22,7 @@ export const Preview = () => {
           autoPlay
           loop
           muted
+          playsInline
           width="550px"
           className="rounded-md shadow-xl trpcgif trpcgif--v10-light"
         >


### PR DESCRIPTION
This PR changes the following:

- Adds the `playsInline` attribute to the mp4 v10 previews so that it works on safari mobile.