### PR TITLE
turbo types

### DIFF
--- a/packages/client/src/TRPCClientError.ts
+++ b/packages/client/src/TRPCClientError.ts
@@ -2,14 +2,14 @@ import {
   AnyRouter,
   DefaultErrorShape,
   Maybe,
-  Procedure,
   inferRouterError,
 } from '@trpc/server';
 import { TRPCErrorResponse } from '@trpc/server/rpc';
+import { AnyProcedure } from 'packages/server/dist';
 
-type RouterOrProcedure = AnyRouter | Procedure<any>;
+type RouterOrProcedure = AnyRouter | AnyProcedure;
 
-type inferErrorShape<TRouterOrProcedure extends AnyRouter | Procedure<any>> =
+type inferErrorShape<TRouterOrProcedure extends RouterOrProcedure> =
   TRouterOrProcedure extends AnyRouter
     ? inferRouterError<TRouterOrProcedure>
     : TRouterOrProcedure['_def']['_config']['errorShape'];

--- a/packages/client/src/TRPCClientError.ts
+++ b/packages/client/src/TRPCClientError.ts
@@ -1,11 +1,11 @@
 import {
+  AnyProcedure,
   AnyRouter,
   DefaultErrorShape,
   Maybe,
   inferRouterError,
 } from '@trpc/server';
 import { TRPCErrorResponse } from '@trpc/server/rpc';
-import { AnyProcedure } from 'packages/server/dist';
 
 type RouterOrProcedure = AnyRouter | AnyProcedure;
 

--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -23,5 +23,4 @@ export type {
   TRPCRequestOptions,
   CreateTRPCClientOptions,
   TRPCClient,
-  AssertLegacyDef,
 } from './internals/TRPCClient';

--- a/packages/client/src/createTRPCClientProxy.ts
+++ b/packages/client/src/createTRPCClientProxy.ts
@@ -70,14 +70,12 @@ type DecoratedProcedureRecord<
   TProcedures extends ProcedureRouterRecord,
   TRouter extends AnyRouter,
 > = {
-  [TKey in keyof TProcedures]: TProcedures[TKey] extends LegacyV9ProcedureTag
-    ? never
-    : TProcedures[TKey] extends AnyRouter
+  [TKey in keyof TProcedures]: TProcedures[TKey] extends AnyRouter
     ? DecoratedProcedureRecord<
         TProcedures[TKey]['_def']['record'],
         TProcedures[TKey]
       >
-    : DecorateProcedure<assertProcedure<TProcedures[TKey]>, TRouter>;
+    : DecorateProcedure<TProcedures[TKey], TRouter>;
 };
 
 const clientCallTypeMap: Record<

--- a/packages/client/src/createTRPCClientProxy.ts
+++ b/packages/client/src/createTRPCClientProxy.ts
@@ -70,12 +70,14 @@ type DecoratedProcedureRecord<
   TProcedures extends ProcedureRouterRecord,
   TRouter extends AnyRouter,
 > = {
-  [TKey in keyof TProcedures]: TProcedures[TKey] extends AnyRouter
+  [TKey in keyof TProcedures]: TProcedures[TKey] extends LegacyV9ProcedureTag
+    ? never
+    : TProcedures[TKey] extends AnyRouter
     ? DecoratedProcedureRecord<
         TProcedures[TKey]['_def']['record'],
         TProcedures[TKey]
       >
-    : DecorateProcedure<TProcedures[TKey], TRouter>;
+    : DecorateProcedure<assertProcedure<TProcedures[TKey]>, TRouter>;
 };
 
 const clientCallTypeMap: Record<

