### PR TITLE
www: add border & shadow around `QuickIntro`

### DIFF
--- a/www/docs/landing-intro/Step1.md
+++ b/www/docs/landing-intro/Step1.md
@@ -7,7 +7,7 @@ import z from 'zod';
 
 const t = initTRPC.create();
 
-export const appRouter = t.router({
+const appRouter = t.router({
   greeting: t.procedure
     .input(z.object({ name: z.string() }))
     .query((req) => {

--- a/www/src/components/Button.tsx
+++ b/www/src/components/Button.tsx
@@ -19,7 +19,7 @@ export const Button = ({
   const className = clsx(
     'inline-grid appearance-none cursor-pointer text-sm sm:text-base font-bold tracking-normal px-2 sm:px-4 py-1.5 sm:py-2 gap-1 sm:gap-1.5 grid-flow-col rounded-lg shadow-xl shadow-sky-500/20 no-underline hover:no-underline justify-center items-center transition-all duration-300',
     {
-      ['bg-primary text-white hover:text-white hover:bg-sky-700']:
+      ['bg-primary text-white hover:text-white hover:bg-primary-dark']:
         variant === 'primary',
       ['bg-gradient-to-r from-sky-50 to-sky-200 text-slate-800 hover:text-primary-darker']:
         variant === 'secondary',

--- a/www/src/components/QuickIntro.tsx
+++ b/www/src/components/QuickIntro.tsx
@@ -27,7 +27,7 @@ const Step: FC<StepProps> = ({ num, title, description, code, rightSide }) => {
       </div>
       <div className="flex-1">
         <div className="flex flex-col justify-center gap-3 lg:flex-row lg:items-center lg:justify-start">
-          <div className="grid w-6 h-6 rounded-full dark:bg-zinc-200 bg-[#313131] place-items-center">
+          <div className="grid w-6 h-6 rounded-full dark:bg-primary-200 bg-primary place-items-center">
             <p className="font-bold dark:text-[#313131] text-white">{num}</p>
           </div>
           <h2 className="text-xl font-bold lg:text-2xl">{title}</h2>

--- a/www/src/components/QuickIntro.tsx
+++ b/www/src/components/QuickIntro.tsx
@@ -96,7 +96,7 @@ const steps: Omit<StepProps, 'num'>[] = [
 
 export const QuickIntro: FC = () => {
   return (
-    <section id="#quick-intro">
+    <section className="border border-gray-100 rounded-xl p-4 md:p-8 shadow-lg dark:shadow-lg dark:shadow-gray-900 dark:border-gray-900">
       <SectionTitle
         id="quick-intro"
         title={


### PR DESCRIPTION
Add border & shadow around `QuickIntro`. Feels a bit better I think, esp on mobile to have it in a container so one knows where it starts and ends