### PR TITLE
move HTTP-specific options from `TRPCClient` to links

### DIFF
--- a/examples/.interop/cloudflare-workers/package.json
+++ b/examples/.interop/cloudflare-workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/interop-cloudflare-workers",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "private": true,
   "type": "module",
   "scripts": {
@@ -8,8 +8,8 @@
     "test-dev": "start-server-and-test 'wrangler dev --local' 8787 'node --loader ts-node/esm src/client.ts'"
   },
   "dependencies": {
-    "@trpc/client": "^10.0.0-proxy-alpha.76",
-    "@trpc/server": "^10.0.0-proxy-alpha.76",
+    "@trpc/client": "^10.0.0-proxy-alpha.77",
+    "@trpc/server": "^10.0.0-proxy-alpha.77",
     "zod": "^3.0.0"
   },
   "devDependencies": {

--- a/examples/.interop/express-server/package.json
+++ b/examples/.interop/express-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/interop-express-server",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server",
@@ -13,9 +13,9 @@
     "test-start": "start-server-and-test 'node dist/server' 2021 'node dist/client'"
   },
   "dependencies": {
-    "@trpc/client": "^10.0.0-proxy-alpha.76",
-    "@trpc/react": "^10.0.0-proxy-alpha.76",
-    "@trpc/server": "^10.0.0-proxy-alpha.76",
+    "@trpc/client": "^10.0.0-proxy-alpha.77",
+    "@trpc/react": "^10.0.0-proxy-alpha.77",
+    "@trpc/server": "^10.0.0-proxy-alpha.77",
     "@types/node-fetch": "^2.5.11",
     "abort-controller": "^3.0.0",
     "express": "^4.17.1",

--- a/examples/.interop/express-server/src/client.ts
+++ b/examples/.interop/express-server/src/client.ts
@@ -56,10 +56,15 @@ async function main() {
   }
   await sleep();
   const authedClient = createTRPCClient<AppRouter>({
-    links: [loggerLink(), httpBatchLink({ url })],
-    headers: () => ({
-      authorization: 'secret',
-    }),
+    links: [
+      loggerLink(),
+      httpBatchLink({
+        url,
+        headers: () => ({
+          authorization: 'secret',
+        }),
+      }),
+    ],
   });
 
   await authedClient.query('admin.secret');

--- a/examples/.interop/fastify-server/package.json
+++ b/examples/.interop/fastify-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/interop-fastify-server",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "private": true,
   "scripts": {
     "build": "tsc",
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@fastify/websocket": "^5.0.0",
-    "@trpc/client": "^10.0.0-proxy-alpha.76",
-    "@trpc/server": "^10.0.0-proxy-alpha.76",
+    "@trpc/client": "^10.0.0-proxy-alpha.77",
+    "@trpc/server": "^10.0.0-proxy-alpha.77",
     "abort-controller": "^3.0.0",
     "fastify": "^3.27.1",
     "fastify-websocket": "^4.0.0",

--- a/examples/.interop/lambda-api-gateway/package.json
+++ b/examples/.interop/lambda-api-gateway/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@examples/interop-lambda-api-gateway",
   "private": true,
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@trpc/client": "^10.0.0-proxy-alpha.76",
-    "@trpc/server": "^10.0.0-proxy-alpha.76",
+    "@trpc/client": "^10.0.0-proxy-alpha.77",
+    "@trpc/server": "^10.0.0-proxy-alpha.77",
     "node-fetch": "^2.6.1",
     "ts-node": "^10.3.0"
   },

--- a/examples/.interop/next-minimal-starter-migration/package.json
+++ b/examples/.interop/next-minimal-starter-migration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/interop-next-minimal-migration",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -9,10 +9,10 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^4.0.10",
-    "@trpc/client": "^10.0.0-proxy-alpha.76",
-    "@trpc/next": "^10.0.0-proxy-alpha.76",
-    "@trpc/react": "^10.0.0-proxy-alpha.76",
-    "@trpc/server": "^10.0.0-proxy-alpha.76",
+    "@trpc/client": "^10.0.0-proxy-alpha.77",
+    "@trpc/next": "^10.0.0-proxy-alpha.77",
+    "@trpc/react": "^10.0.0-proxy-alpha.77",
+    "@trpc/server": "^10.0.0-proxy-alpha.77",
     "next": "latest",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/examples/.interop/next-minimal-starter-migration/src/pages/_app.tsx
+++ b/examples/.interop/next-minimal-starter-migration/src/pages/_app.tsx
@@ -1,3 +1,4 @@
+import { httpBatchLink } from '@trpc/client';
 import { withTRPC } from '@trpc/next';
 import { AppType } from 'next/dist/shared/lib/utils';
 import { AppRouter } from './api/trpc/[trpc]';
@@ -10,7 +11,7 @@ export default withTRPC<AppRouter>({
   config({ ctx }) {
     const url = 'http://localhost:3000/api/trpc';
     return {
-      url,
+      links: [httpBatchLink({ url })],
     };
   },
 })(MyApp);

--- a/examples/.interop/next-minimal-starter/package.json
+++ b/examples/.interop/next-minimal-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/interop-next-minimal",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -9,10 +9,10 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^4.0.10",
-    "@trpc/client": "^10.0.0-proxy-alpha.76",
-    "@trpc/next": "^10.0.0-proxy-alpha.76",
-    "@trpc/react": "^10.0.0-proxy-alpha.76",
-    "@trpc/server": "^10.0.0-proxy-alpha.76",
+    "@trpc/client": "^10.0.0-proxy-alpha.77",
+    "@trpc/next": "^10.0.0-proxy-alpha.77",
+    "@trpc/react": "^10.0.0-proxy-alpha.77",
+    "@trpc/server": "^10.0.0-proxy-alpha.77",
     "next": "latest",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/examples/.interop/next-minimal-starter/src/pages/_app.tsx
+++ b/examples/.interop/next-minimal-starter/src/pages/_app.tsx
@@ -1,3 +1,4 @@
+import { httpBatchLink } from '@trpc/client';
 import { withTRPC } from '@trpc/next';
 import { AppType } from 'next/dist/shared/lib/utils';
 import { AppRouter } from './api/trpc/[trpc]';
@@ -10,7 +11,11 @@ export default withTRPC<AppRouter>({
   config({ ctx }) {
     const url = 'http://localhost:3000/api/trpc';
     return {
-      url,
+      links: [
+        httpBatchLink({
+          url,
+        }),
+      ],
     };
   },
 })(MyApp);

--- a/examples/.interop/next-prisma-starter-websockets/package.json
+++ b/examples/.interop/next-prisma-starter-websockets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/interop-next-starter-websockets",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "private": true,
   "scripts": {
     "build:1-generate": "prisma generate",
@@ -40,10 +40,10 @@
   "dependencies": {
     "@prisma/client": "^3.0.1",
     "@tanstack/react-query": "^4.0.10",
-    "@trpc/client": "^10.0.0-proxy-alpha.76",
-    "@trpc/next": "^10.0.0-proxy-alpha.76",
-    "@trpc/react": "^10.0.0-proxy-alpha.76",
-    "@trpc/server": "^10.0.0-proxy-alpha.76",
+    "@trpc/client": "^10.0.0-proxy-alpha.77",
+    "@trpc/next": "^10.0.0-proxy-alpha.77",
+    "@trpc/react": "^10.0.0-proxy-alpha.77",
+    "@trpc/server": "^10.0.0-proxy-alpha.77",
     "clsx": "^1.1.1",
     "next": "^12.1.6",
     "next-auth": "^4.2.0",

--- a/examples/.interop/next-prisma-starter/package.json
+++ b/examples/.interop/next-prisma-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/legacy-next-starter",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "private": true,
   "scripts": {
     "build:1-migrate": "prisma migrate deploy",
@@ -34,10 +34,10 @@
   "dependencies": {
     "@prisma/client": "^3.0.1",
     "@tanstack/react-query": "^4.0.10",
-    "@trpc/client": "^10.0.0-proxy-alpha.76",
-    "@trpc/next": "^10.0.0-proxy-alpha.76",
-    "@trpc/react": "^10.0.0-proxy-alpha.76",
-    "@trpc/server": "^10.0.0-proxy-alpha.76",
+    "@trpc/client": "^10.0.0-proxy-alpha.77",
+    "@trpc/next": "^10.0.0-proxy-alpha.77",
+    "@trpc/react": "^10.0.0-proxy-alpha.77",
+    "@trpc/server": "^10.0.0-proxy-alpha.77",
     "clsx": "^1.1.1",
     "next": "^12.1.6",
     "react": "^18.1.0",

--- a/examples/.interop/next-prisma-todomvc/package.json
+++ b/examples/.interop/next-prisma-todomvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/interop-todo-web",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "private": true,
   "scripts": {
     "migrate-sqlite": "npx prisma migrate dev --name init --schema=./prisma/_sqlite/schema.prisma",
@@ -25,10 +25,10 @@
   "dependencies": {
     "@prisma/client": "^3.0.1",
     "@tanstack/react-query": "^4.0.10",
-    "@trpc/client": "^10.0.0-proxy-alpha.76",
-    "@trpc/next": "^10.0.0-proxy-alpha.76",
-    "@trpc/react": "^10.0.0-proxy-alpha.76",
-    "@trpc/server": "^10.0.0-proxy-alpha.76",
+    "@trpc/client": "^10.0.0-proxy-alpha.77",
+    "@trpc/next": "^10.0.0-proxy-alpha.77",
+    "@trpc/react": "^10.0.0-proxy-alpha.77",
+    "@trpc/server": "^10.0.0-proxy-alpha.77",
     "clsx": "^1.1.1",
     "jest": "^27.1.0",
     "jest-playwright": "^0.0.1",

--- a/examples/.interop/next-prisma-todomvc/src/pages/_app.tsx
+++ b/examples/.interop/next-prisma-todomvc/src/pages/_app.tsx
@@ -1,3 +1,4 @@
+import { httpBatchLink } from '@trpc/client';
 import { withTRPC } from '@trpc/next';
 import { AppType } from 'next/dist/shared/lib/utils';
 import { transformer } from '../utils/trpc';
@@ -9,7 +10,11 @@ const MyApp: AppType = ({ Component, pageProps }) => {
 export default withTRPC({
   config() {
     return {
-      url: '/api/trpc',
+      links: [
+        httpBatchLink({
+          url: '/api/trpc',
+        }),
+      ],
       transformer,
     };
   },

--- a/examples/.interop/standalone-server/package.json
+++ b/examples/.interop/standalone-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/interop-standalone-server",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server",
@@ -12,9 +12,9 @@
     "test-start": "start-server-and-test 'node dist/server' 2022 'node dist/client'"
   },
   "dependencies": {
-    "@trpc/client": "^10.0.0-proxy-alpha.76",
-    "@trpc/react": "^10.0.0-proxy-alpha.76",
-    "@trpc/server": "^10.0.0-proxy-alpha.76",
+    "@trpc/client": "^10.0.0-proxy-alpha.77",
+    "@trpc/react": "^10.0.0-proxy-alpha.77",
+    "@trpc/server": "^10.0.0-proxy-alpha.77",
     "@types/node-fetch": "^2.5.11",
     "abort-controller": "^3.0.0",
     "node-fetch": "^2.6.1",

--- a/examples/cloudflare-workers/package.json
+++ b/examples/cloudflare-workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/cloudflare-workers",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "private": true,
   "type": "module",
   "scripts": {
@@ -8,8 +8,8 @@
     "test-dev": "start-server-and-test 'wrangler dev --local' 8787 'node --loader ts-node/esm src/client.ts'"
   },
   "dependencies": {
-    "@trpc/client": "^10.0.0-proxy-alpha.76",
-    "@trpc/server": "^10.0.0-proxy-alpha.76",
+    "@trpc/client": "^10.0.0-proxy-alpha.77",
+    "@trpc/server": "^10.0.0-proxy-alpha.77",
     "zod": "^3.0.0"
   },
   "devDependencies": {

--- a/examples/express-minimal/package.json
+++ b/examples/express-minimal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/express-minimal",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server",
@@ -13,9 +13,9 @@
     "test-start": "start-server-and-test 'node dist/server' 3000 'node dist/client'"
   },
   "dependencies": {
-    "@trpc/client": "^10.0.0-proxy-alpha.76",
-    "@trpc/react": "^10.0.0-proxy-alpha.76",
-    "@trpc/server": "^10.0.0-proxy-alpha.76",
+    "@trpc/client": "^10.0.0-proxy-alpha.77",
+    "@trpc/react": "^10.0.0-proxy-alpha.77",
+    "@trpc/server": "^10.0.0-proxy-alpha.77",
     "@types/node-fetch": "^2.5.11",
     "express": "^4.17.1",
     "node-fetch": "^2.6.1",

--- a/examples/express-minimal/src/client.ts
+++ b/examples/express-minimal/src/client.ts
@@ -1,4 +1,4 @@
-import { createTRPCProxyClient } from '@trpc/client';
+import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
 import fetch from 'node-fetch';
 import type { AppRouter } from './router';
 
@@ -7,7 +7,11 @@ global.fetch = fetch as any;
 
 async function main() {
   const client = createTRPCProxyClient<AppRouter>({
-    url: 'http://localhost:3000/trpc',
+    links: [
+      httpBatchLink({
+        url: 'http://localhost:3000/trpc',
+      }),
+    ],
   });
 
   const withoutInputQuery = await client.hello.greeting.query();

--- a/examples/express-server/package.json
+++ b/examples/express-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/express-server",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server",
@@ -13,9 +13,9 @@
     "test-start": "start-server-and-test 'node dist/server' 2021 'node dist/client'"
   },
   "dependencies": {
-    "@trpc/client": "^10.0.0-proxy-alpha.76",
-    "@trpc/react": "^10.0.0-proxy-alpha.76",
-    "@trpc/server": "^10.0.0-proxy-alpha.76",
+    "@trpc/client": "^10.0.0-proxy-alpha.77",
+    "@trpc/react": "^10.0.0-proxy-alpha.77",
+    "@trpc/server": "^10.0.0-proxy-alpha.77",
     "@types/node-fetch": "^2.5.11",
     "abort-controller": "^3.0.0",
     "express": "^4.17.1",

--- a/examples/express-server/src/client.ts
+++ b/examples/express-server/src/client.ts
@@ -1,6 +1,7 @@
 import {
   createTRPCClient,
   createTRPCClientProxy,
+  createTRPCProxyClient,
   httpBatchLink,
   loggerLink,
 } from '@trpc/client';
@@ -19,7 +20,7 @@ const sleep = (ms = 100) => new Promise((resolve) => setTimeout(resolve, ms));
 async function main() {
   const url = `http://localhost:2021/trpc`;
 
-  const client = createTRPCClient<AppRouter>({
+  const proxy = createTRPCProxyClient<AppRouter>({
     links: [
       () =>
         ({ op, next }) => {
@@ -36,8 +37,6 @@ async function main() {
       httpBatchLink({ url }),
     ],
   });
-
-  const proxy = createTRPCClientProxy(client);
 
   await sleep();
 

--- a/examples/express-server/src/client.ts
+++ b/examples/express-server/src/client.ts
@@ -1,10 +1,4 @@
-import {
-  createTRPCClient,
-  createTRPCClientProxy,
-  createTRPCProxyClient,
-  httpBatchLink,
-  loggerLink,
-} from '@trpc/client';
+import { createTRPCProxyClient, httpBatchLink, loggerLink } from '@trpc/client';
 import { tap } from '@trpc/server/observable';
 import AbortController from 'abort-controller';
 import fetch from 'node-fetch';

--- a/examples/express-server/src/client.ts
+++ b/examples/express-server/src/client.ts
@@ -20,7 +20,7 @@ const sleep = (ms = 100) => new Promise((resolve) => setTimeout(resolve, ms));
 async function main() {
   const url = `http://localhost:2021/trpc`;
 
-  const proxy = createTRPCProxyClient<AppRouter>({
+  const trpc = createTRPCProxyClient<AppRouter>({
     links: [
       () =>
         ({ op, next }) => {
@@ -43,38 +43,42 @@ async function main() {
   // parallel queries
   await Promise.all([
     //
-    proxy.hello.query(),
-    proxy.hello.query('client'),
+    trpc.hello.query(),
+    trpc.hello.query('client'),
   ]);
 
-  const postCreate = await proxy.post.createPost.mutate({
+  const postCreate = await trpc.post.createPost.mutate({
     title: 'hello client',
   });
   console.log('created post', postCreate.title);
   await sleep();
 
-  const postList = await proxy.post.listPosts.query();
+  const postList = await trpc.post.listPosts.query();
   console.log('has posts', postList, 'first:', postList[0].title);
   await sleep();
 
   try {
-    await proxy.admin.secret.query();
+    await trpc.admin.secret.query();
   } catch (cause) {
     // will fail
   }
   await sleep();
 
-  const authedClient = createTRPCClient<AppRouter>({
-    links: [loggerLink(), httpBatchLink({ url })],
-    headers: () => ({
-      authorization: 'secret',
-    }),
+  const authedClient = createTRPCProxyClient<AppRouter>({
+    links: [
+      loggerLink(),
+      httpBatchLink({
+        url,
+        headers: () => ({
+          authorization: 'secret',
+        }),
+      }),
+    ],
   });
-  const authedClientProxy = createTRPCClientProxy(authedClient);
 
-  await authedClientProxy.admin.secret.query();
+  await authedClient.admin.secret.query();
 
-  const msgs = await proxy.message.listMessages.query();
+  const msgs = await trpc.message.listMessages.query();
   console.log('msgs', msgs);
 
   console.log('👌 should be a clean exit if everything is working right');

--- a/examples/fastify-server/package.json
+++ b/examples/fastify-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/fastify-server",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "private": true,
   "scripts": {
     "build": "tsc",
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@fastify/websocket": "^5.0.0",
-    "@trpc/client": "^10.0.0-proxy-alpha.76",
-    "@trpc/server": "^10.0.0-proxy-alpha.76",
+    "@trpc/client": "^10.0.0-proxy-alpha.77",
+    "@trpc/server": "^10.0.0-proxy-alpha.77",
     "abort-controller": "^3.0.0",
     "fastify": "^3.27.1",
     "fastify-websocket": "^4.0.0",

--- a/examples/lambda-api-gateway/package.json
+++ b/examples/lambda-api-gateway/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@examples/lambda-api-gateway",
   "private": true,
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@trpc/client": "^10.0.0-proxy-alpha.76",
-    "@trpc/server": "^10.0.0-proxy-alpha.76",
+    "@trpc/client": "^10.0.0-proxy-alpha.77",
+    "@trpc/server": "^10.0.0-proxy-alpha.77",
     "node-fetch": "^2.6.1",
     "ts-node": "^10.3.0"
   },

--- a/examples/minimal/client/index.ts
+++ b/examples/minimal/client/index.ts
@@ -1,8 +1,12 @@
-import { createTRPCProxyClient } from '@trpc/client';
+import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
 import type { AppRouter } from '../server';
 
 const client = createTRPCProxyClient<AppRouter>({
-  url: 'http://localhost:2022',
+  links: [
+    httpBatchLink({
+      url: 'http://localhost:2022',
+    }),
+  ],
 });
 
 async function main() {

--- a/examples/minimal/client/package.json
+++ b/examples/minimal/client/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@examples/minimal-client",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "private": true,
   "dependencies": {
-    "@trpc/client": "^10.0.0-proxy-alpha.76"
+    "@trpc/client": "^10.0.0-proxy-alpha.77"
   }
 }

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@examples/minimal",
   "private": true,
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node server",
     "dev:client": "nodemon -e ts -w . -x 'wait-port 2022 && ts-node client'",

--- a/examples/minimal/server/package.json
+++ b/examples/minimal/server/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@examples/minimal-server",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "private": true,
   "dependencies": {
-    "@trpc/server": "^10.0.0-proxy-alpha.76"
+    "@trpc/server": "^10.0.0-proxy-alpha.77"
   }
 }

--- a/examples/next-minimal-starter/package.json
+++ b/examples/next-minimal-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/next-minimal",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -9,10 +9,10 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^4.0.10",
-    "@trpc/client": "^10.0.0-proxy-alpha.76",
-    "@trpc/next": "^10.0.0-proxy-alpha.76",
-    "@trpc/react": "^10.0.0-proxy-alpha.76",
-    "@trpc/server": "^10.0.0-proxy-alpha.76",
+    "@trpc/client": "^10.0.0-proxy-alpha.77",
+    "@trpc/next": "^10.0.0-proxy-alpha.77",
+    "@trpc/react": "^10.0.0-proxy-alpha.77",
+    "@trpc/server": "^10.0.0-proxy-alpha.77",
     "next": "latest",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/examples/next-minimal-starter/src/utils/trpc.ts
+++ b/examples/next-minimal-starter/src/utils/trpc.ts
@@ -1,3 +1,4 @@
+import { httpBatchLink } from '@trpc/client';
 import { createTRPCNext } from '@trpc/next';
 import { AppRouter } from '../pages/api/trpc/[trpc]';
 
@@ -20,7 +21,11 @@ function getBaseUrl() {
 export const trpc = createTRPCNext<AppRouter>({
   config() {
     return {
-      url: getBaseUrl() + '/api/trpc',
+      links: [
+        httpBatchLink({
+          url: getBaseUrl() + '/api/trpc',
+        }),
+      ],
     };
   },
   ssr: true,

--- a/examples/next-prisma-starter-sqlite/package.json
+++ b/examples/next-prisma-starter-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/next-starter-sqlite",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "private": true,
   "scripts": {
     "build:1-migrate": "prisma migrate deploy",
@@ -33,10 +33,10 @@
   "dependencies": {
     "@prisma/client": "^3.0.1",
     "@tanstack/react-query": "^4.0.10",
-    "@trpc/client": "^10.0.0-proxy-alpha.76",
-    "@trpc/next": "^10.0.0-proxy-alpha.76",
-    "@trpc/react": "^10.0.0-proxy-alpha.76",
-    "@trpc/server": "^10.0.0-proxy-alpha.76",
+    "@trpc/client": "^10.0.0-proxy-alpha.77",
+    "@trpc/next": "^10.0.0-proxy-alpha.77",
+    "@trpc/react": "^10.0.0-proxy-alpha.77",
+    "@trpc/server": "^10.0.0-proxy-alpha.77",
     "clsx": "^1.1.1",
     "next": "^12.1.6",
     "react": "^18.1.0",

--- a/examples/next-prisma-starter-websockets/package.json
+++ b/examples/next-prisma-starter-websockets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/next-starter-websockets",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "private": true,
   "scripts": {
     "build:1-generate": "prisma generate",
@@ -40,10 +40,10 @@
   "dependencies": {
     "@prisma/client": "^3.0.1",
     "@tanstack/react-query": "^4.0.10",
-    "@trpc/client": "^10.0.0-proxy-alpha.76",
-    "@trpc/next": "^10.0.0-proxy-alpha.76",
-    "@trpc/react": "^10.0.0-proxy-alpha.76",
-    "@trpc/server": "^10.0.0-proxy-alpha.76",
+    "@trpc/client": "^10.0.0-proxy-alpha.77",
+    "@trpc/next": "^10.0.0-proxy-alpha.77",
+    "@trpc/react": "^10.0.0-proxy-alpha.77",
+    "@trpc/server": "^10.0.0-proxy-alpha.77",
     "clsx": "^1.1.1",
     "next": "^12.1.6",
     "next-auth": "^4.2.0",

--- a/examples/next-prisma-starter/package.json
+++ b/examples/next-prisma-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/trpc-next-prisma-starter",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "private": true,
   "scripts": {
     "build:1-migrate": "prisma migrate deploy",
@@ -33,10 +33,10 @@
   "dependencies": {
     "@prisma/client": "^3.0.1",
     "@tanstack/react-query": "^4.0.10",
-    "@trpc/client": "^10.0.0-proxy-alpha.76",
-    "@trpc/next": "^10.0.0-proxy-alpha.76",
-    "@trpc/react": "^10.0.0-proxy-alpha.76",
-    "@trpc/server": "^10.0.0-proxy-alpha.76",
+    "@trpc/client": "^10.0.0-proxy-alpha.77",
+    "@trpc/next": "^10.0.0-proxy-alpha.77",
+    "@trpc/react": "^10.0.0-proxy-alpha.77",
+    "@trpc/server": "^10.0.0-proxy-alpha.77",
     "clsx": "^1.1.1",
     "next": "^12.1.6",
     "react": "^18.1.0",

--- a/examples/next-prisma-starter/src/utils/trpc.ts
+++ b/examples/next-prisma-starter/src/utils/trpc.ts
@@ -65,40 +65,38 @@ export const trpc = createTRPCNext<AppRouter, SSRContext>({
             process.env.NODE_ENV === 'development' ||
             (opts.direction === 'down' && opts.result instanceof Error),
         }),
-
         httpBatchLink({
           url: `${getBaseUrl()}/api/trpc`,
+          /**
+           * Set custom request headers on every request from tRPC
+           * @link http://localhost:3000/docs/v10/header
+           * @link http://localhost:3000/docs/v10/ssr
+           */
+          headers() {
+            if (ctx?.req) {
+              // To use SSR properly, you need to forward the client's headers to the server
+              // This is so you can pass through things like cookies when we're server-side rendering
+
+              // If you're using Node 18, omit the "connection" header
+              const {
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                connection: _connection,
+                ...headers
+              } = ctx.req.headers;
+              return {
+                ...headers,
+                // Optional: inform server that it's an SSR request
+                'x-ssr': '1',
+              };
+            }
+            return {};
+          },
         }),
       ],
       /**
        * @link https://react-query.tanstack.com/reference/QueryClient
        */
       // queryClientConfig: { defaultOptions: { queries: { staleTime: 60 } } },
-
-      /**
-       * Set custom request headers on every request from tRPC
-       * @link http://localhost:3000/docs/v10/header
-       * @link http://localhost:3000/docs/v10/ssr
-       */
-      headers() {
-        if (ctx?.req) {
-          // To use SSR properly, you need to forward the client's headers to the server
-          // This is so you can pass through things like cookies when we're server-side rendering
-
-          // If you're using Node 18, omit the "connection" header
-          const {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            connection: _connection,
-            ...headers
-          } = ctx.req.headers;
-          return {
-            ...headers,
-            // Optional: inform server that it's an SSR request
-            'x-ssr': '1',
-          };
-        }
-        return {};
-      },
     };
   },
   /**

--- a/examples/next-prisma-todomvc/package.json
+++ b/examples/next-prisma-todomvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/trpc-next-prisma-todomvc",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "private": true,
   "scripts": {
     "migrate-sqlite": "npx prisma migrate dev --name init --schema=./prisma/_sqlite/schema.prisma",
@@ -25,10 +25,10 @@
   "dependencies": {
     "@prisma/client": "^3.0.1",
     "@tanstack/react-query": "^4.0.10",
-    "@trpc/client": "^10.0.0-proxy-alpha.76",
-    "@trpc/next": "^10.0.0-proxy-alpha.76",
-    "@trpc/react": "^10.0.0-proxy-alpha.76",
-    "@trpc/server": "^10.0.0-proxy-alpha.76",
+    "@trpc/client": "^10.0.0-proxy-alpha.77",
+    "@trpc/next": "^10.0.0-proxy-alpha.77",
+    "@trpc/react": "^10.0.0-proxy-alpha.77",
+    "@trpc/server": "^10.0.0-proxy-alpha.77",
     "clsx": "^1.1.1",
     "jest": "^27.1.0",
     "jest-playwright": "^0.0.1",

--- a/examples/standalone-server/package.json
+++ b/examples/standalone-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/standalone-server",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server",
@@ -12,9 +12,9 @@
     "test-start": "start-server-and-test 'node dist/server' 2022 'node dist/client'"
   },
   "dependencies": {
-    "@trpc/client": "^10.0.0-proxy-alpha.76",
-    "@trpc/react": "^10.0.0-proxy-alpha.76",
-    "@trpc/server": "^10.0.0-proxy-alpha.76",
+    "@trpc/client": "^10.0.0-proxy-alpha.77",
+    "@trpc/react": "^10.0.0-proxy-alpha.77",
+    "@trpc/server": "^10.0.0-proxy-alpha.77",
     "@types/node-fetch": "^2.5.11",
     "abort-controller": "^3.0.0",
     "node-fetch": "^2.6.1",

--- a/examples/standalone-server/src/client.ts
+++ b/examples/standalone-server/src/client.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {
-  createTRPCClient,
-  createTRPCClientProxy,
+  createTRPCProxyClient,
   createWSClient,
   httpLink,
   splitLink,
@@ -21,7 +20,7 @@ globalAny.WebSocket = ws;
 const wsClient = createWSClient({
   url: `ws://localhost:2022`,
 });
-const client = createTRPCClient<AppRouter>({
+const trpc = createTRPCProxyClient<AppRouter>({
   links: [
     // call subscriptions through websockets and the rest over http
     splitLink({
@@ -37,16 +36,15 @@ const client = createTRPCClient<AppRouter>({
     }),
   ],
 });
-const proxy = createTRPCClientProxy(client);
 
 async function main() {
-  const helloResponse = await proxy.greeting.greeting.query({
+  const helloResponse = await trpc.greeting.hello.query({
     name: 'world',
   });
 
   console.log('helloResponse', helloResponse);
 
-  const createPostRes = await proxy.post.createPost.mutate({
+  const createPostRes = await trpc.post.createPost.mutate({
     title: 'hello world',
     text: 'check out https://tRPC.io',
   });
@@ -54,7 +52,7 @@ async function main() {
 
   let count = 0;
   await new Promise<void>((resolve) => {
-    const subscription = proxy.post.randomNumber.subscribe(undefined, {
+    const subscription = trpc.post.randomNumber.subscribe(undefined, {
       onData(data) {
         // ^ note that `data` here is inferred
         console.log('received', data);

--- a/examples/standalone-server/src/server.ts
+++ b/examples/standalone-server/src/server.ts
@@ -22,7 +22,7 @@ type Context = inferAsyncReturnType<typeof createContext>;
 const t = initTRPC.context<Context>().create();
 
 const greetingRouter = t.router({
-  greeting: t.procedure
+  hello: t.procedure
     .input(
       z.object({
         name: z.string(),

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "registry": "https://registry.npmjs.org/",
   "publishConfig": {
     "access": "public"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/client",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "description": "tRPC Client lib",
   "author": "KATT",
   "license": "MIT",
@@ -66,7 +66,7 @@
     "@trpc/server": "^10.0.0-alpha.48"
   },
   "devDependencies": {
-    "@trpc/server": "^10.0.0-proxy-alpha.76"
+    "@trpc/server": "^10.0.0-proxy-alpha.77"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -5,8 +5,10 @@ import type { AnyRouter } from '@trpc/server';
 import {
   TRPCClient as Client,
   CreateTRPCClientOptions,
+  TRPCRequestOptions,
 } from './internals/TRPCClient';
 import { httpBatchLink } from './links';
+import { HTTPLinkOptions } from './links/internals/httpUtils';
 
 /**
  * @deprecated use `createTRPCProxyClient` instead
@@ -19,13 +21,25 @@ export function createTRPCClient<TRouter extends AnyRouter>(
          * @deprecated use `links` instead
          */
         url: string;
+        /**
+         * @deprecated use `links` instead
+         */
+        headers?: HTTPLinkOptions['headers'];
+        /**
+         * @deprecated use `links` instead
+         */
+        fetch?: HTTPLinkOptions['fetch'];
+        /**
+         * @deprecated use `links` instead
+         */
+        AbortController?: HTTPLinkOptions['AbortController'];
       },
 ) {
   const getLinks = () => {
     if ('links' in opts) {
       return opts.links;
     }
-    return [httpBatchLink({ url: opts.url })];
+    return [httpBatchLink(opts)];
   };
   const client = new Client<TRouter>({
     links: getLinks(),
@@ -36,7 +50,7 @@ export function createTRPCClient<TRouter extends AnyRouter>(
 // Also the client created above needs to somehow be like `TRPCClient<Router> & Omit<Router, 'createCaller' | 'createProcedure' | '_def' | 'transformer' | 'errorFormatter' | 'getErrorShape>`
 
 export type {
-  AssertLegacyDef,
   CreateTRPCClientOptions,
   TRPCClient,
+  TRPCRequestOptions,
 } from './internals/TRPCClient';

--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -1,11 +1,10 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { AnyRouter } from '@trpc/server';
+import type { AnyRouter, ClientDataTransformerOptions } from '@trpc/server';
 import {
   TRPCClient as Client,
   CreateTRPCClientOptions,
-  TRPCRequestOptions,
 } from './internals/TRPCClient';
 import { httpBatchLink } from './links';
 import { HTTPLinkOptions } from './links/internals/httpUtils';
@@ -17,6 +16,7 @@ export function createTRPCClient<TRouter extends AnyRouter>(
   opts:
     | CreateTRPCClientOptions<TRouter>
     | {
+        transformer?: ClientDataTransformerOptions;
         /**
          * @deprecated use `links` instead
          */
@@ -42,6 +42,7 @@ export function createTRPCClient<TRouter extends AnyRouter>(
     return [httpBatchLink(opts)];
   };
   const client = new Client<TRouter>({
+    transformer: opts.transformer,
     links: getLinks(),
   });
   return client;

--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -6,22 +6,38 @@ import {
   TRPCClient as Client,
   CreateTRPCClientOptions,
 } from './internals/TRPCClient';
+import { httpBatchLink } from './links';
 
 /**
  * @deprecated use `createTRPCProxyClient` instead
  */
 export function createTRPCClient<TRouter extends AnyRouter>(
-  opts: CreateTRPCClientOptions<TRouter>,
+  opts:
+    | CreateTRPCClientOptions<TRouter>
+    | {
+        /**
+         * @deprecated use `links` instead
+         */
+        url: string;
+      },
 ) {
-  const client = new Client<TRouter>(opts);
+  const getLinks = () => {
+    if ('links' in opts) {
+      return opts.links;
+    }
+    return [httpBatchLink({ url: opts.url })];
+  };
+  const client = new Client<TRouter>({
+    links: getLinks(),
+  });
   return client;
 }
 
 // Also the client created above needs to somehow be like `TRPCClient<Router> & Omit<Router, 'createCaller' | 'createProcedure' | '_def' | 'transformer' | 'errorFormatter' | 'getErrorShape>`
 
 export type {
-  TRPCRequestOptions,
+  AssertLegacyDef,
   CreateTRPCClientOptions,
   TRPCClient,
-  AssertLegacyDef,
+  TRPCRequestOptions,
 } from './internals/TRPCClient';

--- a/packages/client/src/createTRPCClientProxy.ts
+++ b/packages/client/src/createTRPCClientProxy.ts
@@ -21,6 +21,7 @@ import { TRPCClientError } from './TRPCClientError';
 import { CreateTRPCClientOptions, createTRPCClient } from './createTRPCClient';
 import {
   TRPCClient as Client,
+  TRPCClient,
   TRPCSubscriptionObserver,
 } from './internals/TRPCClient';
 
@@ -111,7 +112,7 @@ export function createTRPCClientProxy<TRouter extends AnyRouter>(
 export function createTRPCProxyClient<TRouter extends AnyRouter>(
   opts: CreateTRPCClientOptions<TRouter>,
 ) {
-  const client = createTRPCClient<TRouter>(opts);
+  const client = new TRPCClient<TRouter>(opts);
   const proxy = createTRPCClientProxy(client);
   return proxy;
 }

--- a/packages/client/src/internals/fetchHelpers.ts
+++ b/packages/client/src/internals/fetchHelpers.ts
@@ -1,3 +1,5 @@
+import { Maybe } from '@trpc/server';
+
 export function getWindow() {
   if (typeof window !== 'undefined') {
     return window;
@@ -5,7 +7,7 @@ export function getWindow() {
   return globalThis;
 }
 export function getAbortController(
-  ac?: typeof AbortController,
-): typeof AbortController | undefined {
-  return ac ?? getWindow().AbortController ?? undefined;
+  ac: Maybe<typeof AbortController>,
+): typeof AbortController | null {
+  return ac ?? getWindow().AbortController ?? null;
 }

--- a/packages/client/src/links/httpBatchLink.ts
+++ b/packages/client/src/links/httpBatchLink.ts
@@ -7,6 +7,7 @@ import {
   HTTPResult,
   getUrl,
   httpRequest,
+  resolveHTTPLinkOptions,
 } from './internals/httpUtils';
 import { transformResult } from './internals/transformResult';
 import { TRPCLink } from './types';
@@ -18,6 +19,7 @@ export interface HttpBatchLinkOptions extends HTTPLinkOptions {
 export function httpBatchLink<TRouter extends AnyRouter>(
   opts: HttpBatchLinkOptions,
 ): TRPCLink<TRouter> {
+  const resolvedOpts = resolveHTTPLinkOptions(opts);
   // initialized config
   return (runtime) => {
     type BatchOperation = { id: number; path: string; input: unknown };
@@ -33,7 +35,13 @@ export function httpBatchLink<TRouter extends AnyRouter>(
         const path = batchOps.map((op) => op.path).join(',');
         const inputs = batchOps.map((op) => op.input);
 
-        const url = getUrl({ url: opts.url, runtime, type, path, inputs });
+        const url = getUrl({
+          ...resolvedOpts,
+          runtime,
+          type,
+          path,
+          inputs,
+        });
         return url.length <= maxURLLength;
       };
 
@@ -42,7 +50,7 @@ export function httpBatchLink<TRouter extends AnyRouter>(
         const inputs = batchOps.map((op) => op.input);
 
         const { promise, cancel } = httpRequest({
-          url: opts.url,
+          ...resolvedOpts,
           runtime,
           type,
           path,

--- a/packages/client/src/links/httpLink.ts
+++ b/packages/client/src/links/httpLink.ts
@@ -1,20 +1,24 @@
 import { AnyRouter } from '@trpc/server';
 import { observable } from '@trpc/server/observable';
 import { TRPCClientError } from '../TRPCClientError';
-import { HTTPLinkOptions, httpRequest } from './internals/httpUtils';
+import {
+  HTTPLinkOptions,
+  httpRequest,
+  resolveHTTPLinkOptions,
+} from './internals/httpUtils';
 import { transformResult } from './internals/transformResult';
 import { TRPCLink } from './types';
 
 export function httpLink<TRouter extends AnyRouter>(
   opts: HTTPLinkOptions,
 ): TRPCLink<TRouter> {
-  const { url } = opts;
+  const resolvedOpts = resolveHTTPLinkOptions(opts);
   return (runtime) =>
     ({ op }) =>
       observable((observer) => {
         const { path, input, type } = op;
         const { promise, cancel } = httpRequest({
-          url,
+          ...resolvedOpts,
           runtime,
           type,
           path,

--- a/packages/client/src/links/types.ts
+++ b/packages/client/src/links/types.ts
@@ -3,14 +3,26 @@ import { Observable, Observer } from '@trpc/server/observable';
 import { TRPCResultMessage, TRPCSuccessResponse } from '@trpc/server/rpc';
 import { TRPCClientError } from '../TRPCClientError';
 
+/**
+ * @internal
+ */
 export type CancelFn = () => void;
 
+/**
+ * @internal
+ */
 export type PromiseAndCancel<TValue> = {
   promise: Promise<TValue>;
   cancel: CancelFn;
 };
 
+/**
+ * @internal
+ */
 export type OperationContext = Record<string, unknown>;
+/**
+ * @internal
+ */
 export type Operation<TInput = unknown> = {
   id: number;
   type: 'query' | 'mutation' | 'subscription';
@@ -19,6 +31,9 @@ export type Operation<TInput = unknown> = {
   context: OperationContext;
 };
 
+/**
+ * @internal
+ */
 export type HTTPHeaders = Record<string, string | string[] | undefined>;
 
 /**
@@ -31,12 +46,12 @@ export type TRPCFetch = (
 ) => Promise<Response>;
 
 export interface TRPCClientRuntime {
-  fetch: TRPCFetch;
-  AbortController?: typeof AbortController;
-  headers: () => HTTPHeaders | Promise<HTTPHeaders>;
   transformer: DataTransformer;
 }
 
+/**
+ * @internal
+ */
 export interface OperationResultEnvelope<TOutput> {
   result:
     | TRPCSuccessResponse<TOutput>['result']
@@ -44,16 +59,25 @@ export interface OperationResultEnvelope<TOutput> {
   context?: OperationContext;
 }
 
+/**
+ * @internal
+ */
 export type OperationResultObservable<
   TRouter extends AnyRouter,
   TOutput,
 > = Observable<OperationResultEnvelope<TOutput>, TRPCClientError<TRouter>>;
 
+/**
+ * @internal
+ */
 export type OperationResultObserver<
   TRouter extends AnyRouter,
   TOutput,
 > = Observer<OperationResultEnvelope<TOutput>, TRPCClientError<TRouter>>;
 
+/**
+ * @internal
+ */
 export type OperationLink<
   TRouter extends AnyRouter,
   TInput = unknown,
@@ -63,6 +87,9 @@ export type OperationLink<
   next: (op: Operation<TInput>) => OperationResultObservable<TRouter, TOutput>;
 }) => OperationResultObservable<TRouter, TOutput>;
 
+/**
+ * @public
+ */
 export type TRPCLink<TRouter extends AnyRouter> = (
   opts: TRPCClientRuntime,
 ) => OperationLink<TRouter>;

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -36,14 +36,18 @@ pnpm add @trpc/next@next @trpc/react@next @tanstack/react-query
 Setup tRPC in `utils/trpc.ts`.
 
 ```ts
-import { createTRPCNext } from '@trpc/next';
+import { createTRPCNext, httpBatchLink } from '@trpc/next';
 // Import the router type from your server file
 import type { AppRouter } from '../pages/api/[trpc].ts';
 
 export const trpc = createTRPCNext<AppRouter>({
   config() {
     return {
-      url: 'http://localhost:3000/api/trpc',
+      links: [
+        httpBatchLink({
+          url: 'http://localhost:3000/trpc',
+        }),
+      ],
     };
   },
   ssr: true,

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/next",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "description": "tRPC Next lib",
   "author": "KATT",
   "license": "MIT",
@@ -48,9 +48,9 @@
   },
   "devDependencies": {
     "@tanstack/react-query": "^4.0.10",
-    "@trpc/client": "^10.0.0-proxy-alpha.76",
-    "@trpc/react": "^10.0.0-proxy-alpha.76",
-    "@trpc/server": "^10.0.0-proxy-alpha.76",
+    "@trpc/client": "^10.0.0-proxy-alpha.77",
+    "@trpc/react": "^10.0.0-proxy-alpha.77",
+    "@trpc/server": "^10.0.0-proxy-alpha.77",
     "@types/express": "^4.17.12",
     "express": "^4.17.1",
     "next": "^12.1.6",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/react",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "description": "tRPC React lib",
   "author": "KATT",
   "license": "MIT",
@@ -58,8 +58,8 @@
   },
   "devDependencies": {
     "@tanstack/react-query": "^4.0.10",
-    "@trpc/client": "^10.0.0-proxy-alpha.76",
-    "@trpc/server": "^10.0.0-proxy-alpha.76",
+    "@trpc/client": "^10.0.0-proxy-alpha.77",
+    "@trpc/server": "^10.0.0-proxy-alpha.77",
     "@types/express": "^4.17.12",
     "express": "^4.17.1",
     "next": "^12.1.6",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/server",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "description": "tRPC Server",
   "author": "KATT",
   "license": "MIT",

--- a/packages/server/test/___testHelpers.ts
+++ b/packages/server/test/___testHelpers.ts
@@ -5,6 +5,7 @@ import {
   WebSocketClientOptions,
   createTRPCClientProxy,
   createWSClient,
+  httpBatchLink,
 } from '@trpc/client/src';
 import { createTRPCClient } from '@trpc/client/src';
 import { WithTRPCConfig } from '@trpc/next';
@@ -67,7 +68,7 @@ export function routerToServerAndClientNew<TRouter extends AnyNewRouter>(
     ...opts?.wsClient,
   });
   const trpcClientOptions: WithTRPCConfig<typeof router> = {
-    url: httpUrl,
+    links: [httpBatchLink({ url: httpUrl })],
     ...(opts?.client
       ? typeof opts.client === 'function'
         ? opts.client({ httpUrl, wssUrl, wsClient })

--- a/packages/server/test/createClient.test.ts
+++ b/packages/server/test/createClient.test.ts
@@ -10,22 +10,11 @@ describe('typedefs on createClient', () => {
     });
   });
 
-  test('ok to pass only url', () => {
-    createTRPCProxyClient({
-      url: 'foo',
-    });
-  });
-
   test('error if both url and links are passed', () => {
     createTRPCProxyClient({
       links: [httpBatchLink({ url: 'foo' })],
       // @ts-expect-error - can't pass url along with links
       url: 'foo',
     });
-  });
-
-  test('error if neither url and links are passed', () => {
-    // @ts-expect-error - must pass url or links
-    createTRPCProxyClient({});
   });
 });

--- a/packages/server/test/interop/adapters/express.test.tsx
+++ b/packages/server/test/interop/adapters/express.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Context, router } from './__router';
-import { createTRPCClient } from '@trpc/client/src';
+import { createTRPCClient, httpBatchLink } from '@trpc/client';
 import AbortController from 'abort-controller';
 import express from 'express';
 import http from 'http';
@@ -49,10 +49,13 @@ async function startServer() {
   });
 
   const client = createTRPCClient<typeof router>({
-    url: `http://localhost:${port}/trpc`,
-
-    AbortController: AbortController as any,
-    fetch: fetch as any,
+    links: [
+      httpBatchLink({
+        url: `http://localhost:${port}/trpc`,
+        AbortController: AbortController as any,
+        fetch: fetch as any,
+      }),
+    ],
   });
 
   return {

--- a/packages/server/test/interop/adapters/fastify.test.ts
+++ b/packages/server/test/interop/adapters/fastify.test.ts
@@ -149,16 +149,18 @@ function createClient(opts: ClientOptions = {}) {
   const host = `localhost:${config.port}${config.prefix}`;
   const wsClient = createWSClient({ url: `ws://${host}` });
   const client = createTRPCClient<AppRouter>({
-    headers: opts.headers,
-    AbortController: AbortController as any,
-    fetch: fetch as any,
     links: [
       splitLink({
         condition(op) {
           return op.type === 'subscription';
         },
         true: wsLink({ client: wsClient }),
-        false: httpLink({ url: `http://${host}` }),
+        false: httpLink({
+          url: `http://${host}`,
+          headers: opts.headers,
+          AbortController: AbortController as any,
+          fetch: fetch as any,
+        }),
       }),
     ],
   });

--- a/packages/server/test/interop/clientInternals.test.ts
+++ b/packages/server/test/interop/clientInternals.test.ts
@@ -15,19 +15,19 @@ describe('getAbortController() from..', () => {
     (global as any).AbortController = undefined;
     (global as any).window = {};
     (global as any).window = AbortController = sym;
-    expect(getAbortController()).toBe(sym);
+    expect(getAbortController(null)).toBe(sym);
   });
   test('global', () => {
     const sym: any = Symbol('test');
 
     (global as any).AbortController = sym;
     delete (global as any).window;
-    expect(getAbortController()).toBe(sym);
+    expect(getAbortController(null)).toBe(sym);
   });
   test('neither', () => {
     (global as any).AbortController = undefined;
     (global as any).window = undefined;
-    expect(getAbortController()).toBe(undefined);
+    expect(getAbortController(null)).toBe(undefined);
   });
 });
 

--- a/packages/server/test/interop/clientInternals.test.ts
+++ b/packages/server/test/interop/clientInternals.test.ts
@@ -27,7 +27,7 @@ describe('getAbortController() from..', () => {
   test('neither', () => {
     (global as any).AbortController = undefined;
     (global as any).window = undefined;
-    expect(getAbortController(null)).toBe(undefined);
+    expect(getAbortController(null)).toBe(null);
   });
 });
 

--- a/packages/server/test/interop/index.test.tsx
+++ b/packages/server/test/interop/index.test.tsx
@@ -284,8 +284,15 @@ describe('integration tests', () => {
           server: {
             createContext,
           },
-          client: {
-            headers: () => headers,
+          client({ httpUrl }) {
+            return {
+              links: [
+                httpBatchLink({
+                  headers,
+                  url: httpUrl,
+                }),
+              ],
+            };
           },
         },
       );

--- a/packages/server/test/interop/links.test.ts
+++ b/packages/server/test/interop/links.test.ts
@@ -20,9 +20,6 @@ import { AnyRouter } from '../../src';
 import { observable, observableToPromise } from '../../src/observable';
 
 const mockRuntime: TRPCClientRuntime = {
-  fetch: fetch as any,
-  AbortController: AbortController as any,
-  headers: () => ({}),
   transformer: {
     serialize: (v) => v,
     deserialize: (v) => v,
@@ -285,9 +282,9 @@ describe('batching', () => {
       links: [
         httpBatchLink({
           url: `http://localhost:${httpPort}`,
+          headers: {},
         }),
       ],
-      headers: {},
     });
 
     await expect(client.query('hello')).rejects.toMatchInlineSnapshot(
@@ -319,9 +316,9 @@ test('create client with links', async () => {
       retryLink({ attempts: 3 }),
       httpLink({
         url: `http://localhost:${httpPort}`,
+        headers: {},
       }),
     ],
-    headers: {},
   });
 
   const result = await client.query('hello');

--- a/packages/server/test/interop/middleware.test.ts
+++ b/packages/server/test/interop/middleware.test.ts
@@ -1,5 +1,5 @@
 import { legacyRouterToServerAndClient } from './__legacyRouterToServerAndClient';
-import { HTTPHeaders } from '@trpc/client';
+import { HTTPHeaders, httpBatchLink } from '@trpc/client';
 import { AsyncLocalStorage } from 'async_hooks';
 import { expectTypeOf } from 'expect-type';
 import { z } from 'zod';
@@ -150,8 +150,10 @@ test('allows you to throw an error (e.g. auth)', async () => {
           return {};
         },
       },
-      client: {
-        headers,
+      client({ httpUrl }) {
+        return {
+          links: [httpBatchLink({ url: httpUrl, headers })],
+        };
       },
     },
   );

--- a/packages/server/test/react/createClient.test.tsx
+++ b/packages/server/test/react/createClient.test.tsx
@@ -4,7 +4,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { render, waitFor } from '@testing-library/react';
 import { konn } from 'konn';
 import React, { ReactNode, useState } from 'react';
-import { createTRPCReact } from '../../../react/src';
+import { createTRPCReact, httpBatchLink } from '../../../react/src';
 import { createProxySSGHelpers } from '../../../react/src/ssg';
 import { initTRPC } from '../../src';
 
@@ -21,7 +21,13 @@ const ctx = konn()
 
     function App(props: { children: ReactNode }) {
       const [client] = useState(() =>
-        proxy.createClient({ url: opts.httpUrl }),
+        proxy.createClient({
+          links: [
+            httpBatchLink({
+              url: opts.httpUrl,
+            }),
+          ],
+        }),
       );
       return (
         <proxy.Provider {...{ queryClient, client }}>

--- a/packages/server/test/react/interopBigCompiled.test.tsx
+++ b/packages/server/test/react/interopBigCompiled.test.tsx
@@ -4,7 +4,11 @@
 import { appRouter as bigV10Router } from '../__generated__/bigBoi/_app';
 import { t } from '../__generated__/bigBoi/_trpc';
 import { bigRouter as bigV9Router } from '../__generated__/bigLegacyRouter/bigRouter';
-import { createTRPCClient, createTRPCProxyClient } from '@trpc/client';
+import {
+  createTRPCClient,
+  createTRPCProxyClient,
+  httpBatchLink,
+} from '@trpc/client';
 import { createReactQueryHooks } from '@trpc/react';
 import { expectTypeOf } from 'expect-type';
 

--- a/packages/server/test/react/interopBigCompiled.test.tsx
+++ b/packages/server/test/react/interopBigCompiled.test.tsx
@@ -30,7 +30,11 @@ test('raw client', async () => {
 
   try {
     const proxy = createTRPCProxyClient<AppRouter>({
-      url: 'http://localhost:-1',
+      links: [
+        httpBatchLink({
+          url: 'http://localhost:-1',
+        }),
+      ],
     });
     const result = await proxy.r0.greeting.query({ who: 'KATT' });
 

--- a/packages/server/test/regression/issue-2506-headers-throwing.test.ts
+++ b/packages/server/test/regression/issue-2506-headers-throwing.test.ts
@@ -23,11 +23,11 @@ describe('httpLink', () => {
             links: [
               httpLink({
                 url: httpUrl,
+                headers() {
+                  throw new Error('Bad headers fn');
+                },
               }),
             ],
-            headers() {
-              throw new Error('Bad headers fn');
-            },
           };
         },
       });
@@ -58,11 +58,11 @@ describe('httpBatchLink', () => {
             links: [
               httpBatchLink({
                 url: httpUrl,
+                headers() {
+                  throw new Error('Bad headers fn');
+                },
               }),
             ],
-            headers() {
-              throw new Error('Bad headers fn');
-            },
           };
         },
       });

--- a/www/docs/client/aborting-procedures.md
+++ b/www/docs/client/aborting-procedures.md
@@ -48,12 +48,16 @@ tRPC adheres to the industry standard when it comes to aborting procedures. All 
 
 // ---cut---
 // @filename: server.ts
-import { createTRPCProxyClient } from "@trpc/client";
+import { createTRPCProxyClient, httpBatchLink } from "@trpc/client";
 // @noErrors
 import type { AppRouter } from "server.ts";
 
 const proxy = createTRPCProxyClient<AppRouter>({
-  url: "http://localhost:3000/trpc",
+  links: [
+    httpBatchLink({
+      url: 'http://localhost:3000/trpc',
+    }),
+  ],
 });
 
 const ac = new AbortController();

--- a/www/docs/client/header.md
+++ b/www/docs/client/header.md
@@ -5,12 +5,13 @@ sidebar_label: Create Custom Header
 slug: /header
 ---
 
-The headers option can be customize in config when using `createTRPCNext` in nextjs or `createClient` in react.js.
+The headers option can be customize in config when using the `httpBatchLink` or the `httpLink`.
 
-`headers` can be both an object or a function. If it's a function it will gets called dynamically every http request.
+`headers` can be both an object or a function. If it's a function it will gets called dynamically every HTTP request.
 
 ```ts title='utils/trpc.ts'
 import { createTRPCNext } from '@trpc/next';
+import { httpBatchLink } from '@trpc/client';
 
 // Import the router type from your server file
 import type { AppRouter } from "@/server/routers/app";
@@ -19,13 +20,20 @@ export let token: string;
 
 export const trpc = createTRPCNext<AppRouter>({
   config({ ctx }) {
-    /**
-    * Headers will be called on each request.
-    */
-    headers() {
-      return {
-        Authorization: token,
-      }
+    return {
+      links: [
+        httpBatchLink({
+          url: 'http://localhost:3000/api/trpc',
+          /**
+          * Headers will be called on each request.
+          */
+          headers() {
+            return {
+              Authorization: token,
+            }
+          }
+        })
+      ]
     }
   }
 });

--- a/www/docs/client/vanilla.md
+++ b/www/docs/client/vanilla.md
@@ -21,11 +21,15 @@ Create a typesafe client with the `createTRPCClient` method from `@trpc/client`:
 
 ```ts title='client.ts'
 // pages/index.tsx
-import { createTRPCProxyClient } from '@trpc/client';
+import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
 import type { AppRouter } from '../path/to/server/trpc';
 
 const client = createTRPCProxyClient<AppRouter>({
-  url: 'http://localhost:5000/trpc',
+  links: [
+    httpBatchLink({
+      url: 'http://localhost:3000/trpc',
+    }),
+  ],
 });
 ```
 

--- a/www/docs/landing-intro/Step3.md
+++ b/www/docs/landing-intro/Step3.md
@@ -22,7 +22,7 @@ export type AppRouter = typeof appRouter;
 
 ```ts twoslash title='client.ts'
 // @module: esnext
-// @target: es2017
+// @target: esnext
 // @include: server
 // @filename: client.ts
 import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';

--- a/www/docs/landing-intro/Step3.md
+++ b/www/docs/landing-intro/Step3.md
@@ -12,7 +12,7 @@ const appRouter = t.router({
     .query((req) => {
       const { input } = req;
       return {
-        text: `Hello ${input.name}`,
+        text: `Hello ${input.name}` as const,
       };
   }),
 });
@@ -22,23 +22,21 @@ export type AppRouter = typeof appRouter;
 
 ```ts twoslash title='client.ts'
 // @module: esnext
+// @target: es2017
 // @include: server
 // @filename: client.ts
 import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
 import { AppRouter } from './server';
 
 // ---cut---
+const trpc = createTRPCProxyClient<AppRouter>({
+  links: [
+    httpBatchLink({
+      url: 'http://localhost:3000/trpc',
+    }),
+  ],
+});
 
-async function main() {
-  const client = createTRPCProxyClient<AppRouter>({
-    links: [
-      httpBatchLink({
-        url: 'http://localhost:3000/trpc',
-      }),
-    ],
-  });
-
-  const res = await client.greeting.query({ name: 'John' });
-  //    ^?
-}
+const res = await trpc.greeting.query({ name: 'John' });
+//    ^?
 ```

--- a/www/docs/landing-intro/Step3.md
+++ b/www/docs/landing-intro/Step3.md
@@ -24,14 +24,18 @@ export type AppRouter = typeof appRouter;
 // @module: esnext
 // @include: server
 // @filename: client.ts
-import { createTRPCProxyClient } from '@trpc/client';
+import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
 import { AppRouter } from './server';
 
 // ---cut---
 
 async function main() {
   const client = createTRPCProxyClient<AppRouter>({
-    url: 'http://localhost:3000',
+    links: [
+      httpBatchLink({
+        url: 'http://localhost:3000/trpc',
+      }),
+    ],
   });
 
   const res = await client.greeting.query({ name: 'John' });

--- a/www/docs/main/quickstart.mdx
+++ b/www/docs/main/quickstart.mdx
@@ -201,11 +201,15 @@ userCreate(payload: {name: string}) => {id: string; name: string};
 // @include: server
 // ---cut---
 // @filename: client.ts
-import { createTRPCProxyClient } from '@trpc/client';
+import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
 import type { AppRouter } from './server';
 
 const trpc = createTRPCProxyClient<AppRouter>({
-  url: 'http://localhost:3000/api/trpc',
+  links: [
+    httpBatchLink({
+      url: 'http://localhost:3000/trpc',
+    }),
+  ],
 });
 ```
 
@@ -215,11 +219,15 @@ const trpc = createTRPCProxyClient<AppRouter>({
 // @module: esnext
 // @include: server
 // @filename: client.ts
-import { createTRPCProxyClient } from '@trpc/client';
+import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
 import type { AppRouter } from './server';
 
 const trpc = createTRPCProxyClient<AppRouter>({
-  url: 'http://localhost:3000/api/trpc',
+  links: [
+    httpBatchLink({
+      url: 'http://localhost:3000/trpc',
+    }),
+  ],
 });
 
 // ---cut---
@@ -238,11 +246,15 @@ const createdUser = await trpc.userCreate.mutate({ name: 'sachinraja' });
 // @module: esnext
 // @include: server
 // @filename: client.ts
-import { createTRPCProxyClient } from '@trpc/client';
+import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
 import type { AppRouter } from './server';
 
 const trpc = createTRPCProxyClient<AppRouter>({
-  url: 'http://localhost:3000/api/trpc',
+  links: [
+    httpBatchLink({
+      url: 'http://localhost:3000/trpc',
+    }),
+  ],
 });
 
 // ---cut---

--- a/www/docs/migration/migrate-from-v9-to-v10.mdx
+++ b/www/docs/migration/migrate-from-v9-to-v10.mdx
@@ -273,6 +273,10 @@ We have changed the API of Subscriptions where subscriptions need to return an `
 
 > 🚧 Feel free to contribute to improve this section
 
+### Custom HTTP options
+
+See [HTTP-specific options moved from `TRPCClient` to links](#http-specific-options-moved-from-trpcclient-to-links).
+
 ### Custom Links
 
 See the [Links documentation](links).

--- a/www/docs/migration/migrate-from-v9-to-v10.mdx
+++ b/www/docs/migration/migrate-from-v9-to-v10.mdx
@@ -333,6 +333,44 @@ const helloQuery = client.greeting.query('KATT', { signal: ac.signal });
 ac.abort();
 ```
 
+#### HTTP-specific options moved from `TRPCClient` to links
+
+Previously, you passed the stuff like HTTP-headers straight onto your `createTRPCClient()`-request, but since tRPC is technically not tied to HTTP itself, we've moved these from the `TRPCClient` to the `httpLink`/`httpBatchLink`.
+
+```ts
+// before:
+import { createTRPCClient } from '@trpc/client';
+
+const client = createTRPCClient({
+  url: '...',
+  fetch: myFetchPonyfill,
+  AbortController: myAbortControllerPonyfill,
+  headers() {
+    return {
+      'x-foo': 'bar',
+    };
+  },
+});
+
+// after:
+import { createTRPCProxyClient, httpLink } from '@trpc/client';
+
+const client = createTRPCProxyClient({
+  links: [
+    httpBatchLink({
+      url: '...',
+      fetch: myFetchPonyfill,
+      AbortController: myAbortControllerPonyfill,
+      headers() {
+        return {
+          'x-foo': 'bar',
+        };
+      },
+    })
+  ]
+});
+```
+
 ## Extras
 
 ### Removal of the teardown option

--- a/www/package.json
+++ b/www/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www",
-  "version": "10.0.0-proxy-alpha.76",
+  "version": "10.0.0-proxy-alpha.77",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
@@ -23,10 +23,10 @@
     "@docusaurus/preset-classic": "^2.1.0",
     "@mdx-js/react": "^1.6.22",
     "@tailwindcss/line-clamp": "^0.4.2",
-    "@trpc/client": "^10.0.0-proxy-alpha.76",
-    "@trpc/next": "^10.0.0-proxy-alpha.76",
-    "@trpc/react": "^10.0.0-proxy-alpha.76",
-    "@trpc/server": "^10.0.0-proxy-alpha.76",
+    "@trpc/client": "^10.0.0-proxy-alpha.77",
+    "@trpc/next": "^10.0.0-proxy-alpha.77",
+    "@trpc/react": "^10.0.0-proxy-alpha.77",
+    "@trpc/server": "^10.0.0-proxy-alpha.77",
     "@visx/hierarchy": "^2.10.0",
     "@visx/responsive": "^2.10.0",
     "clsx": "^1.1.1",

--- a/www/src/components/TwitterWall/script.output.ts
+++ b/www/src/components/TwitterWall/script.output.ts
@@ -26,20 +26,20 @@ export const tweets = [
     "content": "The speed in which you get feedback from tRPC is incredible. It uses the power of TypeScript so if you change somet… "
   },
   {
+    "id": "1569341560646402051",
+    "name": "Anders Bech Mellson",
+    "handle": "andersmellson",
+    "date": "Sep 12",
+    "avatar": "https://pbs.twimg.com/profile_images/1548373336287113216/6oOIlYgP_normal.jpg",
+    "content": "Spent today playing with @trpcio v10 and I'm officially in love 😍 ps. Don't tell my wife 🙊"
+  },
+  {
     "id": "1569033706131562496",
     "name": "Christian Legge",
     "handle": "christian_legge",
     "date": "Sep 11",
     "avatar": "https://pbs.twimg.com/profile_images/1569016481286864897/G7rAUufS_normal.jpg",
     "content": "Spent all of yesterday learning and implementing @trpcio and wow, what a great investment. I can't believe how much… "
-  },
-  {
-    "id": "1558827229424979973",
-    "name": "Rey Mooy",
-    "handle": "itzyaboirey",
-    "date": "Aug 14",
-    "avatar": "https://pbs.twimg.com/profile_images/1564202144109977600/t4D80P02_normal.jpg",
-    "content": "Yo, first time trying @trpcio and it's mind blowing 🤯"
   },
   {
     "id": "1567560240882716677",
@@ -146,19 +146,19 @@ export const tweets = [
     "content": "I’ve been playing with @trpcio and Solito together and this is without a doubt the fastest way to iterate on an api… "
   },
   {
+    "id": "1569588272392990720",
+    "name": "Sock, the dev",
+    "handle": "sockthedev",
+    "date": "Sep 13",
+    "avatar": "https://pbs.twimg.com/profile_images/1569584517161324544/po3hKnjN_normal.jpg",
+    "content": "If you are all in on TypeScript you MUST use tRPC for your API. No ifs, no buts. \n\ntRPC destroys the boundary betwe… "
+  },
+  {
     "id": "1562081793863475201",
     "name": "Jökull Solberg",
     "handle": "jokull",
     "date": "Aug 23",
     "avatar": "https://pbs.twimg.com/profile_images/1389495075248484354/pmii-f0T_normal.jpg",
     "content": "tRPC is insane. I’m building a Stripe integration – I return Stripe API payloads from the server I get the response… "
-  },
-  {
-    "id": "1556633654679445506",
-    "name": "Doot | ddot",
-    "handle": "ddotgg",
-    "date": "Aug 08",
-    "avatar": "https://pbs.twimg.com/profile_images/1561737413583638535/t37pLCLY_normal.png",
-    "content": "@alexdotjs Woah! Hey alex! Thanks for all your hard work on trpc. it’s been a joy to learn."
   }
 ]


### PR DESCRIPTION
Closes #2709, cc @moltar

## 🎯 Changes

- Removes HTTP-specific options from the `TRPCClient` and moves them to links
- Enables more transport protocols w/o hacking around this
- Makes bundle size smaller for ppl not using `httpBatchLink` as it's not always imported
- Breaking change

**Docs:** https://www-git-issues-2709-trpc.vercel.app/docs/v10/migrate-from-v9-to-v10#http-specific-options-moved-from-trpcclient-to-links


## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.