### PR TITLE
Fix: Detect and support APIGatewayProxyEvent isBase64Encoded

### DIFF
--- a/packages/server/src/adapters/aws-lambda/index.ts
+++ b/packages/server/src/adapters/aws-lambda/index.ts
@@ -33,11 +33,18 @@ function lambdaEventToHTTPRequest(event: APIGatewayEvent): HTTPRequest {
     }
   }
 
+  let body: string | null | undefined;
+  if (event.body && event.isBase64Encoded) {
+    body = Buffer.from(event.body, 'base64').toString('utf8');
+  } else {
+    body = event.body;
+  }
+
   return {
     method: getHTTPMethod(event),
     query: query,
     headers: event.headers,
-    body: event.body,
+    body: body,
   };
 }
 

--- a/packages/server/test/adapters/lambda.utils.ts
+++ b/packages/server/test/adapters/lambda.utils.ts
@@ -135,3 +135,17 @@ export const mockAPIGatewayContext = (): Context => {
     succeed: () => {},
   };
 };
+
+export const mockAPIGatewayProxyEventBase64Encoded = (
+  event: APIGatewayProxyEvent,
+) => {
+  if (event.body) {
+    return {
+      ...event,
+      isBase64Encoded: true,
+      body: Buffer.from(event.body, 'utf8').toString('base64'),
+    } as APIGatewayProxyEvent;
+  } else {
+    return event;
+  }
+};


### PR DESCRIPTION
Hi @trpc team!

(previously filed as #3033)

I started using tRPC recently, and found it pretty magical. Just wanted you to know that what you're working on is very cool. While giving it a spin, something came up.

It turns out that request bodies of mutations (POST) may get base64-encoded by the API Gateway Lambda Proxy integration. When that happens, a TRPCClientError like this will be thrown:

```
TRPCClientError: Unexpected token e in JSON at position 0
{
    message: 'Unexpected token e in JSON at position 0',
    code: -32700,
    data: {
      code: 'PARSE_ERROR',
      httpStatus: 400,
      stack: 'TRPCError: Unexpected token e in JSON at position 0\n' +
        '    at getRawProcedureInputOrThrow (/var/task/dist/index.js:34581:11)\n' +
        '    at Object.resolveHTTPResponse (/var/task/dist/index.js:34661:22)\n' +
        '    at Runtime.handler (/var/task/dist/index.js:33467:48)\n' +
        '    at Runtime.handleOnceNonStreaming (file:///var/runtime/index.mjs:1028:29)'
    }
}
```

Although correctly setting the `content-type` should prevent payloads from being base64 encoded ([v9](https://github.com/trpc/trpc/blob/e0abf0deb3a69e0be0f3ec1bba03d5ef43e50b34/packages/client/src/internals/httpRequest.ts#L63), [v10](https://github.com/trpc/trpc/blob/50d151ed196bfff5cde03740b0467b5158f57959/packages/client/src/links/internals/httpUtils.ts#L136)), it seems that the adapter should still detect and decode payloads based on the `isBase64Encoded` flag in `APIGatewayProxyEvent`.

The key observation is that base64 encoded JSON values (`{"`) begin with `eY...`, which explains the error `TRPCError: Unexpected token e in JSON at position 0`.

I've written a simple change and a test case to verify that payload decoding works correctly. It seems to behave correctly on a tRPC lambda deployment I'm currently working on as well.

Thanks again for taking time to read this and maintain tRPC. If I could be of help to backport this fix to v9 as well, please let me know.

## 🎯 Changes

+ Decode event payload if `isBase64Encoded`
+ Add awsLambda adapter test case using tRPC mutations (POST)
+ Add utility wrapper which mocks base64-encoded requests

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.