### PR TITLE
chore: enable typescript-eslint/recommended-requiring-type-checking

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,9 @@
 {
-  "parser": "@typescript-eslint/parser", // Specifies the ESLint parser
+  "parser": "@typescript-eslint/parser",
   "plugins": ["no-only-tests", "unicorn", "turbo"],
   "extends": [
-    "plugin:@typescript-eslint/recommended", // Uses the recommended rules from the @typescript-eslint/eslint-plugin
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:prettier/recommended"
@@ -19,7 +20,6 @@
     "react/react-in-jsx-scope": "off",
     "react/prop-types": "off",
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-floating-promises": "error",
     "no-only-tests/no-only-tests": "error",
     "@typescript-eslint/no-empty-interface": "off",
     "unicorn/filename-case": [
@@ -60,10 +60,27 @@
   },
   "overrides": [
     {
+      "files": ["examples/**/*", "packages/*/**/*", "scripts/**/*", "www/**/*"],
+      "rules": {
+        // Todo: enable these for even stronger linting! 💪
+        "@typescript-eslint/no-misused-promises": "off",
+        "@typescript-eslint/no-unsafe-argument": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/no-unsafe-call": "off",
+        "@typescript-eslint/no-unsafe-declaration-merging": "off",
+        "@typescript-eslint/no-unsafe-member-access": "off",
+        "@typescript-eslint/no-unsafe-return": "off",
+        "@typescript-eslint/require-await": "off",
+        "@typescript-eslint/restrict-plus-operands": "off",
+        "@typescript-eslint/restrict-template-expressions": "off"
+      }
+    },
+    {
       "files": ["examples/**/*"],
       "rules": {
-        "@typescript-eslint/no-unused-vars": "off",
-        "@typescript-eslint/no-floating-promises": "off"
+        // Todo: enable these for even stronger linting! 💪
+        "@typescript-eslint/no-floating-promises": "off",
+        "@typescript-eslint/no-unused-vars": "off"
       }
     },
     {

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install deps (with cache)
         run: pnpm install --child-concurrency 3
 
+      - name: Build
+        run: pnpm turbo --filter "@trpc/*" build
+
       - name: Run ESLint
         run: pnpm lint
 

--- a/examples/next-prisma-todomvc/src/pages/[filter].tsx
+++ b/examples/next-prisma-todomvc/src/pages/[filter].tsx
@@ -278,8 +278,7 @@ export default function TodosPage({
               <Link
                 href="/all"
                 className={clsx(
-                  !['active', 'completed'].includes(filter as string) &&
-                    'selected',
+                  !['active', 'completed'].includes(filter) && 'selected',
                 )}
               >
                 All

--- a/packages/next/src/createTRPCNext.tsx
+++ b/packages/next/src/createTRPCNext.tsx
@@ -69,6 +69,6 @@ export function createTRPCNext<
       return _withTRPC;
     }
 
-    return createReactProxyDecoration(key as string, hooks);
+    return createReactProxyDecoration(key, hooks);
   });
 }

--- a/packages/next/src/withTRPC.tsx
+++ b/packages/next/src/withTRPC.tsx
@@ -122,8 +122,7 @@ export function withTRPC<
       const { queryClient, trpcClient, ssrState, ssrContext } = prepassProps;
       const hydratedState = trpc.useDehydratedState(
         trpcClient,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (props.pageProps as any).trpcState,
+        props.pageProps.trpcState,
       );
 
       return (

--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -219,7 +219,7 @@ export function createHooksInternalProxy<
       return (trpc as any)[key];
     }
 
-    return createReactProxyDecoration(key as string, trpc);
+    return createReactProxyDecoration(key, trpc);
   });
 }
 

--- a/packages/react-query/src/internals/context.tsx
+++ b/packages/react-query/src/internals/context.tsx
@@ -87,6 +87,24 @@ export const contextProps: (keyof ProxyTRPCContextProps<any, any>)[] = [
 ];
 
 /** @internal */
