### PR TITLE
fix(react-query): fix import from dist folder

### DIFF
--- a/packages/react-query/src/utils/inferReactQueryProcedure.ts
+++ b/packages/react-query/src/utils/inferReactQueryProcedure.ts
@@ -6,7 +6,7 @@ import {
   AnyRouter,
   inferProcedureInput,
 } from '@trpc/server';
-import { inferTransformedProcedureOutput } from '@trpc/server/dist/shared';
+import { inferTransformedProcedureOutput } from '@trpc/server/shared';
 import { UseTRPCMutationOptions, UseTRPCQueryOptions } from '../shared';
 
 type InferQueryOptions<


### PR DESCRIPTION
## 🎯 Changes

Bug fix which replaces an incorrect import from `@trpc/server/dist/shared` with `@trpc/server/shared`. This was causing my Typescript compiler to give the following error:

```
> tsc

../../node_modules/.pnpm/@trpc+react-query@10.7.0_x4ie6nhblo2vtx2aafrgzlfqy4/node_modules/@trpc/react-query/dist/utils/inferReactQueryProcedure.d.ts:3:49 - error TS2307: Cannot find module '@trpc/server/dist/shared' or its corresponding type declarations.

3 import { inferTransformedProcedureOutput } from '@trpc/server/dist/shared';
                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error in ../../node_modules/.pnpm/@trpc+react-query@10.7.0_x4ie6nhblo2vtx2aafrgzlfqy4/node_modules/@trpc/react-query/dist/utils/inferReactQueryProcedure.d.ts:3
```

Unit tests still pass.

## ✅ Checklist

- [X] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [X] If necessary, I have added documentation related to the changes made.
- [X] I have added or updated the tests related to the changes made.