### PR TITLE
Mucked around with middleware pipe typings

### DIFF
--- a/packages/server/src/core/initTRPC.ts
+++ b/packages/server/src/core/initTRPC.ts
@@ -156,3 +156,57 @@ function createTRPCInner<TParams extends PartialRootConfigTypes>() {
     };
   };
 }
+
+// Just testing out the types with the following snippets 🙂
+
+const t = initTRPC.create({});
+
+const fooMiddleware = t.middleware((opts) => {
+  return opts.next({
+    ctx: {
+      foo: 'foo' as const,
+    },
+  });
+});
+
+const barMiddleware = fooMiddleware.pipe((opts) => {
+  opts.ctx.foo;
+  //        ^?
+  return opts.next({
+    ctx: {
+      bar: 'bar' as const,
+    },
+  });
+});
+
+const bazMiddleware = barMiddleware.pipe((opts) => {
+  opts.ctx.foo;
+  //        ^?
+
+  opts.ctx.bar;
+  //        ^?
+
+  return opts.next({
+    ctx: {
+      baz: 'baz' as const,
+    },
+  });
+});
+
+bazMiddleware;
+// ^?
+
+export type TypeOfBazMiddleware = typeof bazMiddleware;
+//           ^?
+
+t.procedure.use(bazMiddleware).query((opts) => {
+  opts.ctx;
+  //    ^?
+
+  opts.ctx.foo;
+  //        ^?
+  opts.ctx.bar;
+  //        ^?
+  opts.ctx.baz;
+  //        ^?
+});


### PR DESCRIPTION
Fixes some of the type unhappiness from #3489:

1. Adds `MiddlewareBuilder` to `use`'s first parameter's type union
2. Adds `MiddlewareBuilder` to `ProcedureBuilderMiddleware`, so the `middleware: ...` passed in `use`'s implementation is allowed
3. Added a quick lil `in` type narrowing in `callRecursive` to account for the parameter being a builder

I know you all like to joke about how you don't know what you're doing, but I _actually_ don't know what's happening. I'm not a tRPC power user and just thought it'd be fun to poke around. Please don't take this PR very seriously. 😄 

I also thought this would be a lot more code than the 1 file changed + 1 testing file? So maybe I'm missing something?