### PR TITLE
prohibit url from being passed along with links

### DIFF
--- a/packages/client/src/internals/TRPCClient.ts
+++ b/packages/client/src/internals/TRPCClient.ts
@@ -46,24 +46,6 @@ interface CreateTRPCClientBaseOptions {
   transformer?: ClientDataTransformerOptions;
 }
 
-/** @internal */
-export interface CreateTRPCClientWithURLOptions
-  extends CreateTRPCClientBaseOptions {
-  /**
-   * HTTP URL of API
-   **/
-  url: string;
-}
-
-/** @internal */
-export interface CreateTRPCClientWithLinksOptions<TRouter extends AnyRouter>
-  extends CreateTRPCClientBaseOptions {
-  /**
-   * @link https://trpc.io/docs/links
-   **/
-  links: TRPCLink<TRouter>[];
-}
-
 type TRPCType = 'subscription' | 'query' | 'mutation';
 export interface TRPCRequestOptions {
   /**
@@ -81,10 +63,21 @@ export interface TRPCSubscriptionObserver<TValue, TError> {
   onComplete: () => void;
 }
 
-/** @internal */
+/**
+ * This type prohibits `url` from being provided along with `links`
+ * @internal
+ */
 export type CreateTRPCClientOptions<TRouter extends AnyRouter> =
-  | CreateTRPCClientWithLinksOptions<TRouter>
-  | CreateTRPCClientWithURLOptions;
+  | CreateTRPCClientBaseOptions &
+      (
+        | {
+            links: TRPCLink<TRouter>[];
+          }
+        | {
+            url: string;
+            links?: never;
+          }
+      );
 
 export type AssertType<T, K> = T extends K ? T : never;
 /**
@@ -146,7 +139,8 @@ export class TRPCClient<TRouter extends AnyRouter> {
 
     const getLinks = (): OperationLink<TRouter>[] => {
       if ('links' in opts) {
-        return opts.links.map((link) => link(this.runtime));
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        return opts.links!.map((link) => link(this.runtime));
       }
       return [httpBatchLink({ url: opts.url })(this.runtime)];
     };

--- a/packages/server/test/createClient.test.ts
+++ b/packages/server/test/createClient.test.ts
@@ -1,0 +1,24 @@
+import { createTRPCProxyClient } from '@trpc/client';
+import { httpBatchLink } from '../../client/src';
+
+describe('typedefs on createClient', () => {
+  test('ok to pass only links', () => {
+    createTRPCProxyClient({
+      links: [httpBatchLink({ url: 'foo' })],
+    });
+  });
+
+  test('ok to pass only url', () => {
+    createTRPCProxyClient({
+      url: 'foo',
+    });
+  });
+
+  test('error if both url and links are passed', () => {
+    createTRPCProxyClient({
+      links: [httpBatchLink({ url: 'foo' })],
+      // @ts-expect-error - can't pass url along with links
+      url: 'foo',
+    });
+  });
+});


### PR DESCRIPTION
Closes https://github.com/trpc/trpc/pull/2642#discussion_r964621116

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

- TypeErrors if `url` is passed together with `links` to improve DX:

![CleanShot 2022-09-07 at 14 49 21@2x](https://user-images.githubusercontent.com/51714798/188882425-ed757d3a-595f-486b-bdcd-b8f7df245949.png)


## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.