### PR TITLE
port: test v10/headers

### DIFF
--- a/packages/tests/server/headers.test.ts
+++ b/packages/tests/server/headers.test.ts
@@ -1,0 +1,76 @@
+import { routerToServerAndClientNew } from './___testHelpers';
+import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
+import { initTRPC } from '@trpc/server';
+import { Dict } from '@trpc/server';
+
+describe('pass headers', () => {
+  type Context = {
+    headers: Dict<string | string[]>;
+  };
+  const t = initTRPC.context<Context>().create();
+
+  const { procedure } = t;
+
+  const router = t.router({
+    greeting: procedure.query(({ ctx }) => {
+      return {
+        'x-special': ctx.headers['x-special'],
+      };
+    }),
+  });
+  const { close, httpUrl } = routerToServerAndClientNew(router, {
+    server: {
+      createContext: ({ req }) => {
+        return {
+          headers: req.headers,
+        };
+      },
+    },
+  });
+
+  afterAll(() => {
+    close();
+  });
+
+  test('no headers', async () => {
+    const client = createTRPCProxyClient<typeof router>({
+      links: [httpBatchLink({ url: httpUrl })],
+    });
+    const res = await client.greeting.query();
+    expect(res).toEqual({
+      'x-special': undefined,
+    });
+  });
+
+  test('custom headers', async () => {
+    const client = createTRPCProxyClient<typeof router>({
+      links: [
+        httpBatchLink({
+          url: httpUrl,
+          headers: { 'X-special': 'special header' },
+        }),
+      ],
+    });
+    const res = await client.greeting.query();
+    expect(res).toEqual({
+      'x-special': 'special header',
+    });
+  });
+
+  test('async headers', async () => {
+    const client = createTRPCProxyClient<typeof router>({
+      links: [
+        httpBatchLink({
+          url: httpUrl,
+          headers: async () => {
+            return { 'X-special': 'async special header' };
+          },
+        }),
+      ],
+    });
+    const res = await client.greeting.query();
+    expect(res).toEqual({
+      'x-special': 'async special header',
+    });
+  });
+});


### PR DESCRIPTION
related to #3229
## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?
- port headers from v9 to v10 test

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.