### PR TITLE
fix: typo from testing www cache

### DIFF
--- a/www/docs/reactjs/useContext.mdx
+++ b/www/docs/reactjs/useContext.mdx
@@ -98,7 +98,7 @@ These are the helpers you'll get access to via `useContext`. The table below wil
 In addition to the above react-query helpers, the context also exposes your tRPC proxy client. This lets you call your procedures with `async`/`await` without needing to create an additional vanilla client.
 
 ```tsx
-import { trpcc } from '../utils/trpc';
+import { trpc } from '../utils/trpc';
 
 function MyComponent() {
   const [apiKey, setApiKey] = useState();


### PR DESCRIPTION
didn't revert my cache test

updated output folder on vercel so this should hit