### PR TITLE
feat: Add type to react-query query key - Attempt round 2!

### DIFF
--- a/packages/react-query/src/internals/getArrayQueryKey.test.ts
+++ b/packages/react-query/src/internals/getArrayQueryKey.test.ts
@@ -1,41 +1,76 @@
 import { getArrayQueryKey } from './getArrayQueryKey';
 
 test('getArrayQueryKey', () => {
-  expect(getArrayQueryKey('foo')).toMatchInlineSnapshot(`
+  expect(getArrayQueryKey('foo', 'query')).toMatchInlineSnapshot(`
     Array [
       Array [
         "foo",
       ],
+      Object {
+        "type": "query",
+      },
     ]
   `);
-  expect(getArrayQueryKey(['foo'])).toMatchInlineSnapshot(`
+  expect(getArrayQueryKey(['foo'], 'query')).toMatchInlineSnapshot(`
     Array [
       Array [
         "foo",
       ],
+      Object {
+        "type": "query",
+      },
     ]
   `);
-  expect(getArrayQueryKey(['foo', 'bar'])).toMatchInlineSnapshot(`
+  expect(getArrayQueryKey('foo', 'infinite')).toMatchInlineSnapshot(`
     Array [
       Array [
         "foo",
       ],
-      "bar",
+      Object {
+        "type": "infinite",
+      },
     ]
   `);
-  expect(getArrayQueryKey([undefined, 'bar'])).toMatchInlineSnapshot(`
+  expect(getArrayQueryKey(['foo'], 'infinite')).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        "foo",
+      ],
+      Object {
+        "type": "infinite",
+      },
+    ]
+  `);
+  expect(getArrayQueryKey(['foo', 'bar'], 'query')).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        "foo",
+      ],
+      Object {
+        "input": "bar",
+        "type": "query",
+      },
+    ]
+  `);
+  expect(getArrayQueryKey([undefined, 'bar'], 'query')).toMatchInlineSnapshot(`
     Array [
       Array [],
-      "bar",
+      Object {
+        "input": "bar",
+        "type": "query",
+      },
     ]
   `);
-  expect(getArrayQueryKey(['post.byId', '1'])).toMatchInlineSnapshot(`
+  expect(getArrayQueryKey(['post.byId', '1'], 'query')).toMatchInlineSnapshot(`
     Array [
       Array [
         "post",
         "byId",
       ],
-      "1",
+      Object {
+        "input": "1",
+        "type": "query",
+      },
     ]
   `);
 });

--- a/packages/react-query/src/internals/getArrayQueryKey.ts
+++ b/packages/react-query/src/internals/getArrayQueryKey.ts
@@ -10,7 +10,7 @@ export type QueryType = 'query' | 'infinite' | 'any';
 export function getArrayQueryKey(
   queryKey: string | [string] | [string, ...unknown[]] | unknown[],
   type: QueryType,
-): [{ path: string[]; input?: unknown; type?: Omit<QueryType, 'any'> }] {
+): [{ arrayPath: string[]; input?: unknown; type?: Omit<QueryType, 'any'> }] {
   const queryKeyArrayed = Array.isArray(queryKey) ? queryKey : [queryKey];
   const [path, input] = queryKeyArrayed;
 
@@ -22,7 +22,7 @@ export function getArrayQueryKey(
   // https://github.com/trpc/trpc/issues/3128
   return [
     {
-      path: arrayPath,
+      arrayPath,
       ...(input && { input: input }),
       ...(type && type !== 'any' && { type: type }),
     },

--- a/packages/react-query/src/internals/getArrayQueryKey.ts
+++ b/packages/react-query/src/internals/getArrayQueryKey.ts
@@ -7,12 +7,22 @@
  */
 export function getArrayQueryKey(
   queryKey: string | [string] | [string, ...unknown[]] | unknown[],
-): [string[]] | [string[], ...unknown[]] | [] {
+  type: 'query' | 'infinite' | 'any',
+): [{ path: string[]; input?: unknown; type?: 'query' | 'infinite' }] {
   const queryKeyArrayed = Array.isArray(queryKey) ? queryKey : [queryKey];
   const [path, ...input] = queryKeyArrayed;
 
   const arrayPath =
     typeof path !== 'string' || path === '' ? [] : path.split('.');
 
-  return [arrayPath, ...input];
+  // Construct a query key that is easy to destructure and flexible for
+  // partial selecting etc.
+  // https://github.com/trpc/trpc/issues/3128
+  return [
+    {
+      path: arrayPath,
+      ...(input && { input: input }),
+      ...(type && type !== 'any' && { type: type }),
+    },
+  ];
 }

--- a/packages/react-query/src/internals/getArrayQueryKey.ts
+++ b/packages/react-query/src/internals/getArrayQueryKey.ts
@@ -10,7 +10,7 @@ export function getArrayQueryKey(
   type: 'query' | 'infinite' | 'any',
 ): [{ path: string[]; input?: unknown; type?: 'query' | 'infinite' }] {
   const queryKeyArrayed = Array.isArray(queryKey) ? queryKey : [queryKey];
-  const [path, ...input] = queryKeyArrayed;
+  const [path, input] = queryKeyArrayed;
 
   const arrayPath =
     typeof path !== 'string' || path === '' ? [] : path.split('.');

--- a/packages/react-query/src/internals/getArrayQueryKey.ts
+++ b/packages/react-query/src/internals/getArrayQueryKey.ts
@@ -10,7 +10,7 @@ export type QueryType = 'query' | 'infinite' | 'any';
 export function getArrayQueryKey(
   queryKey: string | [string] | [string, ...unknown[]] | unknown[],
   type: QueryType,
-): [{ arrayPath: string[]; input?: unknown; type?: Omit<QueryType, 'any'> }] {
+): [string[], { input?: unknown; type?: Exclude<QueryType, 'any'> }] {
   const queryKeyArrayed = Array.isArray(queryKey) ? queryKey : [queryKey];
   const [path, input] = queryKeyArrayed;
 
@@ -21,8 +21,8 @@ export function getArrayQueryKey(
   // partial selecting etc.
   // https://github.com/trpc/trpc/issues/3128
   return [
+    arrayPath,
     {
-      arrayPath,
       ...(input && { input: input }),
       ...(type && type !== 'any' && { type: type }),
     },

--- a/packages/react-query/src/internals/getArrayQueryKey.ts
+++ b/packages/react-query/src/internals/getArrayQueryKey.ts
@@ -1,3 +1,5 @@
+export type QueryType = 'query' | 'infinite' | 'any';
+
 /**
  * To allow easy interactions with groups of related queries, such as
  * invalidating all queries of a router, we use an array as the path when
@@ -7,8 +9,8 @@
  */
 export function getArrayQueryKey(
   queryKey: string | [string] | [string, ...unknown[]] | unknown[],
-  type: 'query' | 'infinite' | 'any',
-): [{ path: string[]; input?: unknown; type?: 'query' | 'infinite' }] {
+  type: QueryType,
+): [{ path: string[]; input?: unknown; type?: Omit<QueryType, 'any'> }] {
   const queryKeyArrayed = Array.isArray(queryKey) ? queryKey : [queryKey];
   const [path, input] = queryKeyArrayed;
 

--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -47,7 +47,7 @@ import {
   TRPCContextProps,
   TRPCContextState,
 } from '../../internals/context';
-import { getArrayQueryKey } from '../../internals/getArrayQueryKey';
+import { QueryType, getArrayQueryKey } from '../../internals/getArrayQueryKey';
 import { CreateTRPCReactOptions, UseMutationOverride } from '../types';
 
 export type OutputWithCursor<TData, TCursor = any> = {
@@ -386,11 +386,15 @@ export function createHooksInternal<
    */
   function useSSRQueryOptionsIfNeeded<
     TOptions extends { retryOnMount?: boolean } | undefined,
-  >(pathAndInput: unknown[], opts: TOptions): TOptions {
+  >(
+    pathAndInput: unknown[],
+    type: Exclude<QueryType, 'any'>,
+    opts: TOptions,
+  ): TOptions {
     const { queryClient, ssrState } = useContext();
     return ssrState &&
       ssrState !== 'mounted' &&
-      queryClient.getQueryCache().find(getArrayQueryKey(pathAndInput, 'any'))
+      queryClient.getQueryCache().find(getArrayQueryKey(pathAndInput, type))
         ?.state.status === 'error'
       ? {
           retryOnMount: false,
@@ -425,7 +429,7 @@ export function createHooksInternal<
     ) {
       void prefetchQuery(pathAndInput as any, opts as any);
     }
-    const ssrOpts = useSSRQueryOptionsIfNeeded(pathAndInput, opts);
+    const ssrOpts = useSSRQueryOptionsIfNeeded(pathAndInput, 'query', opts);
     // request option should take priority over global
     const shouldAbortOnUnmount = opts?.trpc?.abortOnUnmount ?? abortOnUnmount;
 
@@ -597,7 +601,7 @@ export function createHooksInternal<
       void prefetchInfiniteQuery(pathAndInput as any, opts as any);
     }
 
-    const ssrOpts = useSSRQueryOptionsIfNeeded(pathAndInput, opts);
+    const ssrOpts = useSSRQueryOptionsIfNeeded(pathAndInput, 'infinite', opts);
 
     // request option should take priority over global
     const shouldAbortOnUnmount = opts?.trpc?.abortOnUnmount ?? abortOnUnmount;

--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -246,7 +246,7 @@ export function createHooksInternal<
           fetchQuery: useCallback(
             (pathAndInput, opts) => {
               return queryClient.fetchQuery(
-                getArrayQueryKey(pathAndInput),
+                getArrayQueryKey(pathAndInput, 'query'),
                 () =>
                   (client as any).query(...getClientArgs(pathAndInput, opts)),
                 opts,
@@ -257,7 +257,7 @@ export function createHooksInternal<
           fetchInfiniteQuery: useCallback(
             (pathAndInput, opts) => {
               return queryClient.fetchInfiniteQuery(
-                getArrayQueryKey(pathAndInput),
+                getArrayQueryKey(pathAndInput, 'infinite'),
                 ({ pageParam }) => {
                   const [path, input] = pathAndInput;
                   const actualInput = { ...(input as any), cursor: pageParam };
@@ -273,7 +273,7 @@ export function createHooksInternal<
           prefetchQuery: useCallback(
             (pathAndInput, opts) => {
               return queryClient.prefetchQuery(
-                getArrayQueryKey(pathAndInput),
+                getArrayQueryKey(pathAndInput, 'query'),
                 () =>
                   (client as any).query(...getClientArgs(pathAndInput, opts)),
                 opts,
@@ -284,7 +284,7 @@ export function createHooksInternal<
           prefetchInfiniteQuery: useCallback(
             (pathAndInput, opts) => {
               return queryClient.prefetchInfiniteQuery(
-                getArrayQueryKey(pathAndInput),
+                getArrayQueryKey(pathAndInput, 'infinite'),
                 ({ pageParam }) => {
                   const [path, input] = pathAndInput;
                   const actualInput = { ...(input as any), cursor: pageParam };
@@ -301,7 +301,7 @@ export function createHooksInternal<
             (...args: any[]) => {
               const [queryKey, ...rest] = args;
               return queryClient.invalidateQueries(
-                getArrayQueryKey(queryKey),
+                getArrayQueryKey(queryKey, 'any'),
                 ...rest,
               );
             },
@@ -312,7 +312,7 @@ export function createHooksInternal<
               const [queryKey, ...rest] = args;
 
               return queryClient.refetchQueries(
-                getArrayQueryKey(queryKey),
+                getArrayQueryKey(queryKey, 'any'),
                 ...rest,
               );
             },
@@ -320,7 +320,9 @@ export function createHooksInternal<
           ),
           cancelQuery: useCallback(
             (pathAndInput) => {
-              return queryClient.cancelQueries(getArrayQueryKey(pathAndInput));
+              return queryClient.cancelQueries(
+                getArrayQueryKey(pathAndInput, 'any'),
+              );
             },
             [queryClient],
           ),
@@ -328,7 +330,7 @@ export function createHooksInternal<
             (...args) => {
               const [queryKey, ...rest] = args;
               return queryClient.setQueryData(
-                getArrayQueryKey(queryKey),
+                getArrayQueryKey(queryKey, 'query'),
                 ...rest,
               );
             },
@@ -339,7 +341,7 @@ export function createHooksInternal<
               const [queryKey, ...rest] = args;
 
               return queryClient.getQueryData(
-                getArrayQueryKey(queryKey),
+                getArrayQueryKey(queryKey, 'query'),
                 ...rest,
               );
             },
@@ -350,7 +352,7 @@ export function createHooksInternal<
               const [queryKey, ...rest] = args;
 
               return queryClient.setQueryData(
-                getArrayQueryKey(queryKey),
+                getArrayQueryKey(queryKey, 'infinite'),
                 ...rest,
               );
             },
@@ -361,7 +363,7 @@ export function createHooksInternal<
               const [queryKey, ...rest] = args;
 
               return queryClient.getQueryData(
-                getArrayQueryKey(queryKey),
+                getArrayQueryKey(queryKey, 'infinite'),
                 ...rest,
               );
             },
@@ -388,8 +390,8 @@ export function createHooksInternal<
     const { queryClient, ssrState } = useContext();
     return ssrState &&
       ssrState !== 'mounted' &&
-      queryClient.getQueryCache().find(getArrayQueryKey(pathAndInput))?.state
-        .status === 'error'
+      queryClient.getQueryCache().find(getArrayQueryKey(pathAndInput, 'any'))
+        ?.state.status === 'error'
       ? {
           retryOnMount: false,
           ...opts,
@@ -419,7 +421,7 @@ export function createHooksInternal<
       ssrState === 'prepass' &&
       opts?.trpc?.ssr !== false &&
       opts?.enabled !== false &&
-      !queryClient.getQueryCache().find(getArrayQueryKey(pathAndInput))
+      !queryClient.getQueryCache().find(getArrayQueryKey(pathAndInput, 'query'))
     ) {
       void prefetchQuery(pathAndInput as any, opts as any);
     }
@@ -428,7 +430,7 @@ export function createHooksInternal<
     const shouldAbortOnUnmount = opts?.trpc?.abortOnUnmount ?? abortOnUnmount;
 
     const hook = __useQuery(
-      getArrayQueryKey(pathAndInput) as any,
+      getArrayQueryKey(pathAndInput, 'any') as any,
       (queryFunctionContext) => {
         const actualOpts = {
           ...ssrOpts,
@@ -588,7 +590,9 @@ export function createHooksInternal<
       ssrState === 'prepass' &&
       opts?.trpc?.ssr !== false &&
       opts?.enabled !== false &&
-      !queryClient.getQueryCache().find(getArrayQueryKey(pathAndInput))
+      !queryClient
+        .getQueryCache()
+        .find(getArrayQueryKey(pathAndInput, 'infinite'))
     ) {
       void prefetchInfiniteQuery(pathAndInput as any, opts as any);
     }
@@ -599,7 +603,7 @@ export function createHooksInternal<
     const shouldAbortOnUnmount = opts?.trpc?.abortOnUnmount ?? abortOnUnmount;
 
     const hook = __useInfiniteQuery(
-      getArrayQueryKey(pathAndInput) as any,
+      getArrayQueryKey(pathAndInput, 'infinite') as any,
       (queryFunctionContext) => {
         const actualOpts = {
           ...ssrOpts,

--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -430,7 +430,7 @@ export function createHooksInternal<
     const shouldAbortOnUnmount = opts?.trpc?.abortOnUnmount ?? abortOnUnmount;
 
     const hook = __useQuery(
-      getArrayQueryKey(pathAndInput, 'any') as any,
+      getArrayQueryKey(pathAndInput, 'query') as any,
       (queryFunctionContext) => {
         const actualOpts = {
           ...ssrOpts,

--- a/packages/react-query/src/ssg/ssg.ts
+++ b/packages/react-query/src/ssg/ssg.ts
@@ -44,15 +44,18 @@ export function createSSGHelpers<TRouter extends AnyRouter>(
   >(
     ...pathAndInput: [path: TPath, ...args: inferHandlerInput<TProcedure>]
   ) => {
-    return queryClient.prefetchQuery(getArrayQueryKey(pathAndInput), () => {
-      return callProcedure({
-        procedures: router._def.procedures,
-        path: pathAndInput[0],
-        rawInput: pathAndInput[1],
-        ctx,
-        type: 'query',
-      });
-    });
+    return queryClient.prefetchQuery(
+      getArrayQueryKey(pathAndInput, 'query'),
+      () => {
+        return callProcedure({
+          procedures: router._def.procedures,
+          path: pathAndInput[0],
+          rawInput: pathAndInput[1],
+          ctx,
+          type: 'query',
+        });
+      },
+    );
   };
 
   const prefetchInfiniteQuery = async <
@@ -62,7 +65,7 @@ export function createSSGHelpers<TRouter extends AnyRouter>(
     ...pathAndInput: [path: TPath, ...args: inferHandlerInput<TProcedure>]
   ) => {
     return queryClient.prefetchInfiniteQuery(
-      getArrayQueryKey(pathAndInput),
+      getArrayQueryKey(pathAndInput, 'infinite'),
       () => {
         return callProcedure({
           procedures: router._def.procedures,
@@ -82,15 +85,18 @@ export function createSSGHelpers<TRouter extends AnyRouter>(
   >(
     ...pathAndInput: [path: TPath, ...args: inferHandlerInput<TProcedure>]
   ): Promise<TOutput> => {
-    return queryClient.fetchQuery(getArrayQueryKey(pathAndInput), () => {
-      return callProcedure({
-        procedures: router._def.procedures,
-        path: pathAndInput[0],
-        rawInput: pathAndInput[1],
-        ctx,
-        type: 'query',
-      });
-    });
+    return queryClient.fetchQuery(
+      getArrayQueryKey(pathAndInput, 'query'),
+      () => {
+        return callProcedure({
+          procedures: router._def.procedures,
+          path: pathAndInput[0],
+          rawInput: pathAndInput[1],
+          ctx,
+          type: 'query',
+        });
+      },
+    );
   };
 
   const fetchInfiniteQuery = async <
@@ -101,7 +107,7 @@ export function createSSGHelpers<TRouter extends AnyRouter>(
     ...pathAndInput: [path: TPath, ...args: inferHandlerInput<TProcedure>]
   ): Promise<InfiniteData<TOutput>> => {
     return queryClient.fetchInfiniteQuery(
-      getArrayQueryKey(pathAndInput),
+      getArrayQueryKey(pathAndInput, 'infinite'),
       () => {
         return callProcedure({
           procedures: router._def.procedures,

--- a/packages/tests/server/interop/react/dehydrate.test.tsx
+++ b/packages/tests/server/interop/react/dehydrate.test.tsx
@@ -22,12 +22,17 @@ test('dehydrate', async () => {
   expect(dehydrated).toHaveLength(2);
 
   const [cache, cache2] = dehydrated;
-  expect(cache!.queryHash).toMatchInlineSnapshot(`"[[\\"allPosts\\"]]"`);
+  expect(cache!.queryHash).toMatchInlineSnapshot(
+    `"[[\\"allPosts\\"],{\\"type\\":\\"query\\"}]"`,
+  );
   expect(cache!.queryKey).toMatchInlineSnapshot(`
     Array [
       Array [
         "allPosts",
       ],
+      Object {
+        "type": "query",
+      },
     ]
   `);
   expect(cache!.state.data).toEqual(db.posts);

--- a/packages/tests/server/react/useContext.test.tsx
+++ b/packages/tests/server/react/useContext.test.tsx
@@ -375,7 +375,7 @@ test('setData', async () => {
 test('setInfiniteData', async () => {
   const { proxy, App } = ctx;
   function MyComponent() {
-    const listPosts = proxy.post.list.useQuery({}, { enabled: false });
+    const listPosts = proxy.post.list.useInfiniteQuery({}, { enabled: false });
 
     const utils = proxy.useContext();
 

--- a/packages/tests/server/react/useContext.test.tsx
+++ b/packages/tests/server/react/useContext.test.tsx
@@ -575,3 +575,43 @@ describe('cancel', () => {
     });
   });
 });
+
+describe('query keys are stored separtely', () => {
+  test('getInfiniteData() does not data from useQuery()', async () => {
+    const { proxy, App } = ctx;
+
+    const unset = '__unset' as const;
+    const data = {
+      infinite: unset as unknown,
+      query: unset as unknown,
+    };
+    function MyComponent() {
+      const utils = proxy.useContext();
+      const { data: posts } = proxy.post.all.useQuery(undefined, {
+        onSuccess() {
+          data.infinite = utils.post.all.getInfiniteData();
+          data.query = utils.post.all.getData();
+        },
+      });
+
+      return (
+        <div>
+          <p data-testid="initial-post">{posts?.[0]?.text}</p>
+        </div>
+      );
+    }
+
+    render(
+      <App>
+        <MyComponent />
+      </App>,
+    );
+    await waitFor(() => {
+      expect(data.infinite).not.toBe(unset);
+      expect(data.query).not.toBe(unset);
+    });
+
+    expect(data.query).toMatchInlineSnapshot();
+    expect(data.infinite).toBeUndefined();
+  });
+});

--- a/packages/tests/server/react/useContext.test.tsx
+++ b/packages/tests/server/react/useContext.test.tsx
@@ -611,7 +611,14 @@ describe('query keys are stored separtely', () => {
       expect(data.query).not.toBe(unset);
     });
 
-    expect(data.query).toMatchInlineSnapshot();
+    expect(data.query).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "id": 0,
+          "text": "new post",
+        },
+      ]
+    `);
     expect(data.infinite).toBeUndefined();
   });
 });

