### PR TITLE
docs(ssg-helpers): Improve SSG helpers with `prefetch` vs. `fetch` and real context creation

### DIFF
--- a/www/docs/nextjs/ssg-helpers.md
+++ b/www/docs/nextjs/ssg-helpers.md
@@ -40,8 +40,11 @@ export async function getServerSideProps(
   });
   const id = context.params?.id as string;
 
-  // Prefetch `post.byId`
-  await ssg.post.byId.fetch({ id });
+  /*
+   * Prefetching the `post.byId` query here.
+   * `prefetch` does not return the result - if you need that, use `fetch` instead.
+   */
+  await ssg.post.byId.prefetch({ id });
 
   // Make sure to return { props: { trpcState: ssg.dehydrate() } }
   return {

--- a/www/docs/nextjs/ssg-helpers.md
+++ b/www/docs/nextjs/ssg-helpers.md
@@ -9,10 +9,11 @@ slug: /ssg-helpers
 
 ```ts
 import { createProxySSGHelpers } from '@trpc/react/ssg';
+import { createContext } from 'server/context';
 
 const ssg = createProxySSGHelpers({
   router: appRouter,
-  ctx: createContext,
+  ctx: await createContext(),
   transformer: superjson, // optional - adds superjson serialization
 });
 ```

--- a/www/docs/nextjs/ssg-helpers.md
+++ b/www/docs/nextjs/ssg-helpers.md
@@ -42,7 +42,7 @@ export async function getServerSideProps(
 
   /*
    * Prefetching the `post.byId` query here.
-   * `prefetch` does not return the result - if you need that, use `fetch` instead.
+   * `prefetch` does not return the result and never throws - if you need that behavior, use `fetch` instead.
    */
   await ssg.post.byId.prefetch({ id });
 


### PR DESCRIPTION
## 🎯 Changes



- Replace `fetch` with `prefetch` and add a comment to mention their use cases.
We now use `prefetch` instead and also show a small explanation for the difference.

- Import statement for the context creation function
- Use a real example of filling the `ctx` field via `await createContext()`.


  This makes sure to await the context creation when using the SSG helpers in `v10`.
  I'm not sure if this is really needed regarding the implementation, but without it, there's a TypeScript error:
  
  ![image](https://user-images.githubusercontent.com/29319414/192163076-3ffc48e5-2205-4964-80f6-6beedb7a3a08.png)
  
  
  ![image](https://user-images.githubusercontent.com/29319414/192163088-a326d832-fda2-4c19-b8bc-9d425cd06e15.png)
  
  
  For reference, this is how my `createContext` function looks like:
  
  
  ```ts
  import * as trpc from '@trpc/server'
  import * as trpcNext from '@trpc/server/adapters/next'
  import { prisma } from '../prisma/prisma'
  
  /**
   * Creates context for each incoming request.
   * Will be available in all resolvers.
   *
   * @link https://trpc.io/docs/context
   */
  export async function createContext(opts?: trpcNext.CreateNextContextOptions) {
    const req = opts?.req
    const res = opts?.res
  
    return {
      req,
      res,
      prisma,
      // userIdAuth,
    }
  }
  
  export type ContextTRPC = trpc.inferAsyncReturnType<typeof createContext>
  ```
---
### Out of scope

By the way: When using `createNextApiHandler`, just passing through the context creation function is fine. Not sure if different, but maybe a good idea to unify the expected types:

```ts
import { createContextTRPC } from '../../../server/context-trpc'

import * as trpcNext from '@trpc/server/adapters/next'
import { appRouter } from '../../../server/routers/_app'

export default trpcNext.createNextApiHandler({
  router: appRouter,
  // #####  🟦 this is fine!
  createContext: createContextTRPC,
  ...
})

```



## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.