### PR TITLE
chore: Use setup-node action to cache dependencies

### DIFF
--- a/.github/workflows/examples-old-nodes.yml
+++ b/.github/workflows/examples-old-nodes.yml
@@ -24,21 +24,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        run: |
-          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v3
-        name: Setup pnpm cache
-        with:
-          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-pnpm-store-${{ matrix.dir }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-${{ matrix.dir }}-
+          cache: pnpm
 
       - run: node -v
+
       - name: Install deps (with cache)
         run: pnpm --filter ./examples/${{ matrix.dir }}  --filter "@trpc/*" --filter "!@trpc/tests" --filter root install
 
@@ -61,6 +50,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-start }}
+          cache: pnpm
 
       - run: node -v
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -49,22 +49,11 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        run: |
-          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v3
-        name: Setup pnpm cache
-        with:
-          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-pnpm-store-${{ matrix.dir }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-${{ matrix.dir }}-
+          node-version: ${{ matrix.node-start }}
+          cache: pnpm
 
       - run: node -v
+
       - name: Install deps (with cache)
         run: pnpm --filter "./examples/${{ matrix.dir }}/**"  --filter "@trpc/*" --filter "!@trpc/tests" --filter root install
 
@@ -84,11 +73,6 @@ jobs:
         with:
           path: ${{ github.workspace }}/examples/${{ matrix.dir }}/.next/cache
           key: ${{ matrix.dir }}-${{ runner.os }}-${{ matrix.node-start }}-${{ hashFiles('**/pnpm-lock.yaml') }}-nextjs
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-start }}
-          cache: 'pnpm'
 
       - run: node -v
 
@@ -130,37 +114,21 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: ${{ matrix.node-start }}
+          cache: pnpm
 
       - uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
 
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        run: |
-          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v3
-        name: Setup pnpm cache
-        with:
-          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-pnpm-store-${{ matrix.dir }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-${{ matrix.dir }}-
-
       - run: node -v
+
       - name: Install deps (with cache)
         run: pnpm --filter "./examples/${{ matrix.dir }}/**"  --filter "@trpc/*" --filter "!@trpc/tests" --filter root install
 
 
       - name: Build trpc
         run: pnpm turbo --filter "@trpc/*" build
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-start }}
-          cache: 'pnpm'
 
       - run: deno --version
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,19 +21,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        run: |
-          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v3
-        name: Setup pnpm cache
-        with:
-          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-pnpm-store-all-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-all-
+          cache: pnpm
 
       - name: Install deps (with cache)
         run: pnpm install --child-concurrency 3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,19 +32,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        run: |
-          echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v3
-        name: Setup pnpm cache
-        with:
-          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-pnpm-store-trpc-main-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-trpc-main-
+          cache: pnpm
 
       - name: Install deps (with cache)
         run: pnpm --filter "@trpc/*" --filter root install


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## 🎯 Changes

Updated workflows to cache dependencies using [actions/setup-node](https://github.com/actions/setup-node#caching-global-packages-data). `setup-node@v3` or newer has caching **built-in**.

### AS-IS

```yaml
- uses: actions/setup-node@v3
  with:
    node-version: 18.x

- name: Get pnpm store directory
  id: pnpm-cache
  run: |
    echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
- uses: actions/cache@v3
  name: Setup pnpm cache
  with:
    path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
    key: ${{ runner.os }}-pnpm-store-${{ matrix.dir }}-${{ hashFiles('**/pnpm-lock.yaml') }}
    restore-keys: |
      ${{ runner.os }}-pnpm-store-${{ matrix.dir }}-
```

### TO-BE

```yml
- uses: actions/setup-node@v3
  with:
    node-version: 18.x
    cache: pnpm
```

> It’s literally a one line change to pass the `cache: pnpm` input parameter.

## References

- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
- [https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/](https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/)

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.