### PR TITLE
Update tRPC docs link for SSR Headers in example

### DIFF
--- a/examples/next-prisma-starter/src/utils/trpc.ts
+++ b/examples/next-prisma-starter/src/utils/trpc.ts
@@ -68,8 +68,7 @@ export const trpc = createTRPCNext<AppRouter, SSRContext>({
           url: `${getBaseUrl()}/api/trpc`,
           /**
            * Set custom request headers on every request from tRPC
-           * @link http://localhost:3000/docs/v10/header
-           * @link http://localhost:3000/docs/v10/ssr
+           * @link https://trpc.io/docs/ssr
            */
           headers() {
             if (ctx?.req) {


### PR DESCRIPTION
Closes #

## 🎯 Changes

Updated the docs link used in the `examples/next-prisma-starter/src/utils/trpc.ts` file around why client headers were being passed through. The comments were linking to two `localhost` links, one for SSR and another specifically for headers that is a page that doesn't exist. 

Updated to the correct current docs link.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.