### PR TITLE
fix(router): allow naming of inferred type

### DIFF
--- a/packages/server/src/internals.ts
+++ b/packages/server/src/internals.ts
@@ -3,6 +3,7 @@
  */
 export type { DefaultErrorShape } from './error/formatter';
 export type { mergeRoutersGeneric } from './core/internals/__generated__/mergeRoutersGeneric';
+export type { RootConfig } from './core/internals/config';
 export type {
   ProcedureBuilder,
   BuildProcedure,


### PR DESCRIPTION
Closes #2994

## 🎯 Changes

Export `RootConfig`, so TypeScript does not complain about not being able to name an inferred type.

Similar to (and builds on top of) https://github.com/trpc/trpc/pull/1958.

Unsure if this can be captured in a test somehow, as it seems to rely on a more modern `moduleResolution`?