### PR TITLE
fix: apply array query key normalization in SSG helpers

### DIFF
--- a/packages/react/src/internals/getArrayQueryKey.ts
+++ b/packages/react/src/internals/getArrayQueryKey.ts
@@ -1,0 +1,30 @@
+/**
+ * To allow easy interactions with groups of related queries, such as
+ * invalidating all queries of a router, we use an array as the path when
+ * storing in tanstack query. This function converts from the `.` separated
+ * path passed around internally by both the legacy and proxy implementation.
+ * https://github.com/trpc/trpc/issues/2611
+ */
+export function getArrayQueryKey(
+  queryKey: string | [string] | [string, ...unknown[]] | unknown[],
+): [string[]] | [string[], ...unknown[]] | [] {
+  const queryKeyArrayed = Array.isArray(queryKey) ? queryKey : [queryKey];
+  const [path, ...input] = queryKeyArrayed;
+
+  // Handle the case of acting on all queries ... path will not be passed or
+  // it will be an empty string
+  if (typeof path !== 'string' || path === '') {
+    if (input === undefined) {
+      return [[]];
+    } else {
+      return [[], ...input];
+    }
+  } else {
+    const arrayPath = path.split('.');
+    if (input === undefined) {
+      return [arrayPath];
+    } else {
+      return [arrayPath, ...input];
+    }
+  }
+}

--- a/packages/react/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react/src/shared/hooks/createHooksInternal.tsx
@@ -44,6 +44,7 @@ import {
   TRPCContextProps,
   TRPCContextState,
 } from '../../internals/context';
+import { getArrayQueryKey } from '../../internals/getArrayQueryKey';
 import { CreateTRPCReactOptions, UseMutationOverride } from '../types';
 
 export type OutputWithCursor<TData, TCursor = any> = {
@@ -205,37 +206,6 @@ export function createHooksInternal<
 
   const createClient: CreateClient<TRouter> = (opts) => {
     return createTRPCClient(opts);
-  };
-
-  /**
-   * To allow easy interactions with groups of related queries, such as
-   * invalidating all queries of a router, we use an array as the path when
-   * storing in tanstack query. This function converts from the `.` separated
-   * path passed around internally by both the legacy and proxy implementation.
-   * https://github.com/trpc/trpc/issues/2611
-   */
-  const getArrayQueryKey = (
-    queryKey: string | [string] | [string, ...unknown[]] | unknown[],
-  ): [string[]] | [string[], ...unknown[]] | [] => {
-    const queryKeyArrayed = Array.isArray(queryKey) ? queryKey : [queryKey];
-    const [path, ...input] = queryKeyArrayed;
-
-    // Handle the case of acting on all queries ... path will not be passed or
-    // it will be an empty string
-    if (typeof path !== 'string' || path === '') {
-      if (input === undefined) {
-        return [[]];
-      } else {
-        return [[], ...input];
-      }
-    } else {
-      const arrayPath = path.split('.');
-      if (input === undefined) {
-        return [arrayPath];
-      } else {
-        return [arrayPath, ...input];
-      }
-    }
   };
 
   const TRPCProvider: TRPCProvider<TRouter, TSSRContext> = (props) => {

--- a/packages/react/src/ssg/ssg.ts
+++ b/packages/react/src/ssg/ssg.ts
@@ -12,6 +12,7 @@ import {
   inferProcedureOutput,
   inferRouterContext,
 } from '@trpc/server';
+import { getArrayQueryKey } from '../internals/getArrayQueryKey';
 import { CreateTRPCReactQueryClientConfig, getQueryClient } from '../shared';
 
 interface CreateSSGHelpersOptionsBase<TRouter extends AnyRouter> {
@@ -43,7 +44,7 @@ export function createSSGHelpers<TRouter extends AnyRouter>(
   >(
     ...pathAndInput: [path: TPath, ...args: inferHandlerInput<TProcedure>]
   ) => {
-    return queryClient.prefetchQuery(pathAndInput, () => {
+    return queryClient.prefetchQuery(getArrayQueryKey(pathAndInput), () => {
       return callProcedure({
         procedures: router._def.procedures,
         path: pathAndInput[0],
@@ -60,15 +61,18 @@ export function createSSGHelpers<TRouter extends AnyRouter>(
   >(
     ...pathAndInput: [path: TPath, ...args: inferHandlerInput<TProcedure>]
   ) => {
-    return queryClient.prefetchInfiniteQuery(pathAndInput, () => {
-      return callProcedure({
-        procedures: router._def.procedures,
-        path: pathAndInput[0],
-        rawInput: pathAndInput[1],
-        ctx,
-        type: 'query',
-      });
-    });
+    return queryClient.prefetchInfiniteQuery(
+      getArrayQueryKey(pathAndInput),
+      () => {
+        return callProcedure({
+          procedures: router._def.procedures,
+          path: pathAndInput[0],
+          rawInput: pathAndInput[1],
+          ctx,
+          type: 'query',
+        });
+      },
+    );
   };
 
   const fetchQuery = async <
@@ -78,7 +82,7 @@ export function createSSGHelpers<TRouter extends AnyRouter>(
   >(
     ...pathAndInput: [path: TPath, ...args: inferHandlerInput<TProcedure>]
   ): Promise<TOutput> => {
-    return queryClient.fetchQuery(pathAndInput, () => {
+    return queryClient.fetchQuery(getArrayQueryKey(pathAndInput), () => {
       return callProcedure({
         procedures: router._def.procedures,
         path: pathAndInput[0],
@@ -96,15 +100,18 @@ export function createSSGHelpers<TRouter extends AnyRouter>(
   >(
     ...pathAndInput: [path: TPath, ...args: inferHandlerInput<TProcedure>]
   ): Promise<InfiniteData<TOutput>> => {
-    return queryClient.fetchInfiniteQuery(pathAndInput, () => {
-      return callProcedure({
-        procedures: router._def.procedures,
-        path: pathAndInput[0],
-        rawInput: pathAndInput[1],
-        ctx,
-        type: 'query',
-      });
-    });
+    return queryClient.fetchInfiniteQuery(
+      getArrayQueryKey(pathAndInput),
+      () => {
+        return callProcedure({
+          procedures: router._def.procedures,
+          path: pathAndInput[0],
+          rawInput: pathAndInput[1],
+          ctx,
+          type: 'query',
+        });
+      },
+    );
   };
 
   function _dehydrate(

--- a/packages/server/test/interop/react/dehydrate.test.tsx
+++ b/packages/server/test/interop/react/dehydrate.test.tsx
@@ -22,10 +22,12 @@ test('dehydrate', async () => {
   expect(dehydrated).toHaveLength(2);
 
   const [cache, cache2] = dehydrated;
-  expect(cache!.queryHash).toMatchInlineSnapshot(`"[\\"allPosts\\"]"`);
+  expect(cache!.queryHash).toMatchInlineSnapshot(`"[[\\"allPosts\\"]]"`);
   expect(cache!.queryKey).toMatchInlineSnapshot(`
     Array [
-      "allPosts",
+      Array [
+        "allPosts",
+      ],
     ]
   `);
   expect(cache!.state.data).toEqual(db.posts);


### PR DESCRIPTION
Related to #2923.

## 🎯 Changes

This PR updates SSG helpers to use the same `pathAndInput` normalization as was added to the hooks in https://github.com/trpc/trpc/pull/2713.

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.