### PR TITLE
improve initTRPC test coverage

### DIFF
--- a/packages/server/test/initTRPC.test.ts
+++ b/packages/server/test/initTRPC.test.ts
@@ -75,4 +75,24 @@ test('config types', () => {
     expectTypeOf<typeof t._config.$types.ctx>().toEqualTypeOf<Context>();
     expectTypeOf<typeof t._config.$types.meta>().toEqualTypeOf<Meta>();
   }
+
+  {
+    const {
+      _config: { $types },
+    } = initTRPC.create();
+    // @ts-expect-error mock unknown key
+    expect(() => $types.unknown).toThrow(
+      `Tried to access "$types.unknown" which is not available at runtime`,
+    );
+  }
+});
+
+test('detect server env', () => {
+  expect(() => initTRPC.create({ isServer: false })).toThrow(
+    `You're trying to use @trpc/server in a non-server environment. This is not supported by default.`,
+  );
+
+  expect(() =>
+    initTRPC.create({ isServer: false, allowOutsideOfServer: true }),
+  ).not.toThrowError();
 });


### PR DESCRIPTION

## 🎯 Changes

This PR is just for improving `initTRPC` ut coverage.

After PR, coverage of `initTRPC` becomes

|api|statements|branches|functions|lines
|-----|------|------|-----|-----|
|initTRPC|100% ⬆️|100% ⬆️  |100% ⬆️  |  100% ⬆️

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/next/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.