### PR TITLE
fix: TInputContext constraints for TypeScript 4.8

### DIFF
--- a/packages/server/src/deprecated/interop.ts
+++ b/packages/server/src/deprecated/interop.ts
@@ -142,7 +142,7 @@ export type MigrateRouter<
 
 export type MigrateOldRouter<TRouter extends AnyOldRouter> =
   TRouter extends OldRouter<
-    infer TInputContext,
+    infer TInputContext extends Record<string, any>,
     infer TContext,
     infer TMeta,
     infer TQueries,

--- a/packages/server/src/deprecated/router.ts
+++ b/packages/server/src/deprecated/router.ts
@@ -172,7 +172,7 @@ export type inferRouterMeta<TRouter extends AnyRouter> = TRouter extends Router<
  * @public
  * @deprecated
  */
-export type AnyRouter<TContext = any> = Router<
+export type AnyRouter<TContext extends Record<string, any> = any> = Router<
   any,
   TContext,
   any,
@@ -283,8 +283,8 @@ type SwapContext<
  * @deprecated
  */
 export class Router<
-  TInputContext,
-  TContext,
+  TInputContext extends Record<string, any>,
+  TContext extends Record<string, any>,
   TMeta extends Record<string, any>,
   TQueries extends ProcedureRecord<
     TInputContext,
@@ -755,7 +755,7 @@ export class Router<
    * Function to be called before any procedure is invoked
    * @link https://trpc.io/docs/middlewares
    */
-  public middleware<TNewContext>(
+  public middleware<TNewContext extends Record<string, any>>(
     middleware: MiddlewareFunction<TContext, TNewContext, TMeta>,
   ): Router<
     TInputContext,
@@ -890,6 +890,6 @@ export class Router<
 /**
  * @deprecated
  */
-export function router<TContext, TMeta extends Record<string, any> = {}>() {
+export function router<TContext extends Record<string, any>, TMeta extends Record<string, any> = {}>() {
   return new Router<TContext, TContext, TMeta, {}, {}, {}, DefaultErrorShape>();
 }


### PR DESCRIPTION
Closes #2645

## 🎯 Changes

This is a bugfix if tRPC is used against TypeScript 4.8 (in my case 4.8.3). To check or to reproduce the bug without this PR, try bumping Typescript to 4.8.3 in a clean next branch.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.