### PR TITLE
fix(next-prisma-starter): render healthcheck path

### DIFF
--- a/examples/express-server/package.json
+++ b/examples/express-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/express-server",
-  "version": "9.27.3",
+  "version": "9.27.4",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server",
@@ -12,9 +12,9 @@
     "test-start": "start-server-and-test 'node dist/server' 2021 'node dist/client'"
   },
   "dependencies": {
-    "@trpc/client": "^9.27.3",
-    "@trpc/react": "^9.27.3",
-    "@trpc/server": "^9.27.3",
+    "@trpc/client": "^9.27.4",
+    "@trpc/react": "^9.27.4",
+    "@trpc/server": "^9.27.4",
     "abort-controller": "^3.0.0",
     "express": "^4.17.1",
     "node-fetch": "^2.6.1",

--- a/examples/express-server/package.json
+++ b/examples/express-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/express-server",
-  "version": "9.27.2",
+  "version": "9.27.3",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server",
@@ -12,9 +12,9 @@
     "test-start": "start-server-and-test 'node dist/server' 2021 'node dist/client'"
   },
   "dependencies": {
-    "@trpc/client": "^9.27.2",
-    "@trpc/react": "^9.27.2",
-    "@trpc/server": "^9.27.2",
+    "@trpc/client": "^9.27.3",
+    "@trpc/react": "^9.27.3",
+    "@trpc/server": "^9.27.3",
     "abort-controller": "^3.0.0",
     "express": "^4.17.1",
     "node-fetch": "^2.6.1",

--- a/examples/fastify-server/package.json
+++ b/examples/fastify-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/fastify-server",
-  "version": "9.27.2",
+  "version": "9.27.3",
   "private": true,
   "scripts": {
     "build": "tsc",
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@fastify/websocket": "^5.0.0",
-    "@trpc/client": "^9.27.2",
-    "@trpc/server": "^9.27.2",
+    "@trpc/client": "^9.27.3",
+    "@trpc/server": "^9.27.3",
     "abort-controller": "^3.0.0",
     "fastify": "^3.27.1",
     "node-fetch": "^2.6.1",

--- a/examples/fastify-server/package.json
+++ b/examples/fastify-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/fastify-server",
-  "version": "9.27.3",
+  "version": "9.27.4",
   "private": true,
   "scripts": {
     "build": "tsc",
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@fastify/websocket": "^5.0.0",
-    "@trpc/client": "^9.27.3",
-    "@trpc/server": "^9.27.3",
+    "@trpc/client": "^9.27.4",
+    "@trpc/server": "^9.27.4",
     "abort-controller": "^3.0.0",
     "fastify": "^3.27.1",
     "node-fetch": "^2.6.1",

--- a/examples/lambda-api-gateway/package.json
+++ b/examples/lambda-api-gateway/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@examples/lambda-api-gateway",
   "private": true,
-  "version": "9.27.2",
+  "version": "9.27.3",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@trpc/client": "^9.27.2",
-    "@trpc/server": "^9.27.2",
+    "@trpc/client": "^9.27.3",
+    "@trpc/server": "^9.27.3",
     "node-fetch": "^2.6.1",
     "ts-node": "^10.3.0"
   },

--- a/examples/lambda-api-gateway/package.json
+++ b/examples/lambda-api-gateway/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@examples/lambda-api-gateway",
   "private": true,
-  "version": "9.27.3",
+  "version": "9.27.4",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@trpc/client": "^9.27.3",
-    "@trpc/server": "^9.27.3",
+    "@trpc/client": "^9.27.4",
+    "@trpc/server": "^9.27.4",
     "node-fetch": "^2.6.1",
     "ts-node": "^10.3.0"
   },

--- a/examples/next-minimal-starter/package.json
+++ b/examples/next-minimal-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/next-minimal",
-  "version": "9.27.2",
+  "version": "9.27.3",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -8,10 +8,10 @@
     "start": "next start"
   },
   "dependencies": {
-    "@trpc/client": "^9.27.2",
-    "@trpc/next": "^9.27.2",
-    "@trpc/react": "^9.27.2",
-    "@trpc/server": "^9.27.2",
+    "@trpc/client": "^9.27.3",
+    "@trpc/next": "^9.27.3",
+    "@trpc/react": "^9.27.3",
+    "@trpc/server": "^9.27.3",
     "next": "latest",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/examples/next-minimal-starter/package.json
+++ b/examples/next-minimal-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/next-minimal",
-  "version": "9.27.3",
+  "version": "9.27.4",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -8,10 +8,10 @@
     "start": "next start"
   },
   "dependencies": {
-    "@trpc/client": "^9.27.3",
-    "@trpc/next": "^9.27.3",
-    "@trpc/react": "^9.27.3",
-    "@trpc/server": "^9.27.3",
+    "@trpc/client": "^9.27.4",
+    "@trpc/next": "^9.27.4",
+    "@trpc/react": "^9.27.4",
+    "@trpc/server": "^9.27.4",
     "next": "latest",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/examples/next-prisma-starter-websockets/package.json
+++ b/examples/next-prisma-starter-websockets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/next-starter-websockets",
-  "version": "9.27.3",
+  "version": "9.27.4",
   "private": true,
   "scripts": {
     "build:1-generate": "prisma generate",
@@ -39,10 +39,10 @@
   },
   "dependencies": {
     "@prisma/client": "^3.0.1",
-    "@trpc/client": "^9.27.3",
-    "@trpc/next": "^9.27.3",
-    "@trpc/react": "^9.27.3",
-    "@trpc/server": "^9.27.3",
+    "@trpc/client": "^9.27.4",
+    "@trpc/next": "^9.27.4",
+    "@trpc/react": "^9.27.4",
+    "@trpc/server": "^9.27.4",
     "clsx": "^1.1.1",
     "next": "^12.1.6",
     "next-auth": "^4.2.0",

--- a/examples/next-prisma-starter-websockets/package.json
+++ b/examples/next-prisma-starter-websockets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/next-starter-websockets",
-  "version": "9.27.2",
+  "version": "9.27.3",
   "private": true,
   "scripts": {
     "build:1-generate": "prisma generate",
@@ -39,10 +39,10 @@
   },
   "dependencies": {
     "@prisma/client": "^3.0.1",
-    "@trpc/client": "^9.27.2",
-    "@trpc/next": "^9.27.2",
-    "@trpc/react": "^9.27.2",
-    "@trpc/server": "^9.27.2",
+    "@trpc/client": "^9.27.3",
+    "@trpc/next": "^9.27.3",
+    "@trpc/react": "^9.27.3",
+    "@trpc/server": "^9.27.3",
     "clsx": "^1.1.1",
     "next": "^12.1.6",
     "next-auth": "^4.2.0",

--- a/examples/next-prisma-starter/package.json
+++ b/examples/next-prisma-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/next-starter",
-  "version": "9.27.3",
+  "version": "9.27.4",
   "private": true,
   "scripts": {
     "build:1-migrate": "prisma migrate deploy",
@@ -33,10 +33,10 @@
   },
   "dependencies": {
     "@prisma/client": "^3.0.1",
-    "@trpc/client": "^9.27.3",
-    "@trpc/next": "^9.27.3",
-    "@trpc/react": "^9.27.3",
-    "@trpc/server": "^9.27.3",
+    "@trpc/client": "^9.27.4",
+    "@trpc/next": "^9.27.4",
+    "@trpc/react": "^9.27.4",
+    "@trpc/server": "^9.27.4",
     "clsx": "^1.1.1",
     "next": "^12.1.6",
     "react": "^18.1.0",

--- a/examples/next-prisma-starter/package.json
+++ b/examples/next-prisma-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/next-starter",
-  "version": "9.27.2",
+  "version": "9.27.3",
   "private": true,
   "scripts": {
     "build:1-migrate": "prisma migrate deploy",
@@ -33,10 +33,10 @@
   },
   "dependencies": {
     "@prisma/client": "^3.0.1",
-    "@trpc/client": "^9.27.2",
-    "@trpc/next": "^9.27.2",
-    "@trpc/react": "^9.27.2",
-    "@trpc/server": "^9.27.2",
+    "@trpc/client": "^9.27.3",
+    "@trpc/next": "^9.27.3",
+    "@trpc/react": "^9.27.3",
+    "@trpc/server": "^9.27.3",
     "clsx": "^1.1.1",
     "next": "^12.1.6",
     "react": "^18.1.0",

--- a/examples/next-prisma-starter/render.yaml
+++ b/examples/next-prisma-starter/render.yaml
@@ -15,7 +15,7 @@ services:
     buildCommand: yarn --prod=false &&
       yarn build
     startCommand: yarn start
-    healthCheckPath: /api/trpc/healthz
+    healthCheckPath: /api/trpc/health.healthz
     envVars:
       - key: DATABASE_URL
         fromDatabase:

--- a/examples/next-prisma-todomvc/package.json
+++ b/examples/next-prisma-todomvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/todo-web",
-  "version": "9.27.3",
+  "version": "9.27.4",
   "private": true,
   "scripts": {
     "migrate-sqlite": "npx prisma migrate dev --name init --schema=./prisma/_sqlite/schema.prisma",
@@ -24,10 +24,10 @@
   },
   "dependencies": {
     "@prisma/client": "^3.0.1",
-    "@trpc/client": "^9.27.3",
-    "@trpc/next": "^9.27.3",
-    "@trpc/react": "^9.27.3",
-    "@trpc/server": "^9.27.3",
+    "@trpc/client": "^9.27.4",
+    "@trpc/next": "^9.27.4",
+    "@trpc/react": "^9.27.4",
+    "@trpc/server": "^9.27.4",
     "clsx": "^1.1.1",
     "jest": "^27.1.0",
     "jest-playwright": "^0.0.1",

--- a/examples/next-prisma-todomvc/package.json
+++ b/examples/next-prisma-todomvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/todo-web",
-  "version": "9.27.2",
+  "version": "9.27.3",
   "private": true,
   "scripts": {
     "migrate-sqlite": "npx prisma migrate dev --name init --schema=./prisma/_sqlite/schema.prisma",
@@ -24,10 +24,10 @@
   },
   "dependencies": {
     "@prisma/client": "^3.0.1",
-    "@trpc/client": "^9.27.2",
-    "@trpc/next": "^9.27.2",
-    "@trpc/react": "^9.27.2",
-    "@trpc/server": "^9.27.2",
+    "@trpc/client": "^9.27.3",
+    "@trpc/next": "^9.27.3",
+    "@trpc/react": "^9.27.3",
+    "@trpc/server": "^9.27.3",
     "clsx": "^1.1.1",
     "jest": "^27.1.0",
     "jest-playwright": "^0.0.1",

--- a/examples/standalone-server/package.json
+++ b/examples/standalone-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/standalone-server",
-  "version": "9.27.3",
+  "version": "9.27.4",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server",
@@ -12,9 +12,9 @@
     "test-start": "start-server-and-test 'node dist/server' 2022 'node dist/client'"
   },
   "dependencies": {
-    "@trpc/client": "^9.27.3",
-    "@trpc/react": "^9.27.3",
-    "@trpc/server": "^9.27.3",
+    "@trpc/client": "^9.27.4",
+    "@trpc/react": "^9.27.4",
+    "@trpc/server": "^9.27.4",
     "abort-controller": "^3.0.0",
     "node-fetch": "^2.6.1",
     "ws": "^8.0.0",

--- a/examples/standalone-server/package.json
+++ b/examples/standalone-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/standalone-server",
-  "version": "9.27.2",
+  "version": "9.27.3",
   "private": true,
   "scripts": {
     "dev:server": "nodemon -e ts -w . -x ts-node ./src/server",
@@ -12,9 +12,9 @@
     "test-start": "start-server-and-test 'node dist/server' 2022 'node dist/client'"
   },
   "dependencies": {
-    "@trpc/client": "^9.27.2",
-    "@trpc/react": "^9.27.2",
-    "@trpc/server": "^9.27.2",
+    "@trpc/client": "^9.27.3",
+    "@trpc/react": "^9.27.3",
+    "@trpc/server": "^9.27.3",
     "abort-controller": "^3.0.0",
     "node-fetch": "^2.6.1",
     "ws": "^8.0.0",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "9.27.2",
+  "version": "9.27.3",
   "registry": "https://registry.npmjs.org/",
   "publishConfig": {
     "access": "public"

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "9.27.3",
+  "version": "9.27.4",
   "registry": "https://registry.npmjs.org/",
   "publishConfig": {
     "access": "public"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/client",
-  "version": "9.27.3",
+  "version": "9.27.4",
   "description": "tRPC Client lib",
   "author": "KATT",
   "license": "MIT",
@@ -37,7 +37,7 @@
     "@trpc/server": "^9.12.0"
   },
   "devDependencies": {
-    "@trpc/server": "^9.27.3"
+    "@trpc/server": "^9.27.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/client",
-  "version": "9.27.2",
+  "version": "9.27.3",
   "description": "tRPC Client lib",
   "author": "KATT",
   "license": "MIT",
@@ -37,7 +37,7 @@
     "@trpc/server": "^9.12.0"
   },
   "devDependencies": {
-    "@trpc/server": "^9.27.2"
+    "@trpc/server": "^9.27.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/client/src/TRPCClientError.ts
+++ b/packages/client/src/TRPCClientError.ts
@@ -31,8 +31,8 @@ export class TRPCClientError<TRouter extends AnyRouter>
       /**
        * @deprecated use cause
        **/
-      originalError?: Maybe<Error>;
-      cause?: Maybe<Error>;
+      originalError?: Error;
+      cause?: Error;
       isDone?: boolean;
     },
   ) {
@@ -59,7 +59,6 @@ export class TRPCClientError<TRouter extends AnyRouter>
     if (!(result instanceof Error)) {
       return new TRPCClientError<TRouter>((result.error as any).message ?? '', {
         ...opts,
-        cause: null,
         result: result,
       });
     }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/next",
-  "version": "9.27.3",
+  "version": "9.27.4",
   "description": "tRPC Next lib",
   "author": "KATT",
   "license": "MIT",
@@ -43,9 +43,9 @@
     "react-ssr-prepass": "^1.5.0"
   },
   "devDependencies": {
-    "@trpc/client": "^9.27.3",
-    "@trpc/react": "^9.27.3",
-    "@trpc/server": "^9.27.3",
+    "@trpc/client": "^9.27.4",
+    "@trpc/react": "^9.27.4",
+    "@trpc/server": "^9.27.4",
     "@types/express": "^4.17.12",
     "express": "^4.17.1",
     "next": "^12.1.6",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/next",
-  "version": "9.27.2",
+  "version": "9.27.3",
   "description": "tRPC Next lib",
   "author": "KATT",
   "license": "MIT",
@@ -43,9 +43,9 @@
     "react-ssr-prepass": "^1.5.0"
   },
   "devDependencies": {
-    "@trpc/client": "^9.27.2",
-    "@trpc/react": "^9.27.2",
-    "@trpc/server": "^9.27.2",
+    "@trpc/client": "^9.27.3",
+    "@trpc/react": "^9.27.3",
+    "@trpc/server": "^9.27.3",
     "@types/express": "^4.17.12",
     "express": "^4.17.1",
     "next": "^12.1.6",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/react",
-  "version": "9.27.3",
+  "version": "9.27.4",
   "description": "tRPC React lib",
   "author": "KATT",
   "license": "MIT",
@@ -42,8 +42,8 @@
     "@babel/runtime": "^7.9.0"
   },
   "devDependencies": {
-    "@trpc/client": "^9.27.3",
-    "@trpc/server": "^9.27.3",
+    "@trpc/client": "^9.27.4",
+    "@trpc/server": "^9.27.4",
     "@types/express": "^4.17.12",
     "express": "^4.17.1",
     "next": "^12.1.6",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/react",
-  "version": "9.27.2",
+  "version": "9.27.3",
   "description": "tRPC React lib",
   "author": "KATT",
   "license": "MIT",
@@ -42,8 +42,8 @@
     "@babel/runtime": "^7.9.0"
   },
   "devDependencies": {
-    "@trpc/client": "^9.27.2",
-    "@trpc/server": "^9.27.2",
+    "@trpc/client": "^9.27.3",
+    "@trpc/server": "^9.27.3",
     "@types/express": "^4.17.12",
     "express": "^4.17.1",
     "next": "^12.1.6",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/server",
-  "version": "9.27.2",
+  "version": "9.27.3",
   "description": "tRPC Server",
   "author": "KATT",
   "license": "MIT",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/server",
-  "version": "9.27.3",
+  "version": "9.27.4",
   "description": "tRPC Server",
   "author": "KATT",
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3633,9 +3633,9 @@
   integrity sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==
 
 "@types/aws-lambda@^8.10.97":
-  version "8.10.97"
-  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.97.tgz#9b2f2adfa63a215173a9da37604e4f65dd56cb98"
-  integrity sha512-BZk3qO4R2KN8Ts3eR6CW1n8LI46UOgv1KoDZjo8J9vOQvDeX/rsrv1H0BpEAMcSqZ1mLwTEyAMtlua5tlSn0kw==
+  version "8.10.102"
+  resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.102.tgz#d2402224ec30cdddfb669005c25b6ee01fd6f5be"
+  integrity sha512-BT05v46n9KtSHa9SgGuOvm49eSruJ9utD8iNXpdpuUVYk8wOcqmm1LEzpNRkrXxD0CULc38sdLpk6q3Wa2WOwg==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
   version "7.1.15"


### PR DESCRIPTION
The changes in this PR are related to the `next-prisma-starter` template. When I tried to deploy on Render, the healthcheck failed.

## 🎯 Changes

I changed the `healthCheckPath` property in the Render blueprint file to match the path defined in `routers/health.ts`.

This should make Render deploys succeed.
## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
