### PR TITLE
first stab at differentiating query key on `useQuery` and `useInfiniteQuery`

### DIFF
--- a/packages/react-query/src/internals/context.tsx
+++ b/packages/react-query/src/internals/context.tsx
@@ -24,6 +24,7 @@ import type {
   inferProcedureOutput,
 } from '@trpc/server';
 import { createContext } from 'react';
+import { QueryType } from './getQueryKey';
 
 export interface TRPCFetchQueryOptions<TInput, TError, TOutput>
   extends FetchQueryOptions<TInput, TError, TOutput>,
@@ -98,7 +99,11 @@ export interface TRPCContextState<
     TOutput extends inferProcedureOutput<TProcedure>,
     TInput extends inferProcedureInput<TProcedure>,
   >(
-    pathAndInput: [path: TPath, ...args: inferHandlerInput<TProcedure>],
+    pathAndInput: [
+      type: QueryType,
+      path: TPath,
+      ...args: inferHandlerInput<TProcedure>,
+    ],
     opts?: TRPCFetchQueryOptions<TInput, TRPCClientError<TRouter>, TOutput>,
   ): Promise<TOutput>;
   /**

--- a/packages/react-query/src/internals/getArrayQueryKey.ts
+++ b/packages/react-query/src/internals/getArrayQueryKey.ts
@@ -1,3 +1,9 @@
+import { GetQueryKeyReturnType, QueryType } from './getQueryKey';
+
+export type GetArrayQueryKeyReturnType =
+  | [QueryType, string[]]
+  | [QueryType, string[], unknown]
+  | [QueryType];
 /**
  * To allow easy interactions with groups of related queries, such as
  * invalidating all queries of a router, we use an array as the path when
@@ -6,13 +12,12 @@
  * https://github.com/trpc/trpc/issues/2611
  */
 export function getArrayQueryKey(
-  queryKey: string | [string] | [string, ...unknown[]] | unknown[],
-): [string[]] | [string[], ...unknown[]] | [] {
-  const queryKeyArrayed = Array.isArray(queryKey) ? queryKey : [queryKey];
-  const [path, ...input] = queryKeyArrayed;
+  queryKey: GetQueryKeyReturnType,
+): GetArrayQueryKeyReturnType {
+  const [type, path, input] = queryKey;
 
   const arrayPath =
     typeof path !== 'string' || path === '' ? [] : path.split('.');
 
-  return [arrayPath, ...input];
+  return input === undefined ? [type, arrayPath] : [type, arrayPath, input];
 }

--- a/packages/react-query/src/internals/getArrayQueryKey.ts
+++ b/packages/react-query/src/internals/getArrayQueryKey.ts
@@ -1,8 +1,8 @@
-import { GetQueryKeyReturnType, QueryType } from './getQueryKey';
+import { GetQueryKeyReturnType, QueryType, queryTypes } from './getQueryKey';
 
 export type GetArrayQueryKeyReturnType =
-  | [QueryType, string[], unknown?]
-  | [QueryType];
+  | [string[], unknown?, Omit<QueryType, 'all'>?]
+  | [];
 /**
  * To allow easy interactions with groups of related queries, such as
  * invalidating all queries of a router, we use an array as the path when
@@ -18,5 +18,54 @@ export function getArrayQueryKey(
   const arrayPath =
     typeof path !== 'string' || path === '' ? [] : path.split('.');
 
-  return input === undefined ? [type, arrayPath] : [type, arrayPath, input];
+  // Make sure we omit the type for any query key that does not want to
+  // specifically select to allow react query fuzzy matching)
+  // NOTE: We know type if provided will be a `string` where as input will be an `object`
+  if (type === 'any') {
+    return input === undefined ? [arrayPath] : [arrayPath, input];
+  } else {
+    return input === undefined ? [arrayPath, type] : [arrayPath, input, type];
+  }
+}
+
+// An example util function on how to get back from a reactQuery queryKey to a
+// known trpc internal query key
+export function getQueryKeyFromArrayQueryKey(
+  arrayQueryKey: GetArrayQueryKeyReturnType,
+): GetQueryKeyReturnType {
+  const [arrayPath, ...rest] = arrayQueryKey;
+
+  const path = arrayPath?.join('.') || '';
+
+  const type = (rest.find(
+    (val) =>
+      typeof val === 'string' &&
+      queryTypes.some((queryType) => queryType === val),
+  ) || 'any') as QueryType;
+
+  const input = rest.find((val) => typeof val === 'object');
+
+  return [type, path, input];
+}
+
+// An utility function / example of how to process one of the tRPC used
+// reactQuery Array Keys into known constituents
+export function getArrayQueryKeyConstituents(
+  arrayQueryKey: GetArrayQueryKeyReturnType,
+) {
+  const [arrayPath, ...rest] = arrayQueryKey;
+
+  const type = (rest.find(
+    (val) =>
+      typeof val === 'string' &&
+      queryTypes.some((queryType) => queryType === val),
+  ) || 'any') as QueryType;
+
+  const input = rest.find((val) => typeof val === 'object');
+
+  return {
+    type,
+    arrayPath,
+    input,
+  };
 }

--- a/packages/react-query/src/internals/getArrayQueryKey.ts
+++ b/packages/react-query/src/internals/getArrayQueryKey.ts
@@ -1,8 +1,7 @@
 import { GetQueryKeyReturnType, QueryType } from './getQueryKey';
 
 export type GetArrayQueryKeyReturnType =
-  | [QueryType, string[]]
-  | [QueryType, string[], unknown]
+  | [QueryType, string[], unknown?]
   | [QueryType];
 /**
  * To allow easy interactions with groups of related queries, such as

--- a/packages/react-query/src/internals/getQueryKey.ts
+++ b/packages/react-query/src/internals/getQueryKey.ts
@@ -1,4 +1,5 @@
-export type QueryType = 'infinite' | 'query';
+export const queryTypes = ['infinite', 'query', 'any'] as const;
+export type QueryType = typeof queryTypes[number];
 export type GetQueryKeyReturnType = [QueryType, string, unknown?];
 
 /**

--- a/packages/react-query/src/internals/getQueryKey.ts
+++ b/packages/react-query/src/internals/getQueryKey.ts
@@ -1,7 +1,5 @@
 export type QueryType = 'infinite' | 'query';
-export type GetQueryKeyReturnType =
-  | [QueryType, string]
-  | [QueryType, string, unknown];
+export type GetQueryKeyReturnType = [QueryType, string, unknown?];
 
 /**
  * We treat `undefined` as an input the same as omitting an `input`

--- a/packages/react-query/src/internals/getQueryKey.ts
+++ b/packages/react-query/src/internals/getQueryKey.ts
@@ -1,10 +1,16 @@
+export type QueryType = 'infinite' | 'query';
+export type GetQueryKeyReturnType =
+  | [QueryType, string]
+  | [QueryType, string, unknown];
+
 /**
  * We treat `undefined` as an input the same as omitting an `input`
  * https://github.com/trpc/trpc/issues/2290
  */
 export function getQueryKey(
+  type: QueryType,
   path: string,
   input: unknown,
-): [string] | [string, unknown] {
-  return input === undefined ? [path] : [path, input];
+): GetQueryKeyReturnType {
+  return input === undefined ? [type, path] : [type, path, input];
 }

