### PR TITLE
refactor(@trpc/next): rename `setupTRPC` -> `createTRPCNext`

### DIFF
--- a/.tmp/v10-docs.md
+++ b/.tmp/v10-docs.md
@@ -575,7 +575,7 @@ Simpler setup:
  * A set of strongly-typed React hooks from your `AppRouter` type signature with `createReactQueryHooks`.
  * @link https://trpc.io/docs/react#3-create-trpc-hooks
  */
-export const trpc = setupTRPC<AppRouter>({
+export const trpc = createTRPCNext<AppRouter>({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   config() {
     /**

--- a/examples/.interop/cloudflare-workers/package.json
+++ b/examples/.interop/cloudflare-workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/interop-cloudflare-workers",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "private": true,
   "type": "module",
   "scripts": {
@@ -8,8 +8,8 @@
     "test-dev": "start-server-and-test 'wrangler dev --local' 8787 'node --loader ts-node/esm src/client.ts'"
   },
   "dependencies": {
-    "@trpc/client": "^10.0.0-proxy-alpha.69",
-    "@trpc/server": "^10.0.0-proxy-alpha.69",
+    "@trpc/client": "^10.0.0-proxy-alpha.70",
+    "@trpc/server": "^10.0.0-proxy-alpha.70",
     "zod": "^3.0.0"
   },
   "devDependencies": {

--- a/examples/.interop/express-server/package.json
+++ b/examples/.interop/express-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/interop-express-server",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server",
@@ -13,9 +13,9 @@
     "test-start": "start-server-and-test 'node dist/server' 2021 'node dist/client'"
   },
   "dependencies": {
-    "@trpc/client": "^10.0.0-proxy-alpha.69",
-    "@trpc/react": "^10.0.0-proxy-alpha.69",
-    "@trpc/server": "^10.0.0-proxy-alpha.69",
+    "@trpc/client": "^10.0.0-proxy-alpha.70",
+    "@trpc/react": "^10.0.0-proxy-alpha.70",
+    "@trpc/server": "^10.0.0-proxy-alpha.70",
     "@types/node-fetch": "^2.5.11",
     "abort-controller": "^3.0.0",
     "express": "^4.17.1",

--- a/examples/.interop/fastify-server/package.json
+++ b/examples/.interop/fastify-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/interop-fastify-server",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "private": true,
   "scripts": {
     "build": "tsc",
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@fastify/websocket": "^5.0.0",
-    "@trpc/client": "^10.0.0-proxy-alpha.69",
-    "@trpc/server": "^10.0.0-proxy-alpha.69",
+    "@trpc/client": "^10.0.0-proxy-alpha.70",
+    "@trpc/server": "^10.0.0-proxy-alpha.70",
     "abort-controller": "^3.0.0",
     "fastify": "^3.27.1",
     "fastify-websocket": "^4.0.0",

--- a/examples/.interop/lambda-api-gateway/package.json
+++ b/examples/.interop/lambda-api-gateway/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@examples/interop-lambda-api-gateway",
   "private": true,
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@trpc/client": "^10.0.0-proxy-alpha.69",
-    "@trpc/server": "^10.0.0-proxy-alpha.69",
+    "@trpc/client": "^10.0.0-proxy-alpha.70",
+    "@trpc/server": "^10.0.0-proxy-alpha.70",
     "node-fetch": "^2.6.1",
     "ts-node": "^10.3.0"
   },

--- a/examples/.interop/next-minimal-starter-migration/package.json
+++ b/examples/.interop/next-minimal-starter-migration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/interop-next-minimal-migration",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -9,10 +9,10 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^4.0.10",
-    "@trpc/client": "^10.0.0-proxy-alpha.69",
-    "@trpc/next": "^10.0.0-proxy-alpha.69",
-    "@trpc/react": "^10.0.0-proxy-alpha.69",
-    "@trpc/server": "^10.0.0-proxy-alpha.69",
+    "@trpc/client": "^10.0.0-proxy-alpha.70",
+    "@trpc/next": "^10.0.0-proxy-alpha.70",
+    "@trpc/react": "^10.0.0-proxy-alpha.70",
+    "@trpc/server": "^10.0.0-proxy-alpha.70",
     "next": "latest",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/examples/.interop/next-minimal-starter/package.json
+++ b/examples/.interop/next-minimal-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/interop-next-minimal",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -9,10 +9,10 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^4.0.10",
-    "@trpc/client": "^10.0.0-proxy-alpha.69",
-    "@trpc/next": "^10.0.0-proxy-alpha.69",
-    "@trpc/react": "^10.0.0-proxy-alpha.69",
-    "@trpc/server": "^10.0.0-proxy-alpha.69",
+    "@trpc/client": "^10.0.0-proxy-alpha.70",
+    "@trpc/next": "^10.0.0-proxy-alpha.70",
+    "@trpc/react": "^10.0.0-proxy-alpha.70",
+    "@trpc/server": "^10.0.0-proxy-alpha.70",
     "next": "latest",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/examples/.interop/next-prisma-starter-websockets/package.json
+++ b/examples/.interop/next-prisma-starter-websockets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/interop-next-starter-websockets",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "private": true,
   "scripts": {
     "build:1-generate": "prisma generate",
@@ -40,10 +40,10 @@
   "dependencies": {
     "@prisma/client": "^3.0.1",
     "@tanstack/react-query": "^4.0.10",
-    "@trpc/client": "^10.0.0-proxy-alpha.69",
-    "@trpc/next": "^10.0.0-proxy-alpha.69",
-    "@trpc/react": "^10.0.0-proxy-alpha.69",
-    "@trpc/server": "^10.0.0-proxy-alpha.69",
+    "@trpc/client": "^10.0.0-proxy-alpha.70",
+    "@trpc/next": "^10.0.0-proxy-alpha.70",
+    "@trpc/react": "^10.0.0-proxy-alpha.70",
+    "@trpc/server": "^10.0.0-proxy-alpha.70",
     "clsx": "^1.1.1",
     "next": "^12.1.6",
     "next-auth": "^4.2.0",

--- a/examples/.interop/next-prisma-starter/package.json
+++ b/examples/.interop/next-prisma-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/legacy-next-starter",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "private": true,
   "scripts": {
     "build:1-migrate": "prisma migrate deploy",
@@ -34,10 +34,10 @@
   "dependencies": {
     "@prisma/client": "^3.0.1",
     "@tanstack/react-query": "^4.0.10",
-    "@trpc/client": "^10.0.0-proxy-alpha.69",
-    "@trpc/next": "^10.0.0-proxy-alpha.69",
-    "@trpc/react": "^10.0.0-proxy-alpha.69",
-    "@trpc/server": "^10.0.0-proxy-alpha.69",
+    "@trpc/client": "^10.0.0-proxy-alpha.70",
+    "@trpc/next": "^10.0.0-proxy-alpha.70",
+    "@trpc/react": "^10.0.0-proxy-alpha.70",
+    "@trpc/server": "^10.0.0-proxy-alpha.70",
     "clsx": "^1.1.1",
     "next": "^12.1.6",
     "react": "^18.1.0",

--- a/examples/.interop/next-prisma-todomvc/package.json
+++ b/examples/.interop/next-prisma-todomvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/interop-todo-web",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "private": true,
   "scripts": {
     "migrate-sqlite": "npx prisma migrate dev --name init --schema=./prisma/_sqlite/schema.prisma",
@@ -25,10 +25,10 @@
   "dependencies": {
     "@prisma/client": "^3.0.1",
     "@tanstack/react-query": "^4.0.10",
-    "@trpc/client": "^10.0.0-proxy-alpha.69",
-    "@trpc/next": "^10.0.0-proxy-alpha.69",
-    "@trpc/react": "^10.0.0-proxy-alpha.69",
-    "@trpc/server": "^10.0.0-proxy-alpha.69",
+    "@trpc/client": "^10.0.0-proxy-alpha.70",
+    "@trpc/next": "^10.0.0-proxy-alpha.70",
+    "@trpc/react": "^10.0.0-proxy-alpha.70",
+    "@trpc/server": "^10.0.0-proxy-alpha.70",
     "clsx": "^1.1.1",
     "jest": "^27.1.0",
     "jest-playwright": "^0.0.1",

--- a/examples/.interop/standalone-server/package.json
+++ b/examples/.interop/standalone-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/interop-standalone-server",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server",
@@ -12,9 +12,9 @@
     "test-start": "start-server-and-test 'node dist/server' 2022 'node dist/client'"
   },
   "dependencies": {
-    "@trpc/client": "^10.0.0-proxy-alpha.69",
-    "@trpc/react": "^10.0.0-proxy-alpha.69",
-    "@trpc/server": "^10.0.0-proxy-alpha.69",
+    "@trpc/client": "^10.0.0-proxy-alpha.70",
+    "@trpc/react": "^10.0.0-proxy-alpha.70",
+    "@trpc/server": "^10.0.0-proxy-alpha.70",
     "@types/node-fetch": "^2.5.11",
     "abort-controller": "^3.0.0",
     "node-fetch": "^2.6.1",

--- a/examples/cloudflare-workers/package.json
+++ b/examples/cloudflare-workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/cloudflare-workers",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "private": true,
   "type": "module",
   "scripts": {
@@ -8,8 +8,8 @@
     "test-dev": "start-server-and-test 'wrangler dev --local' 8787 'node --loader ts-node/esm src/client.ts'"
   },
   "dependencies": {
-    "@trpc/client": "^10.0.0-proxy-alpha.69",
-    "@trpc/server": "^10.0.0-proxy-alpha.69",
+    "@trpc/client": "^10.0.0-proxy-alpha.70",
+    "@trpc/server": "^10.0.0-proxy-alpha.70",
     "zod": "^3.0.0"
   },
   "devDependencies": {

--- a/examples/express-minimal/package.json
+++ b/examples/express-minimal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/express-minimal",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server",
@@ -13,9 +13,9 @@
     "test-start": "start-server-and-test 'node dist/server' 3000 'node dist/client'"
   },
   "dependencies": {
-    "@trpc/client": "^10.0.0-proxy-alpha.69",
-    "@trpc/react": "^10.0.0-proxy-alpha.69",
-    "@trpc/server": "^10.0.0-proxy-alpha.69",
+    "@trpc/client": "^10.0.0-proxy-alpha.70",
+    "@trpc/react": "^10.0.0-proxy-alpha.70",
+    "@trpc/server": "^10.0.0-proxy-alpha.70",
     "@types/node-fetch": "^2.5.11",
     "express": "^4.17.1",
     "node-fetch": "^2.6.1",

--- a/examples/express-server/package.json
+++ b/examples/express-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/express-server",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server",
@@ -13,9 +13,9 @@
     "test-start": "start-server-and-test 'node dist/server' 2021 'node dist/client'"
   },
   "dependencies": {
-    "@trpc/client": "^10.0.0-proxy-alpha.69",
-    "@trpc/react": "^10.0.0-proxy-alpha.69",
-    "@trpc/server": "^10.0.0-proxy-alpha.69",
+    "@trpc/client": "^10.0.0-proxy-alpha.70",
+    "@trpc/react": "^10.0.0-proxy-alpha.70",
+    "@trpc/server": "^10.0.0-proxy-alpha.70",
     "@types/node-fetch": "^2.5.11",
     "abort-controller": "^3.0.0",
     "express": "^4.17.1",

--- a/examples/fastify-server/package.json
+++ b/examples/fastify-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/fastify-server",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "private": true,
   "scripts": {
     "build": "tsc",
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@fastify/websocket": "^5.0.0",
-    "@trpc/client": "^10.0.0-proxy-alpha.69",
-    "@trpc/server": "^10.0.0-proxy-alpha.69",
+    "@trpc/client": "^10.0.0-proxy-alpha.70",
+    "@trpc/server": "^10.0.0-proxy-alpha.70",
     "abort-controller": "^3.0.0",
     "fastify": "^3.27.1",
     "fastify-websocket": "^4.0.0",

--- a/examples/lambda-api-gateway/package.json
+++ b/examples/lambda-api-gateway/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@examples/lambda-api-gateway",
   "private": true,
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@trpc/client": "^10.0.0-proxy-alpha.69",
-    "@trpc/server": "^10.0.0-proxy-alpha.69",
+    "@trpc/client": "^10.0.0-proxy-alpha.70",
+    "@trpc/server": "^10.0.0-proxy-alpha.70",
     "node-fetch": "^2.6.1",
     "ts-node": "^10.3.0"
   },

--- a/examples/minimal/client/package.json
+++ b/examples/minimal/client/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@examples/minimal-client",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "private": true,
   "dependencies": {
-    "@trpc/client": "^10.0.0-proxy-alpha.69"
+    "@trpc/client": "^10.0.0-proxy-alpha.70"
   }
 }

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@examples/minimal",
   "private": true,
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node server",
     "dev:client": "nodemon -e ts -w . -x 'wait-port 2022 && ts-node client'",

--- a/examples/minimal/server/package.json
+++ b/examples/minimal/server/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@examples/minimal-server",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "private": true,
   "dependencies": {
-    "@trpc/server": "^10.0.0-proxy-alpha.69"
+    "@trpc/server": "^10.0.0-proxy-alpha.70"
   }
 }

--- a/examples/next-minimal-starter/package.json
+++ b/examples/next-minimal-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/next-minimal",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -9,10 +9,10 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^4.0.10",
-    "@trpc/client": "^10.0.0-proxy-alpha.69",
-    "@trpc/next": "^10.0.0-proxy-alpha.69",
-    "@trpc/react": "^10.0.0-proxy-alpha.69",
-    "@trpc/server": "^10.0.0-proxy-alpha.69",
+    "@trpc/client": "^10.0.0-proxy-alpha.70",
+    "@trpc/next": "^10.0.0-proxy-alpha.70",
+    "@trpc/react": "^10.0.0-proxy-alpha.70",
+    "@trpc/server": "^10.0.0-proxy-alpha.70",
     "next": "latest",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/examples/next-minimal-starter/src/utils/trpc.ts
+++ b/examples/next-minimal-starter/src/utils/trpc.ts
@@ -4,10 +4,10 @@ import type { AppRouter } from '../pages/api/trpc/[trpc]';
 export const trpc = createReactQueryHooks<AppRouter>();
 // => { useQuery: ..., useMutation: ...}
 */
-import { setupTRPC } from '@trpc/next';
+import { createTRPCNext } from '@trpc/next';
 import { AppRouter } from '../pages/api/trpc/[trpc]';
 
-export const trpc = setupTRPC<AppRouter>({
+export const trpc = createTRPCNext<AppRouter>({
   config() {
     return {
       url: '/api/trpc',

--- a/examples/next-prisma-starter-sqlite/package.json
+++ b/examples/next-prisma-starter-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/next-starter-sqlite",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "private": true,
   "scripts": {
     "build:1-migrate": "prisma migrate deploy",
@@ -33,10 +33,10 @@
   "dependencies": {
     "@prisma/client": "^3.0.1",
     "@tanstack/react-query": "^4.0.10",
-    "@trpc/client": "^10.0.0-proxy-alpha.69",
-    "@trpc/next": "^10.0.0-proxy-alpha.69",
-    "@trpc/react": "^10.0.0-proxy-alpha.69",
-    "@trpc/server": "^10.0.0-proxy-alpha.69",
+    "@trpc/client": "^10.0.0-proxy-alpha.70",
+    "@trpc/next": "^10.0.0-proxy-alpha.70",
+    "@trpc/react": "^10.0.0-proxy-alpha.70",
+    "@trpc/server": "^10.0.0-proxy-alpha.70",
     "clsx": "^1.1.1",
     "next": "^12.1.6",
     "react": "^18.1.0",

--- a/examples/next-prisma-starter-sqlite/src/utils/trpc.ts
+++ b/examples/next-prisma-starter-sqlite/src/utils/trpc.ts
@@ -1,6 +1,5 @@
 import { httpBatchLink, loggerLink } from '@trpc/client';
-import { setupTRPC } from '@trpc/next';
-import type { inferProcedureInput, inferProcedureOutput } from '@trpc/server';
+import { createTRPCNext } from '@trpc/next';
 import { NextPageContext } from 'next';
 import superjson from 'superjson';
 // ℹ️ Type-only import:
@@ -44,7 +43,7 @@ export interface SSRContext extends NextPageContext {
  * A set of strongly-typed React hooks from your `AppRouter` type signature with `createReactQueryHooks`.
  * @link https://trpc.io/docs/react#3-create-trpc-hooks
  */
-export const trpc = setupTRPC<AppRouter, SSRContext>({
+export const trpc = createTRPCNext<AppRouter, SSRContext>({
   config() {
     /**
      * If you want to use SSR, you need to use the server's full URL

--- a/examples/next-prisma-starter/package.json
+++ b/examples/next-prisma-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/trpc-next-prisma-starter",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "private": true,
   "scripts": {
     "build:1-migrate": "prisma migrate deploy",
@@ -33,10 +33,10 @@
   "dependencies": {
     "@prisma/client": "^3.0.1",
     "@tanstack/react-query": "^4.0.10",
-    "@trpc/client": "^10.0.0-proxy-alpha.69",
-    "@trpc/next": "^10.0.0-proxy-alpha.69",
-    "@trpc/react": "^10.0.0-proxy-alpha.69",
-    "@trpc/server": "^10.0.0-proxy-alpha.69",
+    "@trpc/client": "^10.0.0-proxy-alpha.70",
+    "@trpc/next": "^10.0.0-proxy-alpha.70",
+    "@trpc/react": "^10.0.0-proxy-alpha.70",
+    "@trpc/server": "^10.0.0-proxy-alpha.70",
     "clsx": "^1.1.1",
     "next": "^12.1.6",
     "react": "^18.1.0",

--- a/examples/next-prisma-starter/src/utils/trpc.ts
+++ b/examples/next-prisma-starter/src/utils/trpc.ts
@@ -1,5 +1,5 @@
 import { httpBatchLink, loggerLink } from '@trpc/client';
-import { setupTRPC } from '@trpc/next';
+import { createTRPCNext } from '@trpc/next';
 import type { inferProcedureInput, inferProcedureOutput } from '@trpc/server';
 import { NextPageContext } from 'next';
 import superjson from 'superjson';
@@ -44,7 +44,7 @@ export interface SSRContext extends NextPageContext {
  * A set of strongly-typed React hooks from your `AppRouter` type signature with `createReactQueryHooks`.
  * @link https://trpc.io/docs/react#3-create-trpc-hooks
  */
-export const trpc = setupTRPC<AppRouter, SSRContext>({
+export const trpc = createTRPCNext<AppRouter, SSRContext>({
   config() {
     /**
      * If you want to use SSR, you need to use the server's full URL

--- a/examples/next-prisma-todomvc/package.json
+++ b/examples/next-prisma-todomvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/trpc-next-prisma-todomvc",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "private": true,
   "scripts": {
     "migrate-sqlite": "npx prisma migrate dev --name init --schema=./prisma/_sqlite/schema.prisma",
@@ -25,10 +25,10 @@
   "dependencies": {
     "@prisma/client": "^3.0.1",
     "@tanstack/react-query": "^4.0.10",
-    "@trpc/client": "^10.0.0-proxy-alpha.69",
-    "@trpc/next": "^10.0.0-proxy-alpha.69",
-    "@trpc/react": "^10.0.0-proxy-alpha.69",
-    "@trpc/server": "^10.0.0-proxy-alpha.69",
+    "@trpc/client": "^10.0.0-proxy-alpha.70",
+    "@trpc/next": "^10.0.0-proxy-alpha.70",
+    "@trpc/react": "^10.0.0-proxy-alpha.70",
+    "@trpc/server": "^10.0.0-proxy-alpha.70",
     "clsx": "^1.1.1",
     "jest": "^27.1.0",
     "jest-playwright": "^0.0.1",

--- a/examples/next-prisma-todomvc/src/utils/trpc.ts
+++ b/examples/next-prisma-todomvc/src/utils/trpc.ts
@@ -1,5 +1,5 @@
 import { httpBatchLink, loggerLink } from '@trpc/client';
-import { setupTRPC } from '@trpc/next';
+import { createTRPCNext } from '@trpc/next';
 import type { inferProcedureInput, inferProcedureOutput } from '@trpc/server';
 // ℹ️ Type-only import:
 // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export
@@ -28,7 +28,7 @@ function getBaseUrl() {
  * A set of strongly-typed React hooks from your `AppRouter` type signature with `createReactQueryHooks`.
  * @link https://trpc.io/docs/react#3-create-trpc-hooks
  */
-export const trpc = setupTRPC<AppRouter>({
+export const trpc = createTRPCNext<AppRouter>({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   config() {
     /**

--- a/examples/standalone-server/package.json
+++ b/examples/standalone-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/standalone-server",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server",
@@ -12,9 +12,9 @@
     "test-start": "start-server-and-test 'node dist/server' 2022 'node dist/client'"
   },
   "dependencies": {
-    "@trpc/client": "^10.0.0-proxy-alpha.69",
-    "@trpc/react": "^10.0.0-proxy-alpha.69",
-    "@trpc/server": "^10.0.0-proxy-alpha.69",
+    "@trpc/client": "^10.0.0-proxy-alpha.70",
+    "@trpc/react": "^10.0.0-proxy-alpha.70",
+    "@trpc/server": "^10.0.0-proxy-alpha.70",
     "@types/node-fetch": "^2.5.11",
     "abort-controller": "^3.0.0",
     "node-fetch": "^2.6.1",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "registry": "https://registry.npmjs.org/",
   "publishConfig": {
     "access": "public"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/client",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "description": "tRPC Client lib",
   "author": "KATT",
   "license": "MIT",
@@ -66,7 +66,7 @@
     "@trpc/server": "^10.0.0-alpha.48"
   },
   "devDependencies": {
-    "@trpc/server": "^10.0.0-proxy-alpha.69"
+    "@trpc/server": "^10.0.0-proxy-alpha.70"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -36,11 +36,11 @@ pnpm add @trpc/next@next @trpc/react@next @tanstack/react-query
 Setup tRPC in `utils/trpc.ts`.
 
 ```ts
-import { setupTRPC } from '@trpc/next';
+import { createTRPCNext } from '@trpc/next';
 // Import the router type from your server file
 import type { AppRouter } from '../pages/api/[trpc].ts';
 
-export const trpc = setupTRPC<AppRouter>({
+export const trpc = createTRPCNext<AppRouter>({
   config() {
     return {
       url: 'http://localhost:3000/api/trpc',

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/next",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "description": "tRPC Next lib",
   "author": "KATT",
   "license": "MIT",
@@ -48,9 +48,9 @@
   },
   "devDependencies": {
     "@tanstack/react-query": "^4.0.10",
-    "@trpc/client": "^10.0.0-proxy-alpha.69",
-    "@trpc/react": "^10.0.0-proxy-alpha.69",
-    "@trpc/server": "^10.0.0-proxy-alpha.69",
+    "@trpc/client": "^10.0.0-proxy-alpha.70",
+    "@trpc/react": "^10.0.0-proxy-alpha.70",
+    "@trpc/server": "^10.0.0-proxy-alpha.70",
     "@types/express": "^4.17.12",
     "express": "^4.17.1",
     "next": "^12.1.6",

--- a/packages/next/src/createTRPCNext.tsx
+++ b/packages/next/src/createTRPCNext.tsx
@@ -1,7 +1,7 @@
-import { createReactQueryHooks } from '@trpc/react';
 import {
   DecoratedProcedureRecord,
   DecoratedProcedureUtilsRecord,
+  createHooksInternal,
   createReactProxyDecoration,
   createReactQueryUtilsProxy,
 } from '@trpc/react/shared';
@@ -10,11 +10,11 @@ import { NextPageContext } from 'next/types';
 import { useMemo } from 'react';
 import { WithTRPCNoSSROptions, WithTRPCSSROptions, withTRPC } from './withTRPC';
 
-export function setupTRPC<
+export function createTRPCNext<
   TRouter extends AnyRouter,
   TSSRContext extends NextPageContext = NextPageContext,
 >(opts: WithTRPCNoSSROptions<TRouter> | WithTRPCSSROptions<TRouter>) {
-  const hooks = createReactQueryHooks<TRouter, TSSRContext>();
+  const hooks = createHooksInternal<TRouter, TSSRContext>();
 
   // TODO: maybe set TSSRContext to `never` when using `WithTRPCNoSSROptions`
   const _withTRPC = withTRPC<TRouter, TSSRContext>(opts);

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1,2 +1,2 @@
 export * from './withTRPC';
-export * from './setupNext';
+export * from './createTRPCNext';

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/react",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "description": "tRPC React lib",
   "author": "KATT",
   "license": "MIT",
@@ -58,8 +58,8 @@
   },
   "devDependencies": {
     "@tanstack/react-query": "^4.0.10",
-    "@trpc/client": "^10.0.0-proxy-alpha.69",
-    "@trpc/server": "^10.0.0-proxy-alpha.69",
+    "@trpc/client": "^10.0.0-proxy-alpha.70",
+    "@trpc/server": "^10.0.0-proxy-alpha.70",
     "@types/express": "^4.17.12",
     "express": "^4.17.1",
     "next": "^12.1.6",

--- a/packages/react/src/createTRPCReact.tsx
+++ b/packages/react/src/createTRPCReact.tsx
@@ -16,6 +16,11 @@ import { inferObservableValue } from '@trpc/server/observable';
 import { LegacyV9ProcedureTag } from '@trpc/server/shared';
 import { useMemo } from 'react';
 import {
+  DecoratedProcedureUtilsRecord,
+  createReactProxyDecoration,
+  createReactQueryUtilsProxy,
+} from './shared';
+import {
   CreateReactQueryHooks,
   TRPCProviderProps,
   UseTRPCInfiniteQueryOptions,
@@ -23,12 +28,7 @@ import {
   UseTRPCQueryOptions,
   UseTRPCSubscriptionOptions,
   createHooksInternal,
-} from './internals/createHooksInternal';
-import {
-  DecoratedProcedureUtilsRecord,
-  createReactProxyDecoration,
-  createReactQueryUtilsProxy,
-} from './shared';
+} from './shared/hooks/createHooksInternal';
 
 type DecorateProcedure<
   TProcedure extends Procedure<any>,

--- a/packages/react/src/interop.ts
+++ b/packages/react/src/interop.ts
@@ -4,7 +4,7 @@ import { CreateTRPCReact, createHooksInternalProxy } from './createTRPCReact';
 import {
   CreateReactQueryHooks,
   createHooksInternal,
-} from './internals/createHooksInternal';
+} from './shared/hooks/createHooksInternal';
 
 /**
  * @deprecated use `createTRPCReact` instead

--- a/packages/react/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react/src/shared/hooks/createHooksInternal.tsx
@@ -42,7 +42,7 @@ import {
   TRPCContext,
   TRPCContextProps,
   TRPCContextState,
-} from './context';
+} from '../../internals/context';
 
 export type AssertType<T, K> = T extends K ? T : never;
 
@@ -71,7 +71,7 @@ export interface TRPCUseQueryBaseOptions {
   trpc?: TRPCReactRequestOptions;
 }
 
-export type { TRPCContext, TRPCContextState } from './context';
+export type { TRPCContext, TRPCContextState } from '../../internals/context';
 
 export interface UseTRPCQueryOptions<TPath, TInput, TOutput, TData, TError>
   extends UseQueryOptions<TOutput, TError, TData, [TPath, TInput]>,
@@ -130,6 +130,10 @@ export interface TRPCProviderProps<TRouter extends AnyRouter, TSSRContext>
   children: ReactNode;
 }
 
+/**
+ * Infer the type of a `createReactQueryHooks` function
+ * @internal
+ */
 export function createHooksInternal<
   TRouter extends AnyRouter,
   TSSRContext = unknown,

--- a/packages/react/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react/src/shared/hooks/createHooksInternal.tsx
@@ -131,7 +131,7 @@ export interface TRPCProviderProps<TRouter extends AnyRouter, TSSRContext>
 }
 
 /**
- * Infer the type of a `createReactQueryHooks` function
+ * Create strongly typed react hooks
  * @internal
  */
 export function createHooksInternal<

--- a/packages/react/src/shared/index.ts
+++ b/packages/react/src/shared/index.ts
@@ -1,3 +1,4 @@
 export * from './proxy/decorationProxy';
 export * from './proxy/utilsProxy';
 export type { DecoratedProcedureRecord } from '../createTRPCReact';
+export * from './hooks/createHooksInternal';

--- a/packages/react/src/shared/proxy/decorationProxy.ts
+++ b/packages/react/src/shared/proxy/decorationProxy.ts
@@ -1,7 +1,7 @@
 import { AnyRouter } from '@trpc/server';
 import { createProxy } from '@trpc/server/shared';
-import { CreateReactQueryHooks } from '../../internals/createHooksInternal';
 import { getQueryKey } from '../../internals/getQueryKey';
+import { CreateReactQueryHooks } from '../hooks/createHooksInternal';
 
 /**
  * Create proxy for decorating procedures

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/server",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "description": "tRPC Server",
   "author": "KATT",
   "license": "MIT",

--- a/packages/server/test/interop/react/__testHelpers.tsx
+++ b/packages/server/test/interop/react/__testHelpers.tsx
@@ -18,7 +18,7 @@ import { createReactQueryHooks } from '@trpc/react';
 import hash from 'hash-sum';
 import React, { ReactNode } from 'react';
 import { ZodError, z } from 'zod';
-import { OutputWithCursor } from '../../../../react/src/internals/createHooksInternal';
+import { OutputWithCursor } from '../../../../react/src/shared/hooks/createHooksInternal';
 import { TRPCError } from '../../../src/error/TRPCError';
 import { observable } from '../../../src/observable';
 import { subscriptionPullFactory } from '../../../src/subscription';

--- a/www/docs/client/header.md
+++ b/www/docs/client/header.md
@@ -5,19 +5,19 @@ sidebar_label: Create Custom Header
 slug: /header
 ---
 
-The headers option can be customize in config when using `setupTRPC` in nextjs or `createClient` in react.js.
+The headers option can be customize in config when using `createTRPCNext` in nextjs or `createClient` in react.js.
 
 `headers` can be both an object or a function. If it's a function it will gets called dynamically every http request.
 
 ```ts title='utils/trpc.ts'
-import { setupTRPC } from '@trpc/next';
+import { createTRPCNext } from '@trpc/next';
 
 // Import the router type from your server file
 import type { AppRouter } from "@/server/routers/app";
 
 export let token: string;
 
-export const trpc = setupTRPC<AppRouter>({
+export const trpc = createTRPCNext<AppRouter>({
   config({ ctx }) {
     /**
     * Headers will be called on each request.

--- a/www/docs/client/links.md
+++ b/www/docs/client/links.md
@@ -30,10 +30,10 @@ const somePosts = await Promise.all([
 When sending batch requests, sometimes the URL can become too large causing HTTP errors like [`413 Payload Too Large`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/413), [`414 URI Too Long`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/414), and [`404 Not Found`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404). The `maxURLLength` option will limit the number of requests that can be sent together in a batch.
 
 ```ts title="utils/trpc.ts"
-import { setupTRPC } from '@trpc/next';
+import { createTRPCNext } from '@trpc/next';
 import type { AppRouter } from "@/server/routers/app";
 
-export const trpc = setupTRPC<AppRouter>({
+export const trpc = createTRPCNext<AppRouter>({
   config() {
     return {
       links: [
@@ -66,11 +66,11 @@ export default trpcNext.createNextApiHandler({
 #### 2. Use batch-free link in your tRPC Client
 
 ```tsx title='utils/trpc.ts'
-import { setupTRPC } from '@trpc/next';
+import { createTRPCNext } from '@trpc/next';
 import type { AppRouter } from "@/server/routers/app";
 import { httpLink } from '@trpc/client';
 
-export const trpc = setupTRPC<AppRouter>({
+export const trpc = createTRPCNext<AppRouter>({
   config() {
     return {
       links: [
@@ -90,10 +90,10 @@ export const trpc = setupTRPC<AppRouter>({
 ##### 1. Configure client / `utils/trpc.ts`
 
 ```tsx title='utils/trpc.ts'
-import { setupTRPC } from '@trpc/next';
+import { createTRPCNext } from '@trpc/next';
 import { httpBatchLink, httpLink, splitLink } from '@trpc/client';
 
-export default setupTRPC<AppRouter>({
+export default createTRPCNext<AppRouter>({
   config() {
     const url = `http://localhost:3000`;
 

--- a/www/docs/migration/migrate-from-v9-to-v10.mdx
+++ b/www/docs/migration/migrate-from-v9-to-v10.mdx
@@ -295,15 +295,15 @@ trpc.post.byId.useQuery('1', {
 
 ### `@trpc/next`
 
-#### `setupNext()` - Optional DX Improvement
+#### `createTRPCNext()` - Optional DX Improvement
 
 Setting up tRPC for Next.js is now easier than ever! Here's all you need to get going:
 
 ```ts title="utils/trpc.ts"
-import { setupTRPC } from '@trpc/next';
+import { createTRPCNext } from '@trpc/next';
 import type { AppRouter } from 'routers/_app';
 
-export const trpc = setupTRPC<AppRouter>({
+export const trpc = createTRPCNext<AppRouter>({
   config() {
     return {
       url: '/api/trpc',

--- a/www/docs/nextjs/introduction.md
+++ b/www/docs/nextjs/introduction.md
@@ -132,7 +132,7 @@ export default trpcNext.createNextApiHandler({
 Create a set of strongly-typed hooks using your API's type signature.
 
 ```tsx title='utils/trpc.ts'
-import { setupTRPC } from '@trpc/next';
+import { createTRPCNext } from '@trpc/next';
 import type { AppRouter } from '../pages/api/trpc/[trpc]';
 
 function getBaseUrl() {
@@ -149,7 +149,7 @@ function getBaseUrl() {
   return `http://localhost:${process.env.PORT ?? 3000}`;
 }
 
-export const trpc = setupTRPC<AppRouter>({
+export const trpc = createTRPCNext<AppRouter>({
   config({ ctx }) {
     return {
       /**
@@ -202,7 +202,7 @@ export default function IndexPage() {
 }
 ```
 
-## `setupTRPC()` options
+## `createTRPCNext()` options
 
 ### `config`-callback
 
@@ -231,10 +231,10 @@ Ability to set request headers and HTTP status when server-side rendering.
 #### Example
 
 ```tsx title='utils/trpc.ts'
-import { setupTRPC } from '@trpc/next';
+import { createTRPCNext } from '@trpc/next';
 import type { AppRouter } from '../pages/api/trpc/[trpc]';
 
-export const trpc = setupTRPC<AppRouter>({
+export const trpc = createTRPCNext<AppRouter>({
   config({ ctx }) {
     /* [...] */
   },

--- a/www/docs/nextjs/ssr.md
+++ b/www/docs/nextjs/ssr.md
@@ -13,7 +13,7 @@ In order to execute queries properly during the server-side render step and cust
 import superjson from 'superjson';
 import type { AppRouter } from './api/trpc/[trpc]';
 
-export const trpc = setupTRPC<AppRouter>({
+export const trpc = createTRPCNext<AppRouter>({
   config({ ctx }) {
     if (typeof window !== 'undefined') {
       // during client requests

--- a/www/docs/server/caching.md
+++ b/www/docs/server/caching.md
@@ -22,10 +22,10 @@ If you turn on SSR in your app you might discover that your app loads slow on fo
 ### Example code
 
 ```tsx title='utils/trpc.tsx'
-import { setupTRPC } from '@trpc/next';
+import { createTRPCNext } from '@trpc/next';
 import { AppRouter } from '../server/routers/_app';
 
-export const trpc = setupTRPC<AppRouter>({
+export const trpc = createTRPCNext<AppRouter>({
   config({ ctx }) {
     if (typeof window !== 'undefined') {
       return {

--- a/www/docs/server/data-transformers.md
+++ b/www/docs/server/data-transformers.md
@@ -30,7 +30,7 @@ export const t = initTRPC.create({
 });
 ```
 
-#### 3. Add to `createTRPCProxyClient()` or `setupTRPC()`
+#### 3. Add to `createTRPCProxyClient()` or `createTRPCNext()`
 
 ```ts
 import { createTRPCProxyClient } from '@trpc/client';
@@ -44,13 +44,13 @@ export const client = createTRPCProxyClient<AppRouter>({
 ```
 
 ```ts title='utils/trpc.ts'
-import { setupTRPC } from '@trpc/next';
+import { createTRPCNext } from '@trpc/next';
 import superjson from 'superjson';
 import type { AppRouter } from '~/server/routers/_app';
 
 // [...]
 
-export const trpc = setupTRPC<AppRouter>({
+export const trpc = createTRPCNext<AppRouter>({
   config({ ctx }) {
     return {
       transformer: superjson, // <--

--- a/www/package.json
+++ b/www/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www",
-  "version": "10.0.0-proxy-alpha.69",
+  "version": "10.0.0-proxy-alpha.70",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
@@ -22,10 +22,10 @@
     "@docusaurus/core": "^2.0.0-rc.1",
     "@docusaurus/preset-classic": "^2.0.0-rc.1",
     "@mdx-js/react": "^1.6.22",
-    "@trpc/client": "^10.0.0-proxy-alpha.69",
-    "@trpc/next": "^10.0.0-proxy-alpha.69",
-    "@trpc/react": "^10.0.0-proxy-alpha.69",
-    "@trpc/server": "^10.0.0-proxy-alpha.69",
+    "@trpc/client": "^10.0.0-proxy-alpha.70",
+    "@trpc/next": "^10.0.0-proxy-alpha.70",
+    "@trpc/react": "^10.0.0-proxy-alpha.70",
+    "@trpc/server": "^10.0.0-proxy-alpha.70",
     "@visx/hierarchy": "^2.10.0",
     "@visx/responsive": "^2.10.0",
     "clsx": "^1.1.1",


### PR DESCRIPTION
Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

- Renames `setupTRPC` to `createTRPCNext` to keep coherency between the different packages.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.