### PR TITLE
feat: add `trpc` prop to hooks' return

### DIFF
--- a/packages/react/src/createTRPCReact.tsx
+++ b/packages/react/src/createTRPCReact.tsx
@@ -1,8 +1,3 @@
-import {
-  UseInfiniteQueryResult,
-  UseMutationResult,
-  UseQueryResult,
-} from '@tanstack/react-query';
 import { TRPCClientErrorLike } from '@trpc/client';
 import {
   AnyMutationProcedure,
@@ -33,7 +28,12 @@ import {
   UseTRPCSubscriptionOptions,
   createHooksInternal,
 } from './shared/hooks/createHooksInternal';
-import { CreateTRPCReactOptions } from './shared/types';
+import {
+  CreateTRPCReactOptions,
+  TRPCUseInfiniteQueryResult,
+  TRPCUseMutationResult,
+  TRPCUseQueryResult,
+} from './shared/types';
 
 /**
  * @internal
@@ -55,7 +55,7 @@ export type DecorateProcedure<
           TData,
           TRPCClientErrorLike<TProcedure>
         >,
-      ) => UseQueryResult<TData, TRPCClientErrorLike<TProcedure>>;
+      ) => TRPCUseQueryResult<TData, TRPCClientErrorLike<TProcedure>>;
     } & (inferProcedureInput<TProcedure> extends { cursor?: any }
       ? {
           useInfiniteQuery: <
@@ -69,7 +69,10 @@ export type DecorateProcedure<
               TData,
               TRPCClientErrorLike<TProcedure>
             >,
-          ) => UseInfiniteQueryResult<TData, TRPCClientErrorLike<TProcedure>>;
+          ) => TRPCUseInfiniteQueryResult<
+            TData,
+            TRPCClientErrorLike<TProcedure>
+          >;
         }
       : {})
   : TProcedure extends AnyMutationProcedure
@@ -81,7 +84,7 @@ export type DecorateProcedure<
           inferProcedureOutput<TProcedure>,
           TContext
         >,
-      ) => UseMutationResult<
+      ) => TRPCUseMutationResult<
         inferProcedureOutput<TProcedure>,
         TRPCClientErrorLike<TProcedure>,
         inferProcedureInput<TProcedure>,

--- a/packages/react/src/createTRPCReact.tsx
+++ b/packages/react/src/createTRPCReact.tsx
@@ -23,17 +23,15 @@ import {
   TRPCProvider,
   UseDehydratedState,
   UseTRPCInfiniteQueryOptions,
+  UseTRPCInfiniteQueryResult,
   UseTRPCMutationOptions,
+  UseTRPCMutationResult,
   UseTRPCQueryOptions,
+  UseTRPCQueryResult,
   UseTRPCSubscriptionOptions,
   createHooksInternal,
 } from './shared/hooks/createHooksInternal';
-import {
-  CreateTRPCReactOptions,
-  TRPCUseInfiniteQueryResult,
-  TRPCUseMutationResult,
-  TRPCUseQueryResult,
-} from './shared/types';
+import { CreateTRPCReactOptions } from './shared/types';
 
 /**
  * @internal
@@ -55,7 +53,7 @@ export type DecorateProcedure<
           TData,
           TRPCClientErrorLike<TProcedure>
         >,
-      ) => TRPCUseQueryResult<TData, TRPCClientErrorLike<TProcedure>>;
+      ) => UseTRPCQueryResult<TData, TRPCClientErrorLike<TProcedure>>;
     } & (inferProcedureInput<TProcedure> extends { cursor?: any }
       ? {
           useInfiniteQuery: <
@@ -69,7 +67,7 @@ export type DecorateProcedure<
               TData,
               TRPCClientErrorLike<TProcedure>
             >,
-          ) => TRPCUseInfiniteQueryResult<
+          ) => UseTRPCInfiniteQueryResult<
             TData,
             TRPCClientErrorLike<TProcedure>
           >;
@@ -84,7 +82,7 @@ export type DecorateProcedure<
           inferProcedureOutput<TProcedure>,
           TContext
         >,
-      ) => TRPCUseMutationResult<
+      ) => UseTRPCMutationResult<
         inferProcedureOutput<TProcedure>,
         TRPCClientErrorLike<TProcedure>,
         inferProcedureInput<TProcedure>,

--- a/packages/react/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react/src/shared/hooks/createHooksInternal.tsx
@@ -35,6 +35,7 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import {
@@ -169,10 +170,13 @@ export type UseTRPCInfiniteQueryResult<TData, TError> = UseInfiniteQueryResult<
 export type UseTRPCMutationResult<TData, TError, TVariables, TContext> =
   UseMutationResult<TData, TError, TVariables, TContext> & TRPCHookResult;
 
-function useConstantValue<TValue>(value: TValue): TValue {
-  const [v] = useState(() => value);
-
-  return v;
+/**
+ * Makes a stable reference of the `trpc` prop
+ */
+function useHookResult(value: TRPCHookResult['trpc']): TRPCHookResult['trpc'] {
+  const ref = useRef(value);
+  ref.current.path = value.path;
+  return ref.current;
 }
 /**
  * Create strongly typed react hooks
@@ -453,7 +457,7 @@ export function createHooksInternal<
       },
       ssrOpts,
     ) as UseTRPCQueryResult<TData, TError>;
-    hook.trpc = useConstantValue({
+    hook.trpc = useHookResult({
       path: pathAndInput[0],
     });
 
@@ -502,7 +506,7 @@ export function createHooksInternal<
       TContext
     >;
 
-    hook.trpc = useConstantValue({
+    hook.trpc = useHookResult({
       path: Array.isArray(path) ? path[0] : path,
     });
 
@@ -629,7 +633,7 @@ export function createHooksInternal<
       ssrOpts,
     ) as UseTRPCInfiniteQueryResult<TQueryValues[TPath]['output'], TError>;
 
-    hook.trpc = useConstantValue({
+    hook.trpc = useHookResult({
       path,
     });
     return hook;

--- a/packages/react/src/shared/types.ts
+++ b/packages/react/src/shared/types.ts
@@ -30,30 +30,3 @@ export interface CreateTRPCReactOptions<_TRouter extends AnyRouter> {
     useMutation?: Partial<UseMutationOverride>;
   };
 }
-
-interface TRPCHookResult {
-  trpc: {
-    path: string;
-  };
-}
-
-/**
- * @internal
- */
-export type TRPCUseQueryResult<TData, TError> = UseQueryResult<TData, TError> &
-  TRPCHookResult;
-
-/**
- * @internal
- */
-export type TRPCUseInfiniteQueryResult<TData, TError> = UseInfiniteQueryResult<
-  TData,
-  TError
-> &
-  TRPCHookResult;
-
-/**
- * @internal
- */
-export type TRPCUseMutationResult<TData, TError, TVariables, TContext> =
-  UseMutationResult<TData, TError, TVariables, TContext> & TRPCHookResult;

--- a/packages/react/src/shared/types.ts
+++ b/packages/react/src/shared/types.ts
@@ -1,9 +1,4 @@
-import {
-  QueryClient,
-  UseInfiniteQueryResult,
-  UseMutationResult,
-  UseQueryResult,
-} from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
 import { AnyRouter, MaybePromise } from '@trpc/server';
 
 /**

--- a/packages/react/src/shared/types.ts
+++ b/packages/react/src/shared/types.ts
@@ -1,4 +1,9 @@
-import { QueryClient } from '@tanstack/react-query';
+import {
+  QueryClient,
+  UseInfiniteQueryResult,
+  UseMutationResult,
+  UseQueryResult,
+} from '@tanstack/react-query';
 import { AnyRouter, MaybePromise } from '@trpc/server';
 
 /**
@@ -25,3 +30,30 @@ export interface CreateTRPCReactOptions<_TRouter extends AnyRouter> {
     useMutation?: Partial<UseMutationOverride>;
   };
 }
+
+interface TRPCHookResult {
+  trpc: {
+    path: string;
+  };
+}
+
+/**
+ * @internal
+ */
+export type TRPCUseQueryResult<TData, TError> = UseQueryResult<TData, TError> &
+  TRPCHookResult;
+
+/**
+ * @internal
+ */
+export type TRPCUseInfiniteQueryResult<TData, TError> = UseInfiniteQueryResult<
+  TData,
+  TError
+> &
+  TRPCHookResult;
+
+/**
+ * @internal
+ */
+export type TRPCUseMutationResult<TData, TError, TVariables, TContext> =
+  UseMutationResult<TData, TError, TVariables, TContext> & TRPCHookResult;

--- a/packages/server/test/react/useMutation.test.tsx
+++ b/packages/server/test/react/useMutation.test.tsx
@@ -52,6 +52,8 @@ test('useMutation', async () => {
   function MyComponent() {
     const mutation = proxy.post.create.useMutation();
 
+    expect(mutation.trpc.path).toBe('post.create');
+
     useEffect(() => {
       mutation.mutate({
         text: 'hello',

--- a/packages/server/test/react/useQuery.test.tsx
+++ b/packages/server/test/react/useQuery.test.tsx
@@ -62,6 +62,8 @@ test('useQuery()', async () => {
       id: '1',
     });
 
+    expect(query1.trpc.path).toBe('post.byId');
+
     // @ts-expect-error Should not exist
     proxy.post.byId.useInfiniteQuery;
     const utils = proxy.useContext();
@@ -96,6 +98,7 @@ test('useInfiniteQuery()', async () => {
   const { App, proxy } = ctx;
   function MyComponent() {
     const query1 = proxy.post.list.useInfiniteQuery({});
+    expect(query1.trpc.path).toBe('post.list');
 
     if (!query1.data) {
       return <>...</>;


### PR DESCRIPTION
Closes #2915

## 🎯 Changes

add `trpc` prop to hooks' return

- Gives us the ability to do stuff dynamically based on the path

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.