--- a/packages/react-query/src/shared/proxy/decorationProxy.ts
+++ b/packages/react-query/src/shared/proxy/decorationProxy.ts
@@ -27,7 +27,15 @@ export function createReactProxyDecoration<
     }
     const [input, ...rest] = args;
 
-    const queryKey = getQueryKey(path, input);
+    const queryKey = getQueryKey(
+      lastArg === 'useInfiniteQuery'
+        ? 'infinite'
+        : lastArg === 'useQuery'
+        ? 'query'
+        : 'any',
+      path,
+      input,
+    );
     return (hooks as any)[lastArg](queryKey, ...rest);
   });
 }

--- a/packages/react-query/src/shared/proxy/utilsProxy.ts
+++ b/packages/react-query/src/shared/proxy/utilsProxy.ts
@@ -218,7 +218,11 @@ export function createReactQueryUtilsProxy<
           const [input, updater, ...rest] = args as Parameters<
             AnyDecoratedProcedure[typeof utilName]
           >;
-          const queryKey = getQueryKey(fullPath, input);
+          const queryKey = getQueryKey(
+            name === 'setData' ? 'query' : 'infinite',
+            fullPath,
+            input,
+          );
           return {
             queryKey,
             updater,
@@ -229,7 +233,11 @@ export function createReactQueryUtilsProxy<
         const [input, ...rest] = args as Parameters<
           AnyDecoratedProcedure[typeof utilName]
         >;
-        const queryKey = getQueryKey(fullPath, input);
+        const queryKey = getQueryKey(
+          name.toLowerCase().includes('infinite') ? 'infinite' : 'query',
+          fullPath,
+          input,
+        );
         return {
           queryKey,
           rest,
@@ -239,6 +247,11 @@ export function createReactQueryUtilsProxy<
       const { queryKey, rest, updater } = getOpts(utilName);
 
       const contextMap: Record<keyof AnyDecoratedProcedure, () => unknown> = {
+        // I've only changed this one to show the impact ... We would need to
+        // push the setting of the query type down to all react / next
+        // implementations as This is the only point we know if we are looking
+        // to act on a query or an infinite query or any.... Need to see if
+        // there is a smarter way.
         fetch: () => context.fetchQuery(queryKey, ...rest),
         fetchInfinite: () => context.fetchInfiniteQuery(queryKey, ...rest),
         prefetch: () => context.prefetchQuery(queryKey, ...rest),

--- a/packages/tests/server/react/useContext.test.tsx
+++ b/packages/tests/server/react/useContext.test.tsx
@@ -574,3 +574,43 @@ describe('cancel', () => {
     });
   });
 });
+
+describe('query keys are stored separtely', () => {
+  test('getInfiniteData() does not data from useQuery()', async () => {
+    const { proxy, App } = ctx;
+
+    const unset = '__unset' as const;
+    const data = {
+      infinite: unset as unknown,
+      query: unset as unknown,
+    };
+    function MyComponent() {
+      const utils = proxy.useContext();
+      const { data: posts } = proxy.post.all.useQuery(undefined, {
+        onSuccess() {
+          data.infinite = utils.post.all.getInfiniteData();
+          data.query = utils.post.all.getData();
+        },
+      });
+
+      return (
+        <div>
+          <p data-testid="initial-post">{posts?.[0]?.text}</p>
+        </div>
+      );
+    }
+
+    render(
+      <App>
+        <MyComponent />
+      </App>,
+    );
+    await waitFor(() => {
+      expect(data.infinite).not.toBe(unset);
+      expect(data.query).not.toBe(unset);
+    });
+
+    expect(data.query).toMatchInlineSnapshot();
+    expect(data.infinite).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #3128

## 🎯 Changes

- First stab at #3128
- Changing the react-query query key to `['infiniteQuery' | 'query', path, unknown?]` in order to fix cases where you `getQuery` on a thing that has previously been fetched as `useInfiniteQuery` and vice versa
- Not fully functioning, I don't have time to work on it right now, **help wanted 🙏 🙏 🙏 **

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/next/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.