### PR TITLE
simplify type merging output

### DIFF
--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -64,7 +64,7 @@ export interface BuildProcedure<
 
 type OverwriteIfDefined<TType, TWith> = UnsetMarker extends TType
   ? TWith
-  : FlatOverwrite<TType, TWith>;
+  : Simplify<FlatOverwrite<TType, TWith>>;
 
 type ErrorMessage<TMessage extends string> = TMessage;
 
@@ -101,9 +101,11 @@ export interface ProcedureBuilder<TParams extends ProcedureParams> {
       TParams['_input_in'],
       inferParser<$Parser>['in']
     >;
-    _input_out: Simplify<
-      OverwriteIfDefined<TParams['_input_out'], inferParser<$Parser>['out']>
+    _input_out: OverwriteIfDefined<
+      TParams['_input_out'],
+      inferParser<$Parser>['out']
     >;
+
     _output_in: TParams['_output_in'];
     _output_out: TParams['_output_out'];
   }>;

--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -1,6 +1,6 @@
 import { TRPCError } from '../../error/TRPCError';
 import { getTRPCErrorFromUnknown } from '../../error/utils';
-import { FlatOverwrite, MaybePromise } from '../../types';
+import { FlatOverwrite, MaybePromise, Simplify } from '../../types';
 import {
   MiddlewareFunction,
   MiddlewareResult,
@@ -101,9 +101,8 @@ export interface ProcedureBuilder<TParams extends ProcedureParams> {
       TParams['_input_in'],
       inferParser<$Parser>['in']
     >;
-    _input_out: OverwriteIfDefined<
-      TParams['_input_out'],
-      inferParser<$Parser>['out']
+    _input_out: Simplify<
+      OverwriteIfDefined<TParams['_input_out'], inferParser<$Parser>['out']>
     >;
     _output_in: TParams['_output_in'];
     _output_out: TParams['_output_out'];

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -51,9 +51,11 @@ export type ThenArg<TType> = TType extends PromiseLike<infer U>
 
 /**
  * @internal
+ * @see https://github.com/ianstormtaylor/superstruct/blob/7973400cd04d8ad92bbdc2b6f35acbfb3c934079/src/utils.ts#L323-L325
  */
-export type Simplify<TType> = { [KeyType in keyof TType]: TType[KeyType] };
-
+export type Simplify<TType> = TType extends any[] | Date
+  ? TType
+  : { [K in keyof TType]: TType[K] } & {};
 /**
  * @public
  */

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -24,17 +24,15 @@ type UndefinedKeys<TType> = keyof OmitNever<{
 /**
  * @internal
  */
-export type FlatOverwrite<TType, TWith> = Simplify<
-  InferOptional<
-    {
-      [TKey in keyof TWith | keyof TType]: TKey extends keyof TWith
-        ? TWith[TKey]
-        : TKey extends keyof TType
-        ? TType[TKey]
-        : never;
-    },
-    UndefinedKeys<TType> | UndefinedKeys<TWith>
-  >
+export type FlatOverwrite<TType, TWith> = InferOptional<
+  {
+    [TKey in keyof TWith | keyof TType]: TKey extends keyof TWith
+      ? TWith[TKey]
+      : TKey extends keyof TType
+      ? TType[TKey]
+      : never;
+  },
+  UndefinedKeys<TType> | UndefinedKeys<TWith>
 >;
 
 /**

--- a/packages/server/test/input.test.ts
+++ b/packages/server/test/input.test.ts
@@ -45,6 +45,19 @@ describe('double input validator', () => {
       .mutation(({ input }) => {
         return input;
       }),
+
+    sendMessage2: roomProcedure
+      .input(
+        z.object({
+          text: z.string(),
+        }),
+      )
+      .mutation(({ input }) => {
+        //         ^?
+        input.roomId;
+        input.text;
+        return input;
+      }),
   });
   type AppRouter = typeof appRouter;
   const ctx = konn()


### PR DESCRIPTION
alternative to #2958
- https://www-git-sachin-simplify-trpc.vercel.app/docs/v10/procedures#multiple-input-parsers, versus
- https://trpc.io/docs/v10/procedures#multiple-input-parsers

If I had to guess as to why this works, it's because TypeScript is being forced to evaluate the conditional type. I have no idea why those specific conditions were picked though.