### PR TITLE
fix(types): export AnyRootConfig from internals

### DIFF
--- a/packages/server/src/internals.ts
+++ b/packages/server/src/internals.ts
@@ -3,7 +3,7 @@
  */
 export type { DefaultErrorShape } from './error/formatter';
 export type { mergeRoutersGeneric } from './core/internals/__generated__/mergeRoutersGeneric';
-export type { RootConfig } from './core/internals/config';
+export type { RootConfig, AnyRootConfig } from './core/internals/config';
 export type {
   ProcedureBuilder,
   BuildProcedure,


### PR DESCRIPTION
## 🎯 Changes

Since https://github.com/trpc/trpc/pull/2031, I went back to trpc and noticed that my build is broken because `AnyRootConfig` needs to be exported in order to generate type definition files for my package.

As a reminder, this is necessary to avoid these errors:

```bash
src/config/trpc/index.ts:5:14 - error TS2742: The inferred type of 't' cannot be named without a reference to '../../../../../node_modules/@trpc/server/dist/core/internals/config.js'. This is likely not portable. A type annotation is necessary.

5 export const t = initTRPC.context<Context>().create();
               ~


Found 1 error in src/config/trpc/index.ts:5
```

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/next/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.