### PR TITLE
feat: expose `createInputMiddleware`

### DIFF
--- a/packages/server/src/core/index.ts
+++ b/packages/server/src/core/index.ts
@@ -10,6 +10,7 @@ export type {
   ProcedureArgs,
   ProcedureOptions,
 } from './procedure';
+export { createInputMiddleware } from './internals/procedureBuilder';
 
 export { initTRPC } from './initTRPC';
 export * from './types';

--- a/packages/server/src/core/index.ts
+++ b/packages/server/src/core/index.ts
@@ -10,7 +10,7 @@ export type {
   ProcedureArgs,
   ProcedureOptions,
 } from './procedure';
-export { createInputMiddleware } from './internals/procedureBuilder';
+export { createInputMiddleware, createOutputMiddleware } from './middleware';
 
 export { initTRPC } from './initTRPC';
 export * from './types';

--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -269,12 +269,12 @@ function isPlainObject(obj: unknown) {
  * @internal
  * Please note, `trpc-openapi` uses this function.
  */
-export function createInputMiddleware<T>(
-  parse: ParseFn<T>,
-): ProcedureBuilderMiddleware {
-  return async function inputMiddleware({ next, rawInput, input }) {
-    (inputMiddleware as any)._input = true;
-
+export function createInputMiddleware<T>(parse: ParseFn<T>) {
+  const inputMiddleware: ProcedureBuilderMiddleware = async ({
+    next,
+    rawInput,
+    input,
+  }) => {
     let parsedInput: ReturnType<typeof parse>;
     try {
       parsedInput = await parse(rawInput);
@@ -297,14 +297,12 @@ export function createInputMiddleware<T>(
     // TODO fix this typing?
     return next({ input: combinedInput } as any);
   };
+  inputMiddleware._type = 'input';
+  return inputMiddleware;
 }
 
-export function createOutputMiddleware<T>(
-  parse: ParseFn<T>,
-): ProcedureBuilderMiddleware {
-  return async function outputMiddleware({ next }) {
-    (outputMiddleware as any)._output = true;
-
+export function createOutputMiddleware<T>(parse: ParseFn<T>) {
+  const outputMiddleware: ProcedureBuilderMiddleware = async ({ next }) => {
     const result = await next();
     if (!result.ok) {
       // pass through failures without validating
@@ -324,6 +322,8 @@ export function createOutputMiddleware<T>(
       });
     }
   };
+  outputMiddleware._type = 'output';
+  return outputMiddleware;
 }
 
 function createResolver(

--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -265,10 +265,16 @@ function isPlainObject(obj: unknown) {
   return obj && typeof obj === 'object' && !Array.isArray(obj);
 }
 
+/**
+ * @internal
+ * Please note, `trpc-openapi` uses this function.
+ */
 export function createInputMiddleware<T>(
   parse: ParseFn<T>,
 ): ProcedureBuilderMiddleware {
   return async function inputMiddleware({ next, rawInput, input }) {
+    (inputMiddleware as any)._input = true;
+
     let parsedInput: ReturnType<typeof parse>;
     try {
       parsedInput = await parse(rawInput);
@@ -297,6 +303,8 @@ export function createOutputMiddleware<T>(
   parse: ParseFn<T>,
 ): ProcedureBuilderMiddleware {
   return async function outputMiddleware({ next }) {
+    (outputMiddleware as any)._output = true;
+
     const result = await next();
     if (!result.ok) {
       // pass through failures without validating

--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -1,10 +1,12 @@
 import { TRPCError } from '../../error/TRPCError';
-import {
-  getCauseFromUnknown,
-  getTRPCErrorFromUnknown,
-} from '../../error/utils';
+import { getTRPCErrorFromUnknown } from '../../error/utils';
 import { FlatOverwrite, MaybePromise } from '../../types';
-import { MiddlewareFunction, MiddlewareResult } from '../middleware';
+import {
+  MiddlewareFunction,
+  MiddlewareResult,
+  createInputMiddleware,
+  createOutputMiddleware,
+} from '../middleware';
 import { Parser, inferParser } from '../parser';
 import {
   MutationProcedure,
@@ -15,7 +17,7 @@ import {
 } from '../procedure';
 import { ProcedureType } from '../types';
 import { RootConfig } from './config';
-import { ParseFn, getParseFn } from './getParseFn';
+import { getParseFn } from './getParseFn';
 import { mergeWithoutOverrides } from './mergeWithoutOverrides';
 import { ResolveOptions, middlewareMarker } from './utils';
 import { DefaultValue as FallbackValue, Overwrite, UnsetMarker } from './utils';
@@ -259,71 +261,6 @@ export function createBuilder<TConfig extends RootConfig>(
       ) as SubscriptionProcedure<any>;
     },
   };
-}
-
-function isPlainObject(obj: unknown) {
-  return obj && typeof obj === 'object' && !Array.isArray(obj);
-}
-
-/**
- * @internal
- * Please note, `trpc-openapi` uses this function.
- */
-export function createInputMiddleware<T>(parse: ParseFn<T>) {
-  const inputMiddleware: ProcedureBuilderMiddleware = async ({
-    next,
-    rawInput,
-    input,
-  }) => {
-    let parsedInput: ReturnType<typeof parse>;
-    try {
-      parsedInput = await parse(rawInput);
-    } catch (cause) {
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        cause: getCauseFromUnknown(cause),
-      });
-    }
-
-    // Multiple input parsers
-    const combinedInput =
-      isPlainObject(input) && isPlainObject(parsedInput)
-        ? {
-            ...input,
-            ...parsedInput,
-          }
-        : parsedInput;
-
-    // TODO fix this typing?
-    return next({ input: combinedInput } as any);
-  };
-  inputMiddleware._type = 'input';
-  return inputMiddleware;
-}
-
-export function createOutputMiddleware<T>(parse: ParseFn<T>) {
-  const outputMiddleware: ProcedureBuilderMiddleware = async ({ next }) => {
-    const result = await next();
-    if (!result.ok) {
-      // pass through failures without validating
-      return result;
-    }
-    try {
-      const data = await parse(result.data);
-      return {
-        ...result,
-        data,
-      };
-    } catch (cause) {
-      throw new TRPCError({
-        message: 'Output validation failed',
-        code: 'INTERNAL_SERVER_ERROR',
-        cause: getCauseFromUnknown(cause),
-      });
-    }
-  };
-  outputMiddleware._type = 'output';
-  return outputMiddleware;
 }
 
 function createResolver(

--- a/packages/server/src/core/middleware.ts
+++ b/packages/server/src/core/middleware.ts
@@ -47,29 +47,32 @@ export type MiddlewareResult<TParams extends ProcedureParams> =
 export type MiddlewareFunction<
   TParams extends ProcedureParams,
   TParamsAfter extends ProcedureParams,
-> = (opts: {
-  ctx: TParams['_ctx_out'];
-  type: ProcedureType;
-  path: string;
-  input: TParams['_input_out'];
-  rawInput: unknown;
-  meta: TParams['_meta'];
-  next: {
-    (): Promise<MiddlewareResult<TParams>>;
-    <$TContext>(opts: { ctx: $TContext }): Promise<
-      MiddlewareResult<{
-        _config: any;
-        _ctx_in: TParams['_ctx_in'];
-        _ctx_out: $TContext;
-        _input_in: TParams['_input_in'];
-        _input_out: TParams['_input_out'];
-        _output_in: TParams['_output_in'];
-        _output_out: TParams['_output_out'];
-        _meta: TParams['_meta'];
-      }>
-    >;
-  };
-}) => Promise<MiddlewareResult<TParamsAfter>>;
+> = {
+  (opts: {
+    ctx: TParams['_ctx_out'];
+    type: ProcedureType;
+    path: string;
+    input: TParams['_input_out'];
+    rawInput: unknown;
+    meta: TParams['_meta'];
+    next: {
+      (): Promise<MiddlewareResult<TParams>>;
+      <$TContext>(opts: { ctx: $TContext }): Promise<
+        MiddlewareResult<{
+          _config: any;
+          _ctx_in: TParams['_ctx_in'];
+          _ctx_out: $TContext;
+          _input_in: TParams['_input_in'];
+          _input_out: TParams['_input_out'];
+          _output_in: TParams['_output_in'];
+          _output_out: TParams['_output_out'];
+          _meta: TParams['_meta'];
+        }>
+      >;
+    };
+  }): Promise<MiddlewareResult<TParamsAfter>>;
+  _type?: string | undefined;
+};
 
 /**
  * @internal

--- a/packages/server/src/deprecated/interop.ts
+++ b/packages/server/src/deprecated/interop.ts
@@ -2,11 +2,11 @@ import { CombinedDataTransformer, ProcedureParams, ProcedureType } from '..';
 import { CreateRootConfig, RootConfig } from '../core/internals/config';
 import { getParseFnOrPassThrough } from '../core/internals/getParseFn';
 import { mergeWithoutOverrides } from '../core/internals/mergeWithoutOverrides';
+import { createBuilder } from '../core/internals/procedureBuilder';
 import {
-  createBuilder,
   createInputMiddleware,
   createOutputMiddleware,
-} from '../core/internals/procedureBuilder';
+} from '../core/middleware';
 import {
   MutationProcedure,
   Procedure as NewProcedure,


### PR DESCRIPTION
Unblocks https://github.com/jlalmes/trpc-openapi/issues/73.

## 🎯 Changes

> @jlalmes - (`trpc-openapi`) I need to monkey-patch `z.void()` inputs to `z.object({})`, this was easy in v9 because I just overwrite the `parseInputFn`. However, in v10 the input parser exists inside the `middlewares` as an `ProcedureBuilderMiddleware` type, therefore my plan is the hot-swap the `inputMiddleware`.

> @KATT - happy to "tag" the middleware somehow to make it easy to detect. happy to expose the `createInputMiddleware` but it should be `@internal` and might break.

* Exposes `createInputMiddleware` (`@internal`)
* Tagged the input & output middlewares.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.