### PR TITLE
fix(docs) typo on initTRPC context call

### DIFF
--- a/www/docs/server/context.md
+++ b/www/docs/server/context.md
@@ -39,5 +39,5 @@ type Context = trpc.inferAsyncReturnType<typeof createContext>;
 import { TRPCError, initTRPC } from '@trpc/server';
 import { Context } from '../context';
 
-export const t = initTRPC.context<Context>.create();
+export const t = initTRPC.context<Context>().create();
 ```


### PR DESCRIPTION
Closes #

## 🎯 Changes

from
```
export const t = initTRPC.context<Context>.create();
```

to:
```
export const t = initTRPC.context<Context>().create();
```

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.