### PR TITLE
readme: add dark mode image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-[![tRPC](https://assets.trpc.io/www/trpc-readme.png)](https://trpc.io/)
+<a href="https://trpc.io/" target="_blank" rel="noopener">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://assets.trpc.io/www/trpc-readme-dark.png" />
+    <img alt="tRPC" src="https://assets.trpc.io/www/trpc-readme.png" />
+  </picture>
+</a>
 
 <div align="center">
   <h1>tRPC</h1>


### PR DESCRIPTION
## 🎯 Changes

This PR adds dark mode image for readme

https://user-images.githubusercontent.com/62795688/208726965-ae25fb93-68d0-42de-a89c-f71daa34f5e7.mp4




## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.