### PR TITLE
fix DataTransformer types

### DIFF
--- a/packages/server/src/transformer.ts
+++ b/packages/server/src/transformer.ts
@@ -5,8 +5,12 @@
  * @public
  */
 export type DataTransformer = {
-  serialize<R = any>(object: any): Exclude<R, PromiseLike<any>>;
-  deserialize<R = any>(object: any): Exclude<R, PromiseLike<any>>;
+  serialize<R extends any>(
+    object: any
+  ): R extends Promise<infer _U> ? never : R;
+  deserialize<R extends any>(
+    object: any
+  ): R extends Promise<infer _U> ? never : R;
 };
 
 /**

--- a/packages/server/src/transformer.ts
+++ b/packages/server/src/transformer.ts
@@ -5,10 +5,10 @@
  * @public
  */
 export type DataTransformer = {
-  serialize<R extends any>(
+  serialize<R = any>(
     object: any
   ): R extends Promise<infer _U> ? never : R;
-  deserialize<R extends any>(
+  deserialize<R = any>(
     object: any
   ): R extends Promise<infer _U> ? never : R;
 };

--- a/packages/server/src/transformer.ts
+++ b/packages/server/src/transformer.ts
@@ -1,11 +1,12 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 /**
  * @public
  */
 export type DataTransformer = {
-  serialize(object: any): any;
-  deserialize(object: any): any;
+  serialize<R = any>(object: any): Exclude<R, PromiseLike<any>>;
+  deserialize<R = any>(object: any): Exclude<R, PromiseLike<any>>;
 };
 
 /**


### PR DESCRIPTION
Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

I was chatting on discord with Alex and turns out a transformer cannot be async, 
right now the type is `any` so basically you could use it like this:

```ts
async serialize(data) {
    return {
      ...data,
    };
  },
``` 
and its going to break it because the transformer is not being handled asynchronously

with this pr an error will be thrown whenever `async` is being used

![Screenshot_1](https://user-images.githubusercontent.com/91349014/200082351-bc01e2a0-c810-4a2b-b9cb-e9281c4650f5.png)


## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/next/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.