### PR TITLE
chore: improve VS Code title bar contrast

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,9 @@
   },
   "workbench.colorCustomizations": {
     "titleBar.activeBackground": "#2596be",
-    "titleBar.inactiveBackground": "#004a72"
+    "titleBar.activeForeground": "#ffffff",
+    "titleBar.inactiveBackground": "#004a72",
+    "titleBar.inactiveForeground": "#639db2"
   },
   "editor.stickyScroll.enabled": true,
   "tailwindCSS.experimental.classRegex": [


### PR DESCRIPTION
## 🎯 Changes

Minor (visual) contrast fix for the title bar in VS Code.

### Active State

| Before | After |
| --- | --- |
| ![before-active](https://user-images.githubusercontent.com/5488190/195444611-f066302b-344d-4163-a72c-5e1ae3b8534f.png) | ![after-active](https://user-images.githubusercontent.com/5488190/195444618-3659369c-83be-42d6-8cfa-fd3943583ddb.png) |

### Inactive State

| Before | After |
| --- | --- |
| ![before-inactive](https://user-images.githubusercontent.com/5488190/195444632-06609cbf-ac06-4e90-9f52-647457d4e9fd.png) | ![after-inactive](https://user-images.githubusercontent.com/5488190/195444643-1bf6240a-afbd-4256-8848-3f156c1d4ebe.png) |

