### PR TITLE
ci: use new environment output api

### DIFF
--- a/.github/workflows/examples-old-nodes.yml
+++ b/.github/workflows/examples-old-nodes.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,12 +19,12 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          version: '16.x'
+          node-version: 16.x
 
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache


### PR DESCRIPTION
Github is deprecating their `set_output` api and replacing it with environment files:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This suppresses these warnings:

<img width="1147" alt="CleanShot 2022-11-20 at 01 08 43@2x" src="https://user-images.githubusercontent.com/51714798/202876499-4910eec1-b63d-4c6d-b502-4220256b9a75.png">

Also fixed another warning I saw the other day

<img width="1145" alt="CleanShot 2022-11-20 at 01 06 52@2x" src="https://user-images.githubusercontent.com/51714798/202876478-e5ade2b5-3b7d-407b-aab5-800d6b14da56.png">
