### PR TITLE
passing options onto use client for mutation override

### DIFF
--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -498,7 +498,10 @@ export function createHooksInternal<
     TContext
   > {
     const { client } = useContext();
-    const queryClient = useQueryClient({ context: ReactQueryContext });
+    const queryClient = useQueryClient({  
+      context: ReactQueryContext,
+      ...opts, 
+    });
 
     const hook = __useMutation(
       (input) => {


### PR DESCRIPTION
Closes #

## 🎯 Changes

Passing options set in a useMutation query to the useQueryClient that is used within the mutationSuccessOverrride 

What changes are made in this PR? Is it a feature or a bug fix? Bug Fix

## ✅ Checklist

- [ ✅] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [✅ ] If necessary, I have added documentation related to the changes made.
- [ ✅] I have added or updated the tests related to the changes made.