### PR TITLE
adds docs for abortOnUnmount

### DIFF
--- a/www/docs/client/aborting-procedures.md
+++ b/www/docs/client/aborting-procedures.md
@@ -5,11 +5,51 @@ sidebar_label: Aborting Procedures
 slug: /aborting-procedures
 ---
 
-_If you're looking for how to abort queries and is using @trpc/react, please refer to @tanstack/react-query's [documentation](https://tanstack.com/query/v4/docs/guides/query-cancellation?from=reactQueryV3&original=https://react-query-v3.tanstack.com/guides/query-cancellation#manual-cancellation)._
+## @trpc/react
+By default, TRPC does not cancel requests on unmount. If you want to opt in to this behavior you can provide `abortOnUnmount` in your configuration.
+```ts twoslash title="client.ts"
+// @module: esnext
+
+// ---cut---
+// @filename: utils.ts
+// @noErrors
+import { createTRPCNext } from '@trpc/next';
+
+export const trpc = createTRPCNext<AppRouter, SSRContext>({
+  config() {
+    return {
+      // ...
+      abortOnUnMount: true 
+      // ...
+    };
+  },
+});
+
+```
+You may also override this behavior at the request level.
+```ts twoslash title="client.ts"
+// @module: esnext
+
+// ---cut---
+// @filename: pages/posts/[id].tsx
+// @noErrors
+import { trpc } from '~/utils/trpc';
+
+const PostViewPage: NextPageWithLayout = () => {
+  const id = useRouter().query.id as string;
+  const postQuery = trpc.post.byId.useQuery({ id }, { trpc: abortOnUnmount: true });
+
+  return (...)
+}
+
+```
+> Note: @tanstack/react-query only allows aborting queries.
+
+## @trpc/client
 
 tRPC adheres to the industry standard when it comes to aborting procedures. All you have to do is pass an `AbortSignal` to the query-options and then call its parent `AbortController`'s `abort` method.
 
-```ts twoslash title="client.ts"
+```ts twoslash title="utils.ts"
 // @module: esnext
 
 // ---cut---
@@ -24,13 +64,11 @@ const proxy = createTRPCProxyClient<AppRouter>({
 
 const ac = new AbortController();
 const query = proxy.userById.query('id_bilbo', { signal: ac.signal });
-//    ^?
 
 // Cancelling
 ac.abort();
 
 console.log(query.status);
-//                ^?
 ```
 
-> Note: The vanilla tRPC client allows aborting both queries and mutations, however @tanstack/react-query only allows aborting queries.
+> Note: The vanilla tRPC client allows aborting both queries and mutations

--- a/www/docs/client/aborting-procedures.md
+++ b/www/docs/client/aborting-procedures.md
@@ -20,7 +20,6 @@ trpc.createClient({
   // ...
   abortOnUnmount: true,
 });
-
 ```
 You may also override this behavior at the request level.
 ```ts twoslash title="client.ts"
@@ -37,7 +36,6 @@ const PostViewPage: NextPageWithLayout = () => {
 
   return (...)
 }
-
 ```
 > Note: @tanstack/react-query only allows aborting queries.
 

--- a/www/docs/client/aborting-procedures.md
+++ b/www/docs/client/aborting-procedures.md
@@ -13,16 +13,12 @@ By default, TRPC does not cancel requests on unmount. If you want to opt in to t
 // ---cut---
 // @filename: utils.ts
 // @noErrors
-import { createTRPCNext } from '@trpc/next';
+import { createTRPCReact } from "@trpc/react";
 
-export const trpc = createTRPCNext<AppRouter, SSRContext>({
-  config() {
-    return {
-      // ...
-      abortOnUnMount: true 
-      // ...
-    };
-  },
+export const trpc = createTRPCReact<AppRouter>();
+trpc.createClient({
+  // ...
+  abortOnUnmount: true,
 });
 
 ```

--- a/www/docs/nextjs/introduction.md
+++ b/www/docs/nextjs/introduction.md
@@ -219,6 +219,7 @@ The `config`-argument is a function that returns an object that configures the t
   - `transformer`: a transformer applied to outgoing payloads. Read more about [Data Transformers](data-transformers)
   - `fetch`: customize the implementation of `fetch` used by tRPC internally
   - `AbortController`: customize the implementation of `AbortController` used by tRPC internally
+  - `abortOnUnmount`: determines if in-flight requests will be cancelled on component unmount. This defaults to `false`.
 
 ### `ssr`-boolean (default: `false`)
 


### PR DESCRIPTION
Closes [#2632](https://github.com/trpc/trpc/issues/2632)

## 🎯 Changes

Adds docs for `abortOnUnmount`

### Notes
- need help with tests
- removes type annotations that were `any` and will raise a separate issue (https://github.com/trpc/trpc/issues/2648)

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.