### PR TITLE
docs: add tip about (de)serialization of complex objects using superjson

### DIFF
--- a/www/docs/main/quickstart.mdx
+++ b/www/docs/main/quickstart.mdx
@@ -324,6 +324,10 @@ trpc.u;
 
 ## Next steps
 
+:::tip
+By default, tRPC doesn't (de)serialize objects like `Date`, `Map`, `Set` between the server and client. The easiest way to add support for these is to [use superjson](data-transformers#using-superjson) as a Data Transformer.
+:::
+
 tRPC includes more sophisticated client-side tooling designed for React projects and Next.js.
 
 - [Usage with Next.js](nextjs)


### PR DESCRIPTION
Closes #

## 🎯 Changes

As discussed on [this tweet](https://twitter.com/tomlienard/status/1595856448608735239), this PR adds a note at the end of the Quickstart to use `superjson` if you need to support complex objects:

![Screenshot 2022-11-24 at 20 19 42](https://user-images.githubusercontent.com/43268759/203853238-bd5708eb-af72-4c5b-90eb-e6289befe2e2.png)

This is the best place I found to add this tip, but it might be worth adding it in other places too.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.