### PR TITLE
Fix path to next-prisma-websockets-starter

### DIFF
--- a/www/docs/main/example-apps.mdx
+++ b/www/docs/main/example-apps.mdx
@@ -64,21 +64,21 @@ git clone git@github.com:t3-oss/create-t3-turbo.git
   <TabItem value="npm" label="npm" default>
 
 ```bash
-npx create-next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-starter-websockets trpc-prisma-starter-websockets
+npx create-next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-websockets-starter trpc-prisma-websockets-starter
 ```
 
   </TabItem>
   <TabItem value="yarn" label="yarn">
 
 ```sh
-yarn create next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-starter-websockets trpc-prisma-starter-websockets
+yarn create next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-websockets-starter trpc-prisma-websockets-starter
 ```
 
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
 
 ```sh
-pnpx create-next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-starter-websockets trpc-prisma-starter-websockets
+pnpx create-next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-websockets-starter trpc-prisma-websockets-starter
 ```
 
   </TabItem>


### PR DESCRIPTION
## 🎯 Changes
* Path in the docs does not match path from the examples folder: https://github.com/trpc/trpc/tree/main/examples
* Here's the correct path: https://github.com/trpc/trpc/tree/main/examples/next-prisma-websockets-starter

I've just changed two words around so that the starter file for websockets has the correct path.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x]  (not needed) If necessary, I have added documentation related to the changes made.
- [x]  (not needed) I have added or updated the tests related to the changes made.