### PR TITLE
feat: propagate websocket close code to close listener

### DIFF
--- a/packages/client/src/links/wsLink.ts
+++ b/packages/client/src/links/wsLink.ts
@@ -27,7 +27,7 @@ export interface WebSocketClientOptions {
   WebSocket?: typeof WebSocket;
   retryDelayMs?: typeof retryDelay;
   onOpen?: () => void;
-  onClose?: () => void;
+  onClose?: (code?: number) => void;
 }
 
 export function createWSClient(opts: WebSocketClientOptions) {
@@ -198,9 +198,9 @@ export function createWSClient(opts: WebSocketClientOptions) {
       }
     });
 
-    conn.addEventListener('close', () => {
+    conn.addEventListener('close', ({ code }) => {
       if (state === 'open') {
-        onClose?.();
+        onClose?.(code);
       }
 
       if (activeConnection === conn) {

--- a/packages/client/src/links/wsLink.ts
+++ b/packages/client/src/links/wsLink.ts
@@ -27,7 +27,7 @@ export interface WebSocketClientOptions {
   WebSocket?: typeof WebSocket;
   retryDelayMs?: typeof retryDelay;
   onOpen?: () => void;
-  onClose?: (code?: number) => void;
+  onClose?: (cause?: { code?: number }) => void;
 }
 
 export function createWSClient(opts: WebSocketClientOptions) {
@@ -200,7 +200,7 @@ export function createWSClient(opts: WebSocketClientOptions) {
 
     conn.addEventListener('close', ({ code }) => {
       if (state === 'open') {
-        onClose?.(code);
+        onClose?.({ code });
       }
 
       if (activeConnection === conn) {


### PR DESCRIPTION
Closes #2651

## 🎯 Changes

This PR changes the wsLink, making it possible to get the websocket close code as a listener within the `onClose` callback.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.

**Note: there are no tests for the wsLink part of tRPC.**