--- a/packages/client/src/createTRPCClientProxy.ts
+++ b/packages/client/src/createTRPCClientProxy.ts
@@ -7,7 +7,6 @@ import type {
   AnyQueryProcedure,
   AnyRouter,
   AnySubscriptionProcedure,
-  Procedure,
   ProcedureArgs,
   ProcedureRouterRecord,
   ProcedureType,

--- a/packages/client/src/createTRPCClientProxy.ts
+++ b/packages/client/src/createTRPCClientProxy.ts
@@ -2,7 +2,11 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type {
+  AnyMutationProcedure,
+  AnyProcedure,
+  AnyQueryProcedure,
   AnyRouter,
+  AnySubscriptionProcedure,
   Procedure,
   ProcedureArgs,
   ProcedureRouterRecord,
@@ -13,7 +17,7 @@ import type {
   Unsubscribable,
   inferObservableValue,
 } from '@trpc/server/observable';
-import { LegacyV9ProcedureTag, createProxy } from '@trpc/server/shared';
+import { createProxy } from '@trpc/server/shared';
 import { TRPCClientError } from './TRPCClientError';
 import { CreateTRPCClientOptions, createTRPCClient } from './createTRPCClient';
 import {
@@ -24,12 +28,12 @@ import {
 export type inferRouterProxyClient<TRouter extends AnyRouter> =
   DecoratedProcedureRecord<TRouter['_def']['record'], TRouter>;
 
-type Resolver<TProcedure extends Procedure<any>> = (
+type Resolver<TProcedure extends AnyProcedure> = (
   ...args: ProcedureArgs<TProcedure['_def']>
 ) => Promise<inferProcedureOutput<TProcedure>>;
 
 type SubscriptionResolver<
-  TProcedure extends Procedure<any>,
+  TProcedure extends AnyProcedure,
   TRouter extends AnyRouter,
 > = (
   ...args: [
@@ -45,23 +49,21 @@ type SubscriptionResolver<
 ) => Unsubscribable;
 
 type DecorateProcedure<
-  TProcedure extends Procedure<any>,
+  TProcedure extends AnyProcedure,
   TRouter extends AnyRouter,
-> = TProcedure extends { _type: 'query' }
+> = TProcedure extends AnyQueryProcedure
   ? {
       query: Resolver<TProcedure>;
     }
-  : TProcedure extends { _type: 'mutation' }
+  : TProcedure extends AnyMutationProcedure
   ? {
       mutate: Resolver<TProcedure>;
     }
-  : TProcedure extends { _type: 'subscription' }
+  : TProcedure extends AnySubscriptionProcedure
   ? {
       subscribe: SubscriptionResolver<TProcedure, TRouter>;
     }
   : never;
-
-type assertProcedure<T> = T extends Procedure<any> ? T : never;
 
 /**
  * @internal
@@ -70,14 +72,14 @@ type DecoratedProcedureRecord<
   TProcedures extends ProcedureRouterRecord,
   TRouter extends AnyRouter,
 > = {
-  [TKey in keyof TProcedures]: TProcedures[TKey] extends LegacyV9ProcedureTag
-    ? never
-    : TProcedures[TKey] extends AnyRouter
+  [TKey in keyof TProcedures]: TProcedures[TKey] extends AnyRouter
     ? DecoratedProcedureRecord<
         TProcedures[TKey]['_def']['record'],
         TProcedures[TKey]
       >
-    : DecorateProcedure<assertProcedure<TProcedures[TKey]>, TRouter>;
+    : TProcedures[TKey] extends AnyProcedure
+    ? DecorateProcedure<TProcedures[TKey], TRouter>
+    : never;
 };
 
 const clientCallTypeMap: Record<

--- a/packages/client/src/internals/TRPCClient.ts
+++ b/packages/client/src/internals/TRPCClient.ts
@@ -6,7 +6,6 @@ import {
   inferProcedureOutput,
   inferSubscriptionOutput,
 } from '@trpc/server';
-import { ProcedureRecord } from '@trpc/server';
 import {
   Unsubscribable,
   inferObservableValue,
@@ -79,22 +78,6 @@ export type CreateTRPCClientOptions<TRouter extends AnyRouter> =
             links?: never;
           }
       );
-
-export type AssertType<T, K> = T extends K ? T : never;
-/**
- * @deprecated
- */
-export type AssertLegacyDef<TRouter extends AnyRouter> =
-  TRouter['_def']['legacy'] extends Record<
-    'subscriptions' | 'queries' | 'mutations',
-    ProcedureRecord
-  >
-    ? TRouter['_def']['legacy']
-    : {
-        subscriptions: {};
-        queries: {};
-        mutations: {};
-      };
 
 export class TRPCClient<TRouter extends AnyRouter> {
   private readonly links: OperationLink<TRouter>[];
@@ -197,11 +180,9 @@ export class TRPCClient<TRouter extends AnyRouter> {
     return abortablePromise;
   }
   public query<
-    TQueries extends AssertLegacyDef<TRouter>['queries'],
+    TQueries extends TRouter['_def']['queries'],
     TPath extends string & keyof TQueries,
-    TInput extends inferProcedureInput<
-      AssertType<TQueries, ProcedureRecord>[TPath]
-    >,
+    TInput extends inferProcedureInput<TQueries[TPath]>,
   >(path: TPath, input?: TInput, opts?: TRPCRequestOptions) {
     type TOutput = inferProcedureOutput<TQueries[TPath]>;
     return this.requestAsPromise<TInput, TOutput>({
@@ -213,11 +194,9 @@ export class TRPCClient<TRouter extends AnyRouter> {
     });
   }
   public mutation<
-    TMutations extends AssertLegacyDef<TRouter>['mutations'],
+    TMutations extends TRouter['_def']['mutations'],
     TPath extends string & keyof TMutations,
-    TInput extends inferProcedureInput<
-      AssertType<TMutations, ProcedureRecord>[TPath]
-    >,
+    TInput extends inferProcedureInput<TMutations[TPath]>,
   >(path: TPath, input?: TInput, opts?: TRPCRequestOptions) {
     type TOutput = inferProcedureOutput<TMutations[TPath]>;
     return this.requestAsPromise<TInput, TOutput>({
@@ -229,12 +208,10 @@ export class TRPCClient<TRouter extends AnyRouter> {
     });
   }
   public subscription<
-    TSubscriptions extends AssertLegacyDef<TRouter>['subscriptions'],
+    TSubscriptions extends TRouter['_def']['subscriptions'],
     TPath extends string & keyof TSubscriptions,
     TOutput extends inferSubscriptionOutput<TRouter, TPath>,
-    TInput extends inferProcedureInput<
-      AssertType<TSubscriptions, ProcedureRecord>[TPath]
-    >,
+    TInput extends inferProcedureInput<TSubscriptions[TPath]>,
   >(
     path: TPath,
     input: TInput,

--- a/packages/react/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react/src/shared/hooks/createHooksInternal.tsx
@@ -13,7 +13,6 @@ import {
   hashQueryKey,
 } from '@tanstack/react-query';
 import {
-  AssertLegacyDef,
   CreateTRPCClientOptions,
   TRPCClient,
   TRPCClientErrorLike,
@@ -43,8 +42,6 @@ import {
   TRPCContextProps,
   TRPCContextState,
 } from '../../internals/context';
-
-export type AssertType<T, K> = T extends K ? T : never;
 
 export type OutputWithCursor<TData, TCursor extends any = any> = {
   cursor: TCursor | null;
@@ -151,18 +148,9 @@ export function createHooksInternal<
   TRouter extends AnyRouter,
   TSSRContext = unknown,
 >() {
-  type TQueries = AssertType<
-    AssertLegacyDef<TRouter>['queries'],
-    ProcedureRecord
-  >;
-  type TSubscriptions = AssertType<
-    AssertLegacyDef<TRouter>['subscriptions'],
-    ProcedureRecord
-  >;
-  type TMutations = AssertType<
-    AssertLegacyDef<TRouter>['mutations'],
-    ProcedureRecord
-  >;
+  type TQueries = TRouter['_def']['queries'];
+  type TSubscriptions = TRouter['_def']['subscriptions'];
+  type TMutations = TRouter['_def']['mutations'];
 
   type TError = TRPCClientErrorLike<TRouter>;
   type TInfiniteQueryNames = inferInfiniteQueryNames<TQueries>;

--- a/packages/react/src/shared/proxy/utilsProxy.ts
+++ b/packages/react/src/shared/proxy/utilsProxy.ts
@@ -30,7 +30,7 @@ import { getQueryKey } from '../../internals/getQueryKey';
 
 type DecorateProcedure<
   TRouter extends AnyRouter,
-  TProcedure extends AnyProcedure,
+  TProcedure extends AnyQueryProcedure,
 > = {
   /**
    * @link https://react-query.tanstack.com/guides/prefetching

--- a/packages/react/src/ssg/ssgProxy.ts
+++ b/packages/react/src/ssg/ssgProxy.ts
@@ -5,17 +5,17 @@ import {
   QueryClient,
 } from '@tanstack/react-query';
 import {
+  AnyProcedure,
+  AnyQueryProcedure,
   AnyRouter,
-  OmitNeverKeys,
-  Procedure,
-  QueryProcedure,
+  Filter,
   inferHandlerInput,
   inferProcedureOutput,
 } from '@trpc/server';
 import { createProxy } from '@trpc/server/shared';
 import { CreateSSGHelpersOptions, createSSGHelpers } from './ssg';
 
-type DecorateProcedure<TProcedure extends Procedure<any>> = {
+type DecorateProcedure<TProcedure extends AnyProcedure> = {
   /**
    * @link https://react-query.tanstack.com/guides/prefetching
    */
@@ -44,15 +44,15 @@ type DecorateProcedure<TProcedure extends Procedure<any>> = {
 /**
  * @internal
  */
-export type DecoratedProcedureSSGRecord<TRouter extends AnyRouter> =
-  OmitNeverKeys<{
-    [TKey in keyof TRouter['_def']['record']]: TRouter['_def']['record'][TKey] extends AnyRouter
-      ? DecoratedProcedureSSGRecord<TRouter['_def']['record'][TKey]>
-      : // utils only apply to queries
-      TRouter['_def']['record'][TKey] extends QueryProcedure<any>
-      ? DecorateProcedure<TRouter['_def']['record'][TKey]>
-      : never;
-  }>;
+export type DecoratedProcedureSSGRecord<TRouter extends AnyRouter> = {
+  [TKey in keyof Filter<
+    TRouter['_def']['record'],
+    AnyRouter | AnyQueryProcedure
+  >]: TRouter['_def']['record'][TKey] extends AnyRouter
+    ? DecoratedProcedureSSGRecord<TRouter['_def']['record'][TKey]>
+    : // utils only apply to queries
+      DecorateProcedure<TRouter['_def']['record'][TKey]>;
+};
 
 type AnyDecoratedProcedure = DecorateProcedure<any>;
 

--- a/packages/server/src/core/index.ts
+++ b/packages/server/src/core/index.ts
@@ -7,6 +7,9 @@ export { callProcedure } from './router';
 export type {
   Procedure,
   AnyProcedure,
+  AnyQueryProcedure,
+  AnyMutationProcedure,
+  AnySubscriptionProcedure,
   ProcedureParams,
   ProcedureArgs,
   ProcedureOptions,

--- a/packages/server/src/core/index.ts
+++ b/packages/server/src/core/index.ts
@@ -6,6 +6,7 @@ export type {
 export { callProcedure } from './router';
 export type {
   Procedure,
+  AnyProcedure,
   ProcedureParams,
   ProcedureArgs,
   ProcedureOptions,

--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -9,8 +9,11 @@ import {
 } from '../middleware';
 import { Parser, inferParser } from '../parser';
 import {
+  AnyMutationProcedure,
+  AnyProcedure,
+  AnyQueryProcedure,
+  AnySubscriptionProcedure,
   MutationProcedure,
-  Procedure,
   ProcedureParams,
   QueryProcedure,
   SubscriptionProcedure,
@@ -251,19 +254,19 @@ export function createBuilder<TConfig extends RootConfig>(
       return createResolver(
         { ..._def, query: true },
         resolver,
-      ) as QueryProcedure<any>;
+      ) as AnyQueryProcedure;
     },
     mutation(resolver) {
       return createResolver(
         { ..._def, mutation: true },
         resolver,
-      ) as MutationProcedure<any>;
+      ) as AnyMutationProcedure;
     },
     subscription(resolver) {
       return createResolver(
         { ..._def, subscription: true },
         resolver,
-      ) as SubscriptionProcedure<any>;
+      ) as AnySubscriptionProcedure;
     },
   };
 }
@@ -312,7 +315,7 @@ const caller = appRouter.createCaller({
 const result = await caller.call('myProcedure', input);
 `.trim();
 
-function createProcedureCaller(_def: AnyProcedureBuilderDef): Procedure<any> {
+function createProcedureCaller(_def: AnyProcedureBuilderDef): AnyProcedure {
   const procedure = async function resolve(opts: ProcedureCallOptions) {
     // is direct server-side call
     if (!opts || !('rawInput' in opts)) {
@@ -379,5 +382,5 @@ function createProcedureCaller(_def: AnyProcedureBuilderDef): Procedure<any> {
   procedure._def = _def;
   procedure.meta = _def.meta;
 
-  return procedure as Procedure<any>;
+  return procedure as AnyProcedure;
 }

--- a/packages/server/src/core/procedure.ts
+++ b/packages/server/src/core/procedure.ts
@@ -105,14 +105,16 @@ export interface ProcedureBase<
 
 export interface QueryProcedure<TParams extends ProcedureParams>
   extends ProcedureBase<'query', TParams> {}
+export type AnyQueryProcedure = QueryProcedure<any>;
 
 export interface MutationProcedure<TParams extends ProcedureParams>
   extends ProcedureBase<'mutation', TParams> {}
+export type AnyMutationProcedure = MutationProcedure<any>;
 
 export interface SubscriptionProcedure<TParams extends ProcedureParams>
   extends ProcedureBase<'subscription', TParams> {}
+export type AnySubscriptionProcedure = SubscriptionProcedure<any>;
 
 export interface Procedure<TParams extends ProcedureParams>
   extends ProcedureBase<ProcedureType, TParams> {}
-
 export type AnyProcedure = Procedure<any>;

--- a/packages/server/src/core/types.ts
+++ b/packages/server/src/core/types.ts
@@ -1,5 +1,5 @@
 import { inferObservableValue } from '../observable';
-import { Procedure, ProcedureArgs } from './procedure';
+import { AnyProcedure, ProcedureArgs } from './procedure';
 import { AnyRouter, AnyRouterDef, Router } from './router';
 
 export type inferRouterDef<TRouter extends AnyRouter> = TRouter extends Router<
@@ -23,25 +23,26 @@ export const procedureTypes = ['query', 'mutation', 'subscription'] as const;
  */
 export type ProcedureType = typeof procedureTypes[number];
 
-export type inferHandlerInput<TProcedure extends Procedure<any>> =
-  ProcedureArgs<inferProcedureParams<TProcedure>>;
+export type inferHandlerInput<TProcedure extends AnyProcedure> = ProcedureArgs<
+  inferProcedureParams<TProcedure>
+>;
 
-export type inferProcedureInput<TProcedure extends Procedure<any>> =
+export type inferProcedureInput<TProcedure extends AnyProcedure> =
   inferHandlerInput<TProcedure>[0];
 
 // /**
 //  * @internal
 //  */
-// type inferProcedureFn<TProcedure extends Procedure<any>> =
-//   TProcedure extends QueryProcedure<any>
+// type inferProcedureFn<TProcedure extends AnyProcedure> =
+//   TProcedure extends AnyQueryProcedure
 //     ? TProcedure['query']
-//     : TProcedure extends SubscriptionProcedure<any>
+//     : TProcedure extends AnySubscriptionProcedure
 //     ? TProcedure['subscription']
-//     : TProcedure extends MutationProcedure<any>
+//     : TProcedure extends AnyMutationProcedure
 //     ? TProcedure['mutate']
 //     : never;
 
-export type inferProcedureParams<TProcedure> = TProcedure extends Procedure<any>
+export type inferProcedureParams<TProcedure> = TProcedure extends AnyProcedure
   ? TProcedure['_def']
   : never;
 export type inferProcedureOutput<TProcedure> =
@@ -54,5 +55,5 @@ export type inferSubscriptionOutput<
   inferProcedureOutput<TRouter['_def']['subscriptions'][TPath]>
 >;
 
-export type inferProcedureClientError<T extends Procedure<any>> =
+export type inferProcedureClientError<T extends AnyProcedure> =
   inferProcedureParams<T>['_config']['errorShape'];

--- a/packages/server/src/core/types.ts
+++ b/packages/server/src/core/types.ts
@@ -30,18 +30,6 @@ export type inferHandlerInput<TProcedure extends AnyProcedure> = ProcedureArgs<
 export type inferProcedureInput<TProcedure extends AnyProcedure> =
   inferHandlerInput<TProcedure>[0];
 
-// /**
-//  * @internal
-//  */
-// type inferProcedureFn<TProcedure extends AnyProcedure> =
-//   TProcedure extends AnyQueryProcedure
-//     ? TProcedure['query']
-//     : TProcedure extends AnySubscriptionProcedure
-//     ? TProcedure['subscription']
-//     : TProcedure extends AnyMutationProcedure
-//     ? TProcedure['mutate']
-//     : never;
-
 export type inferProcedureParams<TProcedure> = TProcedure extends AnyProcedure
   ? TProcedure['_def']
   : never;

--- a/packages/server/src/deprecated/interop.ts
+++ b/packages/server/src/deprecated/interop.ts
@@ -149,11 +149,7 @@ export type MigrateRouter<
         'subscription'
       >;
     };
-  } & RouterDef<
-    TInputContext,
-    TErrorShape,
-    TMeta,
-    MigrateProcedureRecord<
+    queries: MigrateProcedureRecord<
       CreateRootConfig<{
         ctx: TInputContext;
         errorShape: TErrorShape;
@@ -162,28 +158,28 @@ export type MigrateRouter<
       }>,
       TQueries,
       'query'
-    > &
-      MigrateProcedureRecord<
-        CreateRootConfig<{
-          ctx: TInputContext;
-          errorShape: TErrorShape;
-          meta: TMeta;
-          transformer: CombinedDataTransformer;
-        }>,
-        TMutations,
-        'mutation'
-      > &
-      MigrateProcedureRecord<
-        CreateRootConfig<{
-          ctx: TInputContext;
-          errorShape: TErrorShape;
-          meta: TMeta;
-          transformer: CombinedDataTransformer;
-        }>,
-        TSubscriptions,
-        'subscription'
-      >
-  >
+    >;
+    mutations: MigrateProcedureRecord<
+      CreateRootConfig<{
+        ctx: TInputContext;
+        errorShape: TErrorShape;
+        meta: TMeta;
+        transformer: CombinedDataTransformer;
+      }>,
+      TMutations,
+      'mutation'
+    >;
+    subscriptions: MigrateProcedureRecord<
+      CreateRootConfig<{
+        ctx: TInputContext;
+        errorShape: TErrorShape;
+        meta: TMeta;
+        transformer: CombinedDataTransformer;
+      }>,
+      TSubscriptions,
+      'subscription'
+    >;
+  } & RouterDef<TInputContext, TErrorShape, TMeta, {}>
 >;
 
 export type MigrateOldRouter<TRouter extends AnyOldRouter> =

--- a/packages/server/src/deprecated/interop.ts
+++ b/packages/server/src/deprecated/interop.ts
@@ -9,11 +9,11 @@ import {
 } from '../core/middleware';
 import {
   MutationProcedure,
-  Procedure as NewProcedure,
   QueryProcedure,
   SubscriptionProcedure,
 } from '../core/procedure';
 import {
+  ProcedureRecord as NewProcedureRecord,
   Router as NewRouter,
   RouterDef,
   createRouterFactory,
@@ -53,26 +53,16 @@ type convertProcedureParams<
     >
   : never;
 
-/**
- * @deprecated
- */
-export type LegacyV9ProcedureTag = {
-  _old: true;
-};
-
 type MigrateProcedure<
   TConfig extends RootConfig,
   TProcedure extends AnyOldProcedure,
   TType extends ProcedureType,
 > = TType extends 'query'
-  ? QueryProcedure<convertProcedureParams<TConfig, TProcedure>> &
-      LegacyV9ProcedureTag
+  ? QueryProcedure<convertProcedureParams<TConfig, TProcedure>>
   : TType extends 'mutation'
-  ? MutationProcedure<convertProcedureParams<TConfig, TProcedure>> &
-      LegacyV9ProcedureTag
+  ? MutationProcedure<convertProcedureParams<TConfig, TProcedure>>
   : TType extends 'subscription'
-  ? SubscriptionProcedure<convertProcedureParams<TConfig, TProcedure>> &
-      LegacyV9ProcedureTag
+  ? SubscriptionProcedure<convertProcedureParams<TConfig, TProcedure>>
   : never;
 
 export type MigrateProcedureRecord<
@@ -117,38 +107,6 @@ export type MigrateRouter<
   TErrorShape extends TRPCErrorShape<any>,
 > = NewRouter<
   {
-    legacy: {
-      queries: MigrateProcedureRecord<
-        CreateRootConfig<{
-          ctx: TInputContext;
-          errorShape: TErrorShape;
-          meta: TMeta;
-          transformer: CombinedDataTransformer;
-        }>,
-        TQueries,
-        'query'
-      >;
-      mutations: MigrateProcedureRecord<
-        CreateRootConfig<{
-          ctx: TInputContext;
-          errorShape: TErrorShape;
-          meta: TMeta;
-          transformer: CombinedDataTransformer;
-        }>,
-        TMutations,
-        'mutation'
-      >;
-      subscriptions: MigrateProcedureRecord<
-        CreateRootConfig<{
-          ctx: TInputContext;
-          errorShape: TErrorShape;
-          meta: TMeta;
-          transformer: CombinedDataTransformer;
-        }>,
-        TSubscriptions,
-        'subscription'
-      >;
-    };
     queries: MigrateProcedureRecord<
       CreateRootConfig<{
         ctx: TInputContext;
@@ -238,11 +196,9 @@ export function migrateRouter<TOldRouter extends AnyOldRouter>(
   const errorFormatter = oldRouter._def.errorFormatter;
   const transformer = oldRouter._def.transformer;
 
-  type ProcRecord = Record<string, NewProcedure<any>>;
-
-  const queries: ProcRecord = {};
-  const mutations: ProcRecord = {};
-  const subscriptions: ProcRecord = {};
+  const queries: NewProcedureRecord = {};
+  const mutations: NewProcedureRecord = {};
+  const subscriptions: NewProcedureRecord = {};
   for (const [name, procedure] of Object.entries(oldRouter._def.queries)) {
     queries[name] = migrateProcedure(procedure as any, 'query');
   }

--- a/packages/server/src/http/resolveHTTPResponse.ts
+++ b/packages/server/src/http/resolveHTTPResponse.ts
@@ -2,6 +2,7 @@
 import {
   AnyRouter,
   ProcedureType,
+  callProcedure,
   inferRouterContext,
   inferRouterError,
 } from '../core';
@@ -180,8 +181,13 @@ export async function resolveHTTPResponse<
         const input = inputs[index];
 
         try {
-          const caller = router.createCaller(ctx);
-          const output = await caller[type](path, input as any);
+          const output = callProcedure({
+            procedures: router._def.procedures,
+            path,
+            rawInput: input,
+            ctx,
+            type,
+          });
           return {
             input,
             path,

--- a/packages/server/src/http/resolveHTTPResponse.ts
+++ b/packages/server/src/http/resolveHTTPResponse.ts
@@ -181,7 +181,7 @@ export async function resolveHTTPResponse<
         const input = inputs[index];
 
         try {
-          const output = callProcedure({
+          const output = await callProcedure({
             procedures: router._def.procedures,
             path,
             rawInput: input,

--- a/packages/server/src/shared/index.ts
+++ b/packages/server/src/shared/index.ts
@@ -1,3 +1,1 @@
 export * from './createProxy';
-
-export type { LegacyV9ProcedureTag } from '../deprecated/interop';

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -63,15 +63,3 @@ type FilterKeys<T extends object, K> = {
  * @internal
  */
 export type Filter<T extends object, K> = Pick<T, FilterKeys<T, K>>;
-
-/**
- * @internal
- */
-export type NeverKeys<T> = {
-  [TKey in keyof T]: T[TKey] extends never ? TKey : never;
-}[keyof T];
-
-/**
- * @internal
- */
-export type OmitNeverKeys<T> = Omit<T, NeverKeys<T>>;

--- a/scripts/generateBigBoi.ts
+++ b/scripts/generateBigBoi.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 
-const NUM_ROUTERS = 50;
+const NUM_ROUTERS = 500;
 
 function createRouter(routerName: string) {
   return `

--- a/scripts/generateBigBoi.ts
+++ b/scripts/generateBigBoi.ts
@@ -1,13 +1,13 @@
 import fs from 'fs';
 
-const NUM_PROCEDURE_OBJECTS = 500;
+const NUM_ROUTERS = 50;
 
-function createProcedureObject(procedureObjectName: string) {
+function createRouter(routerName: string) {
   return `
   import { z } from 'zod';
   import { t } from './_trpc';
   
-  export const ${procedureObjectName} = t.router({
+  export const ${routerName} = t.router({
     greeting: t
       .procedure
       .input(
@@ -59,13 +59,10 @@ const SERVER_DIR = __dirname + '/../packages/server/test/__generated__/bigBoi';
 fs.mkdirSync(SERVER_DIR, { recursive: true });
 
 const indexBuf: string[] = [];
-for (let i = 0; i < NUM_PROCEDURE_OBJECTS; i++) {
-  const procedureObjectName = `r${i}`;
-  indexBuf.push(procedureObjectName);
-  fs.writeFileSync(
-    `${SERVER_DIR}/${procedureObjectName}.ts`,
-    createProcedureObject(procedureObjectName),
-  );
+for (let i = 0; i < NUM_ROUTERS; i++) {
+  const routerName = `r${i}`;
+  indexBuf.push(routerName);
+  fs.writeFileSync(`${SERVER_DIR}/${routerName}.ts`, createRouter(routerName));
 }
 
 const trpcFile = `

--- a/scripts/generateMergeRouters.ts
+++ b/scripts/generateMergeRouters.ts
@@ -22,7 +22,6 @@ const TEMPLATE = `
  ): Router<{
   router: true;
   _ctx: RP0['_ctx'];
-  legacy: __legacy__;
   _errorShape: RP0['_errorShape'];
   _meta: RP0['_meta'];
   transformer: RP0['transformer'];
@@ -31,7 +30,6 @@ const TEMPLATE = `
   mutations: __mutations__;
   subscriptions: __subscriptions__;
   procedures: __procedures__;
-  routers: __routers__;
   record: __records__;
  }> & __records__;
  `.trim();
@@ -49,14 +47,12 @@ const TARGET_DIR =
 
 const partList: string[] = [];
 for (let index = 0; index < NUM_ARGS; index++) {
-  const legacy: string[] = [];
   const generics: string[] = [];
   const args: string[] = [];
   const queries: string[] = [];
   const mutations: string[] = [];
   const subscriptions: string[] = [];
   const procedures: string[] = [];
-  const routers: string[] = [];
   const records: string[] = [];
 
   for (let j = 0; j < index + 1; j++) {
@@ -66,9 +62,7 @@ for (let index = 0; index < NUM_ARGS; index++) {
     mutations.push(`RP${j}['mutations']`);
     subscriptions.push(`RP${j}['subscriptions']`);
     procedures.push(`RP${j}['procedures']`);
-    routers.push(`RP${j}['routers']`);
     records.push(`RP${j}['record']`);
-    legacy.push(`RP${j}['legacy']`);
   }
 
   const part = TEMPLATE.replace('', '')
@@ -78,9 +72,7 @@ for (let index = 0; index < NUM_ARGS; index++) {
     .replace(/__mutations__/g, mutations.join(' & '))
     .replace(/__subscriptions__/g, subscriptions.join(' & '))
     .replace(/__procedures__/g, procedures.join(' & '))
-    .replace(/__routers__/g, routers.join(' & '))
-    .replace(/__records__/g, records.join(' & '))
-    .replace(/__legacy__/g, legacy.join(' & '));
+    .replace(/__records__/g, records.join(' & '));
 
   partList.push(part);
 }


### PR DESCRIPTION
## 🎯 Changes
Remove the filtering for `queries`, `mutations`, and `subscriptions` from the v10 router. Interop routers now inject those properties like they do for `legacy`. This also makes it so we do not have to filter them out on the client.

Delete `OmitNeverKeys`. Instead of that, `Filter` for the properties we want. 

Before:
![image](https://user-images.githubusercontent.com/58836760/190300723-5366674f-2fe0-48e9-8a00-7a8bc85b5c91.png)

After:
![image](https://user-images.githubusercontent.com/58836760/190300687-ef85589e-a997-4fa0-be0f-547f12801b2c.png)

TRACES FROM a `create-t3-app` WITH 50 ROUTERS FROM `generateBigBoi.ts`.
<details>

<summary>Code tested</summary>

<br>

```ts
import type { NextPage } from "next";
import Head from "next/head";
import { trpc } from "../utils/trpc";
import styles from "./index.module.css";

const Home: NextPage = () => {
  const { data } = trpc.r0.greeting.useQuery({ who: "from tRPC" });

  const utils = trpc.useContext();

  utils.r49.greeting.invalidate();
  utils.r44.greeting3.setData('hello from tRPC');

  return (
    <>
      <Head>
        <title>Create T3 App</title>
        <meta name="description" content="Generated by create-t3-app" />
        <link rel="icon" href="/favicon.ico" />
      </Head>
      <div className={styles.containerOuter}>
        <div className={styles.containerInner}>
          <h1 className={styles.title}>
            Create <span className={styles.titlePink}>T3</span> App
          </h1>

          <h3 className={styles.subtitle}>This stack uses:</h3>
          <div className={styles.cardGrid}>
            <TechnologyCard
              name="NextJS"
              description="The React framework for production"
              documentation="https://nextjs.org/"
            />
            <TechnologyCard
              name="TypeScript"
              description="Strongly typed programming language that builds on JavaScript, giving you better tooling at any scale"
              documentation="https://www.typescriptlang.org/"
            />
            <TechnologyCard
              name="TailwindCSS"
              description="Rapidly build modern websites without ever leaving your HTML"
              documentation="https://tailwindcss.com/"
            />
            <TechnologyCard
              name="tRPC"
              description="End-to-end typesafe APIs made easy"
              documentation="https://trpc.io/"
            />
            <TechnologyCard
              name="Next-Auth"
              description="Authentication for Next.js"
              documentation="https://next-auth.js.org/"
            />
            <TechnologyCard
              name="Prisma"
              description="Build data-driven JavaScript & TypeScript apps in less time"
              documentation="https://www.prisma.io/docs/"
            />
          </div>

          <div className={styles.helloFrom}>
            {data ? <p>{data}</p> : <p>Loading...</p>}
          </div>
        </div>
      </div>
    </>
  );
};

export default Home;

type TechnologyCardProps = {
  name: string;
  description: string;
  documentation: string;
};

const TechnologyCard = ({
  name,
  description,
  documentation,
}: TechnologyCardProps) => {
  return (
    <section className={styles.card}>
      <h2 className={styles.cardTitle}>{name}</h2>
      <p className={styles.cardDescription}>{description}</p>
      <a
        className={styles.cardDocumentation}
        href={documentation}
        target="_blank"
        rel="noreferrer"
      >
        Documentation
      </a>
    </section>
  );
};
```

</details>

## How?
- switching `OmitNeverKeys` for `Filter` is ~100ms gain
- making it so v10 routers no longer filter unnecessarily for v9 queries, mutations, and subscriptions is another 100ms gain