### PR TITLE
feat: Allow subset of router's context when creating SSG helpers

### DIFF
--- a/packages/react-query/src/ssg/ssgProxy.ts
+++ b/packages/react-query/src/ssg/ssgProxy.ts
@@ -62,8 +62,8 @@ type AnyDecoratedProcedure = DecorateProcedure<any>;
 /**
  * Create functions you can use for server-side rendering / static generation
  */
-export function createProxySSGHelpers<TRouter extends AnyRouter>(
-  opts: CreateSSGHelpersOptions<TRouter>,
+export function createProxySSGHelpers<TRouter extends AnyRouter, TContext>(
+  opts: CreateSSGHelpersOptions<TRouter, TContext>,
 ) {
   const helpers = createSSGHelpers(opts);
 

--- a/packages/tests/server/react/ssg.test.ts
+++ b/packages/tests/server/react/ssg.test.ts
@@ -1,10 +1,30 @@
 import { InfiniteData } from '@tanstack/react-query';
 import { createProxySSGHelpers } from '@trpc/react-query/src/ssg/ssgProxy';
-import { initTRPC } from '@trpc/server/src';
+import { inferAsyncReturnType, initTRPC } from '@trpc/server/src';
 import { expectTypeOf } from 'expect-type';
+import { CreateNextContextOptions } from 'packages/server/src/adapters/next';
 import { z } from 'zod';
 
-const t = initTRPC.create();
+async function createContextInner() {
+  return {
+    inner: 'inner value',
+  };
+}
+
+async function createContext(opts: CreateNextContextOptions) {
+  const contextInner = await createContextInner();
+
+  return {
+    ...contextInner,
+    outer: 'outer value',
+    req: opts.req,
+    res: opts.res,
+  };
+}
+
+export type Context = inferAsyncReturnType<typeof createContext>;
+
+const t = initTRPC.context<Context>().create();
 
 const appRouter = t.router({
   post: t.router({
@@ -55,4 +75,23 @@ test('prefetchInfinite and dehydrate', async () => {
 
   const data = JSON.stringify(ssg.dehydrate());
   expect(data).toContain('__infResult');
+});
+
+describe('Creating SSG helpers infers the given context type', () => {
+  test('happy path', async () => {
+    createProxySSGHelpers({
+      router: appRouter,
+      ctx: await createContextInner(),
+    });
+  });
+
+  test("given context is not a subset of router's context", async () => {
+    createProxySSGHelpers({
+      router: appRouter,
+      // @ts-expect-error The given context is wrong on purpose.
+      ctx: {
+        wrong: 'on purpose',
+      },
+    });
+  });
 });


### PR DESCRIPTION
## 🎯 Changes

This change infers the given context type when creating SSG helpers. The inferred type must be a subset of the router's context, otherwise the user will see the following error message via the type error:

"_The context you have given is either not a direct match or not a subset of the router's context._"

### Why I want this

- In my router context, I want to set the Next.js `req` and `res` , so I can easily use it in my procedures (e.g. for auth).
- I want to use SSG helpers for both `getServerSideProps` and also `getStaticProps`.


This setup means that some context usages have `req` & `res` and some have not.
I created an inner context creator to mitigate that:

```ts
export async function createContextTRPCInner() {
  return {
    prisma,
  }
}

export async function createContextTRPC(opts: CreateNextContextOptions) {
  const contextInner = await createContextTRPCInner()

  return {
    ...contextInner,
    req: opts.req,
    res: opts.res,
  }
}

export type ContextTRPC = inferAsyncReturnType<typeof createContextTRPC>
```

I use `createContextTRPC` for my routers, as they all have `req` & `res`.

I **wanted** to use `createContextTRPCInner` for the cases where I don't have `req` & `res`, but it won't work: When using `createProxySSGHelpers`, it expects to be passed the context.
But right now, it infers the context type directly from the router, see https://github.com/trpc/trpc/blob/main/packages/react-query/src/ssg/ssg.ts#L20.

### Result of this change

This change will instead infer the context from the giving parameters of `createProxySSGHelpers`.

Here's the error message shown to the user when he tries to give a context that is not a subset of the router's context:

![image](https://user-images.githubusercontent.com/29319414/205141978-56f0a60f-96c3-4a30-a96d-9a53b5631d49.png)

![image](https://user-images.githubusercontent.com/29319414/205142042-a25a3a4b-cbee-43fe-8e7a-c3365f1f293c.png)




### Open topics

- [ ] There's an error shown [in the test I've added](https://github.com/trpc/trpc/blob/3c69cc0643a6e131d87a5d277b3d0165828a6f04/packages/tests/server/react/ssg.test.ts#L14) in my editor, but I don't know what it means:
  
  ![image](https://user-images.githubusercontent.com/29319414/205142162-1630d831-92d6-4ba5-b7e8-79ef0c13dd90.png)



## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.