### PR TITLE
test: port inference, links, outputParser, withTRPC to v10

### DIFF
--- a/packages/tests/server/inference.test.ts
+++ b/packages/tests/server/inference.test.ts
@@ -1,0 +1,244 @@
+import {
+  inferProcedureInput,
+  inferProcedureOutput,
+  initTRPC,
+} from '@trpc/server/src';
+import { Observable, observable } from '@trpc/server/src/observable';
+import { z } from 'zod';
+import { expectTypeOf } from './inferenceUtils';
+
+describe('infer query input & output', () => {
+  const t = initTRPC.create();
+
+  const router = t.router({
+    noInput: t.procedure.input(z.undefined()).query(({ input }) => {
+      return { input };
+    }),
+
+    withInput: t.procedure
+      .input(z.string())
+      .output(
+        z.object({
+          input: z.string(),
+        }),
+      )
+      .query(async ({ input }) => {
+        return { input };
+      }),
+
+    withOutput: t.procedure
+      .output(
+        z.object({
+          input: z.string(),
+        }),
+      )
+      // @ts-expect-error - ensure type inferred from "output" is expected as "resolve" fn return type
+      .query(async ({ input }) => {
+        return { input };
+      }),
+
+    withOutputEmptyObject: t.procedure
+      .input(z.undefined())
+      .output(
+        z.object({
+          input: z.string(),
+        }),
+      )
+      // @ts-expect-error - ensure type inferred from "output" is higher priority than "resolve" fn return type
+      .query(({}) => {
+        return {};
+      }),
+
+    withInputOutput: t.procedure
+      .input(z.string())
+      .output(
+        z.object({
+          input: z.string(),
+        }),
+      )
+      .query(({ input }) => {
+        return { input };
+      }),
+  });
+
+  type TQueries = typeof router['_def']['procedures'];
+
+  test('no input', () => {
+    const input: inferProcedureInput<TQueries['noInput']> = null as any;
+    const output: inferProcedureOutput<TQueries['noInput']> = null as any;
+    expectTypeOf(input).toMatchTypeOf<undefined | null | void>();
+    expectTypeOf(output).toMatchTypeOf<{ input: undefined }>();
+  });
+  test('with input', () => {
+    const input: inferProcedureInput<TQueries['withInput']> = null as any;
+    const output: inferProcedureOutput<TQueries['withInput']> = null as any;
+    expectTypeOf(input).toMatchTypeOf<string>();
+    expectTypeOf(output).toMatchTypeOf<{ input: string }>();
+  });
+  test('with output', () => {
+    const input: inferProcedureInput<TQueries['withOutput']> = null as any;
+    const output: inferProcedureOutput<TQueries['withOutput']> = null as any;
+    expectTypeOf(input).toMatchTypeOf<undefined | null | void>();
+    expectTypeOf(output).toMatchTypeOf<{ input: string }>();
+  });
+  test('with output empty object', () => {
+    const input: inferProcedureInput<TQueries['withOutputEmptyObject']> =
+      null as any;
+    const output: inferProcedureOutput<TQueries['withOutputEmptyObject']> =
+      null as any;
+    expectTypeOf(input).toMatchTypeOf<undefined | null | void>();
+    expectTypeOf(output).toMatchTypeOf<{ input: string }>();
+  });
+  test('with input and output', () => {
+    const input: inferProcedureInput<TQueries['withInputOutput']> = null as any;
+    const output: inferProcedureOutput<TQueries['withInputOutput']> =
+      null as any;
+    expectTypeOf(input).toMatchTypeOf<string>();
+    expectTypeOf(output).toMatchTypeOf<{ input: string }>();
+  });
+});
+
+describe('infer mutation input & output', () => {
+  const t = initTRPC.create();
+
+  const router = t.router({
+    noInput: t.procedure.input(z.undefined()).mutation(async ({ input }) => {
+      return { input };
+    }),
+
+    withInput: t.procedure
+      .input(z.string())
+      .output(
+        z.object({
+          input: z.string(),
+        }),
+      )
+      .mutation(async ({ input }) => {
+        return { input };
+      }),
+
+    withOutput: t.procedure
+      .output(
+        z.object({
+          input: z.string(),
+        }),
+      )
+      // @ts-expect-error - ensure type inferred from "output" is expected as "resolve" fn return type
+      .mutation(async ({ input }) => {
+        return { input };
+      }),
+
+    withOutputEmptyObject: t.procedure
+      .input(z.undefined())
+      .output(
+        z.object({
+          input: z.string(),
+        }),
+      )
+      // @ts-expect-error - ensure type inferred from "output" is higher priority than "resolve" fn return type
+      .mutation(({}) => {
+        return {};
+      }),
+
+    withInputOutput: t.procedure
+      .input(z.string())
+      .output(
+        z.object({
+          input: z.string(),
+        }),
+      )
+      .mutation(({ input }) => {
+        return { input };
+      }),
+  });
+
+  type TMutations = typeof router['_def']['procedures'];
+
+  test('no input', () => {
+    const input: inferProcedureInput<TMutations['noInput']> = null as any;
+    const output: inferProcedureOutput<TMutations['noInput']> = null as any;
+    expectTypeOf(input).toMatchTypeOf<undefined | null | void>();
+    expectTypeOf(output).toMatchTypeOf<{ input: undefined }>();
+  });
+  test('with input', () => {
+    const input: inferProcedureInput<TMutations['withInput']> = null as any;
+    const output: inferProcedureOutput<TMutations['withInput']> = null as any;
+    expectTypeOf(input).toMatchTypeOf<string>();
+    expectTypeOf(output).toMatchTypeOf<{ input: string }>();
+  });
+  test('with output', () => {
+    const input: inferProcedureInput<TMutations['withOutput']> = null as any;
+    const output: inferProcedureOutput<TMutations['withOutput']> = null as any;
+    expectTypeOf(input).toMatchTypeOf<undefined | null | void>();
+    expectTypeOf(output).toMatchTypeOf<{ input: string }>();
+  });
+  test('with output empty object', () => {
+    const input: inferProcedureInput<TMutations['withOutputEmptyObject']> =
+      null as any;
+    const output: inferProcedureOutput<TMutations['withOutputEmptyObject']> =
+      null as any;
+    expectTypeOf(input).toMatchTypeOf<undefined | null | void>();
+    expectTypeOf(output).toMatchTypeOf<{ input: string }>();
+  });
+  test('with input and output', () => {
+    const input: inferProcedureInput<TMutations['withInputOutput']> =
+      null as any;
+    const output: inferProcedureOutput<TMutations['withInputOutput']> =
+      null as any;
+    expectTypeOf(input).toMatchTypeOf<string>();
+    expectTypeOf(output).toMatchTypeOf<{ input: string }>();
+  });
+});
+
+describe('infer subscription input & output', () => {
+  const t = initTRPC.create();
+
+  const router = t.router({
+    noSubscription: t.procedure
+      .input(z.undefined())
+      .subscription(async ({ input }) => {
+        return { input };
+      }),
+
+    noInput: t.procedure.mutation(async ({}) => {
+      return observable(() => () => null);
+    }),
+
+    withInput: t.procedure.input(z.string()).subscription(({ input }) => {
+      return observable<typeof input>((emit) => {
+        emit.next(input);
+        return () => null;
+      });
+    }),
+
+    withOutput: t.procedure
+      .output(
+        z.object({
+          input: z.string(),
+        }),
+      )
+      // @ts-expect-error - ensure type inferred from "output" is expected as "resolve" fn return type
+      .subscription(async ({ input }) => {
+        return observable<typeof input>((emit) => {
+          emit.next(input);
+          return () => null;
+        });
+      }),
+  });
+
+  type TSubscriptions = typeof router['_def']['procedures'];
+
+  test('no input', () => {
+    const input: inferProcedureInput<TSubscriptions['noInput']> = null as any;
+    const output: inferProcedureOutput<TSubscriptions['noInput']> = null as any;
+    expectTypeOf(input).toMatchTypeOf<undefined | null | void>();
+    expectTypeOf(output).toMatchTypeOf<Observable<unknown, unknown>>();
+  });
+  test('with input', () => {
+    const input: inferProcedureInput<TSubscriptions['withInput']> = null as any;
+    const output: inferProcedureOutput<TSubscriptions['withInput']> =
+      null as any;
+    expectTypeOf(input).toMatchTypeOf<string>();
+    expectTypeOf(output).toMatchTypeOf<Observable<string, unknown>>();
+  });
+});

