### PR TITLE
chore(client): swap `any`-types to `unknown` on untyped client

### DIFF
--- a/packages/client/src/internals/TRPCUntypedClient.ts
+++ b/packages/client/src/internals/TRPCUntypedClient.ts
@@ -159,7 +159,7 @@ export class TRPCUntypedClient<TRouter extends AnyRouter> {
     return abortablePromise;
   }
   public query(path: string, input?: unknown, opts?: TRPCRequestOptions) {
-    return this.requestAsPromise<unknown, any>({
+    return this.requestAsPromise<unknown, unknown>({
       type: 'query',
       path,
       input,
@@ -168,7 +168,7 @@ export class TRPCUntypedClient<TRouter extends AnyRouter> {
     });
   }
   public mutation(path: string, input?: unknown, opts?: TRPCRequestOptions) {
-    return this.requestAsPromise<unknown, any>({
+    return this.requestAsPromise<unknown, unknown>({
       type: 'mutation',
       path,
       input,

--- a/packages/tests/server/createGenericClient.test.ts
+++ b/packages/tests/server/createGenericClient.test.ts
@@ -50,11 +50,11 @@ test('query and mutation result type is Promise<any>', () => {
     const queryResult = client.query('foo');
     expectTypeOf<typeof queryResult>().toEqualTypeOf<Promise<any>>();
     const awaitedQueryResult = await queryResult;
-    expectTypeOf<typeof awaitedQueryResult>().toBeAny();
+    expectTypeOf<typeof awaitedQueryResult>().toBeUnknown();
 
     const mutationResult = client.query('foo');
     expectTypeOf<typeof mutationResult>().toEqualTypeOf<Promise<any>>();
     const awaitedMutationResult = await mutationResult;
-    expectTypeOf<typeof awaitedMutationResult>().toBeAny();
+    expectTypeOf<typeof awaitedMutationResult>().toBeUnknown();
   });
 });


### PR DESCRIPTION
Let's be unsafe but not unhinged