### PR TITLE
[docs/www] Small fix to context docs example code

### DIFF
--- a/www/docs/server/context.md
+++ b/www/docs/server/context.md
@@ -32,7 +32,7 @@ export async function createContext(opts?: trpcNext.CreateNextContextOptions) {
     user,
   };
 }
-type Context = trpc.inferAsyncReturnType<typeof createContext>;
+export type Context = trpc.inferAsyncReturnType<typeof createContext>;
 ```
 
 ```ts title='server/routers/_app.ts'


### PR DESCRIPTION
Added an export to the Context type so it can be properly imported in the "routers/_app.ts" file in the example code