### PR TITLE
www/quick-ui-wins

### DIFF
--- a/www/src/components/Button.tsx
+++ b/www/src/components/Button.tsx
@@ -17,7 +17,7 @@ export const Button = ({
   ...props
 }: Props) => {
   const className = clsx(
-    'inline-grid appearance-none cursor-pointer text-sm sm:text-base font-bold tracking-normal px-2 sm:px-4 py-1.5 sm:py-2 gap-1 sm:gap-1.5 grid-flow-col rounded-lg shadow-xl shadow-sky-500/20 no-underline hover:no-underline justify-center items-center transition-all duration-300 ',
+    'inline-grid appearance-none cursor-pointer text-sm sm:text-base font-bold tracking-normal px-2 sm:px-4 py-1.5 sm:py-2 gap-1 sm:gap-1.5 grid-flow-col rounded-lg shadow-xl shadow-sky-500/20 no-underline hover:no-underline justify-center items-center transition-all duration-300',
     {
       ['bg-primary text-white hover:text-white hover:bg-sky-700']:
         variant === 'primary',

--- a/www/src/components/Features.tsx
+++ b/www/src/components/Features.tsx
@@ -1,12 +1,12 @@
 import React, { FC } from 'react';
-import { FaBatteryFull, FaSeedling } from 'react-icons/fa';
+import { FaBatteryFull, FaRegThumbsDown, FaSeedling } from 'react-icons/fa';
 import { FiBriefcase, FiLock, FiTerminal, FiZap } from 'react-icons/fi';
 
 const features = [
   {
     title: 'Automatic typesafety',
     description:
-      'Made a server side change? Typescript will warn you client side! This is inferred from your API-paths, their inputs & outputs.',
+      'Made a server side change? TypeScript will warn you of errors on your client before you even save the file!',
     icon: <FiLock size={20} />,
     color:
       'dark:bg-indigo-900/50 bg-indigo-200 dark:text-indigo-300 text-indigo-600',
@@ -14,37 +14,36 @@ const features = [
   {
     title: 'Snappy DX',
     description:
-      'tRPC has no build or compile steps, meaning no code generation, runtime bloat, or build pipeline.',
+      'tRPC has no build or compile steps, meaning no code generation, runtime bloat or build pipeline.',
     icon: <FiZap size={20} />,
     color:
       'dark:bg-amber-900/50 bg-amber-200 dark:text-amber-300 text-amber-600',
   },
   {
-    title: 'Add easily to any web framework',
+    title: 'Framework agnostic',
     description:
-      "Compatible with any JavaScript framework, such as React, Vue, or Svelte. It's easy to add to your existing brownfield project. ",
+      "Compatible with all JavaScript frameworks and runtimes. It's easy to add to your existing brownfield project.",
     icon: <FiBriefcase size={20} />,
     color: 'dark:bg-pink-900/50 bg-pink-200 dark:text-pink-300 text-pink-600',
   },
   {
     title: 'Autocompletion',
     description:
-      'Using tRPC is like using a SDK for your server code. This means the end of figuring out what endpoints the server accepts. ',
+      "Using tRPC is like using a SDK for your API's server code. Build and refactor your endpoints with confidence.",
     icon: <FiTerminal size={20} />,
     color:
       'dark:bg-orange-900/50 bg-orange-200 dark:text-orange-300 text-orange-600',
   },
   {
     title: 'Light bundle size',
-    description:
-      'tRPC has zero dependencies and a tiny client-side footprint. ',
+    description: 'tRPC has zero dependencies and a tiny client-side footprint.',
     icon: <FaSeedling size={20} />,
     color: 'dark:bg-lime-900/50 bg-lime-200 dark:lime-orange-300 text-lime-600',
   },
   {
     title: 'Batteries included',
     description:
-      'We provide adapters for React, Next.js, Express.js, and more. There are also community-maintained adapters available for frameworks such as Nuxt and Sveltekit.',
+      'We provide adapters for React, Next.js, Express.js, Fastify & Lambda. There are also community-maintained adapters for many more frameworks.',
     icon: <FaBatteryFull size={20} />,
     color: 'dark:bg-sky-900/50 bg-sky-200 dark:lime-sky-300 text-sky-600',
   },

--- a/www/src/components/GithubStarsButton.tsx
+++ b/www/src/components/GithubStarsButton.tsx
@@ -3,7 +3,11 @@ import React, { useEffect, useState } from 'react';
 import { FiStar } from 'react-icons/fi';
 import { Button } from './Button';
 
-export const GithubStarsButton = () => {
+type Props = {
+  className?: string;
+};
+
+export const GithubStarsButton = ({ className }: Props) => {
   const [stars, setStars] = useState<string>();
 
   const fetchStars = async () => {
@@ -23,7 +27,7 @@ export const GithubStarsButton = () => {
       variant="secondary"
       href="https://github.com/trpc/trpc/stargazers"
       target="_blank"
-      className="text-lg"
+      className={className}
     >
       <FiStar size={18} strokeWidth={3} />
       <span>Star</span>

--- a/www/src/css/custom.css
+++ b/www/src/css/custom.css
@@ -21,6 +21,7 @@
   --ifm-code-font-size: 95%;
   --ifm-container-width: 1140px;
   --ifm-container-width-xl: 1320px;
+  --ifm-navbar-shadow: none;
 }
 :root[data-theme='dark'] {
   --ifm-footer-background-color: #171717;
@@ -32,8 +33,8 @@ html {
   @apply selection:text-white selection:bg-sky-500/75 scroll-smooth;
 }
 
-.homepage .navbar {
-  @apply shadow-none;
+.navbar {
+  border-bottom: 1px solid var(--ifm-toc-border-color);
 }
 .homepage .navbar__inner {
   @apply container;

--- a/www/src/pages/index.tsx
+++ b/www/src/pages/index.tsx
@@ -82,12 +82,12 @@ function Home() {
           charSet="utf-8"
         />
       </Head>
-      <main className="px-6 mx-auto space-y-28">
-        <header className="pt-12 lg:pt-16 xl:pt-24 max-w-[66ch] mx-auto text-center">
+      <main className="container px-6 mx-auto space-y-28">
+        <header className="pt-12 mx-auto text-center lg:pt-16 xl:pt-24">
           <h1 className="text-2xl font-extrabold leading-tight tracking-tight text-center whitespace-pre-wrap md:text-3xl lg:text-4xl xl:text-5xl">
             {siteConfig.tagline}
           </h1>
-          <p className="pt-3 text-sm font-medium text-center text-gray-600 md:text-lg dark:text-gray-400">
+          <p className="pt-3 text-sm font-medium text-center max-w-[60ch] text-gray-600 md:text-lg dark:text-gray-400 mx-auto">
             Experience the full power of{' '}
             <span className="underline text-slate-900 dark:text-slate-100 decoration-rose-500 underline-offset-2 decoration-wavy decoration-from-font">
               TypeScript
@@ -96,14 +96,14 @@ function Home() {
             application.
           </p>
           <div className="flex items-center justify-center gap-4 mt-6">
-            <div className="flex-1 flex justify-end">
-              <GithubStarsButton />
+            <div className="flex justify-end flex-1">
+              <GithubStarsButton className="lg:text-lg" />
             </div>
-            <div className="flex-1 flex justify-start">
+            <div className="flex justify-start flex-1">
               <Button
                 variant="primary"
                 href={`/docs/${isV10 ? 'v10' : 'v9'}/quickstart`}
-                className="text-lg"
+                className="lg:text-lg"
               >
                 Quickstart
                 <FiArrowRight size={20} strokeWidth={3} />
@@ -170,7 +170,7 @@ function Home() {
                 <title>GitHub</title>
                 <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
               </svg>
-              <span className="dark:text-zinc-300 text-zinc-900 no-underline font-semibold mx-auto">
+              <span className="mx-auto font-semibold no-underline dark:text-zinc-300 text-zinc-900">
                 Use this template
               </span>
             </Button>


### PR DESCRIPTION
Closes #

## 🎯 Changes

* Added `border-bottom` to navbar. 
* CTA buttons use `text-lg` class on large screen sizes.
* `h1` remains on two lines if screen width permits.
* Landing page gif is wider
* Reworded some landing page features

Before:
<kbd>
![image](https://user-images.githubusercontent.com/69924001/189635122-2fa3ee66-3a47-4571-8062-1d5ae7b7bec6.png)
</kbd>

After
<kbd>
![image](https://user-images.githubusercontent.com/69924001/189635205-08a0a065-4bb3-4f89-be99-e81a50f36ccb.png)
</kbd>

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.