### PR TITLE
perf: Remove OmitNeverKeys extra computations

### DIFF
--- a/examples/next-prisma-starter/src/utils/trpc.ts
+++ b/examples/next-prisma-starter/src/utils/trpc.ts
@@ -90,7 +90,8 @@ export const trpc = createTRPCNext<AppRouter, SSRContext>({
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             connection: _connection,
             ...headers
-          } = ctx.req;
+          } = ctx.req.headers;
+          console.log(headers);
           return {
             ...headers,
             // Optional: inform server that it's an SSR request

--- a/examples/next-prisma-starter/src/utils/trpc.ts
+++ b/examples/next-prisma-starter/src/utils/trpc.ts
@@ -91,7 +91,6 @@ export const trpc = createTRPCNext<AppRouter, SSRContext>({
             connection: _connection,
             ...headers
           } = ctx.req.headers;
-          console.log(headers);
           return {
             ...headers,
             // Optional: inform server that it's an SSR request

--- a/packages/client/src/createTRPCClientProxy.ts
+++ b/packages/client/src/createTRPCClientProxy.ts
@@ -3,7 +3,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type {
   AnyRouter,
-  OmitNeverKeys,
   Procedure,
   ProcedureArgs,
   ProcedureRouterRecord,
@@ -48,15 +47,19 @@ type SubscriptionResolver<
 type DecorateProcedure<
   TProcedure extends Procedure<any>,
   TRouter extends AnyRouter,
-> = OmitNeverKeys<{
-  query: TProcedure extends { _query: true } ? Resolver<TProcedure> : never;
-
-  mutate: TProcedure extends { _mutation: true } ? Resolver<TProcedure> : never;
-
-  subscribe: TProcedure extends { _subscription: true }
-    ? SubscriptionResolver<TProcedure, TRouter>
-    : never;
-}>;
+> = TProcedure extends { _type: 'query' }
+  ? {
+      query: Resolver<TProcedure>;
+    }
+  : TProcedure extends { _type: 'mutation' }
+  ? {
+      mutate: Resolver<TProcedure>;
+    }
+  : TProcedure extends { _type: 'subscription' }
+  ? {
+      subscribe: SubscriptionResolver<TProcedure, TRouter>;
+    }
+  : never;
 
 type assertProcedure<T> = T extends Procedure<any> ? T : never;
 
@@ -66,7 +69,7 @@ type assertProcedure<T> = T extends Procedure<any> ? T : never;
 type DecoratedProcedureRecord<
   TProcedures extends ProcedureRouterRecord,
   TRouter extends AnyRouter,
-> = OmitNeverKeys<{
+> = {
   [TKey in keyof TProcedures]: TProcedures[TKey] extends LegacyV9ProcedureTag
     ? never
     : TProcedures[TKey] extends AnyRouter
@@ -75,7 +78,7 @@ type DecoratedProcedureRecord<
         TProcedures[TKey]
       >
     : DecorateProcedure<assertProcedure<TProcedures[TKey]>, TRouter>;
-}>;
+};
 
 const clientCallTypeMap: Record<
   keyof DecorateProcedure<any, any>,

--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -20,7 +20,12 @@ import { RootConfig } from './config';
 import { getParseFn } from './getParseFn';
 import { mergeWithoutOverrides } from './mergeWithoutOverrides';
 import { ResolveOptions, middlewareMarker } from './utils';
-import { DefaultValue as FallbackValue, Overwrite, UnsetMarker } from './utils';
+import {
+  DefaultValue as FallbackValue,
+  Overwrite,
+  OverwriteKnown,
+  UnsetMarker,
+} from './utils';
 
 type CreateProcedureReturnInput<
   TPrev extends ProcedureParams,
@@ -111,7 +116,7 @@ export interface ProcedureBuilder<TParams extends ProcedureParams> {
     ) => MaybePromise<FallbackValue<TParams['_output_in'], $TOutput>>,
   ): UnsetMarker extends TParams['_output_out']
     ? QueryProcedure<
-        Overwrite<
+        OverwriteKnown<
           TParams,
           {
             _output_in: $TOutput;
@@ -130,7 +135,7 @@ export interface ProcedureBuilder<TParams extends ProcedureParams> {
     ) => MaybePromise<FallbackValue<TParams['_output_in'], $TOutput>>,
   ): UnsetMarker extends TParams['_output_out']
     ? MutationProcedure<
-        Overwrite<
+        OverwriteKnown<
           TParams,
           {
             _output_in: $TOutput;
@@ -149,7 +154,7 @@ export interface ProcedureBuilder<TParams extends ProcedureParams> {
     ) => MaybePromise<FallbackValue<TParams['_output_in'], $TOutput>>,
   ): UnsetMarker extends TParams['_output_out']
     ? SubscriptionProcedure<
-        Overwrite<
+        OverwriteKnown<
           TParams,
           {
             _output_in: $TOutput;

--- a/packages/server/src/core/internals/utils.ts
+++ b/packages/server/src/core/internals/utils.ts
@@ -7,6 +7,12 @@ export type Overwrite<T, U> = Omit<T, keyof U> & U;
 /**
  * @internal
  */
+export type OverwriteKnown<T, U> = {
+  [K in keyof T]: K extends keyof U ? U[K] : T[K];
+};
+/**
+ * @internal
+ */
 export type DefaultValue<TValue, TFallback> = UnsetMarker extends TValue
   ? TFallback
   : TValue;

--- a/packages/server/src/core/procedure.ts
+++ b/packages/server/src/core/procedure.ts
@@ -6,6 +6,7 @@ import {
   ProcedureCallOptions,
 } from './internals/procedureBuilder';
 import { UnsetMarker } from './internals/utils';
+import { ProcedureType } from './types';
 
 type ClientContext = Record<string, unknown>;
 
@@ -85,7 +86,11 @@ export type ProcedureArgs<TParams extends ProcedureParams> =
  *
  * @internal
  */
-export interface ProcedureBase<TParams extends ProcedureParams> {
+export interface ProcedureBase<
+  TType extends ProcedureType,
+  TParams extends ProcedureParams,
+> {
+  _type: TType;
   _def: TParams & ProcedureBuilder<TParams>['_def'];
   /**
    * @deprecated use `._def.meta` instead
@@ -99,23 +104,15 @@ export interface ProcedureBase<TParams extends ProcedureParams> {
 }
 
 export interface QueryProcedure<TParams extends ProcedureParams>
-  extends ProcedureBase<TParams> {
-  _query: true;
-}
+  extends ProcedureBase<'query', TParams> {}
 
 export interface MutationProcedure<TParams extends ProcedureParams>
-  extends ProcedureBase<TParams> {
-  _mutation: true;
-}
+  extends ProcedureBase<'mutation', TParams> {}
 
 export interface SubscriptionProcedure<TParams extends ProcedureParams>
-  extends ProcedureBase<TParams> {
-  _subscription: true;
-}
+  extends ProcedureBase<'subscription', TParams> {}
 
-export type Procedure<TParams extends ProcedureParams> =
-  | QueryProcedure<TParams>
-  | MutationProcedure<TParams>
-  | SubscriptionProcedure<TParams>;
+export interface Procedure<TParams extends ProcedureParams>
+  extends ProcedureBase<ProcedureType, TParams> {}
 
 export type AnyProcedure = Procedure<any>;

--- a/packages/server/src/deprecated/router.ts
+++ b/packages/server/src/deprecated/router.ts
@@ -15,7 +15,7 @@ import {
   DataTransformerOptions,
   defaultTransformer,
 } from '../transformer';
-import { FlatOverwrite, Prefixer, ThenArg } from '../types';
+import { FlatOverwrite, ThenArg } from '../types';
 import { MiddlewareFunction } from './internals/middlewares';
 import {
   CreateProcedureOptions,
@@ -32,6 +32,18 @@ import { MigrateRouter, migrateRouter } from './interop';
 assertNotBrowser();
 
 export type { Procedure } from './internals/procedure';
+
+/**
+ * @internal
+ */
+type Prefix<K extends string, T extends string> = `${K}${T}`;
+
+/**
+ * @internal
+ */
+type Prefixer<TObj extends Record<string, any>, TPrefix extends string> = {
+  [P in keyof TObj as Prefix<TPrefix, string & P>]: TObj[P];
+};
 
 /**
  * @public

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -3,11 +3,6 @@
 /**
  * @internal
  */
-export type Prefix<K extends string, T extends string> = `${K}${T}`;
-
-/**
- * @internal
- */
 export type identity<T> = T;
 
 /**
@@ -20,16 +15,6 @@ export type FlatOverwrite<T, K> = identity<{
     ? T[TKey]
     : never;
 }>;
-
-/**
- * @internal
- */
-export type Prefixer<
-  TObj extends Record<string, any>,
-  TPrefix extends string,
-> = {
-  [P in keyof TObj as Prefix<TPrefix, string & P>]: TObj[P];
-};
 
 /**
  * @public

--- a/www/docs/nextjs/ssr.md
+++ b/www/docs/nextjs/ssr.md
@@ -28,7 +28,7 @@ export const trpc = createTRPCNext<AppRouter>({
     const ONE_DAY_SECONDS = 60 * 60 * 24;
     ctx?.res?.setHeader(
       'Cache-Control',
-      `s-maxage=1, stale-while-revalidate=${ONE_DAY_SECONDS}`
+      `s-maxage=1, stale-while-revalidate=${ONE_DAY_SECONDS}`,
     );
 
     // The server needs to know your app's full url
@@ -55,7 +55,7 @@ export const trpc = createTRPCNext<AppRouter>({
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             connection: _connection,
             ...headers
-          } = ctx.req;
+          } = ctx.req.headers;
 
           return {
             ...headers,
@@ -96,4 +96,3 @@ If you don't remove the `connection` header, the data fetching will fail with `T
 ### Q: Can I use `getServerSideProps` and/or `getStaticProps` while using SSR?
 
 When you enable SSR, tRPC will use `getInitialProps` to prefetch all queries on the server. That causes problems [like this](https://github.com/trpc/trpc/issues/596) when you use `getServerSideProps` in a page and solving it is out of our hands. Though, you can use [SSG Helpers](ssg-helpers) to prefetch queries in `getStaticProps` or `getServerSideProps`.
-

--- a/www/versioned_docs/version-9.x/nextjs/ssr.md
+++ b/www/versioned_docs/version-9.x/nextjs/ssr.md
@@ -10,9 +10,9 @@ The only thing you need to do to get SSR on your application is to set `ssr: tru
 In order to execute queries properly during the server-side render step and customize caching behavior, we might want to add some extra logic inside our `_app.tsx`:
 
 ```tsx title='pages/_app.tsx'
-import React from 'react';
 import { withTRPC } from '@trpc/next';
 import { AppType } from 'next/dist/shared/lib/utils';
+import React from 'react';
 import superjson from 'superjson';
 import type { AppRouter } from './api/trpc/[trpc]';
 
@@ -62,7 +62,7 @@ export default withTRPC<AppRouter>({
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             connection: _connection,
             ...headers
-          } = ctx.req;
+          } = ctx.req.headers;
           return {
             ...headers,
             // Optional: inform server that it's an SSR request
@@ -77,7 +77,6 @@ export default withTRPC<AppRouter>({
 })(MyApp);
 ```
 
-
 ## FAQ
 
 ### Q: Why do I need to forward the client's headers to the server manually? Why doesn't tRPC automatically do that for me?
@@ -91,4 +90,3 @@ If you don't remove the `connection` header, the data fetching will fail with `T
 ### Q: Can I use `getServerSideProps` and/or `getStaticProps` while using SSR?
 
 When you enable SSR, tRPC will use `getInitialProps` to prefetch all queries on the server. That causes problems [like this](https://github.com/trpc/trpc/issues/596) when you use `getServerSideProps` in a page and solving it is out of our hands. Though, you can use [SSG Helpers](ssg-helpers) to prefetch queries in `getStaticProps` or `getServerSideProps`.
-


### PR DESCRIPTION
## 🎯 Changes

Two main tweaks to improve performance. I must admit, I am not certain about how necessary the `{ _mutation: true }` vs `{ _type: "mutation" }` one is to improving the outcome. The main culprit seems to be `OmitNeverKeys`

All measurements done via my environment's
```sh
./build-and-link-trpc.bash && rm ./edge_worker/tsconfig.tsbuildinfo && pnpm -C edge_worker exec tsc --noEmit --generateTrace src
```

Also see https://github.com/trpc/trpc/pull/2687 where I played with interfaces

### Originally (in my env)
![Cole's screen capture of chrometracing 2022-09-11 at 13 51 06@2x](https://user-images.githubusercontent.com/2925395/189541884-75b12889-552f-404e-a4ec-cbc0e4bbaa74.png)

### After this change (in my env)
![Cole's screen capture of chrometracing 2022-09-11 at 14 08 08@2x](https://user-images.githubusercontent.com/2925395/189542550-a11c1820-dfac-4836-a7fe-e3891079c2b6.png)


## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.