### PR TITLE
contributing.md: add build command before running pnpm dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ We use [pnpm](https://pnpm.io) as our package manager, so make sure to [install]
 git clone git@github.com:trpc/trpc.git
 cd trpc
 pnpm install
+pnpm build
 ```
 
 ### Get it running


### PR DESCRIPTION
Closes #

## 🎯 Changes

Just add the `pnpm build` command before you run `pnpm dev`. I had this problem when trying to run the project so I imagine it can be useful for other devs who are trying to contribute.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/next/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.