### PR TITLE
add experimental `useSuspenseQuery()`

### DIFF
--- a/packages/next/src/createTRPCNext.tsx
+++ b/packages/next/src/createTRPCNext.tsx
@@ -1,6 +1,7 @@
 import {
   CreateReactUtilsProxy,
   DecoratedProcedureRecord,
+  ExperimentalFlags,
   createHooksInternal,
   createReactProxyDecoration,
   createReactQueryUtilsProxy,
@@ -14,6 +15,7 @@ import { WithTRPCNoSSROptions, WithTRPCSSROptions, withTRPC } from './withTRPC';
 export function createTRPCNext<
   TRouter extends AnyRouter,
   TSSRContext extends NextPageContext = NextPageContext,
+  TFlags extends ExperimentalFlags = never,
 >(opts: WithTRPCNoSSROptions<TRouter> | WithTRPCSSROptions<TRouter>) {
   const hooks = createHooksInternal<TRouter, TSSRContext>({
     unstable_overrides: opts.unstable_overrides,
@@ -25,7 +27,7 @@ export function createTRPCNext<
   type CreateTRPCNext = {
     useContext(): CreateReactUtilsProxy<TRouter, TSSRContext>;
     withTRPC: typeof _withTRPC;
-  } & DecoratedProcedureRecord<TRouter['_def']['record']>;
+  } & DecoratedProcedureRecord<TRouter['_def']['record'], TFlags>;
 
   return createFlatProxy<CreateTRPCNext>((key) => {
     if (key === 'useContext') {

--- a/packages/next/src/createTRPCNext.tsx
+++ b/packages/next/src/createTRPCNext.tsx
@@ -1,7 +1,6 @@
 import {
   CreateReactUtilsProxy,
   DecoratedProcedureRecord,
-  ExperimentalFlags,
   createHooksInternal,
   createReactProxyDecoration,
   createReactQueryUtilsProxy,
@@ -15,7 +14,7 @@ import { WithTRPCNoSSROptions, WithTRPCSSROptions, withTRPC } from './withTRPC';
 export function createTRPCNext<
   TRouter extends AnyRouter,
   TSSRContext extends NextPageContext = NextPageContext,
-  TFlags extends ExperimentalFlags = never,
+  TFlags = null,
 >(opts: WithTRPCNoSSROptions<TRouter> | WithTRPCSSROptions<TRouter>) {
   const hooks = createHooksInternal<TRouter, TSSRContext>({
     unstable_overrides: opts.unstable_overrides,

--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -24,6 +24,7 @@ import {
   UseDehydratedState,
   UseTRPCInfiniteQueryOptions,
   UseTRPCInfiniteQueryResult,
+  UseTRPCInfiniteQuerySuccessResult,
   UseTRPCMutationOptions,
   UseTRPCMutationResult,
   UseTRPCQueryOptions,
@@ -73,7 +74,28 @@ export type DecorateProcedure<
             TData,
             TRPCClientErrorLike<TProcedure>
           >;
-        }
+        } & (TFlags extends 'ExperimentalSuspense'
+          ? {
+              useSuspenseInfiniteQuery: <
+                _TQueryFnData = inferProcedureOutput<TProcedure>,
+                TData = inferProcedureOutput<TProcedure>,
+              >(
+                input: Omit<inferProcedureInput<TProcedure>, 'cursor'>,
+                opts?: Omit<
+                  UseTRPCInfiniteQueryOptions<
+                    TPath,
+                    inferProcedureInput<TProcedure>,
+                    TData,
+                    TRPCClientErrorLike<TProcedure>
+                  >,
+                  'enabled' | 'suspense'
+                >,
+              ) => UseTRPCInfiniteQuerySuccessResult<
+                TData,
+                TRPCClientErrorLike<TProcedure>
+              >;
+            }
+          : {})
       : {}) &
       (TFlags extends 'ExperimentalSuspense'
         ? {

--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -75,7 +75,7 @@ export type DecorateProcedure<
           >;
         }
       : {}) &
-      (TFlags extends 'Suspense'
+      (TFlags extends 'ExperimentalSuspense'
         ? {
             useSuspenseQuery: <
               TQueryFnData = inferProcedureOutput<TProcedure>,

--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -32,14 +32,14 @@ import {
   UseTRPCSubscriptionOptions,
   createHooksInternal,
 } from './shared/hooks/createHooksInternal';
-import { CreateTRPCReactOptions, ExperimentalFlags } from './shared/types';
+import { CreateTRPCReactOptions } from './shared/types';
 
 /**
  * @internal
  */
 export type DecorateProcedure<
   TProcedure extends AnyProcedure,
-  TFlags extends ExperimentalFlags,
+  TFlags,
   TPath extends string,
 > = TProcedure extends AnyQueryProcedure
   ? {
@@ -131,7 +131,7 @@ export type DecorateProcedure<
  */
 export type DecoratedProcedureRecord<
   TProcedures extends ProcedureRouterRecord,
-  TFlags extends ExperimentalFlags,
+  TFlags,
   TPath extends string = '',
 > = {
   [TKey in keyof TProcedures]: TProcedures[TKey] extends AnyRouter
@@ -145,11 +145,7 @@ export type DecoratedProcedureRecord<
     : never;
 };
 
-export type CreateTRPCReact<
-  TRouter extends AnyRouter,
-  TSSRContext,
-  TFlags extends ExperimentalFlags,
-> = {
+export type CreateTRPCReact<TRouter extends AnyRouter, TSSRContext, TFlags> = {
   useContext(): CreateReactUtilsProxy<TRouter, TSSRContext>;
   Provider: TRPCProvider<TRouter, TSSRContext>;
   createClient: CreateClient<TRouter>;
@@ -162,7 +158,7 @@ export type CreateTRPCReact<
 export function createHooksInternalProxy<
   TRouter extends AnyRouter,
   TSSRContext = unknown,
-  TFlags extends ExperimentalFlags = never,
+  TFlags = null,
 >(trpc: CreateReactQueryHooks<TRouter, TSSRContext>) {
   type CreateHooksInternalProxy = CreateTRPCReact<TRouter, TSSRContext, TFlags>;
 
@@ -188,7 +184,7 @@ export function createHooksInternalProxy<
 export function createTRPCReact<
   TRouter extends AnyRouter,
   TSSRContext = unknown,
-  TFlags extends ExperimentalFlags = never,
+  TFlags = null,
 >(opts?: CreateTRPCReactOptions<TRouter>) {
   const hooks = createHooksInternal<TRouter, TSSRContext>(opts);
   const proxy = createHooksInternalProxy<TRouter, TSSRContext, TFlags>(hooks);

--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -1,3 +1,4 @@
+import { InfiniteData } from '@tanstack/react-query';
 import { TRPCClientErrorLike } from '@trpc/client';
 import {
   AnyMutationProcedure,
@@ -90,10 +91,13 @@ export type DecorateProcedure<
                   >,
                   'enabled' | 'suspense'
                 >,
-              ) => UseTRPCInfiniteQuerySuccessResult<
-                TData,
-                TRPCClientErrorLike<TProcedure>
-              >;
+              ) => [
+                InfiniteData<TData>,
+                UseTRPCInfiniteQuerySuccessResult<
+                  TData,
+                  TRPCClientErrorLike<TProcedure>
+                >,
+              ];
             }
           : {})
       : {}) &
@@ -114,10 +118,10 @@ export type DecorateProcedure<
                 >,
                 'enabled' | 'suspense'
               >,
-            ) => UseTRPCQuerySuccessResult<
+            ) => [
               TData,
-              TRPCClientErrorLike<TProcedure>
-            >;
+              UseTRPCQuerySuccessResult<TData, TRPCClientErrorLike<TProcedure>>,
+            ];
           }
         : {})
   : TProcedure extends AnyMutationProcedure

--- a/packages/react-query/src/interop.ts
+++ b/packages/react-query/src/interop.ts
@@ -13,13 +13,14 @@ import {
 export function createReactQueryHooks<
   TRouter extends AnyRouter,
   TSSRContext = unknown,
+  TFlags = null,
 >(
   opts?: CreateTRPCReactOptions<TRouter>,
 ): CreateReactQueryHooks<TRouter, TSSRContext> & {
-  proxy: CreateTRPCReact<TRouter, TSSRContext, never>;
+  proxy: CreateTRPCReact<TRouter, TSSRContext, TFlags>;
 } {
   const trpc = createHooksInternal<TRouter, TSSRContext>(opts);
-  const proxy = createHooksInternalProxy<TRouter, TSSRContext>(trpc);
+  const proxy = createHooksInternalProxy<TRouter, TSSRContext, TFlags>(trpc);
 
   return {
     ...trpc,

--- a/packages/react-query/src/interop.ts
+++ b/packages/react-query/src/interop.ts
@@ -16,7 +16,7 @@ export function createReactQueryHooks<
 >(
   opts?: CreateTRPCReactOptions<TRouter>,
 ): CreateReactQueryHooks<TRouter, TSSRContext> & {
-  proxy: CreateTRPCReact<TRouter, TSSRContext>;
+  proxy: CreateTRPCReact<TRouter, TSSRContext, never>;
 } {
   const trpc = createHooksInternal<TRouter, TSSRContext>(opts);
   const proxy = createHooksInternalProxy<TRouter, TSSRContext>(trpc);

--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -2,6 +2,7 @@
 import {
   DehydratedState,
   QueryClient,
+  QueryObserverSuccessResult,
   UseInfiniteQueryOptions,
   UseInfiniteQueryResult,
   UseMutationOptions,
@@ -157,6 +158,11 @@ interface TRPCHookResult {
 export type UseTRPCQueryResult<TData, TError> = UseQueryResult<TData, TError> &
   TRPCHookResult;
 
+/**
+ * @internal
+ */
+export type UseTRPCQuerySuccessResult<TData, TError> =
+  QueryObserverSuccessResult<TData, TError> & TRPCHookResult;
 /**
  * @internal
  */

--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import {
   DehydratedState,
+  InfiniteQueryObserverSuccessResult,
   QueryClient,
   QueryObserverSuccessResult,
   UseInfiniteQueryOptions,
@@ -171,6 +172,12 @@ export type UseTRPCInfiniteQueryResult<TData, TError> = UseInfiniteQueryResult<
   TError
 > &
   TRPCHookResult;
+
+/**
+ * @internal
+ */
+export type UseTRPCInfiniteQuerySuccessResult<TData, TError> =
+  InfiniteQueryObserverSuccessResult<TData, TError> & TRPCHookResult;
 
 /**
  * @internal

--- a/packages/react-query/src/shared/proxy/decorationProxy.ts
+++ b/packages/react-query/src/shared/proxy/decorationProxy.ts
@@ -28,9 +28,11 @@ export function createReactProxyDecoration<
     const [input, ...rest] = args;
 
     const queryKey = getQueryKey(path, input);
-    if (lastArg === 'useSuspenseQuery') {
+    if (lastArg.startsWith('useSuspense')) {
       const opts = rest[0] || {};
-      return (hooks as any).useQuery(queryKey, {
+      const fn =
+        lastArg === 'useSuspenseQuery' ? 'useQuery' : 'useInfiniteQuery';
+      return (hooks as any)[fn](queryKey, {
         ...opts,
         suspense: true,
         enabled: true,

--- a/packages/react-query/src/shared/proxy/decorationProxy.ts
+++ b/packages/react-query/src/shared/proxy/decorationProxy.ts
@@ -32,11 +32,12 @@ export function createReactProxyDecoration<
       const opts = rest[0] || {};
       const fn =
         lastArg === 'useSuspenseQuery' ? 'useQuery' : 'useInfiniteQuery';
-      return (hooks as any)[fn](queryKey, {
+      const result = (hooks as any)[fn](queryKey, {
         ...opts,
         suspense: true,
         enabled: true,
       });
+      return [result.data, result];
     }
     return (hooks as any)[lastArg](queryKey, ...rest);
   });

--- a/packages/react-query/src/shared/proxy/decorationProxy.ts
+++ b/packages/react-query/src/shared/proxy/decorationProxy.ts
@@ -28,6 +28,14 @@ export function createReactProxyDecoration<
     const [input, ...rest] = args;
 
     const queryKey = getQueryKey(path, input);
+    if (lastArg === 'useSuspenseQuery') {
+      const opts = rest[0] || {};
+      return (hooks as any).useQuery(queryKey, {
+        ...opts,
+        suspense: true,
+        enabled: true,
+      });
+    }
     return (hooks as any)[lastArg](queryKey, ...rest);
   });
 }

--- a/packages/react-query/src/shared/types.ts
+++ b/packages/react-query/src/shared/types.ts
@@ -37,4 +37,4 @@ export interface CreateTRPCReactOptions<_TRouter extends AnyRouter> {
   reactQueryContext?: React.Context<QueryClient | undefined>;
 }
 
-export type ExperimentalFlags = 'Suspense';
+export type ExperimentalFlags = 'ExperimentalSuspense';

--- a/packages/react-query/src/shared/types.ts
+++ b/packages/react-query/src/shared/types.ts
@@ -36,3 +36,5 @@ export interface CreateTRPCReactOptions<_TRouter extends AnyRouter> {
    */
   reactQueryContext?: React.Context<QueryClient | undefined>;
 }
+
+export type ExperimentalFlags = 'Suspense';

--- a/packages/react-query/src/shared/types.ts
+++ b/packages/react-query/src/shared/types.ts
@@ -36,5 +36,3 @@ export interface CreateTRPCReactOptions<_TRouter extends AnyRouter> {
    */
   reactQueryContext?: React.Context<QueryClient | undefined>;
 }
-
-export type ExperimentalFlags = 'ExperimentalSuspense';

--- a/packages/tests/server/react/__reactHelpers.tsx
+++ b/packages/tests/server/react/__reactHelpers.tsx
@@ -36,7 +36,7 @@ export function getServerAndReactClient<TRouter extends AnyRouter>(
   });
 
   const queryClient = createQueryClient();
-  const proxy = createTRPCReact<typeof appRouter>();
+  const proxy = createTRPCReact<typeof appRouter, unknown, 'Suspense'>();
   const client = opts.client;
 
   function App(props: { children: ReactNode }) {

--- a/packages/tests/server/react/__reactHelpers.tsx
+++ b/packages/tests/server/react/__reactHelpers.tsx
@@ -36,7 +36,11 @@ export function getServerAndReactClient<TRouter extends AnyRouter>(
   });
 
   const queryClient = createQueryClient();
-  const proxy = createTRPCReact<typeof appRouter, unknown, 'Suspense'>();
+  const proxy = createTRPCReact<
+    typeof appRouter,
+    unknown,
+    'ExperimentalSuspense'
+  >();
   const client = opts.client;
 
   function App(props: { children: ReactNode }) {

--- a/packages/tests/server/react/useQuery.test.tsx
+++ b/packages/tests/server/react/useQuery.test.tsx
@@ -104,6 +104,30 @@ test('useQuery()', async () => {
   });
 });
 
+test('useSuspenseQuery()', async () => {
+  const { proxy, App } = ctx;
+  function MyComponent() {
+    const query1 = proxy.post.byId.useSuspenseQuery({
+      id: '1',
+    });
+    expectTypeOf(query1.data).toEqualTypeOf<'__result'>();
+
+    type TData = typeof query1['data'];
+    expectTypeOf<TData>().toMatchTypeOf<'__result'>();
+
+    return <pre>{JSON.stringify(query1.data ?? 'n/a', null, 4)}</pre>;
+  }
+
+  const utils = render(
+    <App>
+      <MyComponent />
+    </App>,
+  );
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent(`__result`);
+  });
+});
+
 test('useInfiniteQuery()', async () => {
   const { App, proxy } = ctx;
   function MyComponent() {

--- a/packages/tests/server/react/useQuery.test.tsx
+++ b/packages/tests/server/react/useQuery.test.tsx
@@ -114,8 +114,9 @@ test('useSuspenseQuery()', async () => {
 
     type TData = typeof query1['data'];
     expectTypeOf<TData>().toMatchTypeOf<'__result'>();
+    expect(query1.data).toBe('__result');
 
-    return <pre>{JSON.stringify(query1.data ?? 'n/a', null, 4)}</pre>;
+    return <>{query1.data}</>;
   }
 
   const utils = render(

--- a/packages/tests/server/react/useQuery.test.tsx
+++ b/packages/tests/server/react/useQuery.test.tsx
@@ -201,3 +201,74 @@ test('deprecated routers', async () => {
     </App>,
   );
 });
+
+test('useSuspenseInfiniteQuery()', async () => {
+  const { App, proxy } = ctx;
+  function MyComponent() {
+    const query1 = proxy.post.list.useSuspenseInfiniteQuery(
+      {},
+      {
+        getNextPageParam(lastPage) {
+          return lastPage.next;
+        },
+      },
+    );
+    expect(query1.trpc.path).toBe('post.list');
+
+    expect(query1.data).not.toBeFalsy();
+
+    type TData = typeof query1['data'];
+    expectTypeOf<TData>().toMatchTypeOf<
+      InfiniteData<{
+        items: typeof fixtureData;
+        next: number | undefined;
+      }>
+    >();
+
+    return (
+      <>
+        <button
+          data-testid="fetchMore"
+          onClick={() => {
+            query1.fetchNextPage();
+          }}
+        >
+          Fetch more
+        </button>
+        <pre>{JSON.stringify(query1.data, null, 4)}</pre>
+      </>
+    );
+  }
+
+  const utils = render(
+    <App>
+      <MyComponent />
+    </App>,
+  );
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent(`[ "1" ]`);
+  });
+  utils.getByTestId('fetchMore').click();
+
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent(`[ "1" ]`);
+    expect(utils.container).toHaveTextContent(`[ "2" ]`);
+  });
+});
+
+test('deprecated routers', async () => {
+  const { proxy, App } = ctx;
+
+  function MyComponent() {
+    // FIXME this should have strike-through
+    proxy.deprecatedRouter.deprecatedProcedure.useQuery();
+
+    return null;
+  }
+
+  render(
+    <App>
+      <MyComponent />
+    </App>,
+  );
+});

--- a/packages/tests/server/react/useQuery.test.tsx
+++ b/packages/tests/server/react/useQuery.test.tsx
@@ -107,13 +107,14 @@ test('useQuery()', async () => {
 test('useSuspenseQuery()', async () => {
   const { proxy, App } = ctx;
   function MyComponent() {
-    const query1 = proxy.post.byId.useSuspenseQuery({
+    const [data, query1] = proxy.post.byId.useSuspenseQuery({
       id: '1',
     });
-    expectTypeOf(query1.data).toEqualTypeOf<'__result'>();
+    expectTypeOf(data).toEqualTypeOf<'__result'>();
 
-    type TData = typeof query1['data'];
+    type TData = typeof data;
     expectTypeOf<TData>().toMatchTypeOf<'__result'>();
+    expect(data).toBe('__result');
     expect(query1.data).toBe('__result');
 
     return <>{query1.data}</>;
@@ -205,7 +206,7 @@ test('deprecated routers', async () => {
 test('useSuspenseInfiniteQuery()', async () => {
   const { App, proxy } = ctx;
   function MyComponent() {
-    const query1 = proxy.post.list.useSuspenseInfiniteQuery(
+    const [data, query1] = proxy.post.list.useSuspenseInfiniteQuery(
       {},
       {
         getNextPageParam(lastPage) {
@@ -216,6 +217,7 @@ test('useSuspenseInfiniteQuery()', async () => {
     expect(query1.trpc.path).toBe('post.list');
 
     expect(query1.data).not.toBeFalsy();
+    expect(data).not.toBeFalsy();
 
     type TData = typeof query1['data'];
     expectTypeOf<TData>().toMatchTypeOf<
@@ -235,7 +237,7 @@ test('useSuspenseInfiniteQuery()', async () => {
         >
           Fetch more
         </button>
-        <pre>{JSON.stringify(query1.data, null, 4)}</pre>
+        <pre>{JSON.stringify(data, null, 4)}</pre>
       </>
     );
   }

--- a/www/docs/reactjs/suspense.md
+++ b/www/docs/reactjs/suspense.md
@@ -1,0 +1,91 @@
+---
+id: suspense
+title: Suspense (Experimental)
+sidebar_label: Suspense (Experimental)
+slug: /suspense
+---
+
+
+:::caution
+- `useSuspense` & `useSuspenseInfiniteQuery` are *experimental* features as its implementation may change as a result of the [`use()` proposal & RSC (React Server Components)](https://github.com/reactjs/rfcs/pull/229)
+- Ensure you're on on React 18.2.0 in order for this to work in SSR
+- When initializing `createTRPCReact` or `createTRPCNext`  you have to pass `'ExperimentalSuspense'` as the **third** generic parameter
+
+:::
+
+### Example
+
+
+```twoslash include server
+// @target: esnext
+
+// @filename: server.ts
+import { initTRPC, TRPCError } from '@trpc/server';
+import { z } from 'zod';
+
+const t = initTRPC.create();
+
+const posts = [
+  { id: '1', title: 'everlong' },
+  { id: '2', title: 'After Dark' },
+];
+
+const appRouter = t.router({
+  post: t.router({
+    all: t.procedure
+      .input(
+        z.object({ 
+          cursor: z.string().nullish(),
+        })
+      )
+      .query(({ input }) => {
+        return {
+          posts,
+          nextCursor: '123' as string | undefined,
+        };
+      }),
+    byId: t.procedure
+      .input(
+        z.object({ 
+          id: z.string(),
+        })
+      )
+      .query(({ input }) => {
+        const post = posts.find(p => p.id === input.id);
+        if (!post) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+          })
+        }
+        return post;
+     }),
+  }),
+});
+
+export type AppRouter = typeof appRouter;
+```
+
+
+```tsx twoslash
+// @target: esnext
+// @include: server
+
+// ---cut---
+
+// @filename: utils/trpc.tsx
+import { createTRPCReact } from '@trpc/react-query';
+import type { AppRouter } from '../server';
+
+export const trpc = createTRPCReact<AppRouter, unknown, 'ExperimentalSuspense'>();
+
+// @filename: pages/index.tsx
+import { trpc } from '../utils/trpc';
+import React from 'react';
+
+function PostView() {
+  const [post, postQuery] = trpc.post.byId.useSuspenseQuery({ id: "1" });
+  //      ^?
+  // [...]
+  return <>..</>
+}
+```


### PR DESCRIPTION
Closes #1354

## 🎯 Changes

- Adds experimental `useSuspenseQuery()` 
- It is **feature-flagged** as the exact implementation might change & we're waiting to see how the `react-query` team on how they're planning to deal with it
- Live demo: https://github.com/KATT/useSuspense-next-prisma-starter


### Enable experimental suspense

```tsx
const trpc = createTRPCReact<
  AppRouter,
  unknown,
  'ExperimentalSuspense' // <------------- This is the magical feature flag
>();
```

### Using it

The above will give you access to a new fresh hook:

```ts
const [data] = trpc.post.byId.useSuspenseQuery({ id: "1" })
//      ^? will be typeeeed and no loading state stuff
```

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/next/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.