### PR TITLE
docs: consistent publicProcedure naming

### DIFF
--- a/www/docs/nextjs/introduction.md
+++ b/www/docs/nextjs/introduction.md
@@ -104,11 +104,11 @@ import { initTRPC, TRPCError } from '@trpc/server';
 // Avoid exporting the entire t-object since it's not very
 // descriptive and can be confusing to newcomers used to t
 // meaning translation in i18n libraries.
-const t = initTRPC.create();
+const t = initTRPC.create()****;
 
 // Base router and procedure helpers
 export const router = t.router;
-export const baseProcedure = t.procedure;
+export const publicProcedure = t.procedure;
 
 // If you have authentication you can create protected procedures
 // NOTE: Below is just an example
@@ -130,10 +130,10 @@ export const authedProcedure = t.procedure.use(({ ctx, next}) => {
 
 ```ts title='server/routers/_app.ts'
 import { z } from 'zod';
-import { router, baseProcedure } from '../trpc';
+import { router, publicProcedure } from '../trpc';
 
 export const appRouter = router({
-  hello: baseProcedure
+  hello: publicProcedure
     .input(
       z.object({
         text: z.string().nullish(),

--- a/www/docs/nextjs/introduction.md
+++ b/www/docs/nextjs/introduction.md
@@ -104,7 +104,7 @@ import { initTRPC, TRPCError } from '@trpc/server';
 // Avoid exporting the entire t-object since it's not very
 // descriptive and can be confusing to newcomers used to t
 // meaning translation in i18n libraries.
-const t = initTRPC.create()****;
+const t = initTRPC.create();
 
 // Base router and procedure helpers
 export const router = t.router;

--- a/www/docs/nextjs/introduction.md
+++ b/www/docs/nextjs/introduction.md
@@ -116,7 +116,7 @@ export const authedProcedure = t.procedure.use(({ ctx, next}) => {
   if (!ctx.session) {
     throw new TRPCError({ code: 'UNAUTHORIZED' });
   }
-  // Express-complient `next` method
+  // Express-compliant `next` method
   return next({
     ctx: {
       // explicitly passing `session` infers the value as non-nullable to the next middleware or resolve function


### PR DESCRIPTION
## 🎯 Changes

Everywhere else in the docs has moved to this `publicProcedure` naming, this example in the Next.js intro seems to have been overlooked

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.