### PR TITLE
fix: `interop()` types not taking transformers into account

### DIFF
--- a/packages/client/src/internals/TRPCClient.ts
+++ b/packages/client/src/internals/TRPCClient.ts
@@ -3,6 +3,7 @@ import {
   ClientDataTransformerOptions,
   DataTransformer,
   inferProcedureInput,
+  inferProcedureOutput,
   inferSubscriptionOutput,
 } from '@trpc/server';
 import {
@@ -134,7 +135,7 @@ export class TRPCClient<TRouter extends AnyRouter> {
     TPath extends string & keyof TQueries,
     TInput extends inferProcedureInput<TQueries[TPath]>,
   >(path: TPath, input?: TInput, opts?: TRPCRequestOptions) {
-    type TOutput = inferTransformedProcedureOutput<TQueries[TPath]>;
+    type TOutput = inferProcedureOutput<TQueries[TPath]>;
     return this.requestAsPromise<TInput, TOutput>({
       type: 'query',
       path,

--- a/packages/tests/server/interop/regression/issue-3303-transformer.test.ts
+++ b/packages/tests/server/interop/regression/issue-3303-transformer.test.ts
@@ -22,7 +22,14 @@ describe('transformer on legacy router', () => {
       const legacyRouter = interop
         .router<Context>()
         .transformer(superjson)
-        .query('oldProcedure', {
+        .query('oldQuery', {
+          resolve() {
+            return {
+              date: new Date(),
+            };
+          },
+        })
+        .mutation('oldMutation', {
           resolve() {
             return {
               date: new Date(),
@@ -68,7 +75,13 @@ describe('transformer on legacy router', () => {
     .done();
 
   test('call old', async () => {
-    const res = await ctx.client.query('oldProcedure');
-    expectTypeOf(res.date).toEqualTypeOf<string>();
+    {
+      const res = await ctx.client.query('oldQuery');
+      expectTypeOf(res.date).toEqualTypeOf<Date>();
+    }
+    {
+      const res = await ctx.client.mutation('oldMutation');
+      expectTypeOf(res.date).toEqualTypeOf<Date>();
+    }
   });
 });

--- a/packages/tests/server/interop/regression/issue-3303-transformer.test.ts
+++ b/packages/tests/server/interop/regression/issue-3303-transformer.test.ts
@@ -1,15 +1,10 @@
 import { routerToServerAndClientNew } from '../../___testHelpers';
-import { createQueryClient } from '../__queryClient';
-import { QueryClientProvider } from '@tanstack/react-query';
-import { render, waitFor } from '@testing-library/react';
-import { createReactQueryHooks, httpBatchLink } from '@trpc/react-query/src';
+import { httpBatchLink } from '@trpc/react-query/src';
 import * as interop from '@trpc/server/src';
-import { inferProcedureOutput, initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server/src';
 import { expectTypeOf } from 'expect-type';
 import { konn } from 'konn';
-import React, { useState } from 'react';
 import superjson from 'superjson';
-import { z } from 'zod';
 
 type Context = {
   foo: 'bar';

--- a/packages/tests/server/interop/regression/issue-3303-transformer.test.ts
+++ b/packages/tests/server/interop/regression/issue-3303-transformer.test.ts
@@ -1,0 +1,74 @@
+import { routerToServerAndClientNew } from '../../___testHelpers';
+import { createQueryClient } from '../__queryClient';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import { createReactQueryHooks, httpBatchLink } from '@trpc/react-query/src';
+import * as interop from '@trpc/server/src';
+import { inferProcedureOutput, initTRPC } from '@trpc/server/src';
+import { expectTypeOf } from 'expect-type';
+import { konn } from 'konn';
+import React, { useState } from 'react';
+import superjson from 'superjson';
+import { z } from 'zod';
+
+type Context = {
+  foo: 'bar';
+};
+
+describe('transformer on legacy router', () => {
+  const ctx = konn()
+    .beforeEach(() => {
+      const t = initTRPC.context<Context>().create();
+      const legacyRouter = interop
+        .router<Context>()
+        .transformer(superjson)
+        .query('oldProcedure', {
+          resolve() {
+            return {
+              date: new Date(),
+            };
+          },
+        });
+
+      const newAppRouter = t.router({
+        newProcedure: t.procedure.query(() => {
+          date: new Date();
+        }),
+      });
+
+      const appRouter = t.mergeRouters(legacyRouter.interop(), newAppRouter);
+
+      const opts = routerToServerAndClientNew(appRouter, {
+        server: {
+          createContext() {
+            return {
+              foo: 'bar',
+            };
+          },
+        },
+        client({ httpUrl }) {
+          return {
+            transformer: superjson,
+            links: [
+              httpBatchLink({
+                url: httpUrl,
+              }),
+            ],
+          };
+        },
+      });
+      return {
+        ...opts,
+        appRouter,
+      };
+    })
+    .afterEach(async (ctx) => {
+      await ctx?.close?.();
+    })
+    .done();
+
+  test('call old', async () => {
+    const res = await ctx.client.query('oldProcedure');
+    expectTypeOf(res.date).toEqualTypeOf<string>();
+  });
+});


### PR DESCRIPTION
Closes #3303

## 🎯 Changes

This changes so the `TRPCClient` uses the old behavior of not taking into account transformers (introduced in [10.2.0](https://github.com/trpc/trpc/releases/tag/v10.2.0)).

The `TRPCClient`'s types are not used outside of v9 stuff and are overridden by the proxy.


Technically, this is a tiny regression from `10.2.0` where some people using interop and _not_ using superjson might notice something, but it just really regressed to the behaviour the would've had a few days ago