### PR TITLE
perf: Remove OmitNeverKeys extra computations + use Interfaces

### DIFF
--- a/packages/client/src/createTRPCClientProxy.ts
+++ b/packages/client/src/createTRPCClientProxy.ts
@@ -3,7 +3,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type {
   AnyRouter,
-  OmitNeverKeys,
   Procedure,
   ProcedureArgs,
   ProcedureRouterRecord,
@@ -48,15 +47,19 @@ type SubscriptionResolver<
 type DecorateProcedure<
   TProcedure extends Procedure<any>,
   TRouter extends AnyRouter,
-> = OmitNeverKeys<{
-  query: TProcedure extends { _query: true } ? Resolver<TProcedure> : never;
-
-  mutate: TProcedure extends { _mutation: true } ? Resolver<TProcedure> : never;
-
-  subscribe: TProcedure extends { _subscription: true }
-    ? SubscriptionResolver<TProcedure, TRouter>
-    : never;
-}>;
+> = TProcedure extends { _type: 'query' }
+  ? {
+      query: Resolver<TProcedure>;
+    }
+  : TProcedure extends { _type: 'mutation' }
+  ? {
+      mutate: Resolver<TProcedure>;
+    }
+  : TProcedure extends { _type: 'subscription' }
+  ? {
+      subscribe: SubscriptionResolver<TProcedure, TRouter>;
+    }
+  : never;
 
 type assertProcedure<T> = T extends Procedure<any> ? T : never;
 
@@ -66,7 +69,7 @@ type assertProcedure<T> = T extends Procedure<any> ? T : never;
 type DecoratedProcedureRecord<
   TProcedures extends ProcedureRouterRecord,
   TRouter extends AnyRouter,
-> = OmitNeverKeys<{
+> = {
   [TKey in keyof TProcedures]: TProcedures[TKey] extends LegacyV9ProcedureTag
     ? never
     : TProcedures[TKey] extends AnyRouter
@@ -75,7 +78,7 @@ type DecoratedProcedureRecord<
         TProcedures[TKey]
       >
     : DecorateProcedure<assertProcedure<TProcedures[TKey]>, TRouter>;
-}>;
+};
 
 const clientCallTypeMap: Record<
   keyof DecorateProcedure<any, any>,

--- a/packages/react/src/createTRPCReact.tsx
+++ b/packages/react/src/createTRPCReact.tsx
@@ -6,7 +6,6 @@ import {
 import { TRPCClientErrorLike } from '@trpc/client';
 import {
   AnyRouter,
-  OmitNeverKeys,
   Procedure,
   ProcedureRouterRecord,
   inferProcedureInput,
@@ -35,9 +34,9 @@ import {
 type DecorateProcedure<
   TProcedure extends Procedure<any>,
   TPath extends string,
-> = OmitNeverKeys<{
-  useQuery: TProcedure extends { _query: true }
-    ? <
+> = TProcedure extends { _type: 'query' }
+  ? {
+      useQuery: <
         TQueryFnData = inferProcedureOutput<TProcedure>,
         TData = inferProcedureOutput<TProcedure>,
       >(
@@ -49,30 +48,28 @@ type DecorateProcedure<
           TData,
           TRPCClientErrorLike<TProcedure>
         >,
-      ) => UseQueryResult<TData, TRPCClientErrorLike<TProcedure>>
-    : never;
+      ) => UseQueryResult<TData, TRPCClientErrorLike<TProcedure>>;
 
-  useInfiniteQuery: TProcedure extends { _query: true }
-    ? inferProcedureInput<TProcedure> extends {
+      useInfiniteQuery: inferProcedureInput<TProcedure> extends {
         cursor?: any;
       }
-      ? <
-          _TQueryFnData = inferProcedureOutput<TProcedure>,
-          TData = inferProcedureOutput<TProcedure>,
-        >(
-          input: Omit<inferProcedureInput<TProcedure>, 'cursor'>,
-          opts?: UseTRPCInfiniteQueryOptions<
-            TPath,
-            inferProcedureInput<TProcedure>,
-            TData,
-            TRPCClientErrorLike<TProcedure>
-          >,
-        ) => UseInfiniteQueryResult<TData, TRPCClientErrorLike<TProcedure>>
-      : never
-    : never;
-
-  useMutation: TProcedure extends { _mutation: true }
-    ? <TContext = unknown>(
+        ? <
+            _TQueryFnData = inferProcedureOutput<TProcedure>,
+            TData = inferProcedureOutput<TProcedure>,
+          >(
+            input: Omit<inferProcedureInput<TProcedure>, 'cursor'>,
+            opts?: UseTRPCInfiniteQueryOptions<
+              TPath,
+              inferProcedureInput<TProcedure>,
+              TData,
+              TRPCClientErrorLike<TProcedure>
+            >,
+          ) => UseInfiniteQueryResult<TData, TRPCClientErrorLike<TProcedure>>
+        : never;
+    }
+  : TProcedure extends { _type: 'mutation' }
+  ? {
+      useMutation: <TContext = unknown>(
         opts?: UseTRPCMutationOptions<
           inferProcedureInput<TProcedure>,
           TRPCClientErrorLike<TProcedure>,
@@ -84,19 +81,19 @@ type DecorateProcedure<
         TRPCClientErrorLike<TProcedure>,
         inferProcedureInput<TProcedure>,
         TContext
-      >
-    : never;
-
-  useSubscription: TProcedure extends { _subscription: true }
-    ? (
+      >;
+    }
+  : TProcedure extends { _type: 'subscription' }
+  ? {
+      useSubscription: (
         input: inferProcedureInput<TProcedure>,
         opts?: UseTRPCSubscriptionOptions<
           inferObservableValue<inferProcedureOutput<TProcedure>>,
           TRPCClientErrorLike<TProcedure>
         >,
-      ) => void
-    : never;
-}>;
+      ) => void;
+    }
+  : never;
 
 type assertProcedure<T> = T extends Procedure<any> ? T : never;
 

--- a/packages/server/src/core/procedure.ts
+++ b/packages/server/src/core/procedure.ts
@@ -6,6 +6,7 @@ import {
   ProcedureCallOptions,
 } from './internals/procedureBuilder';
 import { UnsetMarker } from './internals/utils';
+import { ProcedureType } from './types';
 
 type ClientContext = Record<string, unknown>;
 
@@ -85,7 +86,11 @@ export type ProcedureArgs<TParams extends ProcedureParams> =
  *
  * @internal
  */
-export interface ProcedureBase<TParams extends ProcedureParams> {
+export interface ProcedureBase<
+  TType extends ProcedureType,
+  TParams extends ProcedureParams,
+> {
+  _type: TType;
   _def: TParams & ProcedureBuilder<TParams>['_def'];
   /**
    * @deprecated use `._def.meta` instead
@@ -99,23 +104,15 @@ export interface ProcedureBase<TParams extends ProcedureParams> {
 }
 
 export interface QueryProcedure<TParams extends ProcedureParams>
-  extends ProcedureBase<TParams> {
-  _query: true;
-}
+  extends ProcedureBase<'query', TParams> {}
 
 export interface MutationProcedure<TParams extends ProcedureParams>
-  extends ProcedureBase<TParams> {
-  _mutation: true;
-}
+  extends ProcedureBase<'mutation', TParams> {}
 
 export interface SubscriptionProcedure<TParams extends ProcedureParams>
-  extends ProcedureBase<TParams> {
-  _subscription: true;
-}
+  extends ProcedureBase<'subscription', TParams> {}
 
-export type Procedure<TParams extends ProcedureParams> =
-  | QueryProcedure<TParams>
-  | MutationProcedure<TParams>
-  | SubscriptionProcedure<TParams>;
+export interface Procedure<TParams extends ProcedureParams>
+  extends ProcedureBase<ProcedureType, TParams> {}
 
 export type AnyProcedure = Procedure<any>;


### PR DESCRIPTION
# I'm not confident this is worth merging.

I can't tell if it's actually faster. I didn't calculate incremental build time, though.

Based on #2686 

All measurements done via my environment's
```sh
./build-and-link-trpc.bash && rm ./edge_worker/tsconfig.tsbuildinfo && pnpm -C edge_worker exec tsc --noEmit --generateTrace src
```

## 🎯 Changes

### 3
![Cole's screen capture of chrometracing 2022-09-11 at 14 06 25@2x](https://user-images.githubusercontent.com/2925395/189542500-791ed5cc-6342-4219-aa89-2859cc5c5da4.png)

## Extended: "using interfaces instead of OverwriteKnown"

### 4
![Cole's screen capture of chrometracing 2022-09-11 at 13 47 58@2x](https://user-images.githubusercontent.com/2925395/189541778-7dccbb6f-3a90-4864-8689-08b640513933.png)

### 5
![Cole's screen capture of chrometracing 2022-09-11 at 14 11 22@2x](https://user-images.githubusercontent.com/2925395/189542676-f2fb26f0-4b89-47d9-8b54-c439dccf62ec.png)

### 6
![Cole's screen capture of chrometracing 2022-09-11 at 14 14 38@2x](https://user-images.githubusercontent.com/2925395/189542836-b301f760-1d7f-4585-a4e1-327b1daec77b.png)
What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.