### PR TITLE
fix: `TRPCError.cause` should be `undefined` when no cause is set

### DIFF
--- a/packages/server/src/error/TRPCError.ts
+++ b/packages/server/src/error/TRPCError.ts
@@ -17,7 +17,7 @@ export class TRPCError extends Error {
     const message =
       opts.message ?? getMessageFromUnknownError(opts.cause, code);
     const cause: Error | undefined =
-      opts !== undefined ? getErrorFromUnknown(opts.cause) : undefined;
+      opts.cause !== undefined ? getErrorFromUnknown(opts.cause) : undefined;
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore https://github.com/tc39/proposal-error-cause

--- a/packages/tests/server/regression/issue-3351-TRPCError.test.ts
+++ b/packages/tests/server/regression/issue-3351-TRPCError.test.ts
@@ -1,0 +1,9 @@
+import '../___testHelpers';
+import { TRPCError } from '@trpc/server';
+
+test('getErrorFromUnknown', async () => {
+  const err = new TRPCError({
+    code: 'INTERNAL_SERVER_ERROR',
+  });
+  expect(err.cause).toBeUndefined();
+});

--- a/packages/tests/server/regression/issue-3351-TRPCError.test.ts
+++ b/packages/tests/server/regression/issue-3351-TRPCError.test.ts
@@ -1,7 +1,7 @@
 import '../___testHelpers';
 import { TRPCError } from '@trpc/server';
 
-test('getErrorFromUnknown', async () => {
+test('TRPCError cause', async () => {
   const err = new TRPCError({
     code: 'INTERNAL_SERVER_ERROR',
   });


### PR DESCRIPTION
Closes #3351