### PR TITLE
docs: replace zART with create-t3-turbo and move ct3a to starting points

### DIFF
--- a/www/docs/main/awesome-trpc.mdx
+++ b/www/docs/main/awesome-trpc.mdx
@@ -25,7 +25,6 @@ A collection of resources on tRPC.
 | tRPC-SWR - SWR wrapper                                                                              | https://github.com/sachinraja/trpc-swr                                |
 | tRPC Shield - tRPC permissions as another layer of abstraction!                                     | https://github.com/omar-dulaimi/trpc-shield                           |
 | @h4ad/serverless-adapter - Connect tRPC with AWS SQS, AWS API Gateway, and many more event sources. | https://viniciusl.com.br/serverless-adapter/docs/main/frameworks/trpc |
-| create-t3-app - Scaffold a starter project using the t3 stack (Next.js, tRPC, TailwindCSS, Prisma)  | https://create.t3.gg                                                  |
 | tRPC + Next.js + GraphQL Codegen Shopify App template                                               | https://github.com/carstenlebek/shopify-node-app-starter              |
 | tRPC-uWebSockets - Adapter for uWebSockets.js server                                                | https://github.com/romanzy-1612/trpc-uwebsockets                      |
 | tRPC-Remix - Adapter for Remix                                                                      | https://github.com/ggrandi/trpc-remix                                 |
@@ -40,24 +39,25 @@ A collection of resources on tRPC.
 
 ## 🍀 Starting points, example projects, etc
 
-| Description                                                                                      | Link                                                                    |
-| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
-| **Recommended:** Starter project with Prisma, Next.js, tRPC, E2E-testing                         | https://github.com/trpc/examples-next-prisma-starter                    |
-| **zART** - starter repo for monolithic React&nbsp;+&nbsp;React&nbsp;Native development with tRPC | http://github.com/KATT/zART                                             |
-| WebSockets Starter Project                                                                       | https://github.com/trpc/examples-next-prisma-starter-websockets         |
-| tRPC Kitchen Sink - A collection of tRPC usage patterns.                                         | https://github.com/trpc/examples-kitchen-sink                           |
-| Turborepo + Expo + tRPC Starter                                                                  | https://github.com/gunnnnii/turbo-expo-trpc-starter                     |
-| tRPC in a Cloudflare Worker                                                                      | https://github.com/esamattis/trpc-cloudflare-worker                     |
-| tRPC on Commerce Cloud Managed Runtime                                                           | https://github.com/danechitoaie/commerce-cloud-managed-runtime-trpc-poc |
-| tRPC-SvelteKit Example Application                                                               | https://github.com/icflorescu/trpc-sveltekit-example                    |
-| tRPC + Rakkas (Vite framework)                                                                   | https://github.com/sachinraja/trpc-rakkas                               |
-| tRPC + Ultra                                                                                     | https://github.com/sachinraja/trpc-ultra                                |
-| Nx Monorepo + tRPC + Prisma                                                                      | https://github.com/nowlena/nx-trpc-test                                 |
-| NX + tRPC + Prisma + NextJS + Expo                                                               | https://github.com/mwarger/tmdb-watchlist-prisma                        |
-| NX + tRPC + EdgeDB + NextJS + Expo                                                               | https://github.com/mwarger/tmdb-watchlist-edgedb                        |
-| tRPC (w/ Fetch Adapter) + SvelteKit + Tailwind CSS                                               | https://github.com/austins/trpc-sveltekit-fetchadapter-example          |
-| Astro-tRPC example app                                                                           | https://github.com/MoustaphaDev/astro-trpc/tree/master/demo             |
-| SolidStart JWT Authentication                                                                    | https://github.com/OrJDev/solid-trpc-authentication                     |
+| Description                                                                                         | Link                                                                    |
+| --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| **Recommended:** Starter project with Prisma, Next.js, tRPC, E2E-testing                            | https://github.com/trpc/examples-next-prisma-starter                    |
+| **create-t3-turbo** - Clean and simple starter repo using the T3 Stack along with Expo React Native | http://github.com/t3-oss/create-t3-turbo                                |
+| create-t3-app - Scaffold a starter project using the T3 Stack (Next.js, tRPC, TailwindCSS, Prisma)  | https://create.t3.gg                                                    |
+| WebSockets Starter Project                                                                          | https://github.com/trpc/examples-next-prisma-starter-websockets         |
+| tRPC Kitchen Sink - A collection of tRPC usage patterns.                                            | https://github.com/trpc/examples-kitchen-sink                           |
+| Turborepo + Expo + tRPC Starter                                                                     | https://github.com/gunnnnii/turbo-expo-trpc-starter                     |
+| tRPC in a Cloudflare Worker                                                                         | https://github.com/esamattis/trpc-cloudflare-worker                     |
+| tRPC on Commerce Cloud Managed Runtime                                                              | https://github.com/danechitoaie/commerce-cloud-managed-runtime-trpc-poc |
+| tRPC-SvelteKit Example Application                                                                  | https://github.com/icflorescu/trpc-sveltekit-example                    |
+| tRPC + Rakkas (Vite framework)                                                                      | https://github.com/sachinraja/trpc-rakkas                               |
+| tRPC + Ultra                                                                                        | https://github.com/sachinraja/trpc-ultra                                |
+| Nx Monorepo + tRPC + Prisma                                                                         | https://github.com/nowlena/nx-trpc-test                                 |
+| NX + tRPC + Prisma + NextJS + Expo                                                                  | https://github.com/mwarger/tmdb-watchlist-prisma                        |
+| NX + tRPC + EdgeDB + NextJS + Expo                                                                  | https://github.com/mwarger/tmdb-watchlist-edgedb                        |
+| tRPC (w/ Fetch Adapter) + SvelteKit + Tailwind CSS                                                  | https://github.com/austins/trpc-sveltekit-fetchadapter-example          |
+| Astro-tRPC example app                                                                              | https://github.com/MoustaphaDev/astro-trpc/tree/master/demo             |
+| SolidStart JWT Authentication                                                                       | https://github.com/OrJDev/solid-trpc-authentication                     |
 
 ## 🏁 Open-source projects using tRPC
 

--- a/www/docs/main/awesome-trpc.mdx
+++ b/www/docs/main/awesome-trpc.mdx
@@ -25,6 +25,7 @@ A collection of resources on tRPC.
 | tRPC-SWR - SWR wrapper                                                                              | https://github.com/sachinraja/trpc-swr                                |
 | tRPC Shield - tRPC permissions as another layer of abstraction!                                     | https://github.com/omar-dulaimi/trpc-shield                           |
 | @h4ad/serverless-adapter - Connect tRPC with AWS SQS, AWS API Gateway, and many more event sources. | https://viniciusl.com.br/serverless-adapter/docs/main/frameworks/trpc |
+| create-t3-app - Scaffold a starter project using the T3 Stack (Next.js, tRPC, TailwindCSS, Prisma)  | https://create.t3.gg                                                  |
 | tRPC + Next.js + GraphQL Codegen Shopify App template                                               | https://github.com/carstenlebek/shopify-node-app-starter              |
 | tRPC-uWebSockets - Adapter for uWebSockets.js server                                                | https://github.com/romanzy-1612/trpc-uwebsockets                      |
 | tRPC-Remix - Adapter for Remix                                                                      | https://github.com/ggrandi/trpc-remix                                 |


### PR DESCRIPTION
Closes #3190 

## 🎯 Changes

- Removed zART
- Added create-t3-turbo
- Moved ct3a from extensions to starting points

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.