### PR TITLE
fix `setInfiniteData`

### DIFF
--- a/packages/react/src/shared/proxy/utilsProxy.ts
+++ b/packages/react/src/shared/proxy/utilsProxy.ts
@@ -238,13 +238,12 @@ export function createReactQueryUtilsProxy<
         >;
         const queryKey = getQueryKey(fullPath, input);
         return {
-          input,
           queryKey,
           rest,
         };
       };
 
-      const { queryKey, rest, updater, input } = getOpts(utilName);
+      const { queryKey, rest, updater } = getOpts(utilName);
 
       const contextMap: Record<keyof AnyDecoratedProcedure, () => unknown> = {
         fetch: () => context.fetchQuery(queryKey, ...rest),
@@ -257,7 +256,7 @@ export function createReactQueryUtilsProxy<
         cancel: () => context.cancelQuery(queryKey, ...rest),
         setData: () => context.setQueryData(queryKey, updater, ...rest),
         setInfiniteData: () =>
-          context.setInfiniteQueryData(queryKey, input, ...rest),
+          context.setInfiniteQueryData(queryKey, updater, ...rest),
         getData: () => context.getQueryData(queryKey),
         getInfiniteData: () => context.getInfiniteQueryData(queryKey),
       };

--- a/packages/react/src/shared/proxy/utilsProxy.ts
+++ b/packages/react/src/shared/proxy/utilsProxy.ts
@@ -226,7 +226,6 @@ export function createReactQueryUtilsProxy<
           >;
           const queryKey = getQueryKey(fullPath, input);
           return {
-            input,
             queryKey,
             updater,
             rest,

--- a/packages/server/test/regression/issue-2942-useInfiniteQuery-setData.test.tsx
+++ b/packages/server/test/regression/issue-2942-useInfiniteQuery-setData.test.tsx
@@ -11,17 +11,8 @@ const fixtureData = ['1', '2'];
 
 const ctx = konn()
   .beforeEach(() => {
-    const t = initTRPC.create({
-      errorFormatter({ shape }) {
-        return {
-          ...shape,
-          data: {
-            ...shape.data,
-            foo: 'bar' as const,
-          },
-        };
-      },
-    });
+    const t = initTRPC.create();
+
     const appRouter = t.router({
       post: t.router({
         list: t.procedure

--- a/packages/server/test/regression/issue-2942-useInfiniteQuery-setData.test.tsx
+++ b/packages/server/test/regression/issue-2942-useInfiniteQuery-setData.test.tsx
@@ -28,7 +28,7 @@ const ctx = konn()
           .input(
             z.object({
               cursor: z.number().default(0),
-              foo: z.literal('bar'),
+              foo: z.literal('bar').optional().default('bar'),
             }),
           )
           .query(({ input }) => {
@@ -59,7 +59,7 @@ const ctx = konn()
   })
   .done();
 
-test('useInfiniteQuery()', async () => {
+test('with input', async () => {
   const { App, proxy } = ctx;
   function MyComponent() {
     const utils = proxy.useContext();
@@ -95,6 +95,64 @@ test('useInfiniteQuery()', async () => {
             utils.post.list.setInfiniteData((data) => data, {
               foo: 'bar',
             });
+          }}
+        >
+          Fetch more
+        </button>
+        <pre>{JSON.stringify(query1.data ?? 'n/a', null, 4)}</pre>
+      </>
+    );
+  }
+
+  const utils = render(
+    <App>
+      <MyComponent />
+    </App>,
+  );
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent(`[ "1" ]`);
+  });
+  const before = JSON.parse(JSON.stringify(dehydrate(ctx.queryClient)));
+  utils.getByTestId('setInfinite').click();
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  const after = JSON.parse(JSON.stringify(dehydrate(ctx.queryClient)));
+
+  expect(before).toEqual(after);
+});
+
+test('w/o input', async () => {
+  const { App, proxy } = ctx;
+  function MyComponent() {
+    const utils = proxy.useContext();
+    const query1 = proxy.post.list.useInfiniteQuery(
+      {},
+      {
+        getNextPageParam(lastPage) {
+          return lastPage.next;
+        },
+      },
+    );
+    expect(query1.trpc.path).toBe('post.list');
+
+    if (!query1.data) {
+      return <>...</>;
+    }
+
+    type TData = typeof query1['data'];
+    expectTypeOf<TData>().toMatchTypeOf<
+      InfiniteData<{
+        items: typeof fixtureData;
+        next: number | undefined;
+      }>
+    >();
+
+    return (
+      <>
+        <button
+          data-testid="setInfinite"
+          onClick={() => {
+            utils.post.list.setInfiniteData((data) => data);
           }}
         >
           Fetch more

--- a/packages/server/test/regression/issue-2942-useInfiniteQuery-setData.test.tsx
+++ b/packages/server/test/regression/issue-2942-useInfiniteQuery-setData.test.tsx
@@ -1,0 +1,122 @@
+import { getServerAndReactClient } from '../react/__reactHelpers';
+import { InfiniteData, dehydrate } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import { expectTypeOf } from 'expect-type';
+import { konn } from 'konn';
+import React from 'react';
+import { z } from 'zod';
+import { initTRPC } from '../../src';
+
+const fixtureData = ['1', '2'];
+
+const ctx = konn()
+  .beforeEach(() => {
+    const t = initTRPC.create({
+      errorFormatter({ shape }) {
+        return {
+          ...shape,
+          data: {
+            ...shape.data,
+            foo: 'bar' as const,
+          },
+        };
+      },
+    });
+    const appRouter = t.router({
+      post: t.router({
+        list: t.procedure
+          .input(
+            z.object({
+              cursor: z.number().default(0),
+              foo: z.literal('bar'),
+            }),
+          )
+          .query(({ input }) => {
+            return {
+              items: fixtureData.slice(input.cursor, input.cursor + 1),
+              next:
+                input.cursor + 1 > fixtureData.length
+                  ? undefined
+                  : input.cursor + 1,
+            };
+          }),
+      }),
+      /**
+       * @deprecated
+       */
+      deprecatedRouter: t.router({
+        /**
+         * @deprecated
+         */
+        deprecatedProcedure: t.procedure.query(() => '..'),
+      }),
+    });
+
+    return getServerAndReactClient(appRouter);
+  })
+  .afterEach(async (ctx) => {
+    await ctx?.close?.();
+  })
+  .done();
+
+test('useInfiniteQuery()', async () => {
+  const { App, proxy } = ctx;
+  function MyComponent() {
+    const utils = proxy.useContext();
+    const query1 = proxy.post.list.useInfiniteQuery(
+      {
+        foo: 'bar',
+      },
+      {
+        getNextPageParam(lastPage) {
+          return lastPage.next;
+        },
+      },
+    );
+    expect(query1.trpc.path).toBe('post.list');
+
+    if (!query1.data) {
+      return <>...</>;
+    }
+
+    type TData = typeof query1['data'];
+    expectTypeOf<TData>().toMatchTypeOf<
+      InfiniteData<{
+        items: typeof fixtureData;
+        next: number | undefined;
+      }>
+    >();
+
+    return (
+      <>
+        <button
+          data-testid="setInfinite"
+          onClick={() => {
+            utils.post.list.setInfiniteData((data) => data, {
+              foo: 'bar',
+            });
+          }}
+        >
+          Fetch more
+        </button>
+        <pre>{JSON.stringify(query1.data ?? 'n/a', null, 4)}</pre>
+      </>
+    );
+  }
+
+  const utils = render(
+    <App>
+      <MyComponent />
+    </App>,
+  );
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent(`[ "1" ]`);
+  });
+  const before = JSON.parse(JSON.stringify(dehydrate(ctx.queryClient)));
+  utils.getByTestId('setInfinite').click();
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  const after = JSON.parse(JSON.stringify(dehydrate(ctx.queryClient)));
+
+  expect(before).toEqual(after);
+});

--- a/packages/server/test/regression/issue-2942-useInfiniteQuery-setData.test.tsx
+++ b/packages/server/test/regression/issue-2942-useInfiniteQuery-setData.test.tsx
@@ -41,15 +41,6 @@ const ctx = konn()
             };
           }),
       }),
-      /**
-       * @deprecated
-       */
-      deprecatedRouter: t.router({
-        /**
-         * @deprecated
-         */
-        deprecatedProcedure: t.procedure.query(() => '..'),
-      }),
     });
 
     return getServerAndReactClient(appRouter);

--- a/packages/server/test/regression/issue-2942-useInfiniteQuery-setData.test.tsx
+++ b/packages/server/test/regression/issue-2942-useInfiniteQuery-setData.test.tsx
@@ -1,5 +1,9 @@
 import { getServerAndReactClient } from '../react/__reactHelpers';
-import { InfiniteData, dehydrate } from '@tanstack/react-query';
+import {
+  DehydratedState,
+  InfiniteData,
+  dehydrate,
+} from '@tanstack/react-query';
 import { render, waitFor } from '@testing-library/react';
 import { expectTypeOf } from 'expect-type';
 import { konn } from 'konn';
@@ -94,12 +98,28 @@ test('with input', async () => {
   await waitFor(() => {
     expect(utils.container).toHaveTextContent(`[ "1" ]`);
   });
-  const before = JSON.parse(JSON.stringify(dehydrate(ctx.queryClient)));
+
+  const before: DehydratedState['queries'] = JSON.parse(
+    JSON.stringify(dehydrate(ctx.queryClient).queries),
+  );
   utils.getByTestId('setInfinite').click();
   await new Promise((resolve) => setTimeout(resolve, 100));
 
-  const after = JSON.parse(JSON.stringify(dehydrate(ctx.queryClient)));
+  const after: DehydratedState['queries'] = JSON.parse(
+    JSON.stringify(dehydrate(ctx.queryClient).queries),
+  );
 
+  {
+    // Remove update info from diff
+    for (const value of before) {
+      value.state.dataUpdateCount = -1;
+      value.state.dataUpdatedAt = -1;
+    }
+    for (const value of after) {
+      value.state.dataUpdateCount = -1;
+      value.state.dataUpdatedAt = -1;
+    }
+  }
   expect(before).toEqual(after);
 });
 
@@ -152,11 +172,15 @@ test('w/o input', async () => {
   await waitFor(() => {
     expect(utils.container).toHaveTextContent(`[ "1" ]`);
   });
-  const before = JSON.parse(JSON.stringify(dehydrate(ctx.queryClient)));
+  const before: DehydratedState['queries'] = JSON.parse(
+    JSON.stringify(dehydrate(ctx.queryClient).queries),
+  );
   utils.getByTestId('setInfinite').click();
   await new Promise((resolve) => setTimeout(resolve, 100));
 
-  const after = JSON.parse(JSON.stringify(dehydrate(ctx.queryClient)));
+  const after: DehydratedState['queries'] = JSON.parse(
+    JSON.stringify(dehydrate(ctx.queryClient).queries),
+  );
 
   expect(before).toEqual(after);
 });


### PR DESCRIPTION
Closes #2942

## 🎯 Changes

- Not done, only added failing test
- ~~Maybe @sachinraja or @TkDodo could help understanding what's going on~~ nvm, i think i fixed it
  - Extra context: one of the new tests in the repro (w/o input) works, the other one doesn't
  - Might be that we have some types that are lying
  - Can't find any docs for `setInfiniteQueryData` but there are some for [`setQueryData`](https://tanstack.com/query/v4/docs/reference/QueryClient#queryclientsetquerydata)

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.