### PR TITLE
Dark mode for content slider

### DIFF
--- a/www/src/components/ContentSlider.tsx
+++ b/www/src/components/ContentSlider.tsx
@@ -21,9 +21,9 @@ export const ContentSlider = ({ cards }: Props) => {
             key={card.title}
             className="p-6 flex flex-none justify-between flex-col snap-center snap-always border-2 rounded"
           >
-            <p className="text-lg font-bold text-white">{card.title}</p>
+            <p className="text-lg font-bold dark:text-white">{card.title}</p>
             <div>
-              <p className="mt-4 mb-4 text-white">{card.people.join(', ')}</p>
+              <p className="mt-4 mb-4 dark:text-white">{card.people.join(', ')}</p>
               <p className="text-gray-400">{card.time}</p>
             </div>
           </a>


### PR DESCRIPTION
This change adds the `dark:` modifier for white text, because the current content slider currently shows white text on white background:

![image](https://user-images.githubusercontent.com/29319414/202932007-96d67d74-c23b-487e-a874-4a4842eb3252.png)
