### PR TITLE
Fix Shoutout double up in V10 Blog Post

### DIFF
--- a/www/blog/2022-11-21-announcing-trpc-10.mdx
+++ b/www/blog/2022-11-21-announcing-trpc-10.mdx
@@ -74,7 +74,7 @@ For more plugins, examples, and adapters, [visit the Awesome tRPC collection](ht
 
 The core team and I want you to know: we're just getting started. We're already busy experimenting with [React Server Components](https://github.com/reactjs/rfcs/pull/229) and Next.js 13.
 
-I also want to give a huuuge shoutout goes out to [Sachin](https://twitter.com/s4chinraja), [Julius](https://twitter.com/jullerino), [James](https://twitter.com/jlalmes), [Ahmed](https://twitter.com/ixahmedxii), [Chris](https://twitter.com/trashh_dev), [Theo](https://twitter.com/t3dotgg), [Anthony](https://twitter.com/shewDev), and [all the contributors who helped make this release possible](https://github.com/trpc/trpc#all-contributors).
+I also want to give a huuuge shoutout to [Sachin](https://twitter.com/s4chinraja), [Julius](https://twitter.com/jullerino), [James](https://twitter.com/jlalmes), [Ahmed](https://twitter.com/ixahmedxii), [Chris](https://twitter.com/trashh_dev), [Theo](https://twitter.com/t3dotgg), [Anthony](https://twitter.com/shewDev), and [all the contributors who helped make this release possible](https://github.com/trpc/trpc#all-contributors).
 
 Thanks for using and supporting tRPC.
 


### PR DESCRIPTION
Closes #

## 🎯 Changes

The shoutout sentence didn't read right by doubling up!

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/next/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.