### PR TITLE
add `isDev` variable

### DIFF
--- a/packages/server/src/core/initTRPC.ts
+++ b/packages/server/src/core/initTRPC.ts
@@ -94,6 +94,7 @@ function createTRPCInner<TParams extends Partial<InitGenerics>>() {
       meta: $Meta;
       errorShape: $ErrorShape;
       transformer: $Transformer;
+      isDev: boolean;
     }>;
 
     {
@@ -116,6 +117,7 @@ function createTRPCInner<TParams extends Partial<InitGenerics>>() {
       errorShape: null as any,
       ctx: null as any,
       meta: null as any,
+      isDev: options?.isDev ?? process.env.NODE_ENV !== 'production',
     };
     return {
       /**
@@ -137,6 +139,7 @@ function createTRPCInner<TParams extends Partial<InitGenerics>>() {
       router: createRouterFactory<$Config>({
         errorFormatter,
         transformer,
+        isDev: _config.isDev,
       }),
       /**
        * Merge Routers

--- a/packages/server/src/core/internals/config.ts
+++ b/packages/server/src/core/internals/config.ts
@@ -38,6 +38,12 @@ export interface InitOptions<TType extends InitGenerics> {
    * Is this a server environment?
    */
   isServer: boolean;
+  /**
+   * Is this development?
+   * Will be used to decide if API should return stack traces
+   * @default process.env.NODE_ENV !== 'production'
+   */
+  isDev: boolean;
 }
 
 /**
@@ -54,6 +60,7 @@ export interface RootConfig extends InitGenerics {
   transformer: CombinedDataTransformer;
   // FIXME this should probably be restricted
   errorShape: any;
+  isDev: boolean;
 }
 
 /**

--- a/packages/server/src/core/internals/mergeRouters.ts
+++ b/packages/server/src/core/internals/mergeRouters.ts
@@ -40,6 +40,7 @@ export function mergeRouters(...routerList: AnyRouter[]): AnyRouter {
   const router = createRouterFactory({
     errorFormatter,
     transformer,
+    isDev: routerList.some((r) => r._def.isDev),
   })(record);
   return router;
 }

--- a/packages/server/src/deprecated/interop.ts
+++ b/packages/server/src/deprecated/interop.ts
@@ -107,6 +107,7 @@ export type MigrateRouter<
         errorShape: TErrorShape;
         meta: TMeta;
         transformer: CombinedDataTransformer;
+        isDev: boolean;
       }>,
       TQueries,
       'query'
@@ -117,6 +118,7 @@ export type MigrateRouter<
         errorShape: TErrorShape;
         meta: TMeta;
         transformer: CombinedDataTransformer;
+        isDev: boolean;
       }>,
       TMutations,
       'mutation'
@@ -127,6 +129,7 @@ export type MigrateRouter<
         errorShape: TErrorShape;
         meta: TMeta;
         transformer: CombinedDataTransformer;
+        isDev: boolean;
       }>,
       TSubscriptions,
       'subscription'
@@ -212,6 +215,7 @@ export function migrateRouter<TOldRouter extends AnyOldRouter>(
   const newRouter = createRouterFactory<any>({
     transformer,
     errorFormatter,
+    isDev: process.env.NODE_ENV !== 'production',
   })(procedures);
 
   return newRouter as any;

--- a/packages/server/test/isDev.test.ts
+++ b/packages/server/test/isDev.test.ts
@@ -1,0 +1,55 @@
+import { routerToServerAndClientNew, waitError } from './___testHelpers';
+import { TRPCClientError } from '@trpc/client/src';
+import { konn } from 'konn';
+import { initTRPC } from '../src';
+
+const createTestContext = (opts: { isDev: boolean }) =>
+  konn()
+    .beforeEach(() => {
+      const t = initTRPC.create({ isDev: opts.isDev });
+
+      const appRouter = t.router({
+        failingMutation: t.procedure.mutation(() => {
+          if (Math.random() < 2) {
+            throw new Error('Always fails');
+          }
+          return 'hello';
+        }),
+      });
+
+      const res = routerToServerAndClientNew(appRouter);
+
+      return res;
+    })
+    .afterEach(async (ctx) => {
+      await ctx?.close?.();
+    })
+    .done();
+
+describe('isDev:true', () => {
+  const ctx = createTestContext({ isDev: true });
+
+  test('prints stacks', async () => {
+    const error = (await waitError(
+      () => ctx.proxy.failingMutation.mutate(),
+      TRPCClientError,
+    )) as TRPCClientError<typeof ctx.router>;
+
+    expect(error.data?.stack?.split('\n')[0]).toMatchInlineSnapshot(
+      `"Error: Always fails"`,
+    );
+  });
+});
+
+describe('isDev:false', () => {
+  const ctx = createTestContext({ isDev: false });
+
+  test('does not print stack', async () => {
+    const error = (await waitError(
+      () => ctx.proxy.failingMutation.mutate(),
+      TRPCClientError,
+    )) as TRPCClientError<typeof ctx.router>;
+
+    expect(error.data?.stack).toBeUndefined();
+  });
+});

--- a/scripts/generateMergeRouters.ts
+++ b/scripts/generateMergeRouters.ts
@@ -31,6 +31,7 @@ const TEMPLATE = `
   subscriptions: __subscriptions__;
   procedures: __procedures__;
   record: __records__;
+  isDev: boolean;
  }> & __records__;
  `.trim();
 


### PR DESCRIPTION


## 🎯 Changes

- Programmatically supply `isDev: boolean` rather than relying on `process.env.NODE_ENV`

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.