### PR TITLE
fix: rm unused `type`

### DIFF
--- a/packages/client/src/createTRPCClientProxy.ts
+++ b/packages/client/src/createTRPCClientProxy.ts
@@ -14,7 +14,6 @@ import type {
   Unsubscribable,
   inferObservableValue,
 } from '@trpc/server/observable';
-import type { TRPCResultMessage } from '@trpc/server/rpc';
 import { createProxy } from '@trpc/server/shared';
 import { TRPCClientError } from './TRPCClientError';
 import { CreateTRPCClientOptions, createTRPCClient } from './createTRPCClient';


### PR DESCRIPTION
Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.