### PR TITLE
fix: type inference fails when not using a transformer

### DIFF
--- a/packages/server/src/core/types.ts
+++ b/packages/server/src/core/types.ts
@@ -1,4 +1,5 @@
 import { inferObservableValue } from '../observable';
+import { inferTransformedProcedureOutput } from '../shared';
 import { AnyProcedure, ProcedureArgs } from './procedure';
 import { AnyRouter, AnyRouterDef, Router } from './router';
 
@@ -59,7 +60,7 @@ type GetInferenceHelpers<
       : TRouterOrProcedure extends AnyProcedure
       ? TType extends 'input'
         ? inferProcedureInput<TRouterOrProcedure>
-        : inferProcedureOutput<TRouterOrProcedure>
+        : inferTransformedProcedureOutput<TRouterOrProcedure>
       : never
     : never;
 };

--- a/packages/tests/server/regression/serializable-inference.test.tsx
+++ b/packages/tests/server/regression/serializable-inference.test.tsx
@@ -1,0 +1,111 @@
+import { routerToServerAndClientNew } from '../___testHelpers';
+import { httpLink } from '@trpc/client';
+import { inferRouterOutputs, initTRPC } from '@trpc/server/src';
+import { expectTypeOf } from 'expect-type';
+import { konn } from 'konn';
+import superjson from 'superjson';
+
+describe('without transformer', () => {
+  const t = initTRPC.create();
+  const appRouter = t.router({
+    greeting: t.procedure.query(() => {
+      return {
+        message: 'hello',
+        date: new Date(),
+      };
+    }),
+  });
+  const ctx = konn()
+    .beforeEach(() => {
+      const opts = routerToServerAndClientNew(appRouter, {
+        client({ httpUrl }) {
+          return {
+            links: [
+              httpLink({
+                url: httpUrl,
+                headers() {
+                  throw new Error('Bad headers fn');
+                },
+              }),
+            ],
+          };
+        },
+      });
+
+      return opts;
+    })
+    .afterEach(async (ctx) => {
+      await ctx?.close?.();
+    })
+    .done();
+
+  test('output', async () => {
+    const { proxy } = ctx;
+
+    type Output = inferRouterOutputs<typeof appRouter>['greeting'];
+    expectTypeOf<Output>().toEqualTypeOf<{
+      message: string;
+      date: string;
+    }>();
+
+    const res = await proxy.greeting.query();
+    expectTypeOf(res).toEqualTypeOf<{
+      message: string;
+      date: string;
+    }>();
+  });
+});
+
+describe('with transformer', () => {
+  const t = initTRPC.create({
+    transformer: superjson,
+  });
+  const appRouter = t.router({
+    greeting: t.procedure.query(() => {
+      return {
+        message: 'hello',
+        date: new Date(),
+      };
+    }),
+  });
+  const ctx = konn()
+    .beforeEach(() => {
+      const opts = routerToServerAndClientNew(appRouter, {
+        client({ httpUrl }) {
+          return {
+            transformer: superjson,
+            links: [
+              httpLink({
+                url: httpUrl,
+                headers() {
+                  throw new Error('Bad headers fn');
+                },
+              }),
+            ],
+          };
+        },
+      });
+
+      return opts;
+    })
+    .afterEach(async (ctx) => {
+      await ctx?.close?.();
+    })
+    .done();
+
+  test('output', async () => {
+    const { proxy } = ctx;
+
+    type Output = inferRouterOutputs<typeof appRouter>['greeting'];
+    expectTypeOf<Output>().toEqualTypeOf<{
+      message: string;
+      date: Date;
+    }>();
+
+    const res = await proxy.greeting.query();
+    expectTypeOf(res).toEqualTypeOf<{
+      message: string;
+      date: Date;
+    }>();
+  });
+});

--- a/packages/tests/server/regression/serializable-inference.test.tsx
+++ b/packages/tests/server/regression/serializable-inference.test.tsx
@@ -23,9 +23,6 @@ describe('without transformer', () => {
             links: [
               httpLink({
                 url: httpUrl,
-                headers() {
-                  throw new Error('Bad headers fn');
-                },
               }),
             ],
           };
@@ -77,9 +74,6 @@ describe('with transformer', () => {
             links: [
               httpLink({
                 url: httpUrl,
-                headers() {
-                  throw new Error('Bad headers fn');
-                },
               }),
             ],
           };


### PR DESCRIPTION
Regression from #3261 

Inferred types were serialized even when there wasn't a transformer defined

Same bug as found here: https://github.com/trpc/trpc/pull/3298#pullrequestreview-1200729879