+export type TRPCContextResetQueries<TRouter extends AnyRouter> =
+  /**
+   * @link https://react-query.tanstack.com/reference/QueryClient#queryclientresetqueries
+   */
+  (<
+    TPath extends keyof TRouter['_def']['queries'] & string,
+    TInput extends inferProcedureInput<TRouter['_def']['queries'][TPath]>,
+  >(
+    pathAndInput?: [TPath, TInput?] | TPath,
+    filters?: ResetQueryFilters,
+    options?: ResetOptions,
+  ) => Promise<void>) &
+    /**
+     * @link https://react-query.tanstack.com/reference/QueryClient#queryclientresetqueries
+     */
+    ((filters?: ResetQueryFilters, options?: ResetOptions) => Promise<void>);
+
+/** @internal */
 export interface TRPCContextState<
   TRouter extends AnyRouter,
   TSSRContext = undefined,
@@ -94,7 +112,7 @@ export interface TRPCContextState<
   /**
    * @link https://tanstack.com/query/v4/docs/reference/QueryClient#queryclientfetchquery
    */
-  fetchQuery<
+  fetchQuery: <
     TPath extends keyof TRouter['_def']['queries'] & string,
     TProcedure extends TRouter['_def']['queries'][TPath],
     TOutput extends inferTransformedProcedureOutput<TProcedure>,
@@ -102,11 +120,11 @@ export interface TRPCContextState<
   >(
     pathAndInput: [path: TPath, ...args: inferHandlerInput<TProcedure>],
     opts?: TRPCFetchQueryOptions<TInput, TRPCClientError<TRouter>, TOutput>,
-  ): Promise<TOutput>;
+  ) => Promise<TOutput>;
   /**
    * @link https://tanstack.com/query/v4/docs/reference/QueryClient#queryclientfetchinfinitequery
    */
-  fetchInfiniteQuery<
+  fetchInfiniteQuery: <
     TPath extends keyof TRouter['_def']['queries'] & string,
     TProcedure extends TRouter['_def']['queries'][TPath],
     TOutput extends inferTransformedProcedureOutput<TProcedure>,
@@ -118,11 +136,11 @@ export interface TRPCContextState<
       TRPCClientError<TRouter>,
       TOutput
     >,
-  ): Promise<InfiniteData<TOutput>>;
+  ) => Promise<InfiniteData<TOutput>>;
   /**
    * @link https://react-query.tanstack.com/guides/prefetching
    */
-  prefetchQuery<
+  prefetchQuery: <
     TPath extends keyof TRouter['_def']['queries'] & string,
     TProcedure extends TRouter['_def']['queries'][TPath],
     TOutput extends inferTransformedProcedureOutput<TProcedure>,
@@ -130,12 +148,12 @@ export interface TRPCContextState<
   >(
     pathAndInput: [path: TPath, ...args: inferHandlerInput<TProcedure>],
     opts?: TRPCFetchQueryOptions<TInput, TRPCClientError<TRouter>, TOutput>,
-  ): Promise<void>;
+  ) => Promise<void>;
 
   /**
    * @link https://tanstack.com/query/v4/docs/reference/QueryClient#queryclientprefetchinfinitequery
    */
-  prefetchInfiniteQuery<
+  prefetchInfiniteQuery: <
     TPath extends keyof TRouter['_def']['queries'] & string,
     TProcedure extends TRouter['_def']['queries'][TPath],
     TOutput extends inferTransformedProcedureOutput<TProcedure>,
@@ -147,39 +165,24 @@ export interface TRPCContextState<
       TRPCClientError<TRouter>,
       TOutput
     >,
-  ): Promise<void>;
+  ) => Promise<void>;
 
   /**
    * @link https://react-query.tanstack.com/guides/query-invalidation
    */
-  invalidateQueries<
+  invalidateQueries: <
     TPath extends keyof TRouter['_def']['queries'] & string,
     TInput extends inferProcedureInput<TRouter['_def']['queries'][TPath]>,
   >(
     pathAndInput?: [TPath, TInput?] | TPath,
     filters?: InvalidateQueryFilters,
     options?: InvalidateOptions,
-  ): Promise<void>;
+  ) => Promise<void>;
 
   /**
    * @link https://react-query.tanstack.com/reference/QueryClient#queryclientresetqueries
    */
-  resetQueries<
-    TPath extends keyof TRouter['_def']['queries'] & string,
-    TInput extends inferProcedureInput<TRouter['_def']['queries'][TPath]>,
-  >(
-    pathAndInput?: [TPath, TInput?] | TPath,
-    filters?: ResetQueryFilters,
-    options?: ResetOptions,
-  ): Promise<void>;
-
-  /**
-   * @link https://react-query.tanstack.com/reference/QueryClient#queryclientresetqueries
-   */
-  resetQueries(
-    filters?: ResetQueryFilters,
-    options?: ResetOptions,
-  ): Promise<void>;
+  resetQueries: TRPCContextResetQueries<TRouter>;
 
   /**
    * @link https://react-query.tanstack.com/reference/QueryClient#queryclientrefetchqueries
@@ -203,17 +206,17 @@ export interface TRPCContextState<
   /**
    * @link https://react-query.tanstack.com/guides/query-cancellation
    */
