### PR TITLE
Fix changed `yarn db-reset` command in `next-prisma-starter` example `README`

### DIFF
--- a/examples/next-prisma-starter/README.md
+++ b/examples/next-prisma-starter/README.md
@@ -53,7 +53,7 @@ yarn dx
 
 ```bash
 yarn build      # runs `prisma generate` + `prisma migrate` + `next build`
-yarn db-nuke    # resets local db
+yarn db-reset   # resets local db
 yarn dev        # starts next.js
 yarn dx         # starts postgres db + runs migrations + seeds + starts next.js 
 yarn test-dev   # runs e2e tests on dev


### PR DESCRIPTION
Closes #

## 🎯 Changes

The command `yarn db-nuke` no longer exists in [`package.json`](https://github.com/trpc/trpc/blob/c88edc3b8453d949954e7b40300bfd58411e8873/examples/next-prisma-starter/package.json#L11) for the `next-prisma-starter` example even though it is listed in the `README`.  

It seems to have been changed to `yarn db-reset` so this PR fixes this to show the correct command in the README! 👍

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.