### PR TITLE
docs: tweaks

### DIFF
--- a/www/docs/migration/migrate-from-v9-to-v10.mdx
+++ b/www/docs/migration/migrate-from-v9-to-v10.mdx
@@ -514,6 +514,19 @@ The `createContext` function can no longer return either `null` or `undefined`. 
 + createContext: () => ({}),
 ```
 
+### `queryClient` is no longer exposed through tRPC context
+
+tRPC is no longer exposing the `queryClient` instance through `trpc.useContext()`. If you need to access it, import it from `@tanstack/react-query`:
+
+```tsx
+import { useQueryClient } from '@tanstack/react-query';
+
+const MyComponent = () => {
+  const queryClient = useQueryClient();
+  // ...
+};
+```
+
 ### Migrate custom error formatters
 
 You will need to move the contents of your `formatError()` into your root `t` router. See the [Error Formatting docs](error-formatting) for more.

--- a/www/docs/nextjs/introduction.md
+++ b/www/docs/nextjs/introduction.md
@@ -176,6 +176,10 @@ export const trpc = createTRPCNext<AppRouter>({
 // => { useQuery: ..., useMutation: ...}
 ```
 
+:::note
+createTRPCNext does not work with interop mode. If you are migrating from v9 using interop, keep using [the old way of initializing tRPC](../../versioned_docs/version-9.x/nextjs/introduction.md#4-create-trpc-hooks).
+:::
+
 ### 5. Configure `_app.tsx`
 
 ```tsx title='pages/_app.tsx'


### PR DESCRIPTION
Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

- note that `queryClient` is no longer exposed through context
- note that `createTRPCNext` is v10-exclusive and cannot be used with interop

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.