### PR TITLE
fix(next-prisma-starter): render healthcheck path

### DIFF
--- a/examples/next-prisma-starter/render.yaml
+++ b/examples/next-prisma-starter/render.yaml
@@ -14,7 +14,7 @@ services:
     # initialDeployHook: yarn db-seed
     buildCommand: pnpm install && pnpm build
     startCommand: pnpm start
-    healthCheckPath: /api/trpc/healthz
+    healthCheckPath: /api/trpc/health.healthz
     envVars:
       - key: DATABASE_URL
         fromDatabase:

--- a/examples/next-prisma-starter/render.yaml
+++ b/examples/next-prisma-starter/render.yaml
@@ -14,7 +14,7 @@ services:
     # initialDeployHook: yarn db-seed
     buildCommand: pnpm install && pnpm build
     startCommand: pnpm start
-    healthCheckPath: /api/trpc/health.healthz
+    healthCheckPath: /api/trpc/healthcheck
     envVars:
       - key: DATABASE_URL
         fromDatabase:


### PR DESCRIPTION
The changes in this PR are related to the `next-prisma-starter` template. When I tried to deploy on Render, the healthcheck failed.

## 🎯 Changes

I changed the `healthCheckPath` property in the Render blueprint file to match the path defined in `routers/health.ts`.

This should make Render deploys succeed.
## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
