### PR TITLE
docs(error-formatting): Fix invalid TS code (dangling semicolon)

### DIFF
--- a/www/docs/server/error-formatting.md
+++ b/www/docs/server/error-formatting.md
@@ -25,7 +25,7 @@ export const t = initTRPC.context<Context>().create({
           error.cause instanceof ZodError
             ? error.cause.flatten()
             : null,
-      };
+      },
     };
   }
 })


### PR DESCRIPTION
## 🎯 Changes

There's a dangling inline semicolon, which makes the statement invalid TS code.

See: [TS Playground](https://www.typescriptlang.org/play?#code/PTAEFMCdIe0gocAPADnALqAxjAdgZ00wF5QBLXM9AFQCUAFAYQDodd1l0AeRvDpdAD4AFAEpWkcAEMOwgN7xQEaHABicALYyOkeaHwALKSnAAaZbEigAvqNAKlSyegCukXPcWOlzX4eNmXt4AJjJSAFye3t6+zP4mzKHoUqZB0QBeMMEAoiqQ4WnRFnCsWeCgxJWgAOQAQgCCACIA+rTZAIoAqtkAytTVoABkg4XRUJasUi745RSEUrhY4DAAZqAAWlm5lqNFAPzFkJPT4MwrADba4Lhiu9GRuC7n56lFIKAwMCj4o9YA3Gl-l5rPBbPB4O8pM9QABzT7BRCoDDYPCEUAkciUGgMFhsfjcXjsTgicRYSQycDyLzjNSaK66OT6Iwmcw0qy2KKOZxuDwOaKxeKBIpJCKcooC5mnEWvIqgTI5PIFWWONmlYLlSqkOpNVodbp9AbDO5KVVYKYzTHzRbLNabBU7ZXeA6m82nC5XG6iY2OB5PF6jd4rMhIcDBIq-GVKIFR0GiIA)

![image](https://user-images.githubusercontent.com/29319414/193431090-34db641f-d212-4034-98bf-22d453640c5a.png)






### Out of scope

Btw: Is there any explanation what exactly this error formatting is doing? A small sentence or a screenshot would be really nice, no?

I'd be down to do that, but I don't see a difference when I enable the custom error formatting from the docs though.

I created a wrong input on purpose and this is how the error message looks like (no matter the custom formatting):

![image](https://user-images.githubusercontent.com/29319414/193431136-d8c2579e-ab11-4a71-8bbe-29e739260026.png)



