### PR TITLE
Fix typo on next.js introduction page

### DIFF
--- a/www/docs/nextjs/introduction.md
+++ b/www/docs/nextjs/introduction.md
@@ -143,7 +143,7 @@ function getBaseUrl() {
     return `https://${process.env.VERCEL_URL}`;
 
   if (process.env.RENDER_INTERNAL_HOSTNAME) // reference for render.com
-    return `http://${process.env.RENDER_INTERNAL_HOSTNAME}:${process.env.PORT}`;
+    return `https://${process.env.RENDER_INTERNAL_HOSTNAME}:${process.env.PORT}`;
 
   // assume localhost
   return `http://localhost:${process.env.PORT ?? 3000}`;


### PR DESCRIPTION
Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?
The `getBaseUrl()` func describes "http://...RENDER_INTERNAL_HOSTNAME" and should be "https://..."

## ✅ Checklist

- [X] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.