--- a/www/docs/migration/migrate-from-v9-to-v10.mdx
+++ b/www/docs/migration/migrate-from-v9-to-v10.mdx
@@ -473,7 +473,7 @@ trpc.post.byId.useQuery('1', {
 If you only use the tRPC provided API's in your app you will have no problems in
 migrating 👍 However if you have been using the tanstack query client directly
 to do things like update query data for multiple tRPC generated queries using
-[`queryClient.setQueriesData](https://tanstack.com/query/v4/docs/reference/QueryClient#queryclientsetqueriesdata)
+[`queryClient.setQueriesData`](https://tanstack.com/query/v4/docs/reference/QueryClient#queryclientsetqueriesdata)
 you may need to take note!
 :::
 
@@ -482,7 +482,10 @@ whole routers](useContext#invalidating-across-whole-routers) we needed to change
 hood.
 
 We have changed the query keys we use from using a `.` joined string for the
-procedure path to a sub array of elements.
+procedure path to a sub array of elements. We have also added a distinction
+between `query`'s and `infinite` queries when they are placed in the cache. We
+have also moved both this query `type` and the input into an object with named
+properties.
 
 given the simple router below:
 
@@ -499,7 +502,7 @@ export const appRouter = router({
 The query key used for `trpc.user.byId.useQuery({ id: 10 })` would change:
 
 - Key in V9: `["user.byId", { id: 10 }]`
-- Key in v10:`[["user", "byId"],{ id:10 }]`
+- Key in v10:`[["user", "byId"],{ input: { id:10 }, type: 'query' }]`
 
 The majority of developers won't even notice this change, but for the small
 minority that are using the tanstack `queryClient` directly to manipulate tRPC


### PR DESCRIPTION
Closes #3128

## 🎯 Changes

This pull request alters the [react-query](https://tanstack.com/query/v4/docs/adapters/react-query) `queryKey` to also include the `type` of the query (`query` or `infinite`) as well as placing the input within an object alongside it. 

New key Structure: 
```ts
[ 
   string[], //arrayPath!
   { 
      input?: any; 
      type: 'query' | 'infinite' 
   }
]
```
Example:
![image](https://user-images.githubusercontent.com/15039843/201550466-ae2f0680-4be4-461e-b285-84874e4f60b9.png)

This change will mean that an `infinite` query and a `query` of the same endpoint will have different entries within the cache, which is required as the data structures are different!!

This key structure also maintains the ability to invalidate specifically `query`'s or `infinite`'s across entire routers as well as filtering queries using their input when interacting with the react-query `queryClient` directly (Escape Hatch! 👨‍🚒).

## 🔨 Possible improvements

Currently the exposed `invalidate()` function on a router or on a leaf node will invalidate both `queries` and `infiniteQueries` with no way to filter. The ability to specify only `queries` or `infiniteQueries` could be added at a later date but I think for now this should be fine and in line with the philosophy of being indiscriminate added in #3124  

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/next/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.