### PR TITLE
fix(react): allow naming of inferred type

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,4 @@
 export * from '@trpc/client';
 
-export { createTRPCReact } from './createTRPCReact';
+export { createTRPCReact, type CreateTRPCReact } from './createTRPCReact';
 export { createReactQueryHooks } from './interop';


### PR DESCRIPTION
Similar to #2999, this time for `@trpc/react`.

### Describe the bug

Under `"moduleResolution": "Node16"` (or `"NodeNext"`), compilation of TypeScript types for the router can fail with error
```
TS2742: The inferred type of 'trpc' cannot be named without a reference to './node_modules/@trpc/react/dist/createTRPCReact.js'. This is likely not portable. A type annotation is necessary.
```

### Link to reproduction

https://stackblitz.com/edit/trpc-react-inferred-type-cannot-be-named?file=index.ts&view=editor

## 🎯 Changes

Export `CreateTRPCReact`.
