### PR TITLE
add trpc-koa-adapter to 

### DIFF
--- a/www/docs/main/awesome-trpc.mdx
+++ b/www/docs/main/awesome-trpc.mdx
@@ -34,6 +34,7 @@ slug: /awesome-trpc
 | tRPC-Chrome - Web extensions messaging support for tRPC                                             | https://github.com/jlalmes/trpc-chrome                                |
 | tRPC Client For SolidJS W/ Solid Query                                                              | https://github.com/OrJDev/solid-trpc                                  |
 | tRPC API Handler For SolidStart                                                                     | https://github.com/OrJDev/solid-start-trpc                            |
+| trpc-koa-adapter - tRPC adapater for Koa server                                                     | https://github.com/BlairCurrey/trpc-koa-adapter                      |
 
 ## 🍀 Starting points, example projects, etc
 


### PR DESCRIPTION
## 🎯 Changes

Adds `trpc-koa-adpater` (https://github.com/BlairCurrey/trpc-koa-adapter) to list of  `🧩 Extensions & community add-ons` per @KATT 's suggestion in https://github.com/trpc/trpc/issues/3094

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/next/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.