### PR TITLE
fix: use optional chaining for `process.env`

### DIFF
--- a/examples/next-prisma-starter-websockets/src/server/context.ts
+++ b/examples/next-prisma-starter-websockets/src/server/context.ts
@@ -1,4 +1,3 @@
-import { PrismaClient } from '@prisma/client';
 import * as trpc from '@trpc/server';
 import * as trpcNext from '@trpc/server/adapters/next';
 import { NodeHTTPCreateContextFnOptions } from '@trpc/server/adapters/node-http';

--- a/packages/server/src/core/initTRPC.ts
+++ b/packages/server/src/core/initTRPC.ts
@@ -106,7 +106,7 @@ function createTRPCInner<TParams extends PartialRootConfigTypes>() {
 
     const config: $Config = {
       transformer,
-      isDev: runtime?.isDev ?? process?.env?.NODE_ENV !== 'production',
+      isDev: runtime?.isDev ?? globalThis.process?.env?.NODE_ENV !== 'production',
       allowOutsideOfServer: runtime?.allowOutsideOfServer ?? false,
       errorFormatter,
       isServer: runtime?.isServer ?? isServerDefault,

--- a/packages/server/src/core/initTRPC.ts
+++ b/packages/server/src/core/initTRPC.ts
@@ -106,7 +106,8 @@ function createTRPCInner<TParams extends PartialRootConfigTypes>() {
 
     const config: $Config = {
       transformer,
-      isDev: runtime?.isDev ?? globalThis.process?.env?.NODE_ENV !== 'production',
+      isDev:
+        runtime?.isDev ?? globalThis.process?.env?.NODE_ENV !== 'production',
       allowOutsideOfServer: runtime?.allowOutsideOfServer ?? false,
       errorFormatter,
       isServer: runtime?.isServer ?? isServerDefault,

--- a/packages/server/src/core/initTRPC.ts
+++ b/packages/server/src/core/initTRPC.ts
@@ -19,7 +19,7 @@ import {
   RootConfig,
   RootConfigTypes,
   RuntimeConfig,
-  getIsServerDefault,
+  isServerDefault,
 } from './internals/config';
 import { createBuilder } from './internals/procedureBuilder';
 import { PickFirstDefined, ValidateShape } from './internals/utils';
@@ -106,10 +106,10 @@ function createTRPCInner<TParams extends PartialRootConfigTypes>() {
 
     const config: $Config = {
       transformer,
-      isDev: runtime?.isDev ?? process.env.NODE_ENV !== 'production',
+      isDev: runtime?.isDev ?? process?.env?.NODE_ENV !== 'production',
       allowOutsideOfServer: runtime?.allowOutsideOfServer ?? false,
       errorFormatter,
-      isServer: runtime?.isServer ?? getIsServerDefault(),
+      isServer: runtime?.isServer ?? isServerDefault,
       /**
        * @internal
        */
@@ -122,7 +122,7 @@ function createTRPCInner<TParams extends PartialRootConfigTypes>() {
 
     {
       // Server check
-      const isServer: boolean = runtime?.isServer ?? getIsServerDefault();
+      const isServer: boolean = runtime?.isServer ?? isServerDefault;
 
       if (!isServer && runtime?.allowOutsideOfServer !== true) {
         throw new Error(

--- a/packages/server/src/core/initTRPC.ts
+++ b/packages/server/src/core/initTRPC.ts
@@ -19,7 +19,7 @@ import {
   RootConfig,
   RootConfigTypes,
   RuntimeConfig,
-  isServerDefault,
+  getIsServerDefault,
 } from './internals/config';
 import { createBuilder } from './internals/procedureBuilder';
 import { PickFirstDefined, ValidateShape } from './internals/utils';
@@ -109,7 +109,7 @@ function createTRPCInner<TParams extends PartialRootConfigTypes>() {
       isDev: runtime?.isDev ?? process.env.NODE_ENV !== 'production',
       allowOutsideOfServer: runtime?.allowOutsideOfServer ?? false,
       errorFormatter,
-      isServer: runtime?.isServer ?? isServerDefault,
+      isServer: runtime?.isServer ?? getIsServerDefault(),
       /**
        * @internal
        */
@@ -122,7 +122,7 @@ function createTRPCInner<TParams extends PartialRootConfigTypes>() {
 
     {
       // Server check
-      const isServer: boolean = runtime?.isServer ?? isServerDefault;
+      const isServer: boolean = runtime?.isServer ?? getIsServerDefault();
 
       if (!isServer && runtime?.allowOutsideOfServer !== true) {
         throw new Error(

--- a/packages/server/src/core/internals/config.ts
+++ b/packages/server/src/core/internals/config.ts
@@ -17,8 +17,8 @@ export interface RootConfigTypes {
 export const isServerDefault: boolean =
   typeof window === 'undefined' ||
   'Deno' in window ||
-  process?.env?.NODE_ENV === 'test' ||
-  !!process?.env?.JEST_WORKER_ID;
+  globalThis.process?.env?.NODE_ENV === 'test' ||
+  !!globalThis.process?.env?.JEST_WORKER_ID;
 
 /**
  * The runtime config that are used and actually represents real values underneath

--- a/packages/server/src/core/internals/config.ts
+++ b/packages/server/src/core/internals/config.ts
@@ -14,11 +14,11 @@ export interface RootConfigTypes {
 /**
  * The default check to see if we're in a server
  */
-export const getIsServerDefault = (): boolean =>
+export const isServerDefault: boolean =
   typeof window === 'undefined' ||
   'Deno' in window ||
-  process.env.NODE_ENV === 'test' ||
-  !!process.env.JEST_WORKER_ID;
+  process?.env?.NODE_ENV === 'test' ||
+  !!process?.env?.JEST_WORKER_ID;
 
 /**
  * The runtime config that are used and actually represents real values underneath

--- a/packages/server/src/core/internals/config.ts
+++ b/packages/server/src/core/internals/config.ts
@@ -14,7 +14,7 @@ export interface RootConfigTypes {
 /**
  * The default check to see if we're in a server
  */
-export const isServerDefault: boolean =
+export const getIsServerDefault = (): boolean =>
   typeof window === 'undefined' ||
   'Deno' in window ||
   process.env.NODE_ENV === 'test' ||

--- a/packages/server/src/deprecated/router.ts
+++ b/packages/server/src/deprecated/router.ts
@@ -816,7 +816,7 @@ export class Router<
       },
     };
     if (
-      process?.env?.NODE_ENV !== 'production' &&
+      globalThis.process?.env?.NODE_ENV !== 'production' &&
       typeof opts.error.stack === 'string'
     ) {
       shape.data.stack = opts.error.stack;

--- a/packages/server/src/deprecated/router.ts
+++ b/packages/server/src/deprecated/router.ts
@@ -816,7 +816,7 @@ export class Router<
       },
     };
     if (
-      process.env.NODE_ENV !== 'production' &&
+      process?.env?.NODE_ENV !== 'production' &&
       typeof opts.error.stack === 'string'
     ) {
       shape.data.stack = opts.error.stack;


### PR DESCRIPTION
## 🎯 Changes

When using trpc v10 outside of a server environment, `process` may be undefined. We can pass `isServer: false` in the RuntimeConfig, but the default `isServer` value is created in the module scope regardless, so the `process.env` check will throw.

This simply changes `process.env.VAR` to `globalThis.process?.env?.VAR` where applicable to support non-server environments.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.