### PR TITLE
test: port `validators.test.ts` tests to v10

### DIFF
--- a/packages/tests/server/validators.test.ts
+++ b/packages/tests/server/validators.test.ts
@@ -3,6 +3,7 @@ import { routerToServerAndClientNew } from './___testHelpers';
 import '@testing-library/jest-dom';
 import { initTRPC } from '@trpc/server/src';
 import { expectTypeOf } from 'expect-type';
+import { z } from 'zod';
 
 test('no validator', async () => {
   const t = initTRPC.create();
@@ -17,5 +18,114 @@ test('no validator', async () => {
   const { close, proxy } = routerToServerAndClientNew(router);
   const res = await proxy.hello.query();
   expect(res).toBe('test');
+  close();
+});
+
+test('zod', async () => {
+  const t = initTRPC.create();
+
+  const router = t.router({
+    num: t.procedure.input(z.number()).query(({ input }) => {
+      expectTypeOf(input).toBeNumber();
+      return {
+        input,
+      };
+    }),
+  });
+
+  const { close, proxy } = routerToServerAndClientNew(router);
+  const res = await proxy.num.query(123);
+
+  await expect(proxy.num.query('123' as any)).rejects.toMatchInlineSnapshot(`
+            [TRPCClientError: [
+              {
+                "code": "invalid_type",
+                "expected": "number",
+                "received": "string",
+                "path": [],
+                "message": "Expected number, received string"
+              }
+            ]]
+          `);
+  expect(res.input).toBe(123);
+  close();
+});
+
+test('zod async', async () => {
+  const t = initTRPC.create();
+  const input = z.string().refine(async (value) => value === 'foo');
+
+  const router = t.router({
+    q: t.procedure.input(input).query(({ input }) => {
+      expectTypeOf(input).toBeString();
+      return {
+        input,
+      };
+    }),
+  });
+
+  const { close, proxy } = routerToServerAndClientNew(router);
+
+  await expect(proxy.q.query('bar')).rejects.toMatchInlineSnapshot(`
+            [TRPCClientError: [
+              {
+                "code": "custom",
+                "message": "Invalid input",
+                "path": []
+              }
+            ]]
+          `);
+  const res = await proxy.q.query('foo');
+  expect(res).toMatchInlineSnapshot(`
+      Object {
+        "input": "foo",
+      }
+    `);
+  close();
+});
+
+test('zod transform mixed input/output', async () => {
+  const t = initTRPC.create();
+  const input = z.object({
+    length: z.string().transform((s) => s.length),
+  });
+
+  const router = t.router({
+    num: t.procedure.input(input).query(({ input }) => {
+      expectTypeOf(input.length).toBeNumber();
+      return {
+        input,
+      };
+    }),
+  });
+
+  const { close, proxy } = routerToServerAndClientNew(router);
+
+  await expect(proxy.num.query({ length: '123' })).resolves
+    .toMatchInlineSnapshot(`
+            Object {
+              "input": Object {
+                "length": 3,
+              },
+            }
+          `);
+
+  await expect(
+    // @ts-expect-error this should only accept a string
+    proxy.num.query({ length: 123 }),
+  ).rejects.toMatchInlineSnapshot(`
+            [TRPCClientError: [
+              {
+                "code": "invalid_type",
+                "expected": "string",
+                "received": "number",
+                "path": [
+                  "length"
+                ],
+                "message": "Expected string, received number"
+              }
+            ]]
+          `);
+
   close();
 });

--- a/packages/tests/server/validators.test.ts
+++ b/packages/tests/server/validators.test.ts
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { routerToServerAndClientNew } from './___testHelpers';
+import '@testing-library/jest-dom';
+import { initTRPC } from '@trpc/server/src';
+import { expectTypeOf } from 'expect-type';
+
+test('no validator', async () => {
+  const t = initTRPC.create();
+
+  const router = t.router({
+    hello: t.procedure.query(({ input }) => {
+      expectTypeOf(input).toBeSymbol();
+      return 'test';
+    }),
+  });
+
+  const { close, proxy } = routerToServerAndClientNew(router);
+  const res = await proxy.hello.query();
+  expect(res).toBe('test');
+  close();
+});

--- a/packages/tests/server/validators.test.ts
+++ b/packages/tests/server/validators.test.ts
@@ -199,3 +199,58 @@ test('myzod', async () => {
   expect(res.input).toBe(123);
   close();
 });
+
+test('validator fn', async () => {
+  const t = initTRPC.create();
+
+  const numParser = (input: unknown) => {
+    if (typeof input !== 'number') {
+      throw new Error('Not a number');
+    }
+    return input;
+  };
+
+  const router = t.router({
+    num: t.procedure.input(numParser).query(({ input }) => {
+      expectTypeOf(input).toBeNumber();
+      return {
+        input,
+      };
+    }),
+  });
+
+  const { close, proxy } = routerToServerAndClientNew(router);
+  const res = await proxy.num.query(123);
+  await expect(proxy.num.query('123' as any)).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: Not a number]`,
+  );
+  expect(res.input).toBe(123);
+  close();
+});
+
+test('async validator fn', async () => {
+  const t = initTRPC.create();
+  async function numParser(input: unknown) {
+    if (typeof input !== 'number') {
+      throw new Error('Not a number');
+    }
+    return input;
+  }
+
+  const router = t.router({
+    num: t.procedure.input(numParser).query(({ input }) => {
+      expectTypeOf(input).toBeNumber();
+      return {
+        input,
+      };
+    }),
+  });
+
+  const { close, proxy } = routerToServerAndClientNew(router);
+  const res = await proxy.num.query(123);
+  await expect(proxy.num.query('123' as any)).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: Not a number]`,
+  );
+  expect(res.input).toBe(123);
+  close();
+});


### PR DESCRIPTION
Related to #3229 

## 🎯 Changes

Create tests `validators.test.ts` for v10.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.