--- a/packages/tests/server/inferenceUtils.ts
+++ b/packages/tests/server/inferenceUtils.ts
@@ -1,0 +1,335 @@
+/* 
+expect-type from unpublished branch `dx-generics` that fixes `MISMATCH error` for v10 routers
+https://raw.githubusercontent.com/mmkal/expect-type/dx-generics/src/index.ts
+ */
+export type Not<T extends boolean> = T extends true ? false : true;
+export type Or<Types extends boolean[]> = Types[number] extends false
+  ? false
+  : true;
+export type And<Types extends boolean[]> = Types[number] extends true
+  ? true
+  : false;
+export type Eq<Left extends boolean, Right extends boolean> = Left extends true
+  ? Right
+  : Not<Right>;
+export type Xor<Types extends [boolean, boolean]> = Not<Eq<Types[0], Types[1]>>;
+
+const secret = Symbol('secret');
+type Secret = typeof secret;
+
+export type IsNever<T> = [T] extends [never] ? true : false;
+export type IsAny<T> = [T] extends [Secret] ? Not<IsNever<T>> : false;
+export type IsUnknown<T> = [unknown] extends [T] ? Not<IsAny<T>> : false;
+export type IsNeverOrAny<T> = Or<[IsNever<T>, IsAny<T>]>;
+export type BrandSpecial<T> = IsAny<T> extends true
+  ? { special: true; type: 'any' }
+  : IsUnknown<T> extends true
+  ? { special: true; type: 'unknown' }
+  : IsNever<T> extends true
+  ? { special: true; type: 'never' }
+  : never;
+
+/**
+ * Recursively walk a type and replace it with a branded type related to the original. This is useful for
+ * equality-checking stricter than `A extends B ? B extends A ? true : false : false`, because it detects
+ * the difference between a few edge-case types that vanilla typescript doesn't by default:
+ * - `any` vs `unknown`
+ * - `{ readonly a: string }` vs `{ a: string }`
+ * - `{ a?: string }` vs `{ a: string | undefined }`
+ */
+export type DeepBrand<T> = IsNever<T> extends true
+  ? { type: 'never' }
+  : IsAny<T> extends true
+  ? { type: 'any' }
+  : IsUnknown<T> extends true
+  ? { type: 'unknown' }
+  : T extends
+      | string
+      | number
+      | boolean
+      | symbol
+      | bigint
+      | null
+      | undefined
+      | void
+  ? {
+      type: 'primitive';
+      value: T;
+    }
+  : T extends new (...args: any[]) => any
+  ? {
+      type: 'constructor';
+      params: ConstructorParams<T>;
+      instance: DeepBrand<InstanceType<Extract<T, new (...args: any) => any>>>;
+    }
+  : T extends (...args: infer P) => infer R // avoid functions with different params/return values matching
+  ? {
+      type: 'function';
+      params: DeepBrand<P>;
+      return: DeepBrand<R>;
+      this: DeepBrand<ThisParameterType<T>>;
+    }
+  : T extends any[]
+  ? {
+      type: 'array';
+      items: { [K in keyof T]: T[K] };
+    }
+  : {
+      type: 'object';
+      properties: { [K in keyof T]: DeepBrand<T[K]> };
+      readonly: ReadonlyKeys<T>;
+      required: RequiredKeys<T>;
+      optional: OptionalKeys<T>;
+      constructorParams: DeepBrand<ConstructorParams<T>>;
+    };
+
+export type RequiredKeys<T> = Extract<
+  {
+    [K in keyof T]-?: {} extends Pick<T, K> ? never : K;
+  }[keyof T],
+  keyof T
+>;
+export type OptionalKeys<T> = Exclude<keyof T, RequiredKeys<T>>;
+
+// adapted from some answers to https://github.com/type-challenges/type-challenges/issues?q=label%3A5+label%3Aanswer
+// prettier-ignore
+export type ReadonlyKeys<T> = Extract<{
+  [K in keyof T]-?: ReadonlyEquivalent<
+    {[_K in K]: T[K]},
+    {-readonly [_K in K]: T[K]}
+  > extends true ? never : K;
+}[keyof T], keyof T>;
+
+// prettier-ignore
+type ReadonlyEquivalent<X, Y> = Extends<
+  (<T>() => T extends X ? true : false),
+  (<T>() => T extends Y ? true : false)
+>
+
+export type Extends<L, R> = IsNever<L> extends true
+  ? IsNever<R>
+  : [L] extends [R]
+  ? true
+  : false;
+export type StrictExtends<L, R> = Extends<DeepBrand<L>, DeepBrand<R>>;
+
+export type Equal<Left, Right> = And<
+  [StrictExtends<Left, Right>, StrictExtends<Right, Left>]
+>;
+
+export type Params<Actual> = Actual extends (...args: infer P) => any
+  ? P
+  : never;
+export type ConstructorParams<Actual> = Actual extends new (
+  ...args: infer P
+) => any
+  ? Actual extends new () => any
+    ? P | []
+    : P
+  : never;
+
+type MismatchArgs<B extends boolean, C extends boolean> = Eq<B, C> extends true
+  ? []
+  : [never];
+type Mismatch<T> = (BrandSpecial<T> | T) & {
+  [secret]: 'Type should be satisified';
+};
+
+export interface ExpectTypeOf<Actual, B extends boolean> {
+  toBeAny: (...MISMATCH: MismatchArgs<IsAny<Actual>, B>) => true;
+  toBeUnknown: (...MISMATCH: MismatchArgs<IsUnknown<Actual>, B>) => true;
+  toBeNever: (...MISMATCH: MismatchArgs<IsNever<Actual>, B>) => true;
+  toBeFunction: (
+    ...MISMATCH: MismatchArgs<Extends<Actual, (...args: any[]) => any>, B>
+  ) => true;
+  toBeObject: (...MISMATCH: MismatchArgs<Extends<Actual, object>, B>) => true;
+  toBeArray: (...MISMATCH: MismatchArgs<Extends<Actual, any[]>, B>) => true;
+  toBeNumber: (...MISMATCH: MismatchArgs<Extends<Actual, number>, B>) => true;
+  toBeString: (...MISMATCH: MismatchArgs<Extends<Actual, string>, B>) => true;
+  toBeBoolean: (...MISMATCH: MismatchArgs<Extends<Actual, boolean>, B>) => true;
+  toBeVoid: (...MISMATCH: MismatchArgs<Extends<Actual, void>, B>) => true;
+  toBeSymbol: (...MISMATCH: MismatchArgs<Extends<Actual, symbol>, B>) => true;
+  toBeNull: (...MISMATCH: MismatchArgs<Extends<Actual, null>, B>) => true;
+  toBeUndefined: (
+    ...MISMATCH: MismatchArgs<Extends<Actual, undefined>, B>
+  ) => true;
+  toBeNullable: (
+    ...MISMATCH: MismatchArgs<Not<Equal<Actual, NonNullable<Actual>>>, B>
+  ) => true;
+  toMatchTypeOf: {
+    <
+      Expected extends B extends true
+        ? Extends<Actual, Expected> extends true
+          ? unknown
+          : Mismatch<Actual>
+        : unknown,
+    >(
+      ...MISMATCH: Or<
+        [IsNeverOrAny<Actual>, IsNeverOrAny<Expected>]
+      > extends true
+        ? MismatchArgs<Extends<Actual, Expected>, B>
+        : []
+    ): true;
+    <
+      Expected extends B extends true
+        ? Extends<Actual, Expected> extends true
+          ? unknown
+          : Mismatch<Actual>
+        : unknown,
+    >(
+      expected: Expected,
+      ...MISMATCH: Or<
+        [IsNeverOrAny<Actual>, IsNeverOrAny<Expected>]
+      > extends true
+        ? MismatchArgs<Extends<Actual, Expected>, B>
+        : []
+    ): true;
+  };
+  toEqualTypeOf: {
+    <
+      Expected extends B extends true
+        ? Equal<Actual, Expected> extends true
+          ? unknown
+          : Mismatch<Actual>
+        : unknown,
+    >(
+      ...MISMATCH: Or<
+        [IsNeverOrAny<Actual>, IsNeverOrAny<Expected>]
+      > extends true
+        ? MismatchArgs<Equal<Actual, Expected>, B>
+        : []
+    ): true;
+    <
+      Expected extends B extends true
+        ? Equal<Actual, Expected> extends true
+          ? unknown
+          : Mismatch<Actual>
+        : unknown,
+    >(
+      expected: Expected,
+      ...MISMATCH: Or<
+        [IsNeverOrAny<Actual>, IsNeverOrAny<Expected>]
+      > extends true
+        ? MismatchArgs<Equal<Actual, Expected>, B>
+        : []
+    ): true;
+  };
+  toBeCallableWith: B extends true ? (...args: Params<Actual>) => true : never;
+  toBeConstructibleWith: B extends true
+    ? (...args: ConstructorParams<Actual>) => true
+    : never;
+  toHaveProperty: <K extends string>(
+    key: K,
+    ...MISMATCH: MismatchArgs<Extends<K, keyof Actual>, B>
+  ) => K extends keyof Actual ? ExpectTypeOf<Actual[K], B> : true;
+  extract: <V>(v?: V) => ExpectTypeOf<Extract<Actual, V>, B>;
+  exclude: <V>(v?: V) => ExpectTypeOf<Exclude<Actual, V>, B>;
+  parameter: <K extends keyof Params<Actual>>(
+    number: K,
+  ) => ExpectTypeOf<Params<Actual>[K], B>;
+  parameters: ExpectTypeOf<Params<Actual>, B>;
+  constructorParameters: ExpectTypeOf<ConstructorParams<Actual>, B>;
+  thisParameter: ExpectTypeOf<ThisParameterType<Actual>, B>;
+  instance: Actual extends new (...args: any[]) => infer I
+    ? ExpectTypeOf<I, B>
+    : never;
+  returns: Actual extends (...args: any[]) => infer R
+    ? ExpectTypeOf<R, B>
+    : never;
+  resolves: Actual extends PromiseLike<infer R> ? ExpectTypeOf<R, B> : never;
+  items: Actual extends ArrayLike<infer R> ? ExpectTypeOf<R, B> : never;
+  guards: Actual extends (v: any, ...args: any[]) => v is infer T
+    ? ExpectTypeOf<T, B>
+    : never;
+  asserts: Actual extends (v: any, ...args: any[]) => asserts v is infer T
+    ? // Guard methods `(v: any) => asserts v is T` does not actually defines a return type. Thus, any function taking 1 argument matches the signature before.
+      // In case the inferred assertion type `R` could not be determined (so, `unknown`), consider the function as a non-guard, and return a `never` type.
+      // See https://github.com/microsoft/TypeScript/issues/34636
+      unknown extends T
+      ? never
+      : ExpectTypeOf<T, B>
+    : never;
+  not: ExpectTypeOf<Actual, Not<B>>;
+}
+const fn: any = () => true;
+
+export type _ExpectTypeOf = {
+  <Actual>(actual: Actual): ExpectTypeOf<Actual, true>;
+  <Actual>(): ExpectTypeOf<Actual, true>;
+};
+
+/**
+ * Similar to Jest's `expect`, but with type-awareness.
+ * Gives you access to a number of type-matchers that let you make assertions about the
+ * form of a reference or generic type parameter.
+ *
+ * @example
+ * import {foo, bar} from '../foo'
+ * import {expectTypeOf} from 'expect-type'
+ *
+ * test('foo types', () => {
+ *   // make sure `foo` has type {a: number}
+ *   expectTypeOf(foo).toMatchTypeOf({a: 1})
+ *   expectTypeOf(foo).toHaveProperty('a').toBeNumber()
+ *
+ *   // make sure `bar` is a function taking a string:
+ *   expectTypeOf(bar).parameter(0).toBeString()
+ *   expectTypeOf(bar).returns.not.toBeAny()
+ * })
+ *
+ * @description
+ * See the [full docs](https://npmjs.com/package/expect-type#documentation) for lots more examples.
+ */
+export const expectTypeOf: _ExpectTypeOf = <Actual>(
+  _actual?: Actual,
+): ExpectTypeOf<Actual, true> => {
+  const nonFunctionProperties = [
+    'parameters',
+    'returns',
+    'resolves',
+    'not',
+    'items',
+    'constructorParameters',
+    'thisParameter',
+    'instance',
+    'guards',
+    'asserts',
+  ] as const;
+  type Keys = keyof ExpectTypeOf<any, any>;
+
+  type FunctionsDict = Record<
+    Exclude<Keys, typeof nonFunctionProperties[number]>,
+    any
+  >;
+  const obj: FunctionsDict = {
+    toBeAny: fn,
+    toBeUnknown: fn,
+    toBeNever: fn,
+    toBeFunction: fn,
+    toBeObject: fn,
+    toBeArray: fn,
+    toBeString: fn,
+    toBeNumber: fn,
+    toBeBoolean: fn,
+    toBeVoid: fn,
+    toBeSymbol: fn,
+    toBeNull: fn,
+    toBeUndefined: fn,
+    toBeNullable: fn,
+    toMatchTypeOf: fn,
+    toEqualTypeOf: fn,
+    toBeCallableWith: fn,
+    toBeConstructibleWith: fn,
+    extract: expectTypeOf,
+    exclude: expectTypeOf,
+    toHaveProperty: expectTypeOf,
+    parameter: expectTypeOf,
+  };
+
+  const getterProperties: readonly Keys[] = nonFunctionProperties;
+  getterProperties.forEach((prop: Keys) =>
+    Object.defineProperty(obj, prop, { get: () => expectTypeOf({}) }),
+  );
+
+  return obj as ExpectTypeOf<Actual, true>;
+};