-  cancelQuery<
+  cancelQuery: <
     TPath extends keyof TRouter['_def']['queries'] & string,
     TInput extends inferProcedureInput<TRouter['_def']['queries'][TPath]>,
   >(
     pathAndInput: [TPath, TInput?],
     options?: CancelOptions,
-  ): Promise<void>;
+  ) => Promise<void>;
   /**
    * @link https://react-query.tanstack.com/reference/QueryClient#queryclientsetquerydata
    */
-  setQueryData<
+  setQueryData: <
     TPath extends keyof TRouter['_def']['queries'] & string,
     TInput extends inferProcedureInput<TRouter['_def']['queries'][TPath]>,
     TOutput extends inferTransformedProcedureOutput<
@@ -223,11 +226,11 @@ export interface TRPCContextState<
     pathAndInput: [TPath, TInput?],
     updater: Updater<TOutput | undefined, TOutput | undefined>,
     options?: SetDataOptions,
-  ): void;
+  ) => void;
   /**
    * @link https://react-query.tanstack.com/reference/QueryClient#queryclientgetquerydata
    */
-  getQueryData<
+  getQueryData: <
     TPath extends keyof TRouter['_def']['queries'] & string,
     TInput extends inferProcedureInput<TRouter['_def']['queries'][TPath]>,
     TOutput extends inferTransformedProcedureOutput<
@@ -235,11 +238,11 @@ export interface TRPCContextState<
     >,
   >(
     pathAndInput: [TPath, TInput?],
-  ): TOutput | undefined;
+  ) => TOutput | undefined;
   /**
    * @link https://react-query.tanstack.com/reference/QueryClient#queryclientsetquerydata
    */
-  setInfiniteQueryData<
+  setInfiniteQueryData: <
     TPath extends keyof TRouter['_def']['queries'] & string,
     TInput extends inferProcedureInput<TRouter['_def']['queries'][TPath]>,
     TOutput extends inferTransformedProcedureOutput<
@@ -252,11 +255,11 @@ export interface TRPCContextState<
       InfiniteData<TOutput> | undefined
     >,
     options?: SetDataOptions,
-  ): void;
+  ) => void;
   /**
    * @link https://react-query.tanstack.com/reference/QueryClient#queryclientgetquerydata
    */
-  getInfiniteQueryData<
+  getInfiniteQueryData: <
     TPath extends keyof TRouter['_def']['queries'] & string,
     TInput extends inferProcedureInput<TRouter['_def']['queries'][TPath]>,
     TOutput extends inferTransformedProcedureOutput<
@@ -264,7 +267,7 @@ export interface TRPCContextState<
     >,
   >(
     pathAndInput: [TPath, TInput?],
-  ): InfiniteData<TOutput> | undefined;
+  ) => InfiniteData<TOutput> | undefined;
 }
 
 export const TRPCContext = createContext(null as any);

