### PR TITLE
make react query cancellation configurable

### DIFF
--- a/packages/client/src/internals/TRPCClient.ts
+++ b/packages/client/src/internals/TRPCClient.ts
@@ -33,7 +33,7 @@ interface CreateTRPCClientBaseOptions {
    */
   fetch?: typeof fetch;
   /**
-   * add ponyfill for AbortController
+   * add polyfill for AbortController
    */
   AbortController?: typeof AbortController;
   /**

--- a/packages/next/src/withTRPC.tsx
+++ b/packages/next/src/withTRPC.tsx
@@ -95,21 +95,7 @@ export function withTRPC<
         trpc?: TRPCPrepassProps;
       },
     ) => {
-      const [
-        /**
-         * this shouldn't need to be part of prepass props? below fails though
-         *  TRPCPressProps |  {
-         *    abortOnUnmount: boolean;
-         *    queryClient: QueryClient;
-         *    trpcClient: TRPCClient<TRouter>;
-         *    ssrState: false | "mounting";
-         *    ssrContext: null;
-         *  }
-         *  */
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        { abortOnUnmount, queryClient, trpcClient, ssrState, ssrContext },
-      ] = useState(() => {
+      const [prepassProps] = useState(() => {
         if (props.trpc) {
           return props.trpc;
         }
@@ -118,7 +104,7 @@ export function withTRPC<
         const queryClient = new QueryClient(config.queryClientConfig);
         const trpcClient = trpc.createClient(config);
         return {
-          abortOnUnmount: config.abortOnUnmount ?? false,
+          abortOnUnmount: config.abortOnUnmount,
           queryClient,
           trpcClient,
           ssrState: opts.ssr ? ('mounting' as const) : (false as const),
@@ -126,6 +112,7 @@ export function withTRPC<
         };
       });
 
+      const { queryClient, trpcClient, ssrState, ssrContext } = prepassProps;
       const hydratedState = trpc.useDehydratedState(
         trpcClient,
         props.pageProps?.trpcState,
@@ -133,7 +120,7 @@ export function withTRPC<
 
       return (
         <trpc.Provider
-          abortOnUnmount={abortOnUnmount}
+          abortOnUnmount={(prepassProps as any).abortOnUnmount ?? false}
           client={trpcClient}
           queryClient={queryClient}
           ssrState={ssrState}

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import {
   DehydratedState,
-  QueryClient,
   UseInfiniteQueryOptions,
   UseInfiniteQueryResult,
   UseMutationOptions,
@@ -38,7 +37,12 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import { SSRState, TRPCContext, TRPCContextState } from './internals/context';
+import {
+  SSRState,
+  TRPCContext,
+  TRPCContextProps,
+  TRPCContextState,
+} from './internals/context';
 
 export type AssertType<T, K> = T extends K ? T : never;
 
@@ -132,13 +136,9 @@ function createHookProxy(callback: (...args: [string, ...unknown[]]) => any) {
     },
   });
 }
-export interface TRPCProviderProps<TRouter extends AnyRouter, TSSRContext> {
-  queryClient: QueryClient;
-  client: TRPCClient<TRouter>;
+export interface TRPCProviderProps<TRouter extends AnyRouter, TSSRContext>
+  extends TRPCContextProps<TRouter, TSSRContext> {
   children: ReactNode;
-  ssrContext?: TSSRContext | null;
-  ssrState?: SSRState;
-  abortOnUnmount?: boolean;
 }
 
 /**

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -169,14 +169,14 @@ export function createReactQueryHooks<
   }
 
   function TRPCProvider(props: {
-    abortOnUnmount: boolean;
+    abortOnUnmount?: boolean;
     queryClient: QueryClient;
     client: TRPCClient<TRouter>;
     children: ReactNode;
     ssrContext?: TSSRContext | null;
     ssrState?: SSRState;
   }) {
-    const { abortOnUnmount, client, queryClient, ssrContext } = props;
+    const { abortOnUnmount = false, client, queryClient, ssrContext } = props;
     const [ssrState, setSSRState] = useState<SSRState>(props.ssrState ?? false);
     useEffect(() => {
       // Only updating state to `mounted` if we are using SSR.
@@ -186,7 +186,7 @@ export function createReactQueryHooks<
     return (
       <Context.Provider
         value={{
-          abortOnUnmount: abortOnUnmount,
+          abortOnUnmount,
           queryClient,
           client,
           ssrContext: ssrContext || null,

--- a/packages/react/src/createReactQueryHooks.tsx
+++ b/packages/react/src/createReactQueryHooks.tsx
@@ -57,7 +57,7 @@ export interface TRPCReactRequestOptions
   /**
    * Opt out or into aborting request on unmount
    */
-  cancellable?: boolean;
+  abortOnUnmount?: boolean;
 }
 
 export interface TRPCUseQueryBaseOptions {
@@ -334,15 +334,19 @@ export function createReactQueryHooks<
     }
     const ssrOpts = useSSRQueryOptionsIfNeeded(pathAndInput, opts);
     // request option should take priority over global
-    const shouldAbortOnUnmount = opts?.trpc?.cancellable ?? abortOnUnmount;
+    const shouldAbortOnUnmount = opts?.trpc?.abortOnUnmount ?? abortOnUnmount;
 
     return __useQuery(
       pathAndInput as any,
-      ({ signal }) => {
+      (queryFunctionContext) => {
         const actualOpts = {
           ...ssrOpts,
-          trpc: { ...ssrOpts?.trpc },
-          ...(shouldAbortOnUnmount ? { signal } : {}),
+          trpc: {
+            ...ssrOpts?.trpc,
+            ...(shouldAbortOnUnmount
+              ? { signal: queryFunctionContext.signal }
+              : {}),
+          },
         };
 
         return (client as any).query(

--- a/packages/react/src/internals/context.tsx
+++ b/packages/react/src/internals/context.tsx
@@ -31,24 +31,41 @@ export interface TRPCFetchInfiniteQueryOptions<TInput, TError, TOutput>
 /** @internal */
 export type SSRState = false | 'prepass' | 'mounting' | 'mounted';
 
-/** @internal */
-export interface TRPCContextState<
-  TRouter extends AnyRouter,
-  TSSRContext = undefined,
-> {
-  abortOnUnmount: boolean;
+export interface TRPCContextProps<TRouter extends AnyRouter, TSSRContext> {
+  /**
+   * The react-query `QueryClient`
+   */
   queryClient: QueryClient;
+  /**
+   * The `TRPCClient`
+   */
   client: TRPCClient<TRouter>;
-  ssrContext: TSSRContext | null;
+  /**
+   * The SSR context when server-side rendering
+   * @default null
+   */
+  ssrContext?: TSSRContext | null;
   /**
    * State of SSR hydration.
    * - `false` if not using SSR.
    * - `prepass` when doing a prepass to fetch queries' data
    * - `mounting` before TRPCProvider has been rendered on the client
    * - `mounted` when the TRPCProvider has been rendered on the client
+   * @default false
    */
-  ssrState: SSRState;
+  ssrState?: SSRState;
+  /**
+   * Abort loading query calls when unmounting a component - usually when navigating to a new page
+   * @default false
+   */
+  abortOnUnmount?: boolean;
+}
 
+/** @internal */
+export interface TRPCContextState<
+  TRouter extends AnyRouter,
+  TSSRContext = undefined,
+> extends Required<TRPCContextProps<TRouter, TSSRContext>> {
   /**
    * @link https://react-query.tanstack.com/guides/prefetching
    */

--- a/packages/react/src/internals/context.tsx
+++ b/packages/react/src/internals/context.tsx
@@ -36,6 +36,7 @@ export interface TRPCContextState<
   TRouter extends AnyRouter,
   TSSRContext = undefined,
 > {
+  abortOnUnmount: boolean;
   queryClient: QueryClient;
   client: TRPCClient<TRouter>;
   ssrContext: TSSRContext | null;


### PR DESCRIPTION
Closes https://github.com/trpc/trpc/issues/2612

Wanted to get feedback before I commit to tests / documentation

## 🎯 Changes
Adds a global option to enable cancelling requests on unmount globally(defaults to false) with the option to override per request. I struggled to find a good place to put this so please let me know if you think theres somewhere else better.

```ts
// cancel at the global level
export const trpc = setupTRPC<AppRouter, SSRContext>({
  config() {
   
    return {
     // ...
     abortOnUnmount: true,
     // ...
    };
  },
});
// cancel at the request level (overrides global config)
trpc.todos.get({ id: 1}, { trpc: { ssr: false, abortOnUnmount: false } })

```

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.