### PR TITLE
merge input parsers

### DIFF
--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -105,24 +105,8 @@ export interface ProcedureBuilder<TParams extends ProcedureParams> {
       ? $Parser
       : inferParser<$Parser>['out'] extends Record<string, unknown>
       ? TParams['_input_out'] extends Record<string, unknown>
-        ? // ? Extract<
-          //     {
-          //       [K in Extract<
-          //         Pick<inferParser<$Parser>['out'], keyof TParams['_input_out']>,
-          //         string
-          //       >]: inferParser<$Parser>['out'] extends TParams['_input_out'][K &
-          //         string]
-          //         ? ErrorMessage<'Input schema is not compatible with existing schema'>
-          //         : never;
-          //     }[Extract<
-          //       Pick<inferParser<$Parser>['out'], keyof TParams['_input_out']>,
-          //       string
-          //     >],
-          //     ErrorMessage<'Input schema is not compatible with existing schema'>
-          //   > extends never
-          $Parser
-        : // : ErrorMessage<"Impossible merge - you can't override a defined property with an optional one">
-          ErrorMessage<'All input parsers did not resolve to an object'>
+        ? $Parser
+        : ErrorMessage<'All input parsers did not resolve to an object'>
       : ErrorMessage<'All input parsers did not resolve to an object'>,
   ): ProcedureBuilder<{
     _config: TParams['_config'];

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -5,21 +5,14 @@
  */
 export type identity<TType> = TType;
 
-type InferOptional<TType, TKeys extends keyof TType> = Partial<
+export type InferOptional<TType, TKeys extends keyof TType> = Partial<
   Pick<TType, TKeys>
 > &
   Omit<TType, TKeys>;
 
-type OmitNever<TType> = Pick<
-  TType,
-  {
-    [K in keyof TType]: TType[K] extends never ? never : K;
-  }[keyof TType]
->;
-
-type UndefinedKeys<TType> = keyof OmitNever<{
-  [K in keyof TType]: TType[K] extends undefined ? TType : never;
-}>;
+export type UndefinedKeys<TType> = {
+  [K in keyof TType]: undefined extends TType[K] ? K : never;
+}[keyof TType];
 
 /**
  * @internal

--- a/packages/server/test/input.test.ts
+++ b/packages/server/test/input.test.ts
@@ -401,9 +401,9 @@ test('merges optional with required property', async () => {
     links: [],
   });
 
-  await ignoreErrors(() => {
+  await ignoreErrors(async () => {
     // @ts-expect-error id is not optional
-    client.proc.query({});
-    client.proc.query({ id: 'foo' });
+    await client.proc.query({});
+    await client.proc.query({ id: 'foo' });
   });
 });

--- a/packages/server/test/input.test.ts
+++ b/packages/server/test/input.test.ts
@@ -1,10 +1,10 @@
 import { routerToServerAndClientNew, waitError } from './___testHelpers';
-import { TRPCClientError, createTRPCProxyClient } from '@trpc/client/src';
+import { TRPCClientError, createTRPCProxyClient } from '@trpc/client';
 import {
   inferProcedureInput,
   inferProcedureParams,
   initTRPC,
-} from '@trpc/server/src';
+} from '@trpc/server';
 import { expectTypeOf } from 'expect-type';
 import { konn } from 'konn';
 import { ZodError, z } from 'zod';
@@ -401,9 +401,9 @@ test('merges optional with required property', async () => {
     links: [],
   });
 
-  await ignoreErrors(() =>
-    client.proc.query({
-      id: 'foo',
-    }),
-  );
+  await ignoreErrors(() => {
+    // @ts-expect-error id is not optional
+    client.proc.query({});
+    client.proc.query({ id: 'foo' });
+  });
 });

--- a/packages/server/test/input.test.ts
+++ b/packages/server/test/input.test.ts
@@ -1,10 +1,10 @@
 import { routerToServerAndClientNew, waitError } from './___testHelpers';
-import { TRPCClientError, createTRPCProxyClient } from '@trpc/client';
+import { TRPCClientError, createTRPCProxyClient } from '@trpc/client/src';
 import {
   inferProcedureInput,
   inferProcedureParams,
   initTRPC,
-} from '@trpc/server';
+} from '@trpc/server/src';
 import { expectTypeOf } from 'expect-type';
 import { konn } from 'konn';
 import { ZodError, z } from 'zod';
@@ -377,4 +377,33 @@ test('double validators with undefined', async () => {
       }),
     );
   }
+});
+
+test('merges optional with required property', async () => {
+  const t = initTRPC.create();
+
+  const router = t.router({
+    proc: t.procedure
+      .input(
+        z.object({
+          id: z.string(),
+        }),
+      )
+      .input(
+        z.object({
+          id: z.string().optional(),
+        }),
+      )
+      .query(() => 'hi'),
+  });
+
+  const client = createTRPCProxyClient<typeof router>({
+    links: [],
+  });
+
+  await ignoreErrors(() =>
+    client.proc.query({
+      id: 'foo',
+    }),
+  );
 });


### PR DESCRIPTION
Closes #2980

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?
Properly merge input parser properties.

Example:
```ts
const router = t.router({
    proc: t.procedure
      .input(
        z.object({
          id: z.string(),
        }),
      )
      .input(
        z.object({
          id: z.string().optional(),
          otherKey: z.number()
        }),
      )
      .query(() => 'hi'),
  });

const client = createTRPCProxyClient<typeof router>({
      links: [],
    });
    
// @ts-expect-error id is not optional
client.proc.query({ otherKey: 5 })

// must pass a string
client.proc.query({ id: 'foo', otherKey: 6 })
```

Types are intersected rather than overridden. I like this method better than `ErrorMessage` because it mirrors exactly what is happening internally. I think we'd also continue to struggle with proper merging if we don't end up using the type in this PR.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.