### PR TITLE
fix(typo): rename getMessageFromUnkownError to getMessageFromUnknownE…

### DIFF
--- a/packages/server/src/error/TRPCError.ts
+++ b/packages/server/src/error/TRPCError.ts
@@ -1,4 +1,4 @@
-import { getErrorFromUnknown, getMessageFromUnkownError } from '../error/utils';
+import { getErrorFromUnknown, getMessageFromUnknownError } from '../error/utils';
 import { TRPC_ERROR_CODE_KEY } from '../rpc/codes';
 
 export class TRPCError extends Error {
@@ -11,7 +11,7 @@ export class TRPCError extends Error {
     cause?: unknown;
   }) {
     const code = opts.code;
-    const message = opts.message ?? getMessageFromUnkownError(opts.cause, code);
+    const message = opts.message ?? getMessageFromUnknownError(opts.cause, code);
     const cause: Error | undefined =
       opts !== undefined ? getErrorFromUnknown(opts.cause) : undefined;
 

--- a/packages/server/src/error/utils.ts
+++ b/packages/server/src/error/utils.ts
@@ -1,6 +1,6 @@
 import { TRPCError } from './TRPCError';
 
-export function getMessageFromUnkownError(
+export function getMessageFromUnknownError(
   err: unknown,
   fallback: string,
 ): string {
@@ -18,7 +18,7 @@ export function getErrorFromUnknown(cause: unknown): Error {
   if (cause instanceof Error) {
     return cause;
   }
-  const message = getMessageFromUnkownError(cause, 'Unknown error');
+  const message = getMessageFromUnknownError(cause, 'Unknown error');
   return new Error(message);
 }
 

--- a/packages/server/test/interop/errors.test.ts
+++ b/packages/server/test/interop/errors.test.ts
@@ -11,7 +11,7 @@ import { TRPCClientError } from '../../../client/src';
 import * as trpc from '../../src';
 import { CreateHTTPContextOptions } from '../../src/adapters/standalone';
 import { TRPCError } from '../../src/error/TRPCError';
-import { getMessageFromUnkownError } from '../../src/error/utils';
+import { getMessageFromUnknownError } from '../../src/error/utils';
 import { OnErrorFunction } from '../../src/internals/types';
 
 test('basic', async () => {
@@ -121,9 +121,9 @@ test('unauthorized()', async () => {
 });
 
 test('getMessageFromUnkownError()', () => {
-  expect(getMessageFromUnkownError('test', 'nope')).toBe('test');
-  expect(getMessageFromUnkownError(1, 'test')).toBe('test');
-  expect(getMessageFromUnkownError({}, 'test')).toBe('test');
+  expect(getMessageFromUnknownError('test', 'nope')).toBe('test');
+  expect(getMessageFromUnknownError(1, 'test')).toBe('test');
+  expect(getMessageFromUnknownError({}, 'test')).toBe('test');
 });
 describe('formatError()', () => {
   test('simple', async () => {


### PR DESCRIPTION

Closes #

## 🎯 Changes

Fix a typo in `getMessageFromUnkownError`

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/next/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.