### PR TITLE
feat(server): ability to have `context`  & `meta` as `interface`s

### DIFF
--- a/packages/server/src/core/internals/config.ts
+++ b/packages/server/src/core/internals/config.ts
@@ -5,8 +5,8 @@ import { ErrorFormatter } from '../../error/formatter';
  * @internal
  */
 export interface RootConfigTypes {
-  ctx: Record<string, unknown>;
-  meta: Record<string, unknown>;
+  ctx: Record<any, unknown>;
+  meta: Record<any, unknown>;
   errorShape: unknown;
   transformer: unknown;
 }

--- a/packages/server/src/core/internals/config.ts
+++ b/packages/server/src/core/internals/config.ts
@@ -5,8 +5,8 @@ import { ErrorFormatter } from '../../error/formatter';
  * @internal
  */
 export interface RootConfigTypes {
-  ctx: Record<any, unknown>;
-  meta: Record<any, unknown>;
+  ctx: {};
+  meta: {};
   errorShape: unknown;
   transformer: unknown;
 }

--- a/packages/tests/server/regression/issue-3453-meta-interface.test.ts
+++ b/packages/tests/server/regression/issue-3453-meta-interface.test.ts
@@ -1,0 +1,16 @@
+import '../___packages';
+import { initTRPC } from '@trpc/server';
+
+test('meta as interface', () => {
+  interface Meta {
+    foo: 'bar';
+  }
+  initTRPC.meta<Meta>();
+});
+
+test('context as interface', () => {
+  interface Context {
+    foo: 'bar';
+  }
+  initTRPC.context<Context>();
+});

--- a/packages/tests/server/responseMeta.test.ts
+++ b/packages/tests/server/responseMeta.test.ts
@@ -3,12 +3,17 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { routerToServerAndClientNew } from './___testHelpers';
 import { initTRPC } from '@trpc/server/src';
+import { IncomingMessage, ServerResponse } from 'http';
 import fetch from 'node-fetch';
 
 test('set custom headers in beforeEnd', async () => {
   const onError = jest.fn();
 
-  const t = initTRPC.context().create();
+  interface Context {
+    req: IncomingMessage;
+    res: ServerResponse<IncomingMessage>;
+  }
+  const t = initTRPC.context<Context>().create();
 
   const appRouter = t.router({
     ['public.q']: t.procedure.query(({}) => {


### PR DESCRIPTION
Closes #3453

## 🎯 Changes

We should be able to use `interface` to type `meta` & `context`

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.