### PR TITLE
fix createTRPCNext types

### DIFF
--- a/packages/next/src/withTRPC.tsx
+++ b/packages/next/src/withTRPC.tsx
@@ -9,7 +9,7 @@ import {
   QueryClientProvider,
   dehydrate,
 } from '@tanstack/react-query';
-import type { CreateTRPCClientOptions } from '@trpc/client/src/internals/TRPCClient';
+import type { CreateTRPCClientOptions } from '@trpc/client';
 import {
   TRPCClient,
   TRPCClientError,


### PR DESCRIPTION
Closes #2693

## 🎯 Changes
change to public import of `@trpc/client`