### PR TITLE
Add Zod to installation deps list in NextJs introduction

### DIFF
--- a/www/docs/nextjs/introduction.md
+++ b/www/docs/nextjs/introduction.md
@@ -47,19 +47,19 @@ Recommended but not enforced file structure. This is what you get when starting 
 **npm**
 
 ```bash
-npm install @trpc/server@next @trpc/client@next @trpc/react-query@next @trpc/next@next @tanstack/react-query
+npm install @trpc/server@next @trpc/client@next @trpc/react-query@next @trpc/next@next @tanstack/react-query zod
 ```
 
 **yarn**
 
 ```bash
-yarn add @trpc/server@next @trpc/client@next @trpc/react-query@next @trpc/next@next @tanstack/react-query
+yarn add @trpc/server@next @trpc/client@next @trpc/react-query@next @trpc/next@next @tanstack/react-query zod
 ```
 
 **pnpm**
 
 ```bash
-pnpm add @trpc/server@next @trpc/client@next @trpc/react-query@next @trpc/next@next @tanstack/react-query
+pnpm add @trpc/server@next @trpc/client@next @trpc/react-query@next @trpc/next@next @tanstack/react-query zod
 ```
 
 #### Why @tanstack/react-query?


### PR DESCRIPTION
Closes https://github.com/trpc/trpc/issues/3023

## 🎯 Changes

`zod` has been added to the installation dependencies list used for the NextJS setup, so a user following the steps does not need to review the installation and add it manually.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.