### PR TITLE
callable procedures

### DIFF
--- a/packages/server/src/core/index.ts
+++ b/packages/server/src/core/index.ts
@@ -4,7 +4,6 @@ export type {
   ProcedureRouterRecord,
   CreateRouterInner,
 } from './router';
-export { callProcedure } from './router';
 export type {
   Procedure,
   AnyProcedure,
@@ -15,6 +14,7 @@ export type {
   ProcedureArgs,
   ProcedureOptions,
 } from './procedure';
+export { callProcedure } from './procedure';
 export { createInputMiddleware, createOutputMiddleware } from './middleware';
 
 export { initTRPC } from './initTRPC';

--- a/packages/server/src/core/middleware.ts
+++ b/packages/server/src/core/middleware.ts
@@ -4,7 +4,7 @@ import { AnyRootConfig } from './internals/config';
 import { ParseFn } from './internals/getParseFn';
 import { ProcedureBuilderMiddleware } from './internals/procedureBuilder';
 import { MiddlewareMarker } from './internals/utils';
-import { ProcedureParams } from './procedure';
+import { AnyProcedure, ProcedureParams } from './procedure';
 import { ProcedureType } from './types';
 
 /**
@@ -53,10 +53,17 @@ export type MiddlewareFunction<
 > = {
   (opts: {
     ctx: TParams['_ctx_out'];
+    /**
+     * @deprecated - use procedure.type instead
+     */
     type: ProcedureType;
     path: string;
+    procedure: AnyProcedure;
     input: TParams['_input_out'];
     rawInput: unknown;
+    /**
+     * @deprecated - use procedure._def.meta instead
+     */
     meta: TParams['_meta'] | undefined;
     next: {
       (): Promise<MiddlewareResult<TParams>>;

--- a/packages/server/src/core/procedure.ts
+++ b/packages/server/src/core/procedure.ts
@@ -1,9 +1,13 @@
+import { TRPCError } from '../error/TRPCError';
+import { getTRPCErrorFromUnknown } from '../error/utils';
 import { AnyRootConfig } from './internals/config';
 import {
   ProcedureBuilderDef,
   ProcedureCallOptions,
 } from './internals/procedureBuilder';
-import { UnsetMarker } from './internals/utils';
+import { UnsetMarker, middlewareMarker } from './internals/utils';
+import { MiddlewareResult } from './middleware';
+import { ProcedureRouterRecord } from './router';
 import { ProcedureType } from './types';
 
 type ClientContext = Record<string, unknown>;
@@ -84,13 +88,95 @@ export interface Procedure<
    */
   meta?: TParams['_meta'];
   _procedure: true;
-  /**
-   * @internal
-   */
-  (opts: ProcedureCallOptions): Promise<unknown>;
+  (input: ProcedureArgs<TParams>[0], ctx: TParams['_ctx_out']): Promise<
+    TParams['_output_out']
+  >;
 }
 
 export type AnyQueryProcedure = Procedure<'query', any>;
 export type AnyMutationProcedure = Procedure<'mutation', any>;
 export type AnySubscriptionProcedure = Procedure<'subscription', any>;
 export type AnyProcedure = Procedure<ProcedureType, any>;
+
+/**
+ * @internal
+ */
+export async function callProcedureInner(
+  procedure: AnyProcedure,
+  opts: ProcedureCallOptions,
+) {
+  // run the middlewares recursively with the resolver as the last one
+  const callRecursive = async (
+    callOpts: { ctx: any; index: number; input?: unknown } = {
+      index: 0,
+      ctx: opts.ctx,
+    },
+  ): Promise<MiddlewareResult<any>> => {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const middleware = procedure._def.middlewares[callOpts.index]!;
+      const result = await middleware({
+        ctx: callOpts.ctx,
+        type: opts.type,
+        path: opts.path,
+        procedure,
+        rawInput: opts.rawInput,
+        meta: procedure._def.meta,
+        input: callOpts.input,
+        next: async (nextOpts?: { ctx: any; input?: any }) => {
+          return await callRecursive({
+            index: callOpts.index + 1,
+            ctx:
+              nextOpts && 'ctx' in nextOpts
+                ? { ...callOpts.ctx, ...nextOpts.ctx }
+                : callOpts.ctx,
+            input:
+              nextOpts && 'input' in nextOpts ? nextOpts.input : callOpts.input,
+          });
+        },
+      });
+      return result;
+    } catch (cause) {
+      return {
+        ok: false,
+        error: getTRPCErrorFromUnknown(cause),
+        marker: middlewareMarker,
+      };
+    }
+  };
+
+  // there's always at least one "next" since we wrap this.resolver in a middleware
+  const result = await callRecursive();
+
+  if (!result) {
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message:
+        'No result from middlewares - did you forget to `return next()`?',
+    });
+  }
+  if (!result.ok) {
+    // re-throw original error
+    throw result.error;
+  }
+  return result.data;
+}
+
+/**
+ * @internal
+ */
+export function callProcedure(
+  opts: ProcedureCallOptions & { procedures: ProcedureRouterRecord },
+) {
+  const { type, path } = opts;
+  const procedure = opts.procedures[path];
+
+  if (!procedure || !(type in procedure._def)) {
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message: `No "${type}"-procedure on path "${path}"`,
+    });
+  }
+
+  return callProcedureInner(procedure as AnyProcedure, opts);
+}

--- a/www/docs/server/middlewares.md
+++ b/www/docs/server/middlewares.md
@@ -31,7 +31,7 @@ const isAdmin = t.middleware(async ({ ctx, next }) => {
   return next({
     ctx: {
       user: ctx.user,
-    }
+    },
   });
 });
 
@@ -114,8 +114,6 @@ export const appRouter = t.router({
 });
 ```
 
-
-
 <!-- Commented out this section as I don't think it's needed anymore now that we can have multiple input parsers -->
 <!--
 
@@ -143,7 +141,7 @@ const isUserIdChecked = t.middleware(async ({ next, rawInput, ctx }) => {
   const { userId } = result.data;
   // Check user id auth
   return next({
-    ctx: { 
+    ctx: {
       userId,
     },
   });


### PR DESCRIPTION
## 🎯 Changes

Just an idea I had so you can do this:
```ts
const postById = t.procedure
  .input(z.object({ id: z.number() }))
  .query(({ input }) => {
    return posts.find((post) => post.id === input.id);
  });

postById({ id: 1 }, await createContextInner({}));
```

This could also help with what we've been talking about for RSC.

Don't worry about tests failing. I can fix that if we want to move forward with this.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.