### PR TITLE
Changed 'customize' to 'customized'(Typo fix)

### DIFF
--- a/www/versioned_docs/version-9.x/client/header.md
+++ b/www/versioned_docs/version-9.x/client/header.md
@@ -5,7 +5,7 @@ sidebar_label: Create Custom Header
 slug: /header
 ---
 
-The headers option can be customize in config when using `withTRPC` in nextjs or `createClient` in react.js.
+The headers option can be customized in config when using `withTRPC` in nextjs or `createClient` in react.js.
 
 `headers` can be both an object or a function. If it's a function it will gets called dynamically every http request.
 


### PR DESCRIPTION
Closes #

## 🎯 Changes

Fixed a small typo when I was going through the docs. So I thought I'd change it immediately. Changed the word customize to customized because of the setting of the sentence.

## ✅ Checklist

- [✅] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [✅] If necessary, I have added documentation related to the changes made.
- [✅] I have added or updated the tests related to the changes made.