### PR TITLE
fix(examples): pageProps is `{}` by default

### DIFF
--- a/examples/next-prisma-starter-websockets/src/pages/_app.tsx
+++ b/examples/next-prisma-starter-websockets/src/pages/_app.tsx
@@ -5,7 +5,7 @@ import { trpc } from 'utils/trpc';
 
 const MyApp: AppType = ({ Component, pageProps }) => {
   return (
-    <SessionProvider session={pageProps.session}>
+    <SessionProvider session={(pageProps as any).session}>
       <Component {...pageProps} />
     </SessionProvider>
   );


### PR DESCRIPTION
Closes #2754

## 🎯 Changes

Fixes Next type error (`pageProps` now is `{}` by default).

## ✅ Checklist

- [X] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] ~~If necessary, I have added documentation related to the changes made.~~
- [ ] ~~I have added or updated the tests related to the changes made.~~