### PR TITLE
feat(react): Change to use Array Path for Tanstack Query Key

### DIFF
--- a/packages/server/test/interop/react/invalidateQueries.test.tsx
+++ b/packages/server/test/interop/react/invalidateQueries.test.tsx
@@ -43,8 +43,8 @@ describe('invalidateQueries()', () => {
           <button
             data-testid="refetch"
             onClick={() => {
-              queryClient.invalidateQueries(['allPosts']);
-              queryClient.invalidateQueries(['postById']);
+              queryClient.invalidateQueries([['allPosts']]);
+              queryClient.invalidateQueries([['postById']]);
             }}
           />
         </>


### PR DESCRIPTION
Closes #2611

## 🎯 Changes

As per #2611 this pull request looks to change to using a Sub array for the `path` element of the tanstack querykey in react hooks.

This allows us to take action on related queries such as invalidating all queries on a router which is harder to do with the current use of `.` seperated path keys such as `["post.simple.getById", {id:10}]` rather than `[["post", "simple", "getById"], {id:10}]`.

This will then allow us to implement an extension to the `invalidateQueries` proxy api such as: 

```tsx
utils.post.invalidateQueries() // Notice this is not a full path but a partial one!
```

## 🔨 Implementation

In this PR I have implemented this at the internal hooks level so it reflects across both the proxy and legacy implementation without any breaking changes to those api's. Implementing it this way also allows us to keep code shared between both implementations which we may not be able to do if implemented further down the chain. 

Even though this seems to work well it doesn't feel 100% right so definitely open to comment if I am off the mark or anyone can see problems ... but it does make sense as it's only the tanstack keys we want to affect. 

## ⚠️ Breaking Change (kinda)

The only breaking change from this is if someone is delving in and using the query keys not through the tRPC provided API's but by using Tanstack Query's `queryClient` directly. In this case users will see keys change from something like
`["post. List"]` to `[["post","list"]]`

An example of the breaking change can be seen in the test I had to change in this PR. 

## ☑️ Things left to do: 

- [ ] [One locally failing test left to fix](https://github.com/trpc/trpc/blob/c88edc3b8453d949954e7b40300bfd58411e8873/packages/server/test/interop/react/regression/issue-1645-setErrorStatusSSR.test.tsx#L57) .... Any help on this one is appreciated as I can't see where I have mucked it up ... Might just be too late 😴
- [ ] Add API to be able to use `invalidateQueries` at any proxy path level 
     - Any pointers on how to do this @sachinraja would be appreciated ... I havent quite nailed down where I can hook into a partial path on the proxy types 🤔
- [ ] Add tests of the above new api to invalidate at any path level. 
- [ ] Add documentation on new invalidating capabilities
- [ ] Add a note about the breaking change to Query Keys in a migration page / docs? 

Thanks for bearing with me on this one and all comments welcome; still got a long way to go on my opensource journey! 😜


## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] (½ done) I have added or updated the tests related to the changes made.