### PR TITLE
add create jd app to v10 blog

### DIFF
--- a/www/blog/2022-11-21-announcing-trpc-10.mdx
+++ b/www/blog/2022-11-21-announcing-trpc-10.mdx
@@ -65,6 +65,7 @@ A rich set of sub-libraries is continuing to form around tRPC. Here are a few ex
 - [trpc-openapi](https://github.com/jlalmes/trpc-openapi) to easily create REST-compataible endpoints
 - [create-t3-app](https://github.com/t3-oss/create-t3-app) to bootstrap a full-stack Next.js application with tRPC
 - [create-t3-turbo](https://github.com/t3-oss/create-t3-turbo) to kickstart your next React Native app with tRPC
+- [create-jd-app](https://github.com/orjdev/create-jd-app) to bootstrap a full-stack SolidStart application with tRPC
 - [trpc-chrome](https://github.com/jlalmes/trpc-chrome) for building Chrome extensions using tRPC
 - Adapters for frameworks like [Solid](https://github.com/OrJDev/solid-trpc), [Svelte](https://github.com/icflorescu/trpc-sveltekit-example), and [Vue](https://github.com/michealroberts/usetrpc)
 


### PR DESCRIPTION
Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

add [create jd app](https://github.com/orjdev/create-jd-app) to the v10 annocument blog

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/next/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.