--- a/packages/server/src/adapters/standalone.ts
+++ b/packages/server/src/adapters/standalone.ts
@@ -47,7 +47,7 @@ export function createHTTPServer<TRouter extends AnyRouter>(
 
   return {
     server,
-    listen(port?: number) {
+    listen: (port?: number) => {
       server.listen(port);
       const actualPort =
         port === 0 ? ((server.address() as any).port as number) : port;

--- a/packages/server/src/http/resolveHTTPResponse.ts
+++ b/packages/server/src/http/resolveHTTPResponse.ts
@@ -168,7 +168,7 @@ export async function resolveHTTPResponse<
       const input: Record<number, unknown> = {};
       for (const key in rawInput) {
         const k = key as any as number;
-        const rawValue = (rawInput as any)[k];
+        const rawValue = rawInput[k];
 
         const value = deserializeInputValue(rawValue);
 

--- a/packages/server/src/internals/invert.ts
+++ b/packages/server/src/internals/invert.ts
@@ -9,7 +9,7 @@ type Invert<TType extends Record<PropertyKey, PropertyKey>> = {
 export function invert<TRecord extends Record<PropertyKey, PropertyKey>>(
   obj: TRecord,
 ): Invert<TRecord> {
-  const newObj = Object.create(null) as any;
+  const newObj = Object.create(null);
   for (const key in obj) {
     const v = obj[key];
     newObj[v] = key;

--- a/packages/tests/server/adapters/fastify.test.ts
+++ b/packages/tests/server/adapters/fastify.test.ts
@@ -199,9 +199,7 @@ describe('anonymous user', () => {
     await app.start();
   });
 
-  afterEach(async () => {
-    await app.stop();
-  });
+  afterEach(() => app.stop());
 
   test('fetch POST', async () => {
     const data = { text: 'life', life: 42 };
@@ -327,9 +325,7 @@ describe('authorized user', () => {
     await app.start();
   });
 
-  afterEach(async () => {
-    await app.stop();
-  });
+  afterEach(() => app.stop());
 
   test('query', async () => {
     expect(await app.client.hello.query()).toMatchInlineSnapshot(`
@@ -361,9 +357,7 @@ describe('anonymous user with fastify-plugin', () => {
     await app.start();
   });
 
-  afterEach(async () => {
-    await app.stop();
-  });
+  afterEach(() => app.stop());
 
   test('fetch GET', async () => {
     const req = await fetch(`http://localhost:${config.port}/hello`);

--- a/packages/tests/server/errors.test.ts
+++ b/packages/tests/server/errors.test.ts
@@ -159,7 +159,7 @@ describe('formatError()', () => {
       proxy.err.mutate(1 as any),
       TRPCClientError,
     );
-    delete (clientError.data as any).stack;
+    delete clientError.data.stack;
     expect(clientError.data).toMatchInlineSnapshot(`
 Object {
   "code": "BAD_REQUEST",

--- a/packages/tests/server/interop/adapters/fastify.test.ts
+++ b/packages/tests/server/interop/adapters/fastify.test.ts
@@ -196,9 +196,7 @@ describe('anonymous user', () => {
     await app.start();
   });
 
-  afterEach(async () => {
-    await app.stop();
-  });
+  afterEach(() => app.stop());
 
   test('fetch POST', async () => {
     const data = { text: 'life', life: 42 };
@@ -324,9 +322,7 @@ describe('authorized user', () => {
     await app.start();
   });
 
-  afterEach(async () => {
-    await app.stop();
-  });
+  afterEach(() => app.stop());
 
   test('query', async () => {
     expect(await app.client.query('hello')).toMatchInlineSnapshot(`
@@ -358,9 +354,7 @@ describe('anonymous user with fastify-plugin', () => {
     await app.start();
   });
 
-  afterEach(async () => {
-    await app.stop();
-  });
+  afterEach(() => app.stop());
 
   test('fetch GET', async () => {
     const req = await fetch(`http://localhost:${config.port}/hello`);

--- a/packages/tests/server/interop/errors.test.ts
+++ b/packages/tests/server/interop/errors.test.ts
@@ -160,7 +160,7 @@ describe('formatError()', () => {
       client.mutation('err', 1 as any),
       TRPCClientError,
     );
-    delete (clientError.data as any).stack;
+    delete clientError.data.stack;
     expect(clientError.data).toMatchInlineSnapshot(`
 Object {
   "code": "BAD_REQUEST",

--- a/packages/tests/server/interop/links.test.ts
+++ b/packages/tests/server/interop/links.test.ts
@@ -58,7 +58,7 @@ test('chainer', async () => {
 
   const result = await observableToPromise(chain).promise;
   expect(result?.context?.response).toBeTruthy();
-  result!.context!.response = '[redacted]' as any;
+  result.context!.response = '[redacted]' as any;
   expect(result).toMatchInlineSnapshot(`
     Object {
       "context": Object {
@@ -157,7 +157,7 @@ describe('batching', () => {
     ]);
     for (const res of results) {
       expect(res?.context?.response).toBeTruthy();
-      res!.context!.response = '[redacted]';
+      res.context!.response = '[redacted]';
     }
     expect(results).toMatchInlineSnapshot(`
       Array [

--- a/packages/tests/server/interop/middleware.test.ts
+++ b/packages/tests/server/interop/middleware.test.ts
@@ -371,7 +371,7 @@ test('measure time middleware', async () => {
   expect(await client.query('greeting')).toBe('hello');
   expect(durationMs > -1).toBeTruthy();
 
-  const calls = (logMock.mock.calls as any[]).map((args) => {
+  const calls = logMock.mock.calls.map((args) => {
     // omit durationMs as it's variable
     const [str, { durationMs, ...opts }] = args;
     return [str, opts];

--- a/packages/tests/server/interop/react/__testHelpers.tsx
+++ b/packages/tests/server/interop/react/__testHelpers.tsx
@@ -93,7 +93,7 @@ export function createLegacyAppRouter() {
         let nextCursor: typeof cursor = null;
         for (let index = 0; index < db.posts.length; index++) {
           const element = db.posts[index]!;
-          if (cursor != null && element!.createdAt < cursor) {
+          if (cursor != null && element.createdAt < cursor) {
             continue;
           }
           items.push(element);

--- a/packages/tests/server/links.test.ts
+++ b/packages/tests/server/links.test.ts
@@ -59,7 +59,7 @@ test('chainer', async () => {
 
   const result = await observableToPromise(chain).promise;
   expect(result?.context?.response).toBeTruthy();
-  result!.context!.response = '[redacted]' as any;
+  result.context!.response = '[redacted]' as any;
   expect(result).toMatchInlineSnapshot(`
     Object {
       "context": Object {
@@ -159,7 +159,7 @@ describe('batching', () => {
     ]);
     for (const res of results) {
       expect(res?.context?.response).toBeTruthy();
-      res!.context!.response = '[redacted]';
+      res.context!.response = '[redacted]';
     }
     expect(results).toMatchInlineSnapshot(`
       Array [

--- a/packages/tests/server/react/__testHelpers.tsx
+++ b/packages/tests/server/react/__testHelpers.tsx
@@ -81,7 +81,7 @@ export function createAppRouter() {
         let nextCursor: typeof cursor = null;
         for (let index = 0; index < db.posts.length; index++) {
           const element = db.posts[index]!;
-          if (cursor != null && element!.createdAt < cursor) {
+          if (cursor != null && element.createdAt < cursor) {
             continue;
           }
           items.push(element);

--- a/packages/tests/server/react/invalidateRouters.test.tsx
+++ b/packages/tests/server/react/invalidateRouters.test.tsx
@@ -135,7 +135,7 @@ const ctx = konn()
             let nextCursor: typeof cursor = null;
             for (let index = 0; index < db.posts.length; index++) {
               const element = db.posts[index]!;
-              if (cursor != null && element!.createdAt < cursor) {
+              if (cursor != null && element.createdAt < cursor) {
                 continue;
               }
               items.push(element);

--- a/packages/tests/server/react/useContext.test.tsx
+++ b/packages/tests/server/react/useContext.test.tsx
@@ -206,7 +206,7 @@ test('prefetch', async () => {
     renderProxy(allPosts.data);
     return (
       <>
-        {allPosts!.data!.map((post) => {
+        {allPosts.data!.map((post) => {
           return <div key={post.id}>{post.text}</div>;
         })}
       </>

--- a/scripts/postversion.ts
+++ b/scripts/postversion.ts
@@ -23,7 +23,7 @@ for (const name of packages) {
 
   const content = fs.readFileSync(packageJSON).toString();
 
-  const version = (JSON.parse(content) as any).version;
+  const version = JSON.parse(content).version;
   // matches `"@trpc/*: ".*"` and replaces it with `"@trpc/*: "${version}""`
   const newContent = content.replace(
     /\"@trpc\/(\w+)\": "([^"]|\\")*"/g,

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./tsconfig.json",
   "include": [".eslintrc", "**/*"],
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
~Closes #~ [I was told to just go nuts 😄](https://discord.com/channels/867764511159091230/980118117676118067/1056705880726446130)

## 🎯 Changes

Enables [@typescript-eslint/recommended-requiring-type-checking](https://typescript-eslint.io/linting/configs/#recommended-requiring-type-checking), which is a set of recommended rules that also require [linting with type info](https://typescript-eslint.io/linting/typed-linting) (which was already set up).

Fixes `tsconfig.eslint.json` to properly include compiler options and path mappings so that lint rules have correct type info.

Rules with straightforward-to-fix issues have those issues fixed, with inline comments explaining the rule.

Marks rules that had a lot of non-straightforward-to-fix issues as todos. It'd be good to fix them eventually. But that's out of scope of this PR.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.