### PR TITLE
fix(docs): clarify `cursor`-type in `useInfiniteQuery`

### DIFF
--- a/www/docs/reactjs/useInfiniteQuery.md
+++ b/www/docs/reactjs/useInfiniteQuery.md
@@ -7,7 +7,7 @@ slug: /useInfiniteQuery
 
 :::info
 
-- Your procedure needs to accept a `cursor` input of `any` type
+- Your procedure needs to accept a `cursor` input of any type (`string`, `number`, etc)
 - For more details on infinite queries read the [react-query docs](https://react-query.tanstack.com/reference/useInfiniteQuery)
 - In this example we're using Prisma - see their docs on [cursor-based pagination](https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination)
 


### PR DESCRIPTION
Ref: 

        Hmm I see why I did that. The [docs](https://trpc.io/docs/useInfiniteQuery) say

>  Your procedure needs to accept a `cursor` input of `any` type

and while I see now `lastPage` isn't a reference to the cursor, maybe the markdown code syntax around "any" is confusing when `any` is itself a type that breaks everything.

_Originally posted by @givensuman in https://github.com/trpc/trpc/issues/3428#issuecomment-1358714783_
      