--- a/packages/tests/server/inferenceUtils.ts
+++ b/packages/tests/server/inferenceUtils.ts
@@ -1,6 +1,7 @@
-/* 
-expect-type from unpublished branch `dx-generics` that fixes `MISMATCH error` for v10 routers
+/**
+ * `expect-type` from unpublished branch `dx-generics` that fixes `MISMATCH error` for v10 routers
 https://raw.githubusercontent.com/mmkal/expect-type/dx-generics/src/index.ts
+ * @link https://github.com/mmkal/expect-type/pull/16
  */
 export type Not<T extends boolean> = T extends true ? false : true;
 export type Or<Types extends boolean[]> = Types[number] extends false

--- a/packages/tests/server/links.test.ts
+++ b/packages/tests/server/links.test.ts
@@ -1,0 +1,564 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { routerToServerAndClientNew } from './___testHelpers';
+import {
+  OperationLink,
+  TRPCClientError,
+  TRPCClientRuntime,
+  createTRPCProxyClient,
+  httpBatchLink,
+  httpLink,
+  loggerLink,
+} from '@trpc/client/src';
+import { createChain } from '@trpc/client/src/links/internals/createChain';
+import { retryLink } from '@trpc/client/src/links/retryLink';
+import { AnyRouter, initTRPC } from '@trpc/server/src';
+import { observable, observableToPromise } from '@trpc/server/src/observable';
+import { z } from 'zod';
+
+const mockRuntime: TRPCClientRuntime = {
+  transformer: {
+    serialize: (v) => v,
+    deserialize: (v) => v,
+  },
+};
+test('chainer', async () => {
+  let attempt = 0;
+  const serverCall = jest.fn();
+  const t = initTRPC.create();
+
+  const router = t.router({
+    hello: t.procedure.query(({}) => {
+      attempt++;
+      serverCall();
+      if (attempt < 3) {
+        throw new Error('Errr ' + attempt);
+      }
+      return 'world';
+    }),
+  });
+
+  const { httpPort, close } = routerToServerAndClientNew(router);
+
+  const chain = createChain({
+    links: [
+      retryLink({ attempts: 3 })(mockRuntime),
+      httpLink({
+        url: `http://localhost:${httpPort}`,
+      })(mockRuntime),
+    ],
+    op: {
+      id: 1,
+      type: 'query',
+      path: 'hello',
+      input: null,
+      context: {},
+    },
+  });
+
+  const result = await observableToPromise(chain).promise;
+  expect(result?.context?.response).toBeTruthy();
+  result!.context!.response = '[redacted]' as any;
+  expect(result).toMatchInlineSnapshot(`
+    Object {
+      "context": Object {
+        "response": "[redacted]",
+      },
+      "result": Object {
+        "data": "world",
+        "type": "data",
+      },
+    }
+  `);
+
+  expect(serverCall).toHaveBeenCalledTimes(3);
+
+  close();
+});
+
+test('cancel request', async () => {
+  const onDestroyCall = jest.fn();
+
+  const chain = createChain({
+    links: [
+      () =>
+        observable(() => {
+          return () => {
+            onDestroyCall();
+          };
+        }),
+    ],
+    op: {
+      id: 1,
+      type: 'query',
+      path: 'hello',
+      input: null,
+      context: {},
+    },
+  });
+
+  chain.subscribe({}).unsubscribe();
+
+  expect(onDestroyCall).toHaveBeenCalled();
+});
+
+describe('batching', () => {
+  test('query batching', async () => {
+    const metaCall = jest.fn();
+
+    const t = initTRPC.create();
+
+    const router = t.router({
+      hello: t.procedure.input(z.string().nullish()).query(({ input }) => {
+        return `hello ${input ?? 'world'}`;
+      }),
+    });
+
+    const { httpPort, close } = routerToServerAndClientNew(router, {
+      server: {
+        createContext() {
+          metaCall();
+          return {};
+        },
+        batching: {
+          enabled: true,
+        },
+      },
+    });
+    const links = [
+      httpBatchLink({
+        url: `http://localhost:${httpPort}`,
+      })(mockRuntime),
+    ];
+    const chain1 = createChain({
+      links,
+      op: {
+        id: 1,
+        type: 'query',
+        path: 'hello',
+        input: null,
+        context: {},
+      },
+    });
+
+    const chain2 = createChain({
+      links,
+      op: {
+        id: 2,
+        type: 'query',
+        path: 'hello',
+        input: 'alexdotjs',
+        context: {},
+      },
+    });
+
+    const results = await Promise.all([
+      observableToPromise(chain1).promise,
+      observableToPromise(chain2).promise,
+    ]);
+    for (const res of results) {
+      expect(res?.context?.response).toBeTruthy();
+      res!.context!.response = '[redacted]';
+    }
+    expect(results).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "context": Object {
+            "response": "[redacted]",
+          },
+          "result": Object {
+            "data": "hello world",
+            "type": "data",
+          },
+        },
+        Object {
+          "context": Object {
+            "response": "[redacted]",
+          },
+          "result": Object {
+            "data": "hello alexdotjs",
+            "type": "data",
+          },
+        },
+      ]
+    `);
+
+    expect(metaCall).toHaveBeenCalledTimes(1);
+
+    close();
+  });
+
+  test('batching on maxURLLength', async () => {
+    const createContextFn = jest.fn();
+
+    const t = initTRPC.create();
+
+    const appRouter = t.router({
+      ['big-input']: t.procedure.input(z.string()).query(({ input }) => {
+        return input.length;
+      }),
+    });
+
+    const { proxy, httpUrl, close, router } = routerToServerAndClientNew(
+      appRouter,
+      {
+        server: {
+          createContext() {
+            createContextFn();
+            return {};
+          },
+          batching: {
+            enabled: true,
+          },
+        },
+        client: (opts) => ({
+          links: [
+            httpBatchLink({
+              url: opts.httpUrl,
+              maxURLLength: 2083,
+            }),
+          ],
+        }),
+      },
+    );
+
+    {
+      // queries should be batched into a single request
+      // url length: 118 < 2083
+      const res = await Promise.all([
+        proxy['big-input'].query('*'.repeat(10)),
+        proxy['big-input'].query('*'.repeat(10)),
+      ]);
+
+      expect(res).toEqual([10, 10]);
+      expect(createContextFn).toBeCalledTimes(1);
+      createContextFn.mockClear();
+    }
+    {
+      // queries should be sent and indivdual requests
+      // url length: 2146 > 2083
+      const res = await Promise.all([
+        proxy['big-input'].query('*'.repeat(1024)),
+        proxy['big-input'].query('*'.repeat(1024)),
+      ]);
+
+      expect(res).toEqual([1024, 1024]);
+      expect(createContextFn).toBeCalledTimes(2);
+      createContextFn.mockClear();
+    }
+    {
+      // queries should be batched into a single request
+      // url length: 2146 < 9999
+      const clientWithBigMaxURLLength = createTRPCProxyClient<typeof router>({
+        links: [httpBatchLink({ url: httpUrl, maxURLLength: 9999 })],
+      });
+
+      const res = await Promise.all([
+        clientWithBigMaxURLLength['big-input'].query('*'.repeat(1024)),
+        clientWithBigMaxURLLength['big-input'].query('*'.repeat(1024)),
+      ]);
+
+      expect(res).toEqual([1024, 1024]);
+      expect(createContextFn).toBeCalledTimes(1);
+    }
+
+    close();
+  });
+
+  test('server not configured for batching', async () => {
+    const serverCall = jest.fn();
+
+    const t = initTRPC.create();
+
+    const appRouter = t.router({
+      hello: t.procedure.query(({}) => {
+        serverCall();
+        return 'world';
+      }),
+    });
+
+    const { close, router, httpPort, trpcClientOptions } =
+      routerToServerAndClientNew(appRouter, {
+        server: {
+          batching: {
+            enabled: false,
+          },
+        },
+      });
+    const client = createTRPCProxyClient<typeof router>({
+      ...trpcClientOptions,
+      links: [
+        httpBatchLink({
+          url: `http://localhost:${httpPort}`,
+          headers: {},
+        }),
+      ],
+    });
+
+    await expect(client.hello.query()).rejects.toMatchInlineSnapshot(
+      `[TRPCClientError: Batching is not enabled on the server]`,
+    );
+
+    close();
+  });
+});
+test('create client with links', async () => {
+  let attempt = 0;
+  const serverCall = jest.fn();
+
+  const t = initTRPC.create();
+
+  const appRouter = t.router({
+    hello: t.procedure.query(({}) => {
+      attempt++;
+      serverCall();
+      if (attempt < 3) {
+        throw new Error('Errr ' + attempt);
+      }
+      return 'world';
+    }),
+  });
+
+  const { close, router, httpPort, trpcClientOptions } =
+    routerToServerAndClientNew(appRouter);
+
+  const client = createTRPCProxyClient<typeof router>({
+    ...trpcClientOptions,
+    links: [
+      retryLink({ attempts: 3 }),
+      httpLink({
+        url: `http://localhost:${httpPort}`,
+        headers: {},
+      }),
+    ],
+  });
+
+  const result = await client.hello.query();
+  expect(result).toBe('world');
+
+  close();
+});
+
+describe('loggerLink', () => {
+  const logger = {
+    error: jest.fn(),
+    log: jest.fn(),
+  };
+  const logLink = loggerLink({
+    console: logger,
+  })(mockRuntime);
+  const okLink: OperationLink<AnyRouter> = () =>
+    observable((o) => {
+      o.next({
+        result: {
+          type: 'data',
+          data: undefined,
+        },
+      });
+    });
+  const errorLink: OperationLink<AnyRouter> = () =>
+    observable((o) => {
+      o.error(new TRPCClientError('..'));
+    });
+
+  beforeEach(() => {
+    logger.error.mockReset();
+    logger.log.mockReset();
+  });
+
+  test('query', () => {
+    createChain({
+      links: [logLink, okLink],
+      op: {
+        id: 1,
+        type: 'query',
+        input: null,
+        path: 'n/a',
+        context: {},
+      },
+    })
+      .subscribe({})
+      .unsubscribe();
+
+    expect(logger.log.mock.calls).toHaveLength(2);
+    expect(logger.log.mock.calls[0]![0]!).toMatchInlineSnapshot(
+      `"%c >> query #1 %cn/a%c %O"`,
+    );
+    expect(logger.log.mock.calls[0][1]).toMatchInlineSnapshot(`
+      "
+          background-color: #72e3ff; 
+          color: black;
+          padding: 2px;
+        "
+    `);
+  });
+
+  test('subscription', () => {
+    createChain({
+      links: [logLink, okLink],
+      op: {
+        id: 1,
+        type: 'subscription',
+        input: null,
+        path: 'n/a',
+        context: {},
+      },
+    })
+      .subscribe({})
+      .unsubscribe();
+    expect(logger.log.mock.calls[0]![0]!).toMatchInlineSnapshot(
+      `"%c >> subscription #1 %cn/a%c %O"`,
+    );
+    expect(logger.log.mock.calls[1]![0]!).toMatchInlineSnapshot(
+      `"%c << subscription #1 %cn/a%c %O"`,
+    );
+  });
+
+  test('mutation', () => {
+    createChain({
+      links: [logLink, okLink],
+      op: {
+        id: 1,
+        type: 'mutation',
+        input: null,
+        path: 'n/a',
+        context: {},
+      },
+    })
+      .subscribe({})
+      .unsubscribe();
+
+    expect(logger.log.mock.calls[0]![0]!).toMatchInlineSnapshot(
+      `"%c >> mutation #1 %cn/a%c %O"`,
+    );
+    expect(logger.log.mock.calls[1]![0]!).toMatchInlineSnapshot(
+      `"%c << mutation #1 %cn/a%c %O"`,
+    );
+  });
+
+  test('query 2', () => {
+    createChain({
+      links: [logLink, errorLink],
+      op: {
+        id: 1,
+        type: 'query',
+        input: null,
+        path: 'n/a',
+        context: {},
+      },
+    })
+      .subscribe({})
+      .unsubscribe();
+
+    expect(logger.log.mock.calls[0]![0]!).toMatchInlineSnapshot(
+      `"%c >> query #1 %cn/a%c %O"`,
+    );
+    expect(logger.error.mock.calls[0]![0]!).toMatchInlineSnapshot(
+      `"%c << query #1 %cn/a%c %O"`,
+    );
+  });
+
+  test('custom logger', () => {
+    const logFn = jest.fn();
+    createChain({
+      links: [loggerLink({ logger: logFn })(mockRuntime), errorLink],
+      op: {
+        id: 1,
+        type: 'query',
+        input: null,
+        path: 'n/a',
+        context: {},
+      },
+    })
+      .subscribe({})
+      .unsubscribe();
+    const [firstCall, secondCall] = logFn.mock.calls.map((args) => args[0]);
+    expect(firstCall).toMatchInlineSnapshot(`
+      Object {
+        "context": Object {},
+        "direction": "up",
+        "id": 1,
+        "input": null,
+        "path": "n/a",
+        "type": "query",
+      }
+    `);
+    // omit elapsedMs
+    const { elapsedMs, ...other } = secondCall;
+    expect(typeof elapsedMs).toBe('number');
+    expect(other).toMatchInlineSnapshot(`
+      Object {
+        "context": Object {},
+        "direction": "down",
+        "id": 1,
+        "input": null,
+        "path": "n/a",
+        "result": [TRPCClientError: ..],
+        "type": "query",
+      }
+    `);
+  });
+});
+
+test('chain makes unsub', async () => {
+  const firstLinkUnsubscribeSpy = jest.fn();
+  const firstLinkCompleteSpy = jest.fn();
+
+  const secondLinkUnsubscribeSpy = jest.fn();
+
+  const t = initTRPC.create();
+
+  const appRouter = t.router({
+    hello: t.procedure.query(({}) => {
+      return 'world';
+    }),
+  });
+
+  const { proxy, close } = routerToServerAndClientNew(appRouter, {
+    client() {
+      return {
+        links: [
+          () =>
+            ({ next, op }) =>
+              observable((observer) => {
+                next(op).subscribe({
+                  error(err) {
+                    observer.error(err);
+                  },
+                  next(v) {
+                    observer.next(v);
+                  },
+                  complete() {
+                    firstLinkCompleteSpy();
+                    observer.complete();
+                  },
+                });
+                return () => {
+                  firstLinkUnsubscribeSpy();
+                  observer.complete();
+                };
+              }),
+          () => () =>
+            observable((observer) => {
+              observer.next({
+                result: {
+                  type: 'data',
+                  data: 'world',
+                },
+              });
+              observer.complete();
+              return () => {
+                secondLinkUnsubscribeSpy();
+              };
+            }),
+        ],
+      };
+    },
+  });
+  expect(await proxy.hello.query()).toBe('world');
+  expect(firstLinkCompleteSpy).toHaveBeenCalledTimes(1);
+  expect(firstLinkUnsubscribeSpy).toHaveBeenCalledTimes(1);
+  expect(secondLinkUnsubscribeSpy).toHaveBeenCalledTimes(1);
+  close();
+});

