### PR TITLE
add pagination to next.js example

### DIFF
--- a/examples/next-prisma-starter/prisma/migrations/20220918091608_pagination/migration.sql
+++ b/examples/next-prisma-starter/prisma/migrations/20220918091608_pagination/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[createdAt]` on the table `Post` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Post_createdAt_key" ON "Post"("createdAt");

--- a/examples/next-prisma-starter/prisma/migrations/20220918134120_revert/migration.sql
+++ b/examples/next-prisma-starter/prisma/migrations/20220918134120_revert/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "Post_createdAt_key";

--- a/examples/next-prisma-starter/prisma/schema.prisma
+++ b/examples/next-prisma-starter/prisma/schema.prisma
@@ -15,7 +15,7 @@ model Post {
   title String
   text  String
 
-  // To return `Date`s intact through the API we we use transformers
+  // To return `Date`s intact through the API we use transformers
   // https://trpc.io/docs/data-transformers
   // This is unique so it can be used for cursor-based pagination
   createdAt DateTime @unique @default(now())

--- a/examples/next-prisma-starter/prisma/schema.prisma
+++ b/examples/next-prisma-starter/prisma/schema.prisma
@@ -15,8 +15,9 @@ model Post {
   title String
   text  String
 
-  // To return `Date`s intact through the API we need to add data transformers
+  // To return `Date`s intact through the API we we use transformers
   // https://trpc.io/docs/data-transformers
-  createdAt DateTime @default(now())
+  // This is unique so it can be used for cursor-based pagination
+  createdAt DateTime @unique @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 }

--- a/examples/next-prisma-starter/prisma/schema.prisma
+++ b/examples/next-prisma-starter/prisma/schema.prisma
@@ -18,6 +18,6 @@ model Post {
   // To return `Date`s intact through the API we use transformers
   // https://trpc.io/docs/data-transformers
   // This is unique so it can be used for cursor-based pagination
-  createdAt DateTime @unique @default(now())
+  createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 }

--- a/examples/next-prisma-starter/src/pages/index.tsx
+++ b/examples/next-prisma-starter/src/pages/index.tsx
@@ -1,6 +1,8 @@
 import { trpc } from '../utils/trpc';
 import { NextPageWithLayout } from './_app';
+import { inferProcedureInput } from '@trpc/server';
 import Link from 'next/link';
+import { AppRouter } from '~/server/routers/_app';
 
 const IndexPage: NextPageWithLayout = () => {
   const utils = trpc.useContext();
@@ -46,25 +48,27 @@ const IndexPage: NextPageWithLayout = () => {
 
       <form
         onSubmit={async (e) => {
-          e.preventDefault();
           /**
            * In a real app you probably don't want to use this manually
            * Checkout React Hook Form - it works great with tRPC
-           * @link https://react-hook-form.com/
+           * @see https://react-hook-form.com/
+           * @see https://kitchen-sink.trpc.io/react-hook-form
            */
-
-          const $text: HTMLInputElement = (e as any).target.elements.text;
-          const $title: HTMLInputElement = (e as any).target.elements.title;
-          const input = {
-            title: $title.value,
-            text: $text.value,
+          e.preventDefault();
+          const values = Object.fromEntries(new FormData(e.currentTarget));
+          type Input = inferProcedureInput<AppRouter['post']['add']>;
+          //    ^?
+          const input: Input = {
+            title: values.title as string,
+            text: values.text as string,
           };
           try {
             await addPost.mutateAsync(input);
 
-            $title.value = '';
-            $text.value = '';
-          } catch {}
+            e.currentTarget.reset();
+          } catch (cause) {
+            console.error({ cause }, 'Failed to add post');
+          }
         }}
       >
         <label htmlFor="title">Title:</label>

--- a/examples/next-prisma-starter/src/pages/index.tsx
+++ b/examples/next-prisma-starter/src/pages/index.tsx
@@ -26,12 +26,12 @@ const IndexPage: NextPageWithLayout = () => {
   });
 
   // prefetch all posts for instant navigation
-  useEffect(() => {
-    const allPosts = postsQuery.data?.pages.flatMap((page) => page.items) ?? [];
-    for (const { id } of allPosts) {
-      void utils.post.byId.prefetch({ id });
-    }
-  }, [postsQuery.data, utils]);
+  // useEffect(() => {
+  //   const allPosts = postsQuery.data?.pages.flatMap((page) => page.items) ?? [];
+  //   for (const { id } of allPosts) {
+  //     void utils.post.byId.prefetch({ id });
+  //   }
+  // }, [postsQuery.data, utils]);
 
   return (
     <>

--- a/examples/next-prisma-starter/src/pages/index.tsx
+++ b/examples/next-prisma-starter/src/pages/index.tsx
@@ -51,7 +51,7 @@ const IndexPage: NextPageWithLayout = () => {
         onClick={() => postsQuery.fetchNextPage()}
         disabled={!postsQuery.hasNextPage || postsQuery.isFetchingNextPage}
       >
-        {postsQuery.isFetchingPreviousPage
+        {postsQuery.isFetchingNextPage
           ? 'Loading more...'
           : postsQuery.hasNextPage
           ? 'Load More'

--- a/examples/next-prisma-starter/src/pages/index.tsx
+++ b/examples/next-prisma-starter/src/pages/index.tsx
@@ -37,9 +37,8 @@ const IndexPage: NextPageWithLayout = () => {
     <>
       <h1>Welcome to your tRPC starter!</h1>
       <p>
-        Check <a href="https://trpc.io/docs">the docs</a> whenever you get
-        stuck, or ping <a href="https://twitter.com/alexdotjs">@alexdotjs</a> on
-        Twitter.
+        Check <a href="https://trpc.io/">the docs</a> whenever you get stuck, or
+        ping <a href="https://twitter.com/alexdotjs">@alexdotjs</a> on Twitter.
       </p>
 
       <h2>

--- a/examples/next-prisma-starter/src/pages/index.tsx
+++ b/examples/next-prisma-starter/src/pages/index.tsx
@@ -12,7 +12,7 @@ const IndexPage: NextPageWithLayout = () => {
       limit: 5,
     },
     {
-      getNextPageParam(lastPage) {
+      getPreviousPageParam(lastPage) {
         return lastPage.nextCursor;
       },
     },
@@ -48,15 +48,18 @@ const IndexPage: NextPageWithLayout = () => {
       </h2>
 
       <button
-        onClick={() => postsQuery.fetchNextPage()}
-        disabled={!postsQuery.hasNextPage || postsQuery.isFetchingNextPage}
+        onClick={() => postsQuery.fetchPreviousPage()}
+        disabled={
+          !postsQuery.hasPreviousPage || postsQuery.isFetchingPreviousPage
+        }
       >
-        {postsQuery.isFetchingNextPage
+        {postsQuery.isFetchingPreviousPage
           ? 'Loading more...'
-          : postsQuery.hasNextPage
+          : postsQuery.hasPreviousPage
           ? 'Load More'
           : 'Nothing more to load'}
       </button>
+
       {postsQuery.data?.pages.map((page, index) => (
         <Fragment key={index}>
           {page.items.map((item) => (

--- a/examples/next-prisma-starter/src/pages/index.tsx
+++ b/examples/next-prisma-starter/src/pages/index.tsx
@@ -37,8 +37,13 @@ const IndexPage: NextPageWithLayout = () => {
     <>
       <h1>Welcome to your tRPC starter!</h1>
       <p>
-        Check <a href="https://trpc.io/">the docs</a> whenever you get stuck, or
-        ping <a href="https://twitter.com/alexdotjs">@alexdotjs</a> on Twitter.
+        If you get stuck, check <a href="https://trpc.io">the docs</a>, write a
+        message in our <a href="https://trpc.io/discord">Discord-channel</a>, or
+        write a message in{' '}
+        <a href="https://github.com/trpc/trpc/discussions">
+          GitHub Discussions
+        </a>
+        .
       </p>
 
       <h2>

--- a/examples/next-prisma-starter/src/pages/index.tsx
+++ b/examples/next-prisma-starter/src/pages/index.tsx
@@ -3,7 +3,7 @@ import { NextPageWithLayout } from './_app';
 import { inferProcedureInput } from '@trpc/server';
 import Link from 'next/link';
 import { Fragment } from 'react';
-import { AppRouter } from '~/server/routers/_app';
+import type { AppRouter } from '~/server/routers/_app';
 
 const IndexPage: NextPageWithLayout = () => {
   const utils = trpc.useContext();

--- a/examples/next-prisma-starter/src/pages/index.tsx
+++ b/examples/next-prisma-starter/src/pages/index.tsx
@@ -65,7 +65,7 @@ const IndexPage: NextPageWithLayout = () => {
       </button>
 
       {postsQuery.data?.pages.map((page, index) => (
-        <Fragment key={index}>
+        <Fragment key={page.items[0]?.id || index}>
           {page.items.map((item) => (
             <article key={item.id}>
               <h3>{item.title}</h3>

--- a/examples/next-prisma-starter/src/pages/index.tsx
+++ b/examples/next-prisma-starter/src/pages/index.tsx
@@ -37,9 +37,8 @@ const IndexPage: NextPageWithLayout = () => {
     <>
       <h1>Welcome to your tRPC starter!</h1>
       <p>
-        Check <a href="https://trpc.io/?v10">the docs</a> whenever you get
-        stuck, or ping <a href="https://twitter.com/alexdotjs">@alexdotjs</a> on
-        Twitter.
+        Check <a href="https://trpc.io/">the docs</a> whenever you get stuck, or
+        ping <a href="https://twitter.com/alexdotjs">@alexdotjs</a> on Twitter.
       </p>
 
       <h2>

--- a/examples/next-prisma-starter/src/pages/index.tsx
+++ b/examples/next-prisma-starter/src/pages/index.tsx
@@ -37,8 +37,9 @@ const IndexPage: NextPageWithLayout = () => {
     <>
       <h1>Welcome to your tRPC starter!</h1>
       <p>
-        Check <a href="https://trpc.io/">the docs</a> whenever you get stuck, or
-        ping <a href="https://twitter.com/alexdotjs">@alexdotjs</a> on Twitter.
+        Check <a href="https://trpc.io/?v10">the docs</a> whenever you get
+        stuck, or ping <a href="https://twitter.com/alexdotjs">@alexdotjs</a> on
+        Twitter.
       </p>
 
       <h2>

--- a/examples/next-prisma-starter/src/pages/index.tsx
+++ b/examples/next-prisma-starter/src/pages/index.tsx
@@ -26,11 +26,12 @@ const IndexPage: NextPageWithLayout = () => {
   });
 
   // prefetch all posts for instant navigation
-  // useEffect(() => {
-  //   for (const { id } of postsQuery.data ?? []) {
-  //     utils.post.byId.prefetch({ id })
-  //   }
-  // }, [postsQuery.data, utils]);
+  useEffect(() => {
+    const allPosts = postsQuery.data?.pages.flatMap((page) => page.items) ?? [];
+    for (const { id } of allPosts) {
+      void utils.post.byId.prefetch({ id });
+    }
+  }, [postsQuery.data, utils]);
 
   return (
     <>

--- a/examples/next-prisma-starter/src/server/routers/post.ts
+++ b/examples/next-prisma-starter/src/server/routers/post.ts
@@ -22,16 +22,51 @@ const defaultPostSelect = Prisma.validator<Prisma.PostSelect>()({
 });
 
 export const postRouter = t.router({
-  list: t.procedure.query(() => {
-    /**
-     * For pagination you can have a look at this docs site
-     * @link https://trpc.io/docs/useInfiniteQuery
-     */
+  list: t.procedure
+    .input(
+      z.object({
+        limit: z.number().min(1).max(100).nullish(),
+        cursor: z.date().nullish(),
+      }),
+    )
+    .query(async ({ input }) => {
+      /**
+       * For pagination docs you can have a look here
+       * @see https://trpc.io/docs/useInfiniteQuery
+       * @see https://www.prisma.io/docs/concepts/components/prisma-client/pagination
+       */
 
-    return prisma.post.findMany({
-      select: defaultPostSelect,
-    });
-  }),
+      const limit = input.limit ?? 50;
+      const { cursor } = input;
+
+      const items = await prisma.post.findMany({
+        select: defaultPostSelect,
+        // get an extra item at the end which we'll use as next cursor
+        take: limit + 1,
+        where: {},
+        cursor: cursor
+          ? {
+              createdAt: cursor,
+            }
+          : undefined,
+        orderBy: {
+          createdAt: 'desc',
+        },
+      });
+      let nextCursor: typeof cursor | undefined = undefined;
+      if (items.length > limit) {
+        // Remove the last item and use it as next cursor
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const nextItem = items.pop()!;
+        nextCursor = nextItem.createdAt;
+      }
+
+      return {
+        items,
+        nextCursor,
+      };
+    }),
   byId: t.procedure
     .input(
       z.object({

--- a/examples/next-prisma-starter/src/server/routers/post.ts
+++ b/examples/next-prisma-starter/src/server/routers/post.ts
@@ -26,7 +26,7 @@ export const postRouter = t.router({
     .input(
       z.object({
         limit: z.number().min(1).max(100).nullish(),
-        cursor: z.date().nullish(),
+        cursor: z.string().nullish(),
       }),
     )
     .query(async ({ input }) => {
@@ -46,7 +46,7 @@ export const postRouter = t.router({
         where: {},
         cursor: cursor
           ? {
-              createdAt: cursor,
+              id: cursor,
             }
           : undefined,
         orderBy: {
@@ -59,11 +59,11 @@ export const postRouter = t.router({
 
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const nextItem = items.pop()!;
-        nextCursor = nextItem.createdAt;
+        nextCursor = nextItem.id;
       }
 
       return {
-        items,
+        items: items.reverse(),
         nextCursor,
       };
     }),

--- a/examples/next-prisma-starter/src/utils/trpc.ts
+++ b/examples/next-prisma-starter/src/utils/trpc.ts
@@ -1,6 +1,5 @@
 import { httpBatchLink, loggerLink } from '@trpc/client';
 import { createTRPCNext } from '@trpc/next';
-import type { inferProcedureInput, inferProcedureOutput } from '@trpc/server';
 import { NextPageContext } from 'next';
 import superjson from 'superjson';
 // ℹ️ Type-only import:
@@ -129,23 +128,3 @@ export const trpc = createTRPCNext<AppRouter, SSRContext>({
     return {};
   },
 });
-
-/**
- * This is a helper method to infer the output of a query resolver
- * @example type HelloOutput = inferQueryOutput<'hello'>
- */
-export type inferQueryOutput<
-  TRouteKey extends keyof AppRouter['_def']['queries'],
-> = inferProcedureOutput<AppRouter['_def']['queries'][TRouteKey]>;
-
-export type inferQueryInput<
-  TRouteKey extends keyof AppRouter['_def']['queries'],
-> = inferProcedureInput<AppRouter['_def']['queries'][TRouteKey]>;
-
-export type inferMutationOutput<
-  TRouteKey extends keyof AppRouter['_def']['mutations'],
-> = inferProcedureOutput<AppRouter['_def']['mutations'][TRouteKey]>;
-
-export type inferMutationInput<
-  TRouteKey extends keyof AppRouter['_def']['mutations'],
-> = inferProcedureInput<AppRouter['_def']['mutations'][TRouteKey]>;

--- a/www/vercel.json
+++ b/www/vercel.json
@@ -32,7 +32,7 @@
     },
     {
       "source": "/docs",
-      "destination": "/docs/v9",
+      "destination": "/docs/v10",
       "permanent": false
     },
     {

--- a/www/vercel.json
+++ b/www/vercel.json
@@ -31,6 +31,11 @@
       "permanent": false
     },
     {
+      "source": "/docs",
+      "destination": "/docs/v9",
+      "permanent": false
+    },
+    {
       "source": "/docs/:path((?!v[0-9]).*)",
       "destination": "/docs/v9/:path*"
     }


### PR DESCRIPTION
Adds pagination and simplifies post submission on the `next-prisma-starter`

- https://nextjs.trpc.io/ is slow and has too many posts
- An infinite pagi example as part of the ref project doesn't hurt