### PR TITLE
fix(www): use pnpm in README commands

### DIFF
--- a/www/README.md
+++ b/www/README.md
@@ -5,13 +5,13 @@ This website is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern 
 ## Installation
 
 ```console
-yarn install
+pnpm install
 ```
 
 ## Local Development
 
 ```console
-yarn start
+pnpm start
 ```
 
 This command starts a local development server and open up a browser window. Most changes are reflected live without having to restart the server.
@@ -19,7 +19,7 @@ This command starts a local development server and open up a browser window. Mos
 ## Build
 
 ```console
-yarn build
+pnpm build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.


### PR DESCRIPTION
Closes #

## 🎯 Changes

replace `yarn` with `pnpm` in the docs README commands

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.