--- a/packages/tests/server/outputParser.test.ts
+++ b/packages/tests/server/outputParser.test.ts
@@ -1,0 +1,278 @@
+import { routerToServerAndClientNew } from './___testHelpers';
+import '@testing-library/jest-dom';
+import { initTRPC } from '@trpc/server/src';
+import { expectTypeOf } from 'expect-type';
+import myzod from 'myzod';
+import * as t from 'superstruct';
+import * as yup from 'yup';
+import { z } from 'zod';
+
+test('zod', async () => {
+  const trpc = initTRPC.create();
+  const router = trpc.router({
+    q: trpc.procedure
+      .input(z.string().or(z.number()))
+      .output(
+        z.object({
+          input: z.string(),
+        }),
+      )
+      .query(({ input }) => {
+        return { input: input as string };
+      }),
+  });
+  const { proxy, close } = routerToServerAndClientNew(router);
+
+  const output = await proxy.q.query('foobar');
+  expectTypeOf(output.input).toBeString();
+  expect(output).toMatchInlineSnapshot(`
+    Object {
+      "input": "foobar",
+    }
+  `);
+
+  await expect(proxy.q.query(1234)).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: Output validation failed]`,
+  );
+
+  close();
+});
+
+test('zod async', async () => {
+  const trpc = initTRPC.create();
+  const router = trpc.router({
+    q: trpc.procedure
+      .input(z.string().or(z.number()))
+      .output(
+        z
+          .object({
+            input: z.string(),
+          })
+          .refine(async (value) => !!value),
+      )
+      .query(({ input }) => {
+        return { input: input as string };
+      }),
+  });
+
+  const { proxy, close } = routerToServerAndClientNew(router);
+
+  const output = await proxy.q.query('foobar');
+  expectTypeOf(output.input).toBeString();
+  expect(output).toMatchInlineSnapshot(`
+    Object {
+      "input": "foobar",
+    }
+  `);
+
+  await expect(proxy.q.query(1234)).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: Output validation failed]`,
+  );
+
+  close();
+});
+
+test('zod transform', async () => {
+  const trpc = initTRPC.create();
+  const router = trpc.router({
+    q: trpc.procedure
+      .input(z.string().or(z.number()))
+      .output(
+        z.object({
+          input: z.string().transform((s) => s.length),
+        }),
+      )
+      .query(({ input }) => {
+        return { input: input as string };
+      }),
+  });
+
+  const { proxy, close } = routerToServerAndClientNew(router);
+
+  const output = await proxy.q.query('foobar');
+  expectTypeOf(output.input).toBeNumber();
+  expect(output).toMatchInlineSnapshot(`
+    Object {
+      "input": 6,
+    }
+  `);
+
+  await expect(proxy.q.query(1234)).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: Output validation failed]`,
+  );
+
+  close();
+});
+
+test('superstruct', async () => {
+  const trpc = initTRPC.create();
+  const router = trpc.router({
+    q: trpc.procedure
+      .input(t.union([t.string(), t.number()]))
+      .output(
+        t.object({
+          input: t.string(),
+        }),
+      )
+      .query(({ input }) => {
+        return { input: input as string };
+      }),
+  });
+
+  const { proxy, close } = routerToServerAndClientNew(router);
+
+  const output = await proxy.q.query('foobar');
+  expectTypeOf(output.input).toBeString();
+  expect(output).toMatchInlineSnapshot(`
+    Object {
+      "input": "foobar",
+    }
+  `);
+
+  await expect(proxy.q.query(1234)).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: Output validation failed]`,
+  );
+
+  close();
+});
+
+test('yup', async () => {
+  const yupStringOrNumber = (value: unknown) => {
+    switch (typeof value) {
+      case 'number':
+        return yup.number().required();
+      case 'string':
+        return yup.string().required();
+      default:
+        throw new Error('Fail');
+    }
+  };
+
+  const trpc = initTRPC.create();
+  const router = trpc.router({
+    q: trpc.procedure
+      .input(yup.lazy(yupStringOrNumber))
+      .output(
+        yup.object({
+          input: yup.string().strict().required(),
+        }),
+      )
+      .query(({ input }) => {
+        return { input: input as string };
+      }),
+  });
+
+  const { proxy, close } = routerToServerAndClientNew(router);
+
+  const output = await proxy.q.query('foobar');
+  expectTypeOf(output.input).toBeString();
+  expect(output).toMatchInlineSnapshot(`
+    Object {
+      "input": "foobar",
+    }
+  `);
+
+  await expect(proxy.q.query(1234)).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: Output validation failed]`,
+  );
+
+  close();
+});
+
+test('myzod', async () => {
+  const trpc = initTRPC.create();
+  const router = trpc.router({
+    q: trpc.procedure
+      .input(myzod.string().or(myzod.number()))
+      .output(
+        myzod.object({
+          input: myzod.string(),
+        }),
+      )
+      .query(({ input }) => {
+        return { input: input as string };
+      }),
+  });
+
+  const { proxy, close } = routerToServerAndClientNew(router);
+
+  const output = await proxy.q.query('foobar');
+  expectTypeOf(output.input).toBeString();
+  expect(output).toMatchInlineSnapshot(`
+    Object {
+      "input": "foobar",
+    }
+  `);
+
+  await expect(proxy.q.query(1234)).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: Output validation failed]`,
+  );
+
+  close();
+});
+
+test('validator fn', async () => {
+  const trpc = initTRPC.create();
+  const router = trpc.router({
+    q: trpc.procedure
+      .input((value: unknown) => value as string | number)
+      .output((value: unknown) => {
+        if (typeof (value as any).input === 'string') {
+          return value as { input: string };
+        }
+        throw new Error('Fail');
+      })
+      .query(({ input }) => {
+        return { input: input as string };
+      }),
+  });
+
+  const { proxy, close } = routerToServerAndClientNew(router);
+
+  const output = await proxy.q.query('foobar');
+  expectTypeOf(output.input).toBeString();
+  expect(output).toMatchInlineSnapshot(`
+    Object {
+      "input": "foobar",
+    }
+  `);
+
+  await expect(proxy.q.query(1234)).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: Output validation failed]`,
+  );
+
+  close();
+});
+
+test('async validator fn', async () => {
+  const trpc = initTRPC.create();
+  const router = trpc.router({
+    q: trpc.procedure
+      .input((value: unknown) => value as string | number)
+      .output(async (value: any): Promise<{ input: string }> => {
+        if (value && typeof value.input === 'string') {
+          return { input: value.input };
+        }
+        throw new Error('Fail');
+      })
+      .query(({ input }) => {
+        return { input: input as string };
+      }),
+  });
+
+  const { proxy, close } = routerToServerAndClientNew(router);
+
+  const output = await proxy.q.query('foobar');
+  expectTypeOf(output.input).toBeString();
+  expect(output).toMatchInlineSnapshot(`
+    Object {
+      "input": "foobar",
+    }
+  `);
+
+  await expect(proxy.q.query(1234)).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: Output validation failed]`,
+  );
+
+  close();
+});

