### PR TITLE
www: update next-minimal template iframe link

### DIFF
--- a/www/src/pages/index.tsx
+++ b/www/src/pages/index.tsx
@@ -124,7 +124,9 @@ const HomeContent: React.FC = () => {
         >
           <Iframe
             src={
-              `https://stackblitz.com/github/trpc/trpc/tree/main/examples/next-minimal-starter?` +
+              `https://stackblitz.com/github/trpc/trpc/tree/${
+                isV10 ? 'main' : 'v9.x'
+              }/examples/next-minimal-starter?` +
               searchParams({
                 embed: '1',
                 file: [

--- a/www/src/pages/index.tsx
+++ b/www/src/pages/index.tsx
@@ -124,9 +124,7 @@ const HomeContent: React.FC = () => {
         >
           <Iframe
             src={
-              `https://stackblitz.com/github/trpc/trpc/tree/${
-                isV10 ? 'next' : 'main'
-              }/examples/next-minimal-starter?` +
+              `https://stackblitz.com/github/trpc/trpc/tree/main/examples/next-minimal-starter?` +
               searchParams({
                 embed: '1',
                 file: [


### PR DESCRIPTION
Currently the StackBlitz iframe is broken, since it points to the `next` branch.

![image](https://user-images.githubusercontent.com/6183867/203657754-b59eb02e-e004-4e56-b9ad-eeab97b5c3a4.png)

## 🎯 Changes

This PR updates the link to the `next-minimal` template used by the StackBlitz iframe.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.