### PR TITLE
tRPC v10 (w/ Fetch Adapter) + SvelteKit example

### DIFF
--- a/www/docs/main/awesome-trpc.mdx
+++ b/www/docs/main/awesome-trpc.mdx
@@ -46,6 +46,7 @@ slug: /awesome-trpc
 | Nx Monorepo + tRPC + Prisma                                                                      | https://github.com/nowlena/nx-trpc-test                                 |
 | NX + tRPC + Prisma + NextJS + Expo                                                               | https://github.com/mwarger/tmdb-watchlist-prisma                        |
 | NX + tRPC + EdgeDB + NextJS + Expo                                                               | https://github.com/mwarger/tmdb-watchlist-edgedb                        |
+| tRPC (w/ Fetch Adapter) + SvelteKit + Tailwind CSS                                               | https://github.com/austins/trpc-sveltekit-fetchadapter-example      |
 
 ## 🏁 Open-source projects using tRPC
 


### PR DESCRIPTION
This was done previously in #2509 but it was removed when the docs were updated to be versioned. Confirmed this example is for tRPC v10 and latest SvelteKit.

## 🎯 Changes

Add a link to a simple example of tRPC v10-alpha (w/ Fetch Adapter) + SvelteKit + Tailwind CSS to the Awesome tRPC Collection doc.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.