### PR TITLE
fix: tighten button more + remove `iframe` autofocus

### DIFF
--- a/www/src/components/Button.tsx
+++ b/www/src/components/Button.tsx
@@ -17,7 +17,7 @@ export const Button = ({
   ...props
 }: Props) => {
   const className = clsx(
-    'inline-grid appearance-none cursor-pointer text-sm sm:text-base font-bold tracking-normal px-4 py-2 gap-1.5 sm:gap-1.5 grid-flow-col rounded-lg shadow-xl shadow-sky-500/20 no-underline hover:no-underline justify-center items-center transition-all duration-300 ',
+    'inline-grid appearance-none cursor-pointer text-sm sm:text-base font-bold tracking-normal px-2 sm:px-4 py-1.5 sm:py-2 gap-1.5 sm:gap-1.5 grid-flow-col rounded-lg shadow-xl shadow-sky-500/20 no-underline hover:no-underline justify-center items-center transition-all duration-300 ',
     {
       ['bg-primary text-white hover:text-white hover:bg-sky-700']:
         variant === 'primary',

--- a/www/src/components/Button.tsx
+++ b/www/src/components/Button.tsx
@@ -17,7 +17,7 @@ export const Button = ({
   ...props
 }: Props) => {
   const className = clsx(
-    'inline-grid appearance-none cursor-pointer text-sm sm:text-base font-bold tracking-normal px-2 sm:px-4 py-1.5 sm:py-2 gap-1.5 sm:gap-1.5 grid-flow-col rounded-lg shadow-xl shadow-sky-500/20 no-underline hover:no-underline justify-center items-center transition-all duration-300 ',
+    'inline-grid appearance-none cursor-pointer text-sm sm:text-base font-bold tracking-normal px-2 sm:px-4 py-1.5 sm:py-2 gap-1 sm:gap-1.5 grid-flow-col rounded-lg shadow-xl shadow-sky-500/20 no-underline hover:no-underline justify-center items-center transition-all duration-300 ',
     {
       ['bg-primary text-white hover:text-white hover:bg-sky-700']:
         variant === 'primary',

--- a/www/src/pages/index.tsx
+++ b/www/src/pages/index.tsx
@@ -162,7 +162,7 @@ function Home() {
           />
           <div className="h-[600px] w-full rounded-xl overflow-hidden z-10 relative my-4">
             <iframe
-              sandbox={''}
+              sandbox={true}
               className="h-full w-full absolute"
               src={
                 `https://stackblitz.com/github/trpc/trpc/tree/${

--- a/www/src/pages/index.tsx
+++ b/www/src/pages/index.tsx
@@ -162,6 +162,7 @@ function Home() {
           />
           <div className="h-[600px] w-full rounded-xl overflow-hidden z-10 relative my-4">
             <iframe
+              sandbox={''}
               className="h-full w-full absolute"
               src={
                 `https://stackblitz.com/github/trpc/trpc/tree/${


### PR DESCRIPTION
- Tighten button more
- ~Apparently `<iframe`s steal focus whenever the URL change so I added the `sandbox` attribute that I didn't know existed~
- Hide sandbox on mobile