### PR TITLE
fix: typo for migration docs

### DIFF
--- a/www/docs/migration/migrate-from-v9-to-v10.mdx
+++ b/www/docs/migration/migrate-from-v9-to-v10.mdx
@@ -20,7 +20,7 @@ tRPC v10 features a compatibility layer for users coming from v9. `.interop()` a
 > - If you don't like the variable name `t`, you can call it whatever you want
 > - You should create your root `t`-variable **exactly once** per application
 
-The way you initialize tRPC on the server has been update, we now create a root `t` variable that contains the root information about your app:
+The way you initialize tRPC on the server has been updated, we now create a root `t` variable that contains the root information about your app:
 
 - [Context](context)
 - [Meta data](metadata)


### PR DESCRIPTION

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?
fixed a typo, where it was `update` instead of `updated`

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.