### PR TITLE
fix(docs): change typo`initTRPC()` to `initTRPC`

### DIFF
--- a/www/docs/server/router.md
+++ b/www/docs/server/router.md
@@ -68,7 +68,7 @@ When initializing your router, tRPC allows you to:
 You can use method chaining to customize your `t`-object on initialization. For example:
 
 ```ts
-const t = initTRPC().context<Context>().meta<Meta>().create({
+const t = initTRPC.context<Context>().meta<Meta>().create({
   /* [...] */
 });
 ```


### PR DESCRIPTION
## 🎯 Changes

`initTRPC` is not callable, as TS and the other examples show.