--- a/packages/tests/server/react/withTRPC.test.tsx
+++ b/packages/tests/server/react/withTRPC.test.tsx
@@ -1,0 +1,424 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { createAppRouter } from './__testHelpers';
+import { render, waitFor } from '@testing-library/react';
+import { withTRPC } from '@trpc/next/src';
+import { AppType } from 'next/dist/shared/lib/utils';
+import React from 'react';
+
+let factory: ReturnType<typeof createAppRouter>;
+beforeEach(() => {
+  factory = createAppRouter();
+});
+afterEach(() => {
+  factory.close();
+});
+
+describe('withTRPC()', () => {
+  test('useQuery', async () => {
+    // @ts-ignore
+    const { window } = global;
+
+    // @ts-ignore
+    delete global.window;
+    const { trpc, trpcClientOptions } = factory;
+    const App: AppType = () => {
+      const query = trpc.allPosts.useQuery();
+      return <>{JSON.stringify(query.data)}</>;
+    };
+
+    const Wrapped = withTRPC({
+      config: () => trpcClientOptions,
+      ssr: true,
+    })(App);
+
+    const props = await Wrapped.getInitialProps!({
+      AppTree: Wrapped,
+      Component: <div />,
+    } as any);
+
+    // @ts-ignore
+    global.window = window;
+
+    const utils = render(<Wrapped {...props} />);
+    expect(utils.container).toHaveTextContent('first post');
+  });
+
+  test('useInfiniteQuery', async () => {
+    const { window } = global;
+
+    // @ts-ignore
+    delete global.window;
+    const { trpc, trpcClientOptions } = factory;
+    const App: AppType = () => {
+      const query = trpc.paginatedPosts.useInfiniteQuery(
+        {
+          limit: 10,
+        },
+        {
+          getNextPageParam: (lastPage) => lastPage.nextCursor,
+        },
+      );
+      return <>{JSON.stringify(query.data || query.error)}</>;
+    };
+
+    const Wrapped = withTRPC({
+      config: () => trpcClientOptions,
+      ssr: true,
+    })(App);
+
+    const props = await Wrapped.getInitialProps!({
+      AppTree: Wrapped,
+      Component: <div />,
+    } as any);
+
+    global.window = window;
+
+    const utils = render(<Wrapped {...props} />);
+    expect(utils.container).toHaveTextContent('first post');
+  });
+
+  test('browser render', async () => {
+    const { trpc, trpcClientOptions } = factory;
+    const App: AppType = () => {
+      const query = trpc.allPosts.useQuery();
+      return <>{JSON.stringify(query.data)}</>;
+    };
+
+    const Wrapped = withTRPC({
+      config: () => trpcClientOptions,
+      ssr: true,
+    })(App);
+
+    const props = await Wrapped.getInitialProps!({
+      AppTree: Wrapped,
+      Component: <div />,
+    } as any);
+
+    const utils = render(<Wrapped {...props} />);
+
+    await waitFor(() => {
+      expect(utils.container).toHaveTextContent('first post');
+    });
+  });
+
+  describe('`ssr: false` on query', () => {
+    test('useQuery()', async () => {
+      const { window } = global;
+
+      // @ts-ignore
+      delete global.window;
+      const { trpc, trpcClientOptions } = factory;
+      const App: AppType = () => {
+        const query = trpc.allPosts.useQuery(undefined, {
+          trpc: { ssr: false },
+        });
+        return <>{JSON.stringify(query.data)}</>;
+      };
+
+      const Wrapped = withTRPC({
+        config: () => trpcClientOptions,
+        ssr: true,
+      })(App);
+
+      const props = await Wrapped.getInitialProps!({
+        AppTree: Wrapped,
+        Component: <div />,
+      } as any);
+
+      global.window = window;
+
+      const utils = render(<Wrapped {...props} />);
+      expect(utils.container).not.toHaveTextContent('first post');
+
+      // should eventually be fetched
+      await waitFor(() => {
+        expect(utils.container).toHaveTextContent('first post');
+      });
+    });
+
+    test('useInfiniteQuery', async () => {
+      const { window } = global;
+
+      // @ts-ignore
+      delete global.window;
+      const { trpc, trpcClientOptions } = factory;
+      const App: AppType = () => {
+        const query = trpc.paginatedPosts.useInfiniteQuery(
+          {
+            limit: 10,
+          },
+          {
+            getNextPageParam: (lastPage) => lastPage.nextCursor,
+            trpc: {
+              ssr: false,
+            },
+          },
+        );
+        return <>{JSON.stringify(query.data || query.error)}</>;
+      };
+
+      const Wrapped = withTRPC({
+        config: () => trpcClientOptions,
+        ssr: true,
+      })(App);
+
+      const props = await Wrapped.getInitialProps!({
+        AppTree: Wrapped,
+        Component: <div />,
+      } as any);
+
+      global.window = window;
+
+      const utils = render(<Wrapped {...props} />);
+      expect(utils.container).not.toHaveTextContent('first post');
+
+      // should eventually be fetched
+      await waitFor(() => {
+        expect(utils.container).toHaveTextContent('first post');
+      });
+    });
+  });
+
+  test('useQuery - ssr batching', async () => {
+    // @ts-ignore
+    const { window } = global;
+
+    // @ts-ignore
+    delete global.window;
+    const { trpc, trpcClientOptions, createContext } = factory;
+    const App: AppType = () => {
+      const query1 = trpc.postById.useQuery('1');
+      const query2 = trpc.postById.useQuery('2');
+
+      return <>{JSON.stringify([query1.data, query2.data])}</>;
+    };
+
+    const Wrapped = withTRPC({
+      config: () => trpcClientOptions,
+      ssr: true,
+    })(App);
+
+    const props = await Wrapped.getInitialProps!({
+      AppTree: Wrapped,
+      Component: <div />,
+    } as any);
+
+    // @ts-ignore
+    global.window = window;
+
+    const utils = render(<Wrapped {...props} />);
+    expect(utils.container).toHaveTextContent('first post');
+    expect(utils.container).toHaveTextContent('second post');
+
+    // confirm we've batched if createContext has only been called once
+    expect(createContext).toHaveBeenCalledTimes(1);
+  });
+
+  describe('`enabled: false` on query during ssr', () => {
+    describe('useQuery', () => {
+      test('queryKey does not change', async () => {
+        const { window } = global;
+
+        // @ts-ignore
+        delete global.window;
+        const { trpc, trpcClientOptions } = factory;
+        const App: AppType = () => {
+          const query1 = trpc.postById.useQuery('1');
+          // query2 depends only on query1 status
+          const query2 = trpc.postById.useQuery('2', {
+            enabled: query1.status === 'success',
+          });
+          return (
+            <>
+              <>{JSON.stringify(query1.data)}</>
+              <>{JSON.stringify(query2.data)}</>
+            </>
+          );
+        };
+
+        const Wrapped = withTRPC({
+          config: () => trpcClientOptions,
+          ssr: true,
+        })(App);
+
+        const props = await Wrapped.getInitialProps!({
+          AppTree: Wrapped,
+          Component: <div />,
+        } as any);
+
+        global.window = window;
+
+        const utils = render(<Wrapped {...props} />);
+
+        // when queryKey does not change query2 only fetched in the browser
+        expect(utils.container).toHaveTextContent('first post');
+        expect(utils.container).not.toHaveTextContent('second post');
+
+        await waitFor(() => {
+          expect(utils.container).toHaveTextContent('first post');
+          expect(utils.container).toHaveTextContent('second post');
+        });
+      });
+
+      test('queryKey changes', async () => {
+        const { window } = global;
+
+        // @ts-ignore
+        delete global.window;
+        const { trpc, trpcClientOptions } = factory;
+        const App: AppType = () => {
+          const query1 = trpc.postById.useQuery('1');
+          // query2 depends on data fetched by query1
+          const query2 = trpc.postById.useQuery(
+            // workaround of TS requiring a string param
+            query1.data
+              ? (parseInt(query1.data.id) + 1).toString()
+              : 'definitely not a post id',
+            {
+              enabled: !!query1.data,
+            },
+          );
+          return (
+            <>
+              <>{JSON.stringify(query1.data)}</>
+              <>{JSON.stringify(query2.data)}</>
+            </>
+          );
+        };
+
+        const Wrapped = withTRPC({
+          config: () => trpcClientOptions,
+          ssr: true,
+        })(App);
+
+        const props = await Wrapped.getInitialProps!({
+          AppTree: Wrapped,
+          Component: <div />,
+        } as any);
+
+        global.window = window;
+
+        const utils = render(<Wrapped {...props} />);
+
+        // when queryKey changes both queries are fetched on the server
+        expect(utils.container).toHaveTextContent('first post');
+        expect(utils.container).toHaveTextContent('second post');
+
+        await waitFor(() => {
+          expect(utils.container).toHaveTextContent('first post');
+          expect(utils.container).toHaveTextContent('second post');
+        });
+      });
+    });
+
+    describe('useInfiniteQuery', () => {
+      test('queryKey does not change', async () => {
+        const { window } = global;
+
+        // @ts-ignore
+        delete global.window;
+        const { trpc, trpcClientOptions } = factory;
+        const App: AppType = () => {
+          const query1 = trpc.paginatedPosts.useInfiniteQuery(
+            { limit: 1 },
+            {
+              getNextPageParam: (lastPage) => lastPage.nextCursor,
+            },
+          );
+          // query2 depends only on query1 status
+          const query2 = trpc.paginatedPosts.useInfiniteQuery(
+            { limit: 2 },
+            {
+              getNextPageParam: (lastPage) => lastPage.nextCursor,
+              enabled: query1.status === 'success',
+            },
+          );
+          return (
+            <>
+              <>{JSON.stringify(query1.data)}</>
+              <>{JSON.stringify(query2.data)}</>
+            </>
+          );
+        };
+
+        const Wrapped = withTRPC({
+          config: () => trpcClientOptions,
+          ssr: true,
+        })(App);
+
+        const props = await Wrapped.getInitialProps!({
+          AppTree: Wrapped,
+          Component: <div />,
+        } as any);
+
+        global.window = window;
+
+        const utils = render(<Wrapped {...props} />);
+
+        // when queryKey does not change query2 only fetched in the browser
+        expect(utils.container).toHaveTextContent('first post');
+        expect(utils.container).not.toHaveTextContent('second post');
+
+        await waitFor(() => {
+          expect(utils.container).toHaveTextContent('first post');
+          expect(utils.container).toHaveTextContent('second post');
+        });
+      });
+
+      test('queryKey changes', async () => {
+        const { window } = global;
+
+        // @ts-ignore
+        delete global.window;
+        const { trpc, trpcClientOptions } = factory;
+        const App: AppType = () => {
+          const query1 = trpc.paginatedPosts.useInfiniteQuery(
+            { limit: 1 },
+            {
+              getNextPageParam: (lastPage) => lastPage.nextCursor,
+            },
+          );
+          // query2 depends on data fetched by query1
+          const query2 = trpc.paginatedPosts.useInfiniteQuery(
+            { limit: query1.data ? query1.data.pageParams.length + 1 : 0 },
+            {
+              getNextPageParam: (lastPage) => lastPage.nextCursor,
+              enabled: query1.status === 'success',
+            },
+          );
+          return (
+            <>
+              <>{JSON.stringify(query1.data)}</>
+              <>{JSON.stringify(query2.data)}</>
+            </>
+          );
+        };
+
+        const Wrapped = withTRPC({
+          config: () => trpcClientOptions,
+          ssr: true,
+        })(App);
+
+        const props = await Wrapped.getInitialProps!({
+          AppTree: Wrapped,
+          Component: <div />,
+        } as any);
+
+        global.window = window;
+
+        const utils = render(<Wrapped {...props} />);
+
+        // when queryKey changes both queries are fetched on the server
+        expect(utils.container).toHaveTextContent('first post');
+        expect(utils.container).toHaveTextContent('second post');
+
+        await waitFor(() => {
+          expect(utils.container).toHaveTextContent('first post');
+          expect(utils.container).toHaveTextContent('second post');
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Closes #

## 🎯 Changes

This PR ports  `inference.test.ts`, `links.test.ts`, `outputParser.test.ts`, `withTRPC.test.tsx` to v10
## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.