### PR TITLE
fix: pass ReactQueryContext to useQueryClient in useMutation

### DIFF
--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -77,17 +77,17 @@ export type { TRPCContext, TRPCContextState } from '../../internals/context';
 
 export interface UseTRPCQueryOptions<TPath, TInput, TOutput, TData, TError>
   extends UseQueryOptions<TOutput, TError, TData, [TPath, TInput]>,
-   TRPCUseQueryBaseOptions {}
+    TRPCUseQueryBaseOptions {}
 
 export interface UseTRPCInfiniteQueryOptions<TPath, TInput, TOutput, TError>
   extends UseInfiniteQueryOptions<
-     TOutput,
-     TError,
-     TOutput,
-     TOutput,
-     [TPath, TInput]
-   >,
-   TRPCUseQueryBaseOptions {}
+      TOutput,
+      TError,
+      TOutput,
+      TOutput,
+      [TPath, TInput]
+    >,
+    TRPCUseQueryBaseOptions {}
 
 export interface UseTRPCMutationOptions<
   TInput,
@@ -95,7 +95,7 @@ export interface UseTRPCMutationOptions<
   TOutput,
   TContext = unknown,
 > extends UseMutationOptions<TOutput, TError, TInput, TContext>,
-   TRPCUseQueryBaseOptions {}
+    TRPCUseQueryBaseOptions {}
 
 export interface UseTRPCSubscriptionOptions<TOutput, TError> {
   enabled?: boolean;
@@ -116,8 +116,8 @@ type inferInfiniteQueryNames<TObj extends ProcedureRecord> = {
   [TPath in keyof TObj]: inferProcedureInput<TObj[TPath]> extends {
     cursor?: any;
   }
-   ? TPath
-   : never;
+    ? TPath
+    : never;
 }[keyof TObj];
 
 type inferProcedures<TObj extends ProcedureRecord> = {
@@ -378,9 +378,9 @@ export function createHooksInternal<
       queryClient.getQueryCache().find(getArrayQueryKey(pathAndInput))?.state
         .status === 'error'
       ? {
-        retryOnMount: false,
-        ...opts,
-      }
+          retryOnMount: false,
+          ...opts,
+        }
       : opts;
   }
 

--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -77,17 +77,17 @@ export type { TRPCContext, TRPCContextState } from '../../internals/context';
 
 export interface UseTRPCQueryOptions<TPath, TInput, TOutput, TData, TError>
   extends UseQueryOptions<TOutput, TError, TData, [TPath, TInput]>,
-    TRPCUseQueryBaseOptions {}
+  TRPCUseQueryBaseOptions { }
 
 export interface UseTRPCInfiniteQueryOptions<TPath, TInput, TOutput, TError>
   extends UseInfiniteQueryOptions<
-      TOutput,
-      TError,
-      TOutput,
-      TOutput,
-      [TPath, TInput]
-    >,
-    TRPCUseQueryBaseOptions {}
+    TOutput,
+    TError,
+    TOutput,
+    TOutput,
+    [TPath, TInput]
+  >,
+  TRPCUseQueryBaseOptions { }
 
 export interface UseTRPCMutationOptions<
   TInput,
@@ -95,7 +95,7 @@ export interface UseTRPCMutationOptions<
   TOutput,
   TContext = unknown,
 > extends UseMutationOptions<TOutput, TError, TInput, TContext>,
-    TRPCUseQueryBaseOptions {}
+  TRPCUseQueryBaseOptions { }
 
 export interface UseTRPCSubscriptionOptions<TOutput, TError> {
   enabled?: boolean;
@@ -116,8 +116,8 @@ type inferInfiniteQueryNames<TObj extends ProcedureRecord> = {
   [TPath in keyof TObj]: inferProcedureInput<TObj[TPath]> extends {
     cursor?: any;
   }
-    ? TPath
-    : never;
+  ? TPath
+  : never;
 }[keyof TObj];
 
 type inferProcedures<TObj extends ProcedureRecord> = {
@@ -378,9 +378,9 @@ export function createHooksInternal<
       queryClient.getQueryCache().find(getArrayQueryKey(pathAndInput))?.state
         .status === 'error'
       ? {
-          retryOnMount: false,
-          ...opts,
-        }
+        retryOnMount: false,
+        ...opts,
+      }
       : opts;
   }
 
@@ -458,7 +458,7 @@ export function createHooksInternal<
     TContext
   > {
     const { client } = useContext();
-    const queryClient = useQueryClient();
+    const queryClient = useQueryClient({ context: ReactQueryContext });
 
     const hook = __useMutation(
       (input) => {

--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -77,17 +77,17 @@ export type { TRPCContext, TRPCContextState } from '../../internals/context';
 
 export interface UseTRPCQueryOptions<TPath, TInput, TOutput, TData, TError>
   extends UseQueryOptions<TOutput, TError, TData, [TPath, TInput]>,
-  TRPCUseQueryBaseOptions { }
+   TRPCUseQueryBaseOptions {}
 
 export interface UseTRPCInfiniteQueryOptions<TPath, TInput, TOutput, TError>
   extends UseInfiniteQueryOptions<
-    TOutput,
-    TError,
-    TOutput,
-    TOutput,
-    [TPath, TInput]
-  >,
-  TRPCUseQueryBaseOptions { }
+     TOutput,
+     TError,
+     TOutput,
+     TOutput,
+     [TPath, TInput]
+   >,
+   TRPCUseQueryBaseOptions {}
 
 export interface UseTRPCMutationOptions<
   TInput,
@@ -95,7 +95,7 @@ export interface UseTRPCMutationOptions<
   TOutput,
   TContext = unknown,
 > extends UseMutationOptions<TOutput, TError, TInput, TContext>,
-  TRPCUseQueryBaseOptions { }
+   TRPCUseQueryBaseOptions {}
 
 export interface UseTRPCSubscriptionOptions<TOutput, TError> {
   enabled?: boolean;
@@ -116,8 +116,8 @@ type inferInfiniteQueryNames<TObj extends ProcedureRecord> = {
   [TPath in keyof TObj]: inferProcedureInput<TObj[TPath]> extends {
     cursor?: any;
   }
-  ? TPath
-  : never;
+   ? TPath
+   : never;
 }[keyof TObj];
 
 type inferProcedures<TObj extends ProcedureRecord> = {


### PR DESCRIPTION
🎯 Changes
If a custom `reactQueryContext` then in the invocation of useMutation the useQueryClient didn't receive the custom reactQueryContext

✅ Checklist
- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/next/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.