### PR TITLE
Fix e2e tests in `next-prisma-starter`

### DIFF
--- a/examples/next-prisma-starter/playwright.config.ts
+++ b/examples/next-prisma-starter/playwright.config.ts
@@ -10,6 +10,7 @@ const opts = {
 };
 const config: PlaywrightTestConfig = {
   testDir: './playwright',
+  timeout: 35e3,
   outputDir: './playwright/test-results',
   // 'github' for GitHub Actions CI to generate annotations, plus a concise 'dot'
   // default 'list' when running locally

--- a/examples/next-prisma-starter/playwright/smoke.test.ts
+++ b/examples/next-prisma-starter/playwright/smoke.test.ts
@@ -1,7 +1,5 @@
 import { test, expect } from '@playwright/test';
 
-test.setTimeout(35e3);
-
 test('go to /', async ({ page }) => {
   await page.goto('/');
 


### PR DESCRIPTION
Fixes #3121

## 🎯 Changes

Fix e2e tests by removing `test.setTimeout` from the top of the file and adding timeout to playwright config file.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/next/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.