### PR TITLE
test: port headers, rawFetch, responseMeta

### DIFF
--- a/packages/tests/server/headers.test.tsx
+++ b/packages/tests/server/headers.test.tsx
@@ -1,0 +1,88 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { routerToServerAndClientNew } from './___testHelpers';
+import { createTRPCProxyClient, httpBatchLink } from '@trpc/client/src';
+import { Dict, initTRPC } from '@trpc/server/src';
+
+describe('pass headers', () => {
+  type Context = {
+    headers: Dict<string | string[]>;
+  };
+
+  const t = initTRPC.context<Context>().create();
+
+  const appRouter = t.router({
+    hello: t.procedure.query(({ ctx }) => {
+      return {
+        'x-special': ctx.headers['x-special'],
+      };
+    }),
+  });
+
+  type AppRouter = typeof appRouter;
+
+  const { close, httpUrl } = routerToServerAndClientNew(appRouter, {
+    server: {
+      createContext(opts) {
+        return {
+          headers: opts.req.headers,
+        };
+      },
+      // createContext({ req }) {
+      //   return { headers: req.headers };
+      // },
+    },
+  });
+
+  afterAll(() => {
+    close();
+  });
+
+  test('no headers', async () => {
+    const client = createTRPCProxyClient<AppRouter>({
+      links: [httpBatchLink({ url: httpUrl })],
+    });
+    expect(await client.hello.query()).toMatchInlineSnapshot(`Object {}`);
+  });
+
+  test('custom headers', async () => {
+    const client = createTRPCProxyClient<AppRouter>({
+      links: [
+        httpBatchLink({
+          url: httpUrl,
+          headers() {
+            return {
+              'X-Special': 'special header',
+            };
+          },
+        }),
+      ],
+    });
+    expect(await client.hello.query()).toMatchInlineSnapshot(`
+Object {
+  "x-special": "special header",
+}
+`);
+  });
+
+  test('async headers', async () => {
+    const client = createTRPCProxyClient<AppRouter>({
+      links: [
+        httpBatchLink({
+          url: httpUrl,
+          async headers() {
+            return {
+              'X-Special': 'async special header',
+            };
+          },
+        }),
+      ],
+    });
+    expect(await client.hello.query()).toMatchInlineSnapshot(`
+Object {
+  "x-special": "async special header",
+}
+`);
+  });
+});

--- a/packages/tests/server/rawFetch.test.tsx
+++ b/packages/tests/server/rawFetch.test.tsx
@@ -1,0 +1,57 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { routerToServerAndClientNew } from './___testHelpers';
+import { initTRPC } from '@trpc/server/src';
+import fetch from 'node-fetch';
+import { z } from 'zod';
+
+const factory = () => {
+  const t = initTRPC.context().create();
+
+  const router = t.router({
+    myQuery: t.procedure
+      .input(
+        z
+          .object({
+            name: z.string(),
+          })
+          .optional(),
+      )
+      .query(({ input }) => {
+        return input?.name ?? 'default';
+      }),
+
+    myMutation: t.procedure
+      .input(
+        z.object({
+          name: z.string(),
+        }),
+      )
+      .mutation(async ({ input }) => {
+        return { input };
+      }),
+  });
+  return routerToServerAndClientNew(router);
+};
+test('batching with raw batch', async () => {
+  const { close, httpUrl } = factory();
+
+  {
+    const res = await fetch(
+      `${httpUrl}/myQuery?batch=1&input=${JSON.stringify({
+        '0': { name: 'alexdotjs' },
+      })}`,
+    );
+    const json = await res.json();
+
+    expect(json[0]).toHaveProperty('result');
+    expect(json[0].result).toMatchInlineSnapshot(`
+Object {
+  "data": "alexdotjs",
+}
+`);
+  }
+
+  close();
+});

--- a/packages/tests/server/responseMeta.test.ts
+++ b/packages/tests/server/responseMeta.test.ts
@@ -1,0 +1,77 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { routerToServerAndClientNew } from './___testHelpers';
+import { initTRPC } from '@trpc/server/src';
+import fetch from 'node-fetch';
+
+test('set custom headers in beforeEnd', async () => {
+  const onError = jest.fn();
+
+  const t = initTRPC.context().create();
+
+  const appRouter = t.router({
+    ['public.q']: t.procedure.query(({}) => {
+      return 'public endpoint';
+    }),
+    nonCachedEndpoint: t.procedure.query(({}) => {
+      return 'not cached endpoint';
+    }),
+  });
+
+  const { close, httpUrl } = routerToServerAndClientNew(appRouter, {
+    server: {
+      onError,
+      responseMeta({ ctx, paths, type, errors }) {
+        // assuming you have all your public routes with the kewyord `public` in them
+        const allPublic =
+          paths && paths.every((path) => path.includes('public'));
+        // checking that no procedures errored
+        const allOk = errors.length === 0;
+        // checking we're doing a query request
+        const isQuery = type === 'query';
+
+        if (ctx?.res && allPublic && allOk && isQuery) {
+          // cache request for 1 day + revalidate once every second
+          const ONE_DAY_IN_SECONDS = 60 * 60 * 24;
+          return {
+            headers: {
+              'cache-control': `s-maxage=1, stale-while-revalidate=${ONE_DAY_IN_SECONDS}`,
+            },
+          };
+        }
+        return {};
+      },
+    },
+  });
+  {
+    const res = await fetch(`${httpUrl}/public.q`);
+
+    expect(await res.json()).toMatchInlineSnapshot(`
+Object {
+  "result": Object {
+    "data": "public endpoint",
+  },
+}
+`);
+
+    expect(res.headers.get('cache-control')).toMatchInlineSnapshot(
+      `"s-maxage=1, stale-while-revalidate=86400"`,
+    );
+  }
+  {
+    const res = await fetch(`${httpUrl}/nonCachedEndpoint`);
+
+    expect(await res.json()).toMatchInlineSnapshot(`
+Object {
+  "result": Object {
+    "data": "not cached endpoint",
+  },
+}
+`);
+
+    expect(res.headers.get('cache-control')).toBeNull();
+  }
+
+  close();
+});


### PR DESCRIPTION
Closes #

## 🎯 Changes

This PR ports `headers.test.tsx`, `rawFetch.test.tsx`, `responseMeta.test.tsx` to v10

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.