### PR TITLE
`trpc` instance - rm `initTRPC()()`

### DIFF
--- a/.tmp/v10-docs.md
+++ b/.tmp/v10-docs.md
@@ -166,7 +166,7 @@ type Context = {
 
 export const t = trpc
   .context<Context>()
-  .create({
+  .options({
     /* optional */
     transformer: superjson,
     // errorFormatter: [...]

--- a/.tmp/v10-docs.md
+++ b/.tmp/v10-docs.md
@@ -164,13 +164,13 @@ type Context = {
   };
 };
 
-export const t = initTRPC<{
-  ctx: Context;
-}>()({
-  /* optional */
-  transformer: superjson,
-  // errorFormatter: [...]
-});
+export const t = trpc
+  .context<Context>()
+  .create({
+    /* optional */
+    transformer: superjson,
+    // errorFormatter: [...]
+  });
 
 const {
   /**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ This package contains the core and server-side functionality. If something is sh
 
 #### Building a Router
 
-This is where tRPC has the most interaction with users, so it should be treated with a great deal of importance. We care about offering a simple, intuitive API in which the HTTP layer disappears for the user. Here the user's entry point is [`initTRPC`](packages/server/src/core/initTRPC.ts) where root configuration such as a [data transformer](https://trpc.io/docs/data-transformers) is set and factory functions for router, procedure, middleware, etc. creation are returned.
+This is where tRPC has the most interaction with users, so it should be treated with a great deal of importance. We care about offering a simple, intuitive API in which the HTTP layer disappears for the user. Here the user's entry point is [`trpc`](packages/server/src/core/initTRPC.ts) where root configuration such as a [data transformer](https://trpc.io/docs/data-transformers) is set and factory functions for router, procedure, middleware, etc. creation are returned.
 
 The most complex types are also in this area because we must keep track of the context, meta, middleware, and each procedure and its inputs and outputs. If you are ever struggling to understand a type, feel free to ask for help on [Discord](https://trpc.io/discord).
 

--- a/examples/cloudflare-workers/src/router.ts
+++ b/examples/cloudflare-workers/src/router.ts
@@ -1,4 +1,4 @@
-import { trpc } from '@trpc/server';
+import { trpc as t } from '@trpc/server';
 import { z } from 'zod';
 
 let id = 0;
@@ -11,8 +11,6 @@ const db = {
     },
   ],
 };
-
-const t = trpc.create();
 
 const postRouter = t.router({
   createPost: t.procedure

--- a/examples/cloudflare-workers/src/router.ts
+++ b/examples/cloudflare-workers/src/router.ts
@@ -1,4 +1,4 @@
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import { z } from 'zod';
 
 let id = 0;
@@ -12,7 +12,7 @@ const db = {
   ],
 };
 
-const t = initTRPC()();
+const t = trpc.create();
 
 const postRouter = t.router({
   createPost: t.procedure

--- a/examples/express-minimal/src/router.ts
+++ b/examples/express-minimal/src/router.ts
@@ -1,7 +1,7 @@
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import { z } from 'zod';
 
-const t = initTRPC()();
+const t = trpc.create();
 
 const helloRouter = t.router({
   greeting: t.procedure

--- a/examples/express-minimal/src/router.ts
+++ b/examples/express-minimal/src/router.ts
@@ -1,7 +1,5 @@
-import { trpc } from '@trpc/server';
+import { trpc as t } from '@trpc/server';
 import { z } from 'zod';
-
-const t = trpc.create();
 
 const helloRouter = t.router({
   greeting: t.procedure

--- a/examples/express-server/src/server.ts
+++ b/examples/express-server/src/server.ts
@@ -1,4 +1,4 @@
-import { TRPCError, inferAsyncReturnType, initTRPC } from '@trpc/server';
+import { TRPCError, inferAsyncReturnType, trpc } from '@trpc/server';
 import * as trpcExpress from '@trpc/server/adapters/express';
 import { EventEmitter } from 'events';
 import express from 'express';
@@ -25,7 +25,7 @@ const createContext = ({
 };
 type Context = inferAsyncReturnType<typeof createContext>;
 
-const t = initTRPC<{ ctx: Context }>()();
+const t = trpc.context<Context>().create();
 
 // --------- create procedures etc
 

--- a/examples/express-server/src/server.ts
+++ b/examples/express-server/src/server.ts
@@ -25,7 +25,7 @@ const createContext = ({
 };
 type Context = inferAsyncReturnType<typeof createContext>;
 
-const t = trpc.context<Context>().create();
+const t = trpc.context<Context>();
 
 // --------- create procedures etc
 

--- a/examples/fastify-server/src/server/router/trpc.ts
+++ b/examples/fastify-server/src/server/router/trpc.ts
@@ -2,7 +2,7 @@ import { trpc } from '@trpc/server';
 import superjson from 'superjson';
 import { Context } from './context';
 
-export const t = trpc.context<Context>().create({
+export const t = trpc.context<Context>().options({
   transformer: superjson,
   errorFormatter({ shape }) {
     return shape;

--- a/examples/fastify-server/src/server/router/trpc.ts
+++ b/examples/fastify-server/src/server/router/trpc.ts
@@ -1,10 +1,8 @@
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import superjson from 'superjson';
 import { Context } from './context';
 
-export const t = initTRPC<{
-  ctx: Context;
-}>()({
+export const t = trpc.context<Context>().create({
   transformer: superjson,
   errorFormatter({ shape }) {
     return shape;

--- a/examples/lambda-api-gateway/src/server.ts
+++ b/examples/lambda-api-gateway/src/server.ts
@@ -16,7 +16,7 @@ function createContext({
 }
 type Context = inferAsyncReturnType<typeof createContext>;
 
-const t = trpc.context<Context>.create();
+const t = trpc.context<Context>().create();
 
 const appRouter = t.router({
   greet: t.procedure

--- a/examples/lambda-api-gateway/src/server.ts
+++ b/examples/lambda-api-gateway/src/server.ts
@@ -1,4 +1,4 @@
-import { inferAsyncReturnType, initTRPC } from '@trpc/server';
+import { inferAsyncReturnType, trpc } from '@trpc/server';
 import { awsLambdaRequestHandler } from '@trpc/server/adapters/aws-lambda';
 import type { CreateAWSLambdaContextOptions } from '@trpc/server/adapters/aws-lambda';
 import type { APIGatewayProxyEvent } from 'aws-lambda';
@@ -16,7 +16,7 @@ function createContext({
 }
 type Context = inferAsyncReturnType<typeof createContext>;
 
-const t = initTRPC<{ ctx: Context }>()();
+const t = trpc.context<Context>.create();
 
 const appRouter = t.router({
   greet: t.procedure

--- a/examples/lambda-api-gateway/src/server.ts
+++ b/examples/lambda-api-gateway/src/server.ts
@@ -16,7 +16,7 @@ function createContext({
 }
 type Context = inferAsyncReturnType<typeof createContext>;
 
-const t = trpc.context<Context>().create();
+const t = trpc.context<Context>();
 
 const appRouter = t.router({
   greet: t.procedure

--- a/examples/minimal/server/index.ts
+++ b/examples/minimal/server/index.ts
@@ -1,9 +1,9 @@
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import { createHTTPServer } from '@trpc/server/adapters/standalone';
 
 export type AppRouter = typeof appRouter;
 
-const t = initTRPC()();
+const t = trpc.create();
 
 const appRouter = t.router({
   greet: t.procedure

--- a/examples/minimal/server/index.ts
+++ b/examples/minimal/server/index.ts
@@ -1,9 +1,7 @@
-import { trpc } from '@trpc/server';
+import { trpc as t } from '@trpc/server';
 import { createHTTPServer } from '@trpc/server/adapters/standalone';
 
 export type AppRouter = typeof appRouter;
-
-const t = trpc.create();
 
 const appRouter = t.router({
   greet: t.procedure

--- a/examples/next-minimal-starter/src/pages/api/trpc/[trpc].ts
+++ b/examples/next-minimal-starter/src/pages/api/trpc/[trpc].ts
@@ -1,8 +1,6 @@
-import { trpc } from '@trpc/server';
+import { trpc as t } from '@trpc/server';
 import * as trpcNext from '@trpc/server/adapters/next';
 import { z } from 'zod';
-
-const t = trpc.create();
 
 export const appRouter = t.router({
   hello: t.procedure

--- a/examples/next-minimal-starter/src/pages/api/trpc/[trpc].ts
+++ b/examples/next-minimal-starter/src/pages/api/trpc/[trpc].ts
@@ -1,8 +1,8 @@
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import * as trpcNext from '@trpc/server/adapters/next';
 import { z } from 'zod';
 
-const t = initTRPC()();
+const t = trpc.create();
 
 export const appRouter = t.router({
   hello: t.procedure

--- a/examples/next-prisma-starter-sqlite/src/server/trpc.ts
+++ b/examples/next-prisma-starter-sqlite/src/server/trpc.ts
@@ -1,10 +1,8 @@
 import { Context } from './context';
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import superjson from 'superjson';
 
-export const t = initTRPC<{
-  ctx: Context;
-}>()({
+export const t = trpc.context<Context>().create({
   transformer: superjson,
   errorFormatter({ shape }) {
     return shape;

--- a/examples/next-prisma-starter-sqlite/src/server/trpc.ts
+++ b/examples/next-prisma-starter-sqlite/src/server/trpc.ts
@@ -2,7 +2,7 @@ import { Context } from './context';
 import { trpc } from '@trpc/server';
 import superjson from 'superjson';
 
-export const t = trpc.context<Context>().create({
+export const t = trpc.context<Context>().options({
   transformer: superjson,
   errorFormatter({ shape }) {
     return shape;

--- a/examples/next-prisma-starter/src/server/trpc.ts
+++ b/examples/next-prisma-starter/src/server/trpc.ts
@@ -1,10 +1,8 @@
 import { Context } from './context';
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import superjson from 'superjson';
 
-export const t = initTRPC<{
-  ctx: Context;
-}>()({
+export const t = trpc.context<Context>().create({
   transformer: superjson,
   errorFormatter({ shape }) {
     return shape;

--- a/examples/next-prisma-starter/src/server/trpc.ts
+++ b/examples/next-prisma-starter/src/server/trpc.ts
@@ -2,7 +2,7 @@ import { Context } from './context';
 import { trpc } from '@trpc/server';
 import superjson from 'superjson';
 
-export const t = trpc.context<Context>().create({
+export const t = trpc.context<Context>().options({
   transformer: superjson,
   errorFormatter({ shape }) {
     return shape;

--- a/examples/next-prisma-todomvc/src/server/trpc.ts
+++ b/examples/next-prisma-todomvc/src/server/trpc.ts
@@ -1,9 +1,7 @@
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import superjson from 'superjson';
 import { Context } from './context';
 
-export const t = initTRPC<{
-  ctx: Context;
-}>()({
+export const t = trpc.context<Context>().create({
   transformer: superjson,
 });

--- a/examples/next-prisma-todomvc/src/server/trpc.ts
+++ b/examples/next-prisma-todomvc/src/server/trpc.ts
@@ -2,6 +2,6 @@ import { trpc } from '@trpc/server';
 import superjson from 'superjson';
 import { Context } from './context';
 
-export const t = trpc.context<Context>().create({
+export const t = trpc.context<Context>().options({
   transformer: superjson,
 });

--- a/examples/standalone-server/src/server.ts
+++ b/examples/standalone-server/src/server.ts
@@ -19,7 +19,7 @@ function createContext(
 }
 type Context = inferAsyncReturnType<typeof createContext>;
 
-const t = trpc.context<Context>.create();
+const t = trpc.context<Context>().create();
 
 const greetingRouter = t.router({
   greeting: t.procedure

--- a/examples/standalone-server/src/server.ts
+++ b/examples/standalone-server/src/server.ts
@@ -1,4 +1,4 @@
-import { inferAsyncReturnType, initTRPC } from '@trpc/server';
+import { inferAsyncReturnType, trpc } from '@trpc/server';
 import {
   CreateHTTPContextOptions,
   createHTTPServer,
@@ -19,7 +19,7 @@ function createContext(
 }
 type Context = inferAsyncReturnType<typeof createContext>;
 
-const t = initTRPC<{ ctx: Context }>()();
+const t = trpc.context<Context>.create();
 
 const greetingRouter = t.router({
   greeting: t.procedure

--- a/examples/standalone-server/src/server.ts
+++ b/examples/standalone-server/src/server.ts
@@ -19,7 +19,7 @@ function createContext(
 }
 type Context = inferAsyncReturnType<typeof createContext>;
 
-const t = trpc.context<Context>().create();
+const t = trpc.context<Context>();
 
 const greetingRouter = t.router({
   greeting: t.procedure

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -36,7 +36,7 @@ We also recommend installing `zod` to validate procedure inputs.
 ## Basic Example
 
 ```ts
-import { inferAsyncReturnType, initTRPC } from '@trpc/server';
+import { inferAsyncReturnType, trpc } from '@trpc/server';
 import {
   CreateHTTPContextOptions,
   createHTTPServer,
@@ -52,7 +52,7 @@ function createContext(opts: CreateHTTPContextOptions) {
 type Context = inferAsyncReturnType<typeof createContext>;
 
 // Initialize tRPC
-const t = initTRPC<{ ctx: Context }>()();
+const t = trpc.context<Context>.create();
 
 // Create main router
 const appRouter = t.router({

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -52,7 +52,7 @@ function createContext(opts: CreateHTTPContextOptions) {
 type Context = inferAsyncReturnType<typeof createContext>;
 
 // Initialize tRPC
-const t = trpc.context<Context>.create();
+const t = trpc.context<Context>;
 
 // Create main router
 const appRouter = t.router({

--- a/packages/server/src/core/index.ts
+++ b/packages/server/src/core/index.ts
@@ -11,5 +11,5 @@ export type {
   ProcedureOptions,
 } from './procedure';
 
-export { initTRPC } from './initTRPC';
+export { trpc } from './initTRPC';
 export * from './types';

--- a/packages/server/src/core/initTRPC.ts
+++ b/packages/server/src/core/initTRPC.ts
@@ -23,7 +23,48 @@ import { PickFirstDefined, ValidateShape } from './internals/utils';
 import { createMiddlewareFactory } from './middleware';
 import { createRouterFactory } from './router';
 
-export function initTRPC<TParams extends Partial<InitGenerics> = {}>() {
+export class TRPCBuilder<TParams extends Partial<InitGenerics> = {}> {
+  context<TNewContext extends InitGenerics['ctx']>() {
+    return new TRPCBuilder<Omit<TParams, 'ctx'> & { ctx: TNewContext }>();
+  }
+  meta<TNewMeta extends InitGenerics['meta']>() {
+    return new TRPCBuilder<Omit<TParams, 'meta'> & { meta: TNewMeta }>();
+  }
+  create<
+    TOptions extends Partial<
+      InitOptions<{
+        ctx: TParams['ctx'] extends undefined
+          ? {}
+          : NonNullable<TParams['ctx']>;
+        meta: TParams['meta'] extends undefined
+          ? {}
+          : NonNullable<TParams['meta']>;
+      }>
+    >,
+  >(
+    options?:
+      | ValidateShape<
+          TOptions,
+          Partial<
+            InitOptions<{
+              ctx: TParams['ctx'] extends undefined
+                ? {}
+                : NonNullable<TParams['ctx']>;
+              meta: TParams['meta'] extends undefined
+                ? {}
+                : NonNullable<TParams['meta']>;
+            }>
+          >
+        >
+      | undefined,
+  ) {
+    return initTRPC<TParams>()<TOptions>(options);
+  }
+}
+
+export const trpc = new TRPCBuilder();
+
+function initTRPC<TParams extends Partial<InitGenerics>>() {
   type $Generics = CreateInitGenerics<{
     ctx: TParams['ctx'] extends undefined ? {} : NonNullable<TParams['ctx']>;
     meta: TParams['meta'] extends undefined ? {} : NonNullable<TParams['meta']>;

--- a/packages/server/src/core/initTRPC.ts
+++ b/packages/server/src/core/initTRPC.ts
@@ -30,53 +30,13 @@ export class TRPCBuilder<TParams extends Partial<InitGenerics> = {}> {
   meta<TNewMeta extends InitGenerics['meta']>() {
     return new TRPCBuilder<Omit<TParams, 'meta'> & { meta: TNewMeta }>();
   }
-  create<
-    TOptions extends Partial<
-      InitOptions<{
-        ctx: TParams['ctx'] extends undefined
-          ? {}
-          : NonNullable<TParams['ctx']>;
-        meta: TParams['meta'] extends undefined
-          ? {}
-          : NonNullable<TParams['meta']>;
-      }>
-    >,
-  >(
-    options?:
-      | ValidateShape<
-          TOptions,
-          Partial<
-            InitOptions<{
-              ctx: TParams['ctx'] extends undefined
-                ? {}
-                : NonNullable<TParams['ctx']>;
-              meta: TParams['meta'] extends undefined
-                ? {}
-                : NonNullable<TParams['meta']>;
-            }>
-          >
-        >
-      | undefined,
+
+  create<TOptions extends $Helpers<TParams>['$Options']>(
+    options?: ValidateShape<TOptions, $Helpers<TParams>['$Options']>,
   ) {
-    return initTRPC<TParams>()<TOptions>(options);
-  }
-}
-
-export const trpc = new TRPCBuilder();
-
-function initTRPC<TParams extends Partial<InitGenerics>>() {
-  type $Generics = CreateInitGenerics<{
-    ctx: TParams['ctx'] extends undefined ? {} : NonNullable<TParams['ctx']>;
-    meta: TParams['meta'] extends undefined ? {} : NonNullable<TParams['meta']>;
-  }>;
-
-  type $Context = $Generics['ctx'];
-  type $Meta = PickFirstDefined<$Generics['meta'], undefined>;
-  type $Options = Partial<InitOptions<$Generics>>;
-
-  return function initTRPCInner<TOptions extends $Options>(
-    options?: ValidateShape<TOptions, $Options>,
-  ) {
+    type $HelperTypes = $Helpers<TParams>;
+    type $Context = $HelperTypes['$Generics']['ctx'];
+    type $Meta = $HelperTypes['$Generics']['meta'];
     type $Formatter = PickFirstDefined<
       TOptions['errorFormatter'],
       ErrorFormatter<$Context, DefaultErrorShape>
@@ -131,5 +91,20 @@ function initTRPC<TParams extends Partial<InitGenerics>>() {
        */
       mergeRouters: mergeRoutersGeneric,
     };
-  };
+  }
 }
+
+type $Generics<TParams extends Partial<InitGenerics>> = CreateInitGenerics<{
+  ctx: TParams['ctx'] extends undefined ? {} : NonNullable<TParams['ctx']>;
+  meta: TParams['meta'] extends undefined ? {} : NonNullable<TParams['meta']>;
+}>;
+
+type $Helpers<TParams extends Partial<InitGenerics>> = {
+  $Generics: $Generics<TParams>;
+
+  $Context: $Generics<TParams>['ctx'];
+  $Meta: PickFirstDefined<$Generics<TParams>['meta'], undefined>;
+  $Options: Partial<InitOptions<$Generics<TParams>>>;
+};
+
+export const trpc = new TRPCBuilder();

--- a/packages/server/src/core/internals/config.ts
+++ b/packages/server/src/core/internals/config.ts
@@ -27,7 +27,7 @@ export interface InitOptions<T extends InitGenerics> {
 export type CreateInitGenerics<T extends InitGenerics> = T;
 
 /**
- * The config that is resolved after both calls of `initTRPC()` has been called
+ * The config that is resolved after `trpc.create()` has been called
  * Combination of `InitTOptions` + `InitGenerics`
  * @internal
  */

--- a/packages/server/src/core/internals/config.ts
+++ b/packages/server/src/core/internals/config.ts
@@ -27,7 +27,7 @@ export interface InitOptions<T extends InitGenerics> {
 export type CreateInitGenerics<T extends InitGenerics> = T;
 
 /**
- * The config that is resolved after `trpc.create()` has been called
+ * The config that is resolved after `trpc` has been created
  * Combination of `InitTOptions` + `InitGenerics`
  * @internal
  */

--- a/packages/server/test/abortQuery.test.ts
+++ b/packages/server/test/abortQuery.test.ts
@@ -1,7 +1,5 @@
 import { routerToServerAndClientNew, waitMs } from './___testHelpers';
-import { trpc } from '../src/core';
-
-const t = trpc.create();
+import { trpc as t } from '../src/core';
 
 const router = t.router({
   testQuery: t.procedure.query(async () => {

--- a/packages/server/test/abortQuery.test.ts
+++ b/packages/server/test/abortQuery.test.ts
@@ -1,7 +1,7 @@
 import { routerToServerAndClientNew, waitMs } from './___testHelpers';
-import { initTRPC } from '../src/core';
+import { trpc } from '../src/core';
 
-const t = initTRPC()();
+const t = trpc.create();
 
 const router = t.router({
   testQuery: t.procedure.query(async () => {

--- a/packages/server/test/caller.test.ts
+++ b/packages/server/test/caller.test.ts
@@ -3,11 +3,9 @@ import { expectTypeOf } from 'expect-type';
 import { z } from 'zod';
 import { TRPCError, trpc } from '../src';
 
-const t = trpc
-  .context<{
-    foo?: 'bar';
-  }>()
-  .create();
+const t = trpc.context<{
+  foo?: 'bar';
+}>();
 
 const { procedure } = t;
 

--- a/packages/server/test/caller.test.ts
+++ b/packages/server/test/caller.test.ts
@@ -1,13 +1,15 @@
 import { waitError } from './___testHelpers';
 import { expectTypeOf } from 'expect-type';
 import { z } from 'zod';
-import { TRPCError, initTRPC } from '../src';
+import { TRPCError, trpc } from '../src';
 
-const t = initTRPC<{
-  ctx: {
-    foo?: 'bar';
-  };
-}>()();
+const t = trpc
+  .context<{
+    ctx: {
+      foo?: 'bar';
+    };
+  }>()
+  .create();
 
 const { procedure } = t;
 

--- a/packages/server/test/caller.test.ts
+++ b/packages/server/test/caller.test.ts
@@ -5,9 +5,7 @@ import { TRPCError, trpc } from '../src';
 
 const t = trpc
   .context<{
-    ctx: {
-      foo?: 'bar';
-    };
+    foo?: 'bar';
   }>()
   .create();
 

--- a/packages/server/test/children.test.ts
+++ b/packages/server/test/children.test.ts
@@ -1,10 +1,8 @@
 import { routerToServerAndClientNew } from './___testHelpers';
 import { expectTypeOf } from 'expect-type';
-import { trpc } from '../src';
+import { trpc as t } from '../src';
 
 test('children', async () => {
-  const t = trpc.create();
-
   const router = t.router({
     foo: t.procedure.query(() => 'bar'),
     child: t.router({
@@ -53,8 +51,6 @@ test('children', async () => {
 });
 
 test('w/o children', async () => {
-  const t = trpc.create();
-
   const foo = t.procedure.query(() => 'bar');
   const router = t.router({
     foo,

--- a/packages/server/test/children.test.ts
+++ b/packages/server/test/children.test.ts
@@ -1,9 +1,9 @@
 import { routerToServerAndClientNew } from './___testHelpers';
 import { expectTypeOf } from 'expect-type';
-import { initTRPC } from '../src';
+import { trpc } from '../src';
 
 test('children', async () => {
-  const t = initTRPC()();
+  const t = trpc.create();
 
   const router = t.router({
     foo: t.procedure.query(() => 'bar'),
@@ -53,7 +53,7 @@ test('children', async () => {
 });
 
 test('w/o children', async () => {
-  const t = initTRPC()();
+  const t = trpc.create();
 
   const foo = t.procedure.query(() => 'bar');
   const router = t.router({

--- a/packages/server/test/concat.test.ts
+++ b/packages/server/test/concat.test.ts
@@ -16,7 +16,7 @@ const mockUser: User = {
 };
 const ctx = konn()
   .beforeEach(() => {
-    const t = trpc.context<Context>().create();
+    const t = trpc.context<Context>();
 
     const isAuthed = t.middleware(({ next, ctx }) => {
       if (!ctx.user) {

--- a/packages/server/test/concat.test.ts
+++ b/packages/server/test/concat.test.ts
@@ -1,7 +1,7 @@
 import { routerToServerAndClientNew } from './___testHelpers';
 import { expectTypeOf } from 'expect-type';
 import { konn } from 'konn';
-import { TRPCError, initTRPC } from '../src';
+import { TRPCError, trpc } from '../src';
 
 type User = {
   id: string;
@@ -16,9 +16,7 @@ const mockUser: User = {
 };
 const ctx = konn()
   .beforeEach(() => {
-    const t = initTRPC<{
-      ctx: Context;
-    }>()();
+    const t = trpc.context<Context>().create();
 
     const isAuthed = t.middleware(({ next, ctx }) => {
       if (!ctx.user) {

--- a/packages/server/test/errorFormatting.test.ts
+++ b/packages/server/test/errorFormatting.test.ts
@@ -12,7 +12,7 @@ function isTRPCClientError<TRouter extends AnyRouter>(
 }
 
 describe('no custom error formatter', () => {
-  const t = trpc.create();
+  const t = trpc;
 
   const appRouter = t.router({
     greeting: t.procedure.query(() => {
@@ -48,7 +48,7 @@ describe('no custom error formatter', () => {
 });
 
 describe('with custom error formatter', () => {
-  const t = trpc.create({
+  const t = trpc.options({
     errorFormatter({ shape }) {
       return {
         ...shape,

--- a/packages/server/test/errorFormatting.test.ts
+++ b/packages/server/test/errorFormatting.test.ts
@@ -48,7 +48,7 @@ describe('no custom error formatter', () => {
 });
 
 describe('with custom error formatter', () => {
-  const t = initTRPC()({
+  const t = trpc.create({
     errorFormatter({ shape }) {
       return {
         ...shape,

--- a/packages/server/test/errorFormatting.test.ts
+++ b/packages/server/test/errorFormatting.test.ts
@@ -2,7 +2,7 @@ import { routerToServerAndClientNew, waitError } from './___testHelpers';
 import { TRPCClientError } from '@trpc/client';
 import { expectTypeOf } from 'expect-type';
 import { konn } from 'konn';
-import { AnyRouter, DefaultErrorShape, initTRPC } from '../src';
+import { AnyRouter, DefaultErrorShape, trpc } from '../src';
 import { DefaultErrorData } from '../src/error/formatter';
 
 function isTRPCClientError<TRouter extends AnyRouter>(
@@ -12,7 +12,7 @@ function isTRPCClientError<TRouter extends AnyRouter>(
 }
 
 describe('no custom error formatter', () => {
-  const t = initTRPC()();
+  const t = trpc.create();
 
   const appRouter = t.router({
     greeting: t.procedure.query(() => {

--- a/packages/server/test/initTRPC.test.ts
+++ b/packages/server/test/initTRPC.test.ts
@@ -8,11 +8,9 @@ import {
 } from '../src/transformer';
 
 test('default transformer', () => {
-  const t = trpc
-    .context<{
-      foo: 'bar';
-    }>()
-    .create();
+  const t = trpc.context<{
+    foo: 'bar';
+  }>();
   const router = t.router({});
 
   expectTypeOf(router._def._ctx).toMatchTypeOf<{
@@ -25,7 +23,7 @@ test('custom transformer', () => {
     deserialize: (v) => v,
     serialize: (v) => v,
   };
-  const t = trpc.create({
+  const t = trpc.options({
     transformer,
   });
   const router = t.router({});

--- a/packages/server/test/initTRPC.test.ts
+++ b/packages/server/test/initTRPC.test.ts
@@ -25,7 +25,7 @@ test('custom transformer', () => {
     deserialize: (v) => v,
     serialize: (v) => v,
   };
-  const t = initTRPC()({
+  const t = trpc.create({
     transformer,
   });
   const router = t.router({});

--- a/packages/server/test/initTRPC.test.ts
+++ b/packages/server/test/initTRPC.test.ts
@@ -1,6 +1,6 @@
 import './___packages';
 import { expectTypeOf } from 'expect-type';
-import { initTRPC } from '../src/core';
+import { trpc } from '../src/core';
 import {
   CombinedDataTransformer,
   DataTransformerOptions,
@@ -8,11 +8,11 @@ import {
 } from '../src/transformer';
 
 test('default transformer', () => {
-  const t = initTRPC<{
-    ctx: {
+  const t = trpc
+    .context<{
       foo: 'bar';
-    };
-  }>()();
+    }>()
+    .create();
   const router = t.router({});
 
   expectTypeOf(router._def._ctx).toMatchTypeOf<{

--- a/packages/server/test/input.test.ts
+++ b/packages/server/test/input.test.ts
@@ -3,7 +3,7 @@ import { TRPCClientError } from '@trpc/client';
 import { expectTypeOf } from 'expect-type';
 import { konn } from 'konn';
 import { ZodError, z } from 'zod';
-import { inferProcedureInput, initTRPC } from '../src/core';
+import { inferProcedureInput, trpc } from '../src/core';
 
 describe('double input validator', () => {
   const t = initTRPC()({
@@ -97,7 +97,7 @@ describe('double input validator', () => {
 });
 
 test('only allow double input validator for object-like inputs', () => {
-  const t = initTRPC()();
+  const t = trpc.create();
 
   try {
     t.procedure.input(z.literal('hello')).input(

--- a/packages/server/test/input.test.ts
+++ b/packages/server/test/input.test.ts
@@ -6,7 +6,7 @@ import { ZodError, z } from 'zod';
 import { inferProcedureInput, trpc } from '../src/core';
 
 describe('double input validator', () => {
-  const t = initTRPC()({
+  const t = trpc.create({
     errorFormatter({ shape, error }) {
       return {
         ...shape,

--- a/packages/server/test/input.test.ts
+++ b/packages/server/test/input.test.ts
@@ -6,7 +6,7 @@ import { ZodError, z } from 'zod';
 import { inferProcedureInput, trpc } from '../src/core';
 
 describe('double input validator', () => {
-  const t = trpc.create({
+  const t = trpc.options({
     errorFormatter({ shape, error }) {
       return {
         ...shape,
@@ -97,7 +97,7 @@ describe('double input validator', () => {
 });
 
 test('only allow double input validator for object-like inputs', () => {
-  const t = trpc.create();
+  const t = trpc;
 
   try {
     t.procedure.input(z.literal('hello')).input(

--- a/packages/server/test/middlewares.test.ts
+++ b/packages/server/test/middlewares.test.ts
@@ -9,7 +9,7 @@ test('decorate independently', () => {
   type Context = {
     user: User | null;
   };
-  const t = trpc.context<Context>().create();
+  const t = trpc.context<Context>();
 
   const isAuthed = t.middleware(({ next, ctx }) => {
     if (!ctx.user) {

--- a/packages/server/test/middlewares.test.ts
+++ b/packages/server/test/middlewares.test.ts
@@ -1,5 +1,5 @@
 import { expectTypeOf } from 'expect-type';
-import { TRPCError, initTRPC } from '../src';
+import { TRPCError, trpc } from '../src';
 
 test('decorate independently', () => {
   type User = {
@@ -9,9 +9,7 @@ test('decorate independently', () => {
   type Context = {
     user: User | null;
   };
-  const t = initTRPC<{
-    ctx: Context;
-  }>()();
+  const t = trpc.context<Context>().create();
 
   const isAuthed = t.middleware(({ next, ctx }) => {
     if (!ctx.user) {

--- a/packages/server/test/react/errors.test.tsx
+++ b/packages/server/test/react/errors.test.tsx
@@ -6,14 +6,14 @@ import { expectTypeOf } from 'expect-type';
 import { konn } from 'konn';
 import React from 'react';
 import { ZodError, z } from 'zod';
-import { trpc } from '../../src';
+import { trpc as t } from '../../src';
 
 jest.retryTimes(3);
 
 describe('custom error formatter', () => {
   const ctx = konn()
     .beforeEach(() => {
-      const t = trpc.create({
+      const t = trpc.options({
         errorFormatter({ shape, error }) {
           return {
             ...shape,
@@ -109,7 +109,6 @@ describe('custom error formatter', () => {
 describe('no custom formatter', () => {
   const ctx = konn()
     .beforeEach(() => {
-      const t = trpc.create();
       const appRouter = t.router({
         post: t.router({
           byId: t.procedure
@@ -189,7 +188,6 @@ describe('no custom formatter', () => {
 });
 
 test('types', async () => {
-  const t = trpc.create();
   const appRouter = t.router({
     post: t.router({
       byId: t.procedure

--- a/packages/server/test/react/errors.test.tsx
+++ b/packages/server/test/react/errors.test.tsx
@@ -13,7 +13,7 @@ jest.retryTimes(3);
 describe('custom error formatter', () => {
   const ctx = konn()
     .beforeEach(() => {
-      const t = initTRPC()({
+      const t = trpc.create({
         errorFormatter({ shape, error }) {
           return {
             ...shape,

--- a/packages/server/test/react/errors.test.tsx
+++ b/packages/server/test/react/errors.test.tsx
@@ -6,7 +6,7 @@ import { expectTypeOf } from 'expect-type';
 import { konn } from 'konn';
 import React from 'react';
 import { ZodError, z } from 'zod';
-import { trpc as t } from '../../src';
+import { trpc } from '../../src';
 
 jest.retryTimes(3);
 
@@ -109,6 +109,7 @@ describe('custom error formatter', () => {
 describe('no custom formatter', () => {
   const ctx = konn()
     .beforeEach(() => {
+      const t = trpc;
       const appRouter = t.router({
         post: t.router({
           byId: t.procedure
@@ -188,6 +189,7 @@ describe('no custom formatter', () => {
 });
 
 test('types', async () => {
+  const t = trpc;
   const appRouter = t.router({
     post: t.router({
       byId: t.procedure

--- a/packages/server/test/react/errors.test.tsx
+++ b/packages/server/test/react/errors.test.tsx
@@ -6,7 +6,7 @@ import { expectTypeOf } from 'expect-type';
 import { konn } from 'konn';
 import React from 'react';
 import { ZodError, z } from 'zod';
-import { initTRPC } from '../../src';
+import { trpc } from '../../src';
 
 jest.retryTimes(3);
 
@@ -109,7 +109,7 @@ describe('custom error formatter', () => {
 describe('no custom formatter', () => {
   const ctx = konn()
     .beforeEach(() => {
-      const t = initTRPC()();
+      const t = trpc.create();
       const appRouter = t.router({
         post: t.router({
           byId: t.procedure
@@ -189,7 +189,7 @@ describe('no custom formatter', () => {
 });
 
 test('types', async () => {
-  const t = initTRPC()();
+  const t = trpc.create();
   const appRouter = t.router({
     post: t.router({
       byId: t.procedure

--- a/packages/server/test/react/interop-basic.test.tsx
+++ b/packages/server/test/react/interop-basic.test.tsx
@@ -8,11 +8,11 @@ import { konn } from 'konn';
 import React, { useState } from 'react';
 import { z } from 'zod';
 import * as trpc from '../../src';
-import { inferProcedureOutput, initTRPC } from '../../src';
+import { inferProcedureOutput, trpc } from '../../src';
 
 const ctx = konn()
   .beforeEach(() => {
-    const t = initTRPC()();
+    const t = trpc.create();
     const legacyRouter = trpc.router().query('oldProcedure', {
       input: z.string().optional(),
       resolve({ input }) {

--- a/packages/server/test/react/interop-basic.test.tsx
+++ b/packages/server/test/react/interop-basic.test.tsx
@@ -8,11 +8,10 @@ import { konn } from 'konn';
 import React, { useState } from 'react';
 import { z } from 'zod';
 import * as interop from '../../src';
-import { inferProcedureOutput, trpc } from '../../src';
+import { inferProcedureOutput, trpc as t } from '../../src';
 
 const ctx = konn()
   .beforeEach(() => {
-    const t = trpc.create();
     const legacyRouter = interop.router().query('oldProcedure', {
       input: z.string().optional(),
       resolve({ input }) {

--- a/packages/server/test/react/interop-basic.test.tsx
+++ b/packages/server/test/react/interop-basic.test.tsx
@@ -7,13 +7,13 @@ import { expectTypeOf } from 'expect-type';
 import { konn } from 'konn';
 import React, { useState } from 'react';
 import { z } from 'zod';
-import * as trpc from '../../src';
+import * as interop from '../../src';
 import { inferProcedureOutput, trpc } from '../../src';
 
 const ctx = konn()
   .beforeEach(() => {
     const t = trpc.create();
-    const legacyRouter = trpc.router().query('oldProcedure', {
+    const legacyRouter = interop.router().query('oldProcedure', {
       input: z.string().optional(),
       resolve({ input }) {
         return `oldProcedureOutput__input:${input ?? 'n/a'}`;

--- a/packages/server/test/react/ssg.test.ts
+++ b/packages/server/test/react/ssg.test.ts
@@ -2,9 +2,9 @@ import { InfiniteData } from '@tanstack/react-query';
 import { expectTypeOf } from 'expect-type';
 import { z } from 'zod';
 import { createProxySSGHelpers } from '../../../react/src/ssg/ssgProxy';
-import { initTRPC } from '../../src';
+import { trpc } from '../../src';
 
-const t = initTRPC()();
+const t = trpc.create();
 
 const appRouter = t.router({
   post: t.router({

--- a/packages/server/test/react/ssg.test.ts
+++ b/packages/server/test/react/ssg.test.ts
@@ -2,9 +2,7 @@ import { InfiniteData } from '@tanstack/react-query';
 import { expectTypeOf } from 'expect-type';
 import { z } from 'zod';
 import { createProxySSGHelpers } from '../../../react/src/ssg/ssgProxy';
-import { trpc } from '../../src';
-
-const t = trpc.create();
+import { trpc as t } from '../../src';
 
 const appRouter = t.router({
   post: t.router({

--- a/packages/server/test/react/trpc-options.test.tsx
+++ b/packages/server/test/react/trpc-options.test.tsx
@@ -3,11 +3,10 @@ import { render, waitFor } from '@testing-library/react';
 import { konn } from 'konn';
 import React, { useEffect } from 'react';
 import { z } from 'zod';
-import { trpc } from '../../src';
+import { trpc as t } from '../../src';
 
 const ctx = konn()
   .beforeEach(() => {
-    const t = trpc.create();
     const appRouter = t.router({
       greeting: t.procedure
         .input(

--- a/packages/server/test/react/trpc-options.test.tsx
+++ b/packages/server/test/react/trpc-options.test.tsx
@@ -3,11 +3,11 @@ import { render, waitFor } from '@testing-library/react';
 import { konn } from 'konn';
 import React, { useEffect } from 'react';
 import { z } from 'zod';
-import { initTRPC } from '../../src';
+import { trpc } from '../../src';
 
 const ctx = konn()
   .beforeEach(() => {
-    const t = initTRPC()();
+    const t = trpc.create();
     const appRouter = t.router({
       greeting: t.procedure
         .input(

--- a/packages/server/test/react/useContext.test.tsx
+++ b/packages/server/test/react/useContext.test.tsx
@@ -16,7 +16,7 @@ type Post = {
 const defaultPost = { id: 0, text: 'new post' };
 const ctx = konn()
   .beforeEach(() => {
-    const t = initTRPC()({
+    const t = trpc.create({
       errorFormatter({ shape }) {
         return {
           ...shape,

--- a/packages/server/test/react/useContext.test.tsx
+++ b/packages/server/test/react/useContext.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { konn } from 'konn';
 import React, { useEffect, useState } from 'react';
 import { z } from 'zod';
-import { initTRPC } from '../../src/core';
+import { trpc } from '../../src/core';
 
 jest.retryTimes(3);
 

--- a/packages/server/test/react/useContext.test.tsx
+++ b/packages/server/test/react/useContext.test.tsx
@@ -16,7 +16,7 @@ type Post = {
 const defaultPost = { id: 0, text: 'new post' };
 const ctx = konn()
   .beforeEach(() => {
-    const t = trpc.create({
+    const t = trpc.options({
       errorFormatter({ shape }) {
         return {
           ...shape,

--- a/packages/server/test/react/useMutation.test.tsx
+++ b/packages/server/test/react/useMutation.test.tsx
@@ -4,7 +4,7 @@ import { expectTypeOf } from 'expect-type';
 import { konn } from 'konn';
 import React, { useEffect } from 'react';
 import { z } from 'zod';
-import { initTRPC } from '../../src';
+import { trpc } from '../../src';
 
 const ctx = konn()
   .beforeEach(() => {

--- a/packages/server/test/react/useMutation.test.tsx
+++ b/packages/server/test/react/useMutation.test.tsx
@@ -8,7 +8,7 @@ import { trpc } from '../../src';
 
 const ctx = konn()
   .beforeEach(() => {
-    const t = initTRPC()({
+    const t = trpc.create({
       errorFormatter({ shape }) {
         return {
           ...shape,

--- a/packages/server/test/react/useMutation.test.tsx
+++ b/packages/server/test/react/useMutation.test.tsx
@@ -8,7 +8,7 @@ import { trpc } from '../../src';
 
 const ctx = konn()
   .beforeEach(() => {
-    const t = trpc.create({
+    const t = trpc.options({
       errorFormatter({ shape }) {
         return {
           ...shape,

--- a/packages/server/test/react/useQuery.test.tsx
+++ b/packages/server/test/react/useQuery.test.tsx
@@ -5,7 +5,7 @@ import { expectTypeOf } from 'expect-type';
 import { konn } from 'konn';
 import React, { useEffect } from 'react';
 import { z } from 'zod';
-import { initTRPC } from '../../src';
+import { trpc } from '../../src';
 
 const ctx = konn()
   .beforeEach(() => {

--- a/packages/server/test/react/useQuery.test.tsx
+++ b/packages/server/test/react/useQuery.test.tsx
@@ -9,7 +9,7 @@ import { trpc } from '../../src';
 
 const ctx = konn()
   .beforeEach(() => {
-    const t = trpc.create({
+    const t = trpc.options({
       errorFormatter({ shape }) {
         return {
           ...shape,

--- a/packages/server/test/react/useQuery.test.tsx
+++ b/packages/server/test/react/useQuery.test.tsx
@@ -9,7 +9,7 @@ import { trpc } from '../../src';
 
 const ctx = konn()
   .beforeEach(() => {
-    const t = initTRPC()({
+    const t = trpc.create({
       errorFormatter({ shape }) {
         return {
           ...shape,

--- a/packages/server/test/react/useSubscription.test.tsx
+++ b/packages/server/test/react/useSubscription.test.tsx
@@ -5,7 +5,7 @@ import { expectTypeOf } from 'expect-type';
 import { konn } from 'konn';
 import React, { useState } from 'react';
 import { z } from 'zod';
-import { initTRPC } from '../../src';
+import { trpc } from '../../src';
 import { observable } from '../../src/observable';
 
 const ee = new EventEmitter();

--- a/packages/server/test/react/useSubscription.test.tsx
+++ b/packages/server/test/react/useSubscription.test.tsx
@@ -12,7 +12,7 @@ const ee = new EventEmitter();
 
 const ctx = konn()
   .beforeEach(() => {
-    const t = trpc.create({
+    const t = trpc.options({
       errorFormatter({ shape }) {
         return {
           ...shape,

--- a/packages/server/test/react/useSubscription.test.tsx
+++ b/packages/server/test/react/useSubscription.test.tsx
@@ -12,7 +12,7 @@ const ee = new EventEmitter();
 
 const ctx = konn()
   .beforeEach(() => {
-    const t = initTRPC()({
+    const t = trpc.create({
       errorFormatter({ shape }) {
         return {
           ...shape,

--- a/packages/server/test/regression/issue-2506-headers-throwing.test.ts
+++ b/packages/server/test/regression/issue-2506-headers-throwing.test.ts
@@ -2,9 +2,8 @@ import { routerToServerAndClientNew, waitError } from '../___testHelpers';
 import { TRPCClientError, httpBatchLink, httpLink } from '@trpc/client';
 import { konn } from 'konn';
 import { z } from 'zod';
-import { trpc } from '../../src';
+import { trpc as t } from '../../src';
 
-const t = trpc.create();
 const appRouter = t.router({
   q: t.procedure.input(z.enum(['good', 'bad'])).query(({ input }) => {
     if (input === 'bad') {

--- a/packages/server/test/regression/issue-2506-headers-throwing.test.ts
+++ b/packages/server/test/regression/issue-2506-headers-throwing.test.ts
@@ -2,9 +2,9 @@ import { routerToServerAndClientNew, waitError } from '../___testHelpers';
 import { TRPCClientError, httpBatchLink, httpLink } from '@trpc/client';
 import { konn } from 'konn';
 import { z } from 'zod';
-import { initTRPC } from '../../src';
+import { trpc } from '../../src';
 
-const t = initTRPC()();
+const t = trpc.create();
 const appRouter = t.router({
   q: t.procedure.input(z.enum(['good', 'bad'])).query(({ input }) => {
     if (input === 'bad') {

--- a/packages/server/test/regression/issue-2540-undefined-mutation.test.ts
+++ b/packages/server/test/regression/issue-2540-undefined-mutation.test.ts
@@ -169,7 +169,7 @@ describe('no transformer', () => {
 });
 
 describe('with superjson', () => {
-  const t = initTRPC()({
+  const t = trpc.create({
     transformer: superjson,
   });
   const appRouter = t.router({

--- a/packages/server/test/regression/issue-2540-undefined-mutation.test.ts
+++ b/packages/server/test/regression/issue-2540-undefined-mutation.test.ts
@@ -3,10 +3,10 @@ import { routerToServerAndClientNew } from '../___testHelpers';
 import { httpBatchLink, httpLink } from '@trpc/client';
 import { konn } from 'konn';
 import superjson from 'superjson';
-import { initTRPC } from '../../src';
+import { trpc } from '../../src';
 
 describe('no transformer', () => {
-  const t = initTRPC()();
+  const t = trpc.create();
   const appRouter = t.router({
     goodQuery: t.procedure.query(async () => {
       return 'good' as const;

--- a/packages/server/test/regression/issue-2540-undefined-mutation.test.ts
+++ b/packages/server/test/regression/issue-2540-undefined-mutation.test.ts
@@ -6,7 +6,7 @@ import superjson from 'superjson';
 import { trpc } from '../../src';
 
 describe('no transformer', () => {
-  const t = trpc.create();
+  const t = trpc;
   const appRouter = t.router({
     goodQuery: t.procedure.query(async () => {
       return 'good' as const;
@@ -169,7 +169,7 @@ describe('no transformer', () => {
 });
 
 describe('with superjson', () => {
-  const t = trpc.create({
+  const t = trpc.options({
     transformer: superjson,
   });
   const appRouter = t.router({

--- a/packages/server/test/smoke.test.ts
+++ b/packages/server/test/smoke.test.ts
@@ -4,24 +4,24 @@ import { TRPCClientError, wsLink } from '@trpc/client';
 import { EventEmitter } from 'events';
 import { expectTypeOf } from 'expect-type';
 import { z } from 'zod';
-import { inferProcedureParams, initTRPC } from '../src';
+import { inferProcedureParams, trpc } from '../src';
 import { Unsubscribable, observable } from '../src/observable';
 
-const t = initTRPC<{
-  ctx: {
+const t = trpc
+  .context<{
     foo?: 'bar';
-  };
-}>()({
-  errorFormatter({ shape }) {
-    return {
-      ...shape,
-      data: {
-        ...shape.data,
-        foo: 'bar' as const,
-      },
-    };
-  },
-});
+  }>()
+  .create({
+    errorFormatter({ shape }) {
+      return {
+        ...shape,
+        data: {
+          ...shape.data,
+          foo: 'bar' as const,
+        },
+      };
+    },
+  });
 const { procedure } = t;
 
 test('old client - happy path w/o input', async () => {

--- a/packages/server/test/smoke.test.ts
+++ b/packages/server/test/smoke.test.ts
@@ -11,7 +11,7 @@ const t = trpc
   .context<{
     foo?: 'bar';
   }>()
-  .create({
+  .options({
     errorFormatter({ shape }) {
       return {
         ...shape,

--- a/scripts/generateBigBoi.ts
+++ b/scripts/generateBigBoi.ts
@@ -71,7 +71,7 @@ for (let i = 0; i < NUM_PROCEDURE_OBJECTS; i++) {
 const trpcFile = `
 import { trpc } from '../../../src';
 
-export const t = trpc.create();
+export const t = trpc;
 `.trim();
 const indexFile = `
 import { t } from './_trpc';

--- a/scripts/generateBigBoi.ts
+++ b/scripts/generateBigBoi.ts
@@ -69,9 +69,9 @@ for (let i = 0; i < NUM_PROCEDURE_OBJECTS; i++) {
 }
 
 const trpcFile = `
-import { initTRPC } from '../../../src';
+import { trpc } from '../../../src';
 
-export const t = initTRPC()();
+export const t = trpc.create();
 `.trim();
 const indexFile = `
 import { t } from './_trpc';

--- a/www/docs/further/subscriptions.md
+++ b/www/docs/further/subscriptions.md
@@ -21,15 +21,13 @@ Subscriptions & WebSockets are in beta & might change without a major version bu
 ### Adding a subscription procedure
 
 ```tsx title='server/router.ts'
-import { trpc } from '@trpc/server';
+import { trpc as t } from '@trpc/server';
 import { observable } from '@trpc/server/observable';
 import { EventEmitter } from 'events';
 import { z } from 'zod';
 
 // create a global event emitter (could be replaced by redis, etc)
 const ee = new EventEmitter();
-
-const t = trpc.create();
 
 export const appRouter = t.router({
   onAdd: t.procedure.subscription(() => {

--- a/www/docs/further/subscriptions.md
+++ b/www/docs/further/subscriptions.md
@@ -21,7 +21,7 @@ Subscriptions & WebSockets are in beta & might change without a major version bu
 ### Adding a subscription procedure
 
 ```tsx title='server/router.ts'
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import { observable } from '@trpc/server/observable';
 import { EventEmitter } from 'events';
 import { z } from 'zod';
@@ -29,7 +29,7 @@ import { z } from 'zod';
 // create a global event emitter (could be replaced by redis, etc)
 const ee = new EventEmitter();
 
-const t = initTRPC()();
+const t = trpc.create();
 
 export const appRouter = t.router({
   onAdd: t.procedure.subscription(() => {

--- a/www/docs/main/quickstart.mdx
+++ b/www/docs/main/quickstart.mdx
@@ -19,10 +19,10 @@ We highly encourage you to check out [the Example Apps](example-apps.md) to get 
 // @module: esnext
 
 // @filename: server.ts
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import { z } from 'zod';
 
-const t = initTRPC()();
+const t = trpc.create();
 
 interface User {
   id: string;
@@ -122,9 +122,9 @@ userCreate(data: {name:string}) => { id: string; name: string; }
 First we define a router somewhere in our server codebase:
 
 ```ts twoslash title='server.ts'
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 
-const t = initTRPC()();
+const t = trpc.create();
 
 const appRouter = t.router({});
 
@@ -145,10 +145,10 @@ The following would create a query procedure called `userById` that takes a sing
 
 ```ts twoslash title='server.ts'
 // @filename: server.ts
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import { z } from 'zod';
 
-const t = initTRPC()();
+const t = trpc.create();
 
 interface User {
   id: string;

--- a/www/docs/main/quickstart.mdx
+++ b/www/docs/main/quickstart.mdx
@@ -19,10 +19,8 @@ We highly encourage you to check out [the Example Apps](example-apps.md) to get 
 // @module: esnext
 
 // @filename: server.ts
-import { trpc } from '@trpc/server';
+import { trpc as t } from '@trpc/server';
 import { z } from 'zod';
-
-const t = trpc.create();
 
 interface User {
   id: string;
@@ -122,9 +120,7 @@ userCreate(data: {name:string}) => { id: string; name: string; }
 First we define a router somewhere in our server codebase:
 
 ```ts twoslash title='server.ts'
-import { trpc } from '@trpc/server';
-
-const t = trpc.create();
+import { trpc as t } from '@trpc/server';
 
 const appRouter = t.router({});
 
@@ -145,10 +141,8 @@ The following would create a query procedure called `userById` that takes a sing
 
 ```ts twoslash title='server.ts'
 // @filename: server.ts
-import { trpc } from '@trpc/server';
+import { trpc as t } from '@trpc/server';
 import { z } from 'zod';
-
-const t = trpc.create();
 
 interface User {
   id: string;

--- a/www/docs/migration/migrate-from-v9-to-v10.mdx
+++ b/www/docs/migration/migrate-from-v9-to-v10.mdx
@@ -27,10 +27,7 @@ The way you initialize tRPC on the server has been update, we now create a root 
 The way the `t` variable is defined is simply like this:
 
 ```ts title='/src/server/trpc.ts'
-import { trpc } from '@trpc/server';
-
-// Beware of the double `()()`
-export const t = trpc.create();
+import { trpc as t } from '@trpc/server';
 ```
 
 Here's a full example of how the `t` variable may look like with a data-transformer, openapi metadata and error formatter:
@@ -55,7 +52,7 @@ interface Meta {
   };
 }
 
-export const t = trpc.context<Context>().meta<Meta>().create({
+export const t = trpc.context<Context>().meta<Meta>().options({
   errorFormatter({ shape, error }) {
     return {
       ...shape,
@@ -191,7 +188,7 @@ When you've done this, you can start migrating to the new way of doing things.
 import superjson from 'superjson';
 import { Context } from './context';
 
-export const t = trpc.context<Context>().create({
+export const t = trpc.context<Context>().options({
   // Optional:
   transformer: superjson,
   // Optional:

--- a/www/docs/migration/migrate-from-v9-to-v10.mdx
+++ b/www/docs/migration/migrate-from-v9-to-v10.mdx
@@ -27,16 +27,16 @@ The way you initialize tRPC on the server has been update, we now create a root 
 The way the `t` variable is defined is simply like this:
 
 ```ts title='/src/server/trpc.ts'
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 
 // Beware of the double `()()`
-export const t = initTRPC()();
+export const t = trpc.create();
 ```
 
 Here's a full example of how the `t` variable may look like with a data-transformer, openapi metadata and error formatter:
 
 ```ts title='/src/server/trpc.ts'
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import superjson from 'superjson';
 
 // This is usually inferred
@@ -55,10 +55,7 @@ interface Meta {
   };
 }
 
-export const t = initTRPC<{
-  ctx: Context;
-  meta: Meta;
-}>()({
+export const t = trpc.context<Context>().meta<Meta>().create({
   errorFormatter({ shape, error }) {
     return {
       ...shape,
@@ -194,9 +191,7 @@ When you've done this, you can start migrating to the new way of doing things.
 import superjson from 'superjson';
 import { Context } from './context';
 
-export const t = initTRPC<{
-  ctx: Context;
-}>()({
+export const t = trpc.context<Context>().create({
   // Optional:
   transformer: superjson,
   // Optional:

--- a/www/docs/nextjs/introduction.md
+++ b/www/docs/nextjs/introduction.md
@@ -93,11 +93,9 @@ Implement your tRPC router in `./pages/api/trpc/[trpc].ts`. If you need to split
 <details><summary>View sample router</summary>
 
 ```ts title='./pages/api/trpc/[trpc].ts'
-import { trpc } from '@trpc/server';
+import { trpc as t } from '@trpc/server';
 import * as trpcNext from '@trpc/server/adapters/next';
 import { z } from 'zod';
-
-export const t = trpc.create();
 
 export const appRouter = t.router({
   hello: t.procedure

--- a/www/docs/nextjs/introduction.md
+++ b/www/docs/nextjs/introduction.md
@@ -93,11 +93,11 @@ Implement your tRPC router in `./pages/api/trpc/[trpc].ts`. If you need to split
 <details><summary>View sample router</summary>
 
 ```ts title='./pages/api/trpc/[trpc].ts'
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import * as trpcNext from '@trpc/server/adapters/next';
 import { z } from 'zod';
 
-export const t = initTRPC()();
+export const t = trpc.create();
 
 export const appRouter = t.router({
   hello: t.procedure

--- a/www/docs/reactjs/useInfiniteQuery.md
+++ b/www/docs/reactjs/useInfiniteQuery.md
@@ -16,10 +16,8 @@ slug: /useInfiniteQuery
 ## Example Procedure
 
 ```tsx title='server/routers/_app.ts'
-import { trpc } from '@trpc/server'
+import { trpc as t } from '@trpc/server'
 import { Context } from './[trpc]';
-
-export const t = trpc.create()
 
 export const appRouter = t.router({
   infinitePosts: t

--- a/www/docs/reactjs/useInfiniteQuery.md
+++ b/www/docs/reactjs/useInfiniteQuery.md
@@ -16,10 +16,10 @@ slug: /useInfiniteQuery
 ## Example Procedure
 
 ```tsx title='server/routers/_app.ts'
-import { initTRPC } from '@trpc/server'
+import { trpc } from '@trpc/server'
 import { Context } from './[trpc]';
 
-export const t = initTRPC()()
+export const t = trpc.create()
 
 export const appRouter = t.router({
   infinitePosts: t

--- a/www/docs/reactjs/useMutation.md
+++ b/www/docs/reactjs/useMutation.md
@@ -14,10 +14,8 @@ Works like react-query's mutations - [see their docs](https://react-query.tansta
 <details><summary>Backend code</summary>
 
 ```tsx title='server/routers/_app.ts'
-import { trpc } from '@trpc/server'
+import { trpc as t } from '@trpc/server'
 import { z } from 'zod';
-
-export const t = trpc.create()
 
 export const appRouter = t.router({
   // Create procedure at path 'login'

--- a/www/docs/reactjs/useMutation.md
+++ b/www/docs/reactjs/useMutation.md
@@ -14,10 +14,10 @@ Works like react-query's mutations - [see their docs](https://react-query.tansta
 <details><summary>Backend code</summary>
 
 ```tsx title='server/routers/_app.ts'
-import { initTRPC } from '@trpc/server'
+import { trpc } from '@trpc/server'
 import { z } from 'zod';
 
-export const t = initTRPC()()
+export const t = trpc.create()
 
 export const appRouter = t.router({
   // Create procedure at path 'login'

--- a/www/docs/reactjs/useQuery.md
+++ b/www/docs/reactjs/useQuery.md
@@ -23,10 +23,10 @@ You'll notice that you get autocompletion on the `path` and automatic typesafety
 <details><summary>Backend code</summary>
 
 ```tsx title='server/routers/_app.ts'
-import { initTRPC } from '@trpc/server'
+import { trpc } from '@trpc/server'
 import { z } from 'zod';
 
-export const t = initTRPC()()
+export const t = trpc.create()
 
 export const appRouter = t.router({
   // Create procedure at path 'hello'

--- a/www/docs/reactjs/useQuery.md
+++ b/www/docs/reactjs/useQuery.md
@@ -23,10 +23,8 @@ You'll notice that you get autocompletion on the `path` and automatic typesafety
 <details><summary>Backend code</summary>
 
 ```tsx title='server/routers/_app.ts'
-import { trpc } from '@trpc/server'
+import { trpc as t } from '@trpc/server'
 import { z } from 'zod';
-
-export const t = trpc.create()
 
 export const appRouter = t.router({
   // Create procedure at path 'hello'

--- a/www/docs/server/authorization.md
+++ b/www/docs/server/authorization.md
@@ -44,10 +44,10 @@ type Context = inferAsyncReturnType<typeof createContext>;
 ## Option 1: Authorize using resolver
 
 ```ts title='server/routers/_app.ts'
-import { TRPCError, initTRPC } from '@trpc/server';
+import { TRPCError, trpc } from '@trpc/server';
 import { Context } from '../context';
 
-export const t = initTRPC<{ ctx: Context }>()();
+export const t = trpc.context<Context>.create();
 
 const appRouter = t.router({
   // open for anyone
@@ -69,7 +69,7 @@ const appRouter = t.router({
 ## Option 2: Authorize using middleware
 
 ```ts title='server/routers/_app.ts'
-import { TRPCError, initTRPC } from '@trpc/server';
+import { TRPCError, trpc } from '@trpc/server';
 
 const isAuthed = t.middleware(({ next, ctx }) => {
   if (!params.ctx.user?.isAdmin) {
@@ -82,7 +82,7 @@ const isAuthed = t.middleware(({ next, ctx }) => {
   });
 });
 
-export const t = initTRPC<{ ctx: Context }>()();
+export const t = trpc.context<Context>.create();
 
 // you can reuse this for any procedure
 const protectedProcedure = t.procedure.use(isAuthed);

--- a/www/docs/server/authorization.md
+++ b/www/docs/server/authorization.md
@@ -44,10 +44,8 @@ type Context = inferAsyncReturnType<typeof createContext>;
 ## Option 1: Authorize using resolver
 
 ```ts title='server/routers/_app.ts'
-import { TRPCError, trpc } from '@trpc/server';
+import { TRPCError, trpc as t } from '@trpc/server';
 import { Context } from '../context';
-
-export const t = trpc.context<Context>.create();
 
 const appRouter = t.router({
   // open for anyone
@@ -82,7 +80,7 @@ const isAuthed = t.middleware(({ next, ctx }) => {
   });
 });
 
-export const t = trpc.context<Context>.create();
+export const t = trpc.context<Context>();
 
 // you can reuse this for any procedure
 const protectedProcedure = t.procedure.use(isAuthed);

--- a/www/docs/server/aws-lambda.md
+++ b/www/docs/server/aws-lambda.md
@@ -46,10 +46,10 @@ yarn add @trpc/server
 Implement your tRPC router. A sample router is given below:
 
 ```ts title='server.ts'
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import { z } from 'zod';
 
-export const t = initTRPC()();
+export const t = trpc.create();
 
 const appRouter = t.router({
   getUser: t.procedure.input(z.string()).query((req) => {

--- a/www/docs/server/aws-lambda.md
+++ b/www/docs/server/aws-lambda.md
@@ -46,10 +46,8 @@ yarn add @trpc/server
 Implement your tRPC router. A sample router is given below:
 
 ```ts title='server.ts'
-import { trpc } from '@trpc/server';
+import { trpc as t } from '@trpc/server';
 import { z } from 'zod';
-
-export const t = trpc.create();
 
 const appRouter = t.router({
   getUser: t.procedure.input(z.string()).query((req) => {

--- a/www/docs/server/caching.md
+++ b/www/docs/server/caching.md
@@ -86,7 +86,7 @@ export const createContext = async ({
 
 type Context = inferAsyncReturnType<typeof createContext>;
 
-export const t = trpc.context<Context>.create();
+export const t = trpc.context<Context>();
 
 const waitFor = async (ms: number) =>
   new Promise((resolve) => setTimeout(resolve, ms));

--- a/www/docs/server/caching.md
+++ b/www/docs/server/caching.md
@@ -70,7 +70,7 @@ Since all queries are normal HTTP `GET`s we can use normal HTTP headers to cache
 > Assuming you're deploying your API somewhere that can handle stale-while-revalidate cache headers like Vercel.
 
 ```tsx title='server.ts'
-import { inferAsyncReturnType, initTRPC } from '@trpc/server';
+import { inferAsyncReturnType, trpc } from '@trpc/server';
 import * as trpcNext from '@trpc/server/adapters/next';
 
 export const createContext = async ({
@@ -86,7 +86,7 @@ export const createContext = async ({
 
 type Context = inferAsyncReturnType<typeof createContext>;
 
-export const t = initTRPC<{ ctx: Context }>()();
+export const t = trpc.context<Context>.create();
 
 const waitFor = async (ms: number) =>
   new Promise((resolve) => setTimeout(resolve, ms));

--- a/www/docs/server/context.md
+++ b/www/docs/server/context.md
@@ -39,5 +39,5 @@ type Context = trpc.inferAsyncReturnType<typeof createContext>;
 import { TRPCError, trpc } from '@trpc/server';
 import { Context } from '../context';
 
-export const t = trpc.context<Context>.create();
+export const t = trpc.context<Context>();
 ```

--- a/www/docs/server/context.md
+++ b/www/docs/server/context.md
@@ -36,8 +36,8 @@ type Context = trpc.inferAsyncReturnType<typeof createContext>;
 ```
 
 ```ts title='server/routers/_app.ts'
-import { TRPCError, initTRPC } from '@trpc/server';
+import { TRPCError, trpc } from '@trpc/server';
 import { Context } from '../context';
 
-export const t = initTRPC<{ ctx: Context }>()();
+export const t = trpc.context<Context>.create();
 ```

--- a/www/docs/server/data-transformers.md
+++ b/www/docs/server/data-transformers.md
@@ -19,13 +19,13 @@ SuperJSON allows us to transparently use e.g. standard `Date`/`Map`/`Set`s over 
 yarn add superjson
 ```
 
-#### 2. Add to your `initTRPC`
+#### 2. Add to your `trpc`
 
 ```ts title='routers/router/_app.ts'
 import { trpc } from '@trpc/server';
 import superjson from 'superjson';
 
-export const t = initTRPC()({
+export const t = trpc.create({
   transformer: superjson,
 });
 ```
@@ -97,7 +97,7 @@ export const transformer = {
 import { trpc } from '@trpc/server';
 import { transformer } from '../../utils/trpc';
 
-export const t = initTRPC()({
+export const t = trpc.create({
   transformer,
 });
 

--- a/www/docs/server/data-transformers.md
+++ b/www/docs/server/data-transformers.md
@@ -25,7 +25,7 @@ yarn add superjson
 import { trpc } from '@trpc/server';
 import superjson from 'superjson';
 
-export const t = trpc.create({
+export const t = trpc.options({
   transformer: superjson,
 });
 ```
@@ -97,7 +97,7 @@ export const transformer = {
 import { trpc } from '@trpc/server';
 import { transformer } from '../../utils/trpc';
 
-export const t = trpc.create({
+export const t = trpc.options({
   transformer,
 });
 

--- a/www/docs/server/data-transformers.md
+++ b/www/docs/server/data-transformers.md
@@ -22,7 +22,7 @@ yarn add superjson
 #### 2. Add to your `initTRPC`
 
 ```ts title='routers/router/_app.ts'
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import superjson from 'superjson';
 
 export const t = initTRPC()({
@@ -94,7 +94,7 @@ export const transformer = {
 #### 3. Add to your `AppRouter`
 
 ```ts title='server/routers/_app.ts'
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import { transformer } from '../../utils/trpc';
 
 export const t = initTRPC()({

--- a/www/docs/server/error-formatting.md
+++ b/www/docs/server/error-formatting.md
@@ -12,9 +12,9 @@ The error formatting in your router will be inferred all the way to your client 
 ### Adding custom formatting
 
 ```ts title='server.ts'
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 
-export const t = initTRPC<{ ctx: Context }>()({
+export const t = trpc.context<Context>().create({
   errorFormatter({ shape, error }) {
     return {
       ...shape,

--- a/www/docs/server/error-formatting.md
+++ b/www/docs/server/error-formatting.md
@@ -14,7 +14,7 @@ The error formatting in your router will be inferred all the way to your client 
 ```ts title='server.ts'
 import { trpc } from '@trpc/server';
 
-export const t = trpc.context<Context>().create({
+export const t = trpc.context<Context>().options({
   errorFormatter({ shape, error }) {
     return {
       ...shape,

--- a/www/docs/server/error-handling.md
+++ b/www/docs/server/error-handling.md
@@ -52,9 +52,7 @@ tRPC provides an error subclass, `TRPCError`, which you can use to represent an 
 For example, throwing this error:
 
 ```ts title='server.ts'
-import { trpc } from '@trpc/server';
-
-const t = trpc.create();
+import { trpc as t } from '@trpc/server';
 
 const appRouter = trpc.router({
   hello: t.procedure.query(() => {

--- a/www/docs/server/error-handling.md
+++ b/www/docs/server/error-handling.md
@@ -52,9 +52,9 @@ tRPC provides an error subclass, `TRPCError`, which you can use to represent an 
 For example, throwing this error:
 
 ```ts title='server.ts'
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 
-const t = initTRPC()();
+const t = trpc.create();
 
 const appRouter = trpc.router({
   hello: t.procedure.query(() => {

--- a/www/docs/server/express.md
+++ b/www/docs/server/express.md
@@ -44,10 +44,8 @@ yarn add @trpc/server zod
 Implement your tRPC router. A sample router is given below:
 
 ```ts title='server.ts'
-import { trpc } from '@trpc/server';
+import { trpc as t } from '@trpc/server';
 import { z } from 'zod';
-
-export const t = trpc.create();
 
 export const appRouter = t.router({
   getUser: t.procedure.input(z.string()).query((req) => {
@@ -85,7 +83,7 @@ const createContext = ({
 }: trpcExpress.CreateExpressContextOptions) => ({}); // no context
 type Context = inferAsyncReturnType<typeof createContext>;
 
-const t = trpc.context<Context>.create();
+const t = trpc.context<Context>();
 const appRouter = t.router({
   // [...]
 });

--- a/www/docs/server/express.md
+++ b/www/docs/server/express.md
@@ -44,10 +44,10 @@ yarn add @trpc/server zod
 Implement your tRPC router. A sample router is given below:
 
 ```ts title='server.ts'
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import { z } from 'zod';
 
-export const t = initTRPC()();
+export const t = trpc.create();
 
 export const appRouter = t.router({
   getUser: t.procedure.input(z.string()).query((req) => {
@@ -75,7 +75,7 @@ If your router file starts getting too big, split your router into several subro
 tRPC includes an adapter for Express out of the box. This adapter lets you convert your tRPC router into an Express middleware.
 
 ```ts title='server.ts'
-import { inferAsyncReturnType, initTRPC } from '@trpc/server';
+import { inferAsyncReturnType, trpc } from '@trpc/server';
 import * as trpcExpress from '@trpc/server/adapters/express';
 
 // created for each request
@@ -85,7 +85,7 @@ const createContext = ({
 }: trpcExpress.CreateExpressContextOptions) => ({}); // no context
 type Context = inferAsyncReturnType<typeof createContext>;
 
-const t = initTRPC<{ ctx: Context }>()();
+const t = trpc.context<Context>.create();
 const appRouter = t.router({
   // [...]
 });

--- a/www/docs/server/fastify.md
+++ b/www/docs/server/fastify.md
@@ -54,7 +54,7 @@ A sample router is given below, save it in a file named `router.ts`.
   <summary>router.ts</summary>
 
 ```ts title='router.ts'
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import { z } from 'zod';
 
 type User = {
@@ -65,7 +65,7 @@ type User = {
 
 const users: Record<string, User> = {};
 
-export const t = initTRPC()();
+export const t = trpc.create();
 
 export const appRouter = t.router({
   getUserById: t.procedure.input(z.string()).query(({ input }) => {
@@ -181,10 +181,10 @@ Work in progress: https://github.com/trpc/trpc/issues/2114
 Edit the `router.ts` file created in the previous steps and add the following code:
 
 ```ts title='router.ts'
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import { observable } from '@trpc/server/observable';
 
-const t = initTRPC()();
+const t = trpc.create();
 
 export const appRouter = t.router({
   randomNumber: t.procedure.subscription(() => {

--- a/www/docs/server/fastify.md
+++ b/www/docs/server/fastify.md
@@ -54,7 +54,7 @@ A sample router is given below, save it in a file named `router.ts`.
   <summary>router.ts</summary>
 
 ```ts title='router.ts'
-import { trpc } from '@trpc/server';
+import { trpc as t } from '@trpc/server';
 import { z } from 'zod';
 
 type User = {
@@ -64,8 +64,6 @@ type User = {
 };
 
 const users: Record<string, User> = {};
-
-export const t = trpc.create();
 
 export const appRouter = t.router({
   getUserById: t.procedure.input(z.string()).query(({ input }) => {
@@ -181,10 +179,8 @@ Work in progress: https://github.com/trpc/trpc/issues/2114
 Edit the `router.ts` file created in the previous steps and add the following code:
 
 ```ts title='router.ts'
-import { trpc } from '@trpc/server';
+import { trpc as t } from '@trpc/server';
 import { observable } from '@trpc/server/observable';
-
-const t = trpc.create();
 
 export const appRouter = t.router({
   randomNumber: t.procedure.subscription(() => {

--- a/www/docs/server/fetch.md
+++ b/www/docs/server/fetch.md
@@ -63,7 +63,7 @@ type User = {
 
 const users: Record<string, User> = {};
 
-export const t = trpc.context<Context>.create();
+export const t = trpc.context<Context>();
 
 export const appRouter = t.router({
   getUserById: t.procedure.input(z.string()).query(({ input }) => {

--- a/www/docs/server/fetch.md
+++ b/www/docs/server/fetch.md
@@ -51,7 +51,7 @@ A sample router is given below, save it in a file named `router.ts`.
   <summary>router.ts</summary>
 
 ```ts title='router.ts'
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import { z } from 'zod';
 import { Context } from './context';
 
@@ -63,7 +63,7 @@ type User = {
 
 const users: Record<string, User> = {};
 
-export const t = initTRPC<{ ctx: Context }>()();
+export const t = trpc.context<Context>.create();
 
 export const appRouter = t.router({
   getUserById: t.procedure.input(z.string()).query(({ input }) => {

--- a/www/docs/server/merging-routers.md
+++ b/www/docs/server/merging-routers.md
@@ -17,9 +17,7 @@ Thanks to TypeScript 4.1 template literal types we can also prefix the procedure
 ## Example code
 
 ```ts title='server.ts'
-import { trpc } from '@trpc/server';
-
-export const t = trpc.create();
+import { trpc as t } from '@trpc/server';
 
 const postRouter = t.router({
   create: t.procedure

--- a/www/docs/server/merging-routers.md
+++ b/www/docs/server/merging-routers.md
@@ -17,9 +17,9 @@ Thanks to TypeScript 4.1 template literal types we can also prefix the procedure
 ## Example code
 
 ```ts title='server.ts'
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 
-export const t = initTRPC()();
+export const t = trpc.create();
 
 const postRouter = t.router({
   create: t.procedure

--- a/www/docs/server/metadata.md
+++ b/www/docs/server/metadata.md
@@ -10,7 +10,7 @@ Procedure metadata allows you to add an optional procedure specific `meta` prope
 ## Create router with typed metadata
 
 ```tsx
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 
 // [...]
 
@@ -18,7 +18,7 @@ interface Meta {
   hasAuth: boolean;
 }
 
-export const t = initTRPC<{ ctx: Context; meta: Meta }>()();
+export const t = trpc.context<Context; meta: Meta>.create();
 
 export const appRouter = t.router({
   // [...]
@@ -28,7 +28,7 @@ export const appRouter = t.router({
 ## Example with per route authentication settings
 
 ```tsx title='server.ts'
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 
 // [...]
 
@@ -36,7 +36,7 @@ interface Meta {
   hasAuth: boolean;
 }
 
-export const t = initTRPC<{ ctx: Context; meta: Meta }>()();
+export const t = trpc.context<Context; meta: Meta>.create();
 
 const isAuthed = t.middleware(async ({ meta, next, ctx }) => {
   // only check authorization if enabled

--- a/www/docs/server/metadata.md
+++ b/www/docs/server/metadata.md
@@ -18,7 +18,7 @@ interface Meta {
   hasAuth: boolean;
 }
 
-export const t = trpc.context<Context; meta: Meta>.create();
+export const t = trpc.context<Context>().meta<Meta>();
 
 export const appRouter = t.router({
   // [...]
@@ -36,7 +36,7 @@ interface Meta {
   hasAuth: boolean;
 }
 
-export const t = trpc.context<Context; meta: Meta>.create();
+export const t = trpc.context<Context>().meta<Meta>();
 
 const isAuthed = t.middleware(async ({ meta, next, ctx }) => {
   // only check authorization if enabled

--- a/www/docs/server/middlewares.md
+++ b/www/docs/server/middlewares.md
@@ -22,7 +22,7 @@ interface Context {
   };
 }
 
-export const t = trpc.context<Context>.create();
+export const t = trpc.context<Context>();
 
 const isAdmin = t.middleware(async ({ ctx, next }) => {
   if (!ctx.user?.isAdmin) {
@@ -58,7 +58,7 @@ In the example below timings for queries are logged automatically.
 ```ts
 import { trpc } from '@trpc/server';
 
-export const t = trpc.context<Context>.create();
+export const t = trpc.context<Context>();
 
 const logger = t.middleware(async ({ path, type, next }) => {
   const start = Date.now();
@@ -93,7 +93,7 @@ interface Context {
   };
 }
 
-export const t = trpc.context<Context>.create();
+export const t = trpc.context<Context>();
 
 const isAuthed = t.middleware(({ ctx, next }) => {
   if (!ctx.user) {
@@ -123,9 +123,7 @@ The `rawInput` passed to a middleware has not yet been validated by a procedure'
 :::
 
 ```ts
-import { trpc } from '@trpc/server';
-
-export const t = trpc.create();
+import { trpc as t } from '@trpc/server';
 
 const inputSchema = z.object({ userId: z.string() });
 

--- a/www/docs/server/middlewares.md
+++ b/www/docs/server/middlewares.md
@@ -12,7 +12,7 @@ You are able to add middleware(s) to a procedure with the `t.procedure.use()` me
 In the example below any call to a `protectedProcedure` will ensure that the user is an "admin" before executing.
 
 ```ts
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 
 interface Context {
   user?: {
@@ -22,7 +22,7 @@ interface Context {
   };
 }
 
-export const t = initTRPC<{ ctx: Context }>()();
+export const t = trpc.context<Context>.create();
 
 const isAdmin = t.middleware(async ({ ctx, next }) => {
   if (!ctx.user?.isAdmin) {
@@ -56,9 +56,9 @@ See [Error Handling](error-handling.md) to learn more about the `TRPCError` thro
 In the example below timings for queries are logged automatically.
 
 ```ts
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 
-export const t = initTRPC<{ ctx: Context }>()();
+export const t = trpc.context<Context>.create();
 
 const logger = t.middleware(async ({ path, type, next }) => {
   const start = Date.now();
@@ -84,7 +84,7 @@ export const appRouter = t.router({
 A middleware can change properties of the context, and procedures will receive the new context value:
 
 ```ts
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 
 interface Context {
   // user is nullable
@@ -93,7 +93,7 @@ interface Context {
   };
 }
 
-export const t = initTRPC<{ ctx: Context }>()();
+export const t = trpc.context<Context>.create();
 
 const isAuthed = t.middleware(({ ctx, next }) => {
   if (!ctx.user) {
@@ -123,9 +123,9 @@ The `rawInput` passed to a middleware has not yet been validated by a procedure'
 :::
 
 ```ts
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 
-export const t = initTRPC()();
+export const t = trpc.create();
 
 const inputSchema = z.object({ userId: z.string() });
 

--- a/www/docs/server/output-validation.md
+++ b/www/docs/server/output-validation.md
@@ -25,10 +25,10 @@ tRPC works out-of-the-box with yup/superstruct/zod/myzod/custom validators/[..] 
 ### With [Zod](https://github.com/colinhacks/zod)
 
 ```tsx
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import { z } from 'zod';
 
-export const t = initTRPC()();
+export const t = trpc.create();
 
 export const appRouter = t.router({
   hello: t.procedure
@@ -51,10 +51,10 @@ export type AppRouter = typeof appRouter;
 ### With [Yup](https://github.com/jquense/yup)
 
 ```tsx
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import * as yup from 'yup';
 
-export const t = initTRPC()();
+export const t = trpc.create();
 
 export const appRouter = t.router({
   hello: t.procedure
@@ -76,10 +76,10 @@ export type AppRouter = typeof appRouter;
 ### With [Superstruct](https://github.com/ianstormtaylor/superstruct)
 
 ```tsx
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import { object, string } from 'superstruct';
 
-export const t = initTRPC()();
+export const t = trpc.create();
 
 export const appRouter = t.router({
   hello: t.procedure
@@ -98,9 +98,9 @@ export type AppRouter = typeof appRouter;
 ### With custom validator
 
 ```tsx
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 
-export const t = initTRPC()();
+export const t = trpc.create();
 
 export const appRouter = t.router({
   hello: t.procedure

--- a/www/docs/server/output-validation.md
+++ b/www/docs/server/output-validation.md
@@ -25,10 +25,8 @@ tRPC works out-of-the-box with yup/superstruct/zod/myzod/custom validators/[..] 
 ### With [Zod](https://github.com/colinhacks/zod)
 
 ```tsx
-import { trpc } from '@trpc/server';
+import { trpc as t } from '@trpc/server';
 import { z } from 'zod';
-
-export const t = trpc.create();
 
 export const appRouter = t.router({
   hello: t.procedure
@@ -51,10 +49,8 @@ export type AppRouter = typeof appRouter;
 ### With [Yup](https://github.com/jquense/yup)
 
 ```tsx
-import { trpc } from '@trpc/server';
+import { trpc as t } from '@trpc/server';
 import * as yup from 'yup';
-
-export const t = trpc.create();
 
 export const appRouter = t.router({
   hello: t.procedure
@@ -76,10 +72,8 @@ export type AppRouter = typeof appRouter;
 ### With [Superstruct](https://github.com/ianstormtaylor/superstruct)
 
 ```tsx
-import { trpc } from '@trpc/server';
+import { trpc as t } from '@trpc/server';
 import { object, string } from 'superstruct';
-
-export const t = trpc.create();
 
 export const appRouter = t.router({
   hello: t.procedure
@@ -98,9 +92,7 @@ export type AppRouter = typeof appRouter;
 ### With custom validator
 
 ```tsx
-import { trpc } from '@trpc/server';
-
-export const t = trpc.create();
+import { trpc as t } from '@trpc/server';
 
 export const appRouter = t.router({
   hello: t.procedure

--- a/www/docs/server/router.md
+++ b/www/docs/server/router.md
@@ -20,9 +20,9 @@ tRPC works out-of-the-box with yup/superstruct/zod/myzod/custom validators/[..] 
 ### Example without input
 
 ```tsx
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 
-export const t = initTRPC()();
+export const t = trpc.create();
 
 export const appRouter = t.router({
   // Create procedure at path 'hello'
@@ -37,10 +37,10 @@ export const appRouter = t.router({
 ### With [Zod](https://github.com/colinhacks/zod)
 
 ```ts twoslash
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import { z } from 'zod';
 
-export const t = initTRPC()();
+export const t = trpc.create();
 
 export const appRouter = t.router({
   hello: t.procedure
@@ -68,10 +68,10 @@ export type AppRouter = typeof appRouter;
 
 
 ```ts twoslash title='server.ts'
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import { z } from 'zod';
 
-export const t = initTRPC()();
+export const t = trpc.create();
 
 const roomProcedure = t.procedure.input(
   z.object({
@@ -97,10 +97,10 @@ export type AppRouter = typeof appRouter;
 ### With [Yup](https://github.com/jquense/yup)
 
 ```tsx
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import * as yup from 'yup';
 
-export const t = initTRPC()();
+export const t = trpc.create();
 
 export const appRouter = t.router({
   hello: t.procedure
@@ -122,10 +122,10 @@ export type AppRouter = typeof appRouter;
 ### With [Superstruct](https://github.com/ianstormtaylor/superstruct)
 
 ```tsx
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 import { defaulted, object, string } from 'superstruct';
 
-export const t = initTRPC()();
+export const t = trpc.create();
 
 export const appRouter = t.router({
   hello: t.procedure
@@ -152,9 +152,9 @@ export type AppRouter = typeof appRouter;
 To add multiple procedures, you can define them as properties on the object passed to `t.router()`.
 
 ```tsx
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 
-export const t = initTRPC()();
+export const t = trpc.create();
 
 export const appRouter = t.router({
   hello: t.procedure.query(() => {

--- a/www/docs/server/router.md
+++ b/www/docs/server/router.md
@@ -20,9 +20,7 @@ tRPC works out-of-the-box with yup/superstruct/zod/myzod/custom validators/[..] 
 ### Example without input
 
 ```tsx
-import { trpc } from '@trpc/server';
-
-export const t = trpc.create();
+import { trpc as t } from '@trpc/server';
 
 export const appRouter = t.router({
   // Create procedure at path 'hello'
@@ -37,10 +35,8 @@ export const appRouter = t.router({
 ### With [Zod](https://github.com/colinhacks/zod)
 
 ```ts twoslash
-import { trpc } from '@trpc/server';
+import { trpc as t } from '@trpc/server';
 import { z } from 'zod';
-
-export const t = trpc.create();
 
 export const appRouter = t.router({
   hello: t.procedure
@@ -68,10 +64,8 @@ export type AppRouter = typeof appRouter;
 
 
 ```ts twoslash title='server.ts'
-import { trpc } from '@trpc/server';
+import { trpc as t } from '@trpc/server';
 import { z } from 'zod';
-
-export const t = trpc.create();
 
 const roomProcedure = t.procedure.input(
   z.object({
@@ -97,10 +91,8 @@ export type AppRouter = typeof appRouter;
 ### With [Yup](https://github.com/jquense/yup)
 
 ```tsx
-import { trpc } from '@trpc/server';
+import { trpc as t } from '@trpc/server';
 import * as yup from 'yup';
-
-export const t = trpc.create();
 
 export const appRouter = t.router({
   hello: t.procedure
@@ -122,10 +114,8 @@ export type AppRouter = typeof appRouter;
 ### With [Superstruct](https://github.com/ianstormtaylor/superstruct)
 
 ```tsx
-import { trpc } from '@trpc/server';
+import { trpc as t } from '@trpc/server';
 import { defaulted, object, string } from 'superstruct';
-
-export const t = trpc.create();
 
 export const appRouter = t.router({
   hello: t.procedure
@@ -152,9 +142,7 @@ export type AppRouter = typeof appRouter;
 To add multiple procedures, you can define them as properties on the object passed to `t.router()`.
 
 ```tsx
-import { trpc } from '@trpc/server';
-
-export const t = trpc.create();
+import { trpc as t } from '@trpc/server';
 
 export const appRouter = t.router({
   hello: t.procedure.query(() => {

--- a/www/docs/server/server-side-calls.md
+++ b/www/docs/server/server-side-calls.md
@@ -17,9 +17,8 @@ Then with `router.createCaller({})` function (param of this Context) we retrieve
 We create the router with a input query and then we call the asynchronous `greeting` procedure to get the result.
 
 ```ts
-import { trpc } from '@trpc/server';
+import { trpc as t } from '@trpc/server';
 
-const t = trpc.create();
 const router = t.router({
   // Create procedure at path 'greeting'
   greeting: t.procedure
@@ -37,11 +36,10 @@ We create the router with a mutation and then we call the asynchronous `post` pr
 
 ```ts
 import { z } from 'zod';
-import { trpc } from '@trpc/server';
+import { trpc as t } from '@trpc/server';
 
 const posts = ['One', 'Two', 'Three'];
 
-const t = trpc.create();
 const router = t.router({
   post: t.router({
     delete: t.procedure.input(z.number()).mutation(({ input }) => {
@@ -70,9 +68,7 @@ Below two examples, the former fails because the context doesn't fit the middlew
 <br/>
 
 ```ts
-import { TRPCError, trpc } from '@trpc/server';
-
-const t = trpc.create();
+import { TRPCError, trpc as t } from '@trpc/server';
 
 const isAuthed = t.middleware(({ next, ctx }) => {
   if (!ctx.foo) {

--- a/www/docs/server/server-side-calls.md
+++ b/www/docs/server/server-side-calls.md
@@ -17,9 +17,9 @@ Then with `router.createCaller({})` function (param of this Context) we retrieve
 We create the router with a input query and then we call the asynchronous `greeting` procedure to get the result.
 
 ```ts
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 
-const t = initTRPC()();
+const t = trpc.create();
 const router = t.router({
   // Create procedure at path 'greeting'
   greeting: t.procedure
@@ -37,11 +37,11 @@ We create the router with a mutation and then we call the asynchronous `post` pr
 
 ```ts
 import { z } from 'zod';
-import { initTRPC } from '@trpc/server';
+import { trpc } from '@trpc/server';
 
 const posts = ['One', 'Two', 'Three'];
 
-const t = initTRPC()();
+const t = trpc.create();
 const router = t.router({
   post: t.router({
     delete: t.procedure.input(z.number()).mutation(({ input }) => {
@@ -70,9 +70,9 @@ Below two examples, the former fails because the context doesn't fit the middlew
 <br/>
 
 ```ts
-import { TRPCError, initTRPC } from '@trpc/server';
+import { TRPCError, trpc } from '@trpc/server';
 
-const t = initTRPC()();
+const t = trpc.create();
 
 const isAuthed = t.middleware(({ next, ctx }) => {
   if (!ctx.foo) {


### PR DESCRIPTION
Closes #2595

## 🎯 Changes

Core change: https://github.com/trpc/trpc/pull/2605/files#diff-5fcc784e757060a955b57c434a2c094a47e81634caafe788bc37c304ac6f8003

Going a little further than #2604. Instead of having a `TRPCBuilder` class with a `.create()` method to get a t-thing, add a `TRPC` class which has the `.router(...)`, `.procedure(...)` methods on it. It's equivalent to the return value of `initTRPC()()` but it also has `.context<...>()` and `.meta<...>()` methods, which return new `TRPC` instances with the respective `ctx`/`meta` types. In practice this means this is all you need to do to make a vanilla router:

```ts
import { trpc } from '@trpc/server'

const appRouter = trpc.router({
  greeting: trpc
    .procedure
    .input(z.string())
    .query(({ input }) => `hello ${input}!`)
})
```

Or if you need `ctx`:

```ts
import { trpc } from '@trpc/server'

const t = trpc.context<{ greeting: string }>()

const appRouter = t.router({
  greeting: t
    .procedure
    .input(z.string())
    .query(({ input, ctx }) => `${ctx.greeting} ${input}!`)
})
```

Add options:

```ts
import { trpc } from '@trpc/server'

const t = trpc.context<{ greeting: string }>().options({
  transformer: superjson,
})

const appRouter = t.router({
  greeting: t
    .procedure
    .input(z.string())
    .query(({ input, ctx }) => `${ctx.greeting} ${input}!`)
})
```

___

### Going even further?

If we want to maintain the single-letter import, maybe `trpc` could be aliased to `t`. I didn't do that in this PR, I did `import { trpc as t } from '@trpc/server'` in a few places. Might be worth doing, but might be a bit controversial, so probably better in a follow-up PR.

### Summary

Comparison with #2604:https://github.com/trpc/trpc/compare/trpc.create...trpc.nocreate

What changes are made in this PR? Is it a feature or a bug fix?

Replaces:

- `initTRPC()()` with `import { trpc } from '@trpc/server'`
- `initTRPC<{ context: Context }>()()` with `trpc.context<Context>()`
- `initTRPC<{ meta: Meta }>()()` with `trpc.meta<Meta>()`
- `initTRPC()({ transformer: ... })` with `trpc.options({ transformer })`

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.