### PR TITLE
docs: fix missing import in Next.js docs

### DIFF
--- a/www/docs/nextjs/introduction.md
+++ b/www/docs/nextjs/introduction.md
@@ -134,6 +134,7 @@ Create a set of strongly-typed hooks using your API's type signature.
 ```tsx title='utils/trpc.ts'
 import { createTRPCNext } from '@trpc/next';
 import type { AppRouter } from '../pages/api/trpc/[trpc]';
+import { httpBatchLink } from "@trpc/client";
 
 function getBaseUrl() {
   if (typeof window !== 'undefined') // browser should use relative path

--- a/www/docs/nextjs/introduction.md
+++ b/www/docs/nextjs/introduction.md
@@ -132,7 +132,7 @@ export default trpcNext.createNextApiHandler({
 Create a set of strongly-typed hooks using your API's type signature.
 
 ```tsx title='utils/trpc.ts'
-import { httpBatchLink } from "@trpc/client";
+import { httpBatchLink } from '@trpc/client';
 import { createTRPCNext } from '@trpc/next';
 import type { AppRouter } from '../pages/api/trpc/[trpc]';
 

--- a/www/docs/nextjs/introduction.md
+++ b/www/docs/nextjs/introduction.md
@@ -132,9 +132,9 @@ export default trpcNext.createNextApiHandler({
 Create a set of strongly-typed hooks using your API's type signature.
 
 ```tsx title='utils/trpc.ts'
+import { httpBatchLink } from "@trpc/client";
 import { createTRPCNext } from '@trpc/next';
 import type { AppRouter } from '../pages/api/trpc/[trpc]';
-import { httpBatchLink } from "@trpc/client";
 
 function getBaseUrl() {
   if (typeof window !== 'undefined') // browser should use relative path


### PR DESCRIPTION
Closes #

## 🎯 Changes

This change adds `import { httpBatchLink } from '@trpc/client';` to the "Usage with Next.js" example code. 

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.