### PR TITLE
fix(www): broken link to minimal example in the v10 docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,6 @@ What changes are made in this PR? Is it a feature or a bug fix?
 
 ## ✅ Checklist
 
-- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
+- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/next/CONTRIBUTING.md).
 - [ ] If necessary, I have added documentation related to the changes made.
 - [ ] I have added or updated the tests related to the changes made.

--- a/www/docs/main/example-apps.md
+++ b/www/docs/main/example-apps.md
@@ -96,7 +96,7 @@ Here's some example apps:
       <td><em>n/a</em></td>
       <td>
         <ul>
-          <li><a href="https://github.com/trpc/trpc/tree/main/examples/minimal">Source</a></li>
+          <li><a href="https://github.com/trpc/trpc/tree/next/examples/minimal">Source</a></li>
         </ul>
       </td>
     </tr>


### PR DESCRIPTION
Fix broken link to minimal example in the latest v10 docs. Also, fix a link to the `CONTRIBUTING.md` in the PR template since it looks outdated. (sorry if this is intentional.)

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.