### PR TITLE
chore: rename + alias ssg-helpers

### DIFF
--- a/.wip/changes.md
+++ b/.wip/changes.md
@@ -1,0 +1,9 @@
+# Changes in v11
+
+## `interop`-mode has been removed
+
+...
+
+## SSG Helpers
+
+`createSSGHelpers` were for v9 which has now been removed. the v10 equivalent `createProxySSGHelpers` have been renamed to `createSSGHelpers` now instead. `createProxySSGHelpers` is now deprecated but aliased to `createSSGHelpers` for backwards compatibility.

--- a/packages/react-query/src/ssg/index.ts
+++ b/packages/react-query/src/ssg/index.ts
@@ -1,2 +1,10 @@
-export { createProxySSGHelpers } from './ssgProxy';
-export type { DecoratedProcedureSSGRecord } from './ssgProxy';
+import { createSSGHelpers } from './ssg';
+
+export {
+  createSSGHelpers,
+  /**
+   * @deprecated - use `createSSGHelpers` instead
+   */
+  createSSGHelpers as createProxySSGHelpers,
+};
+export type { DecoratedProcedureSSGRecord } from './ssg';

--- a/packages/react-query/src/ssg/ssg.ts
+++ b/packages/react-query/src/ssg/ssg.ts
@@ -77,7 +77,7 @@ type AnyDecoratedProcedure = DecorateProcedure<any>;
 /**
  * Create functions you can use for server-side rendering / static generation
  */
-export function createProxySSGHelpers<TRouter extends AnyRouter>(
+export function createSSGHelpers<TRouter extends AnyRouter>(
   opts: CreateSSGHelpersOptions<TRouter>,
 ) {
   const { router, transformer, ctx } = opts;
@@ -100,7 +100,7 @@ export function createProxySSGHelpers<TRouter extends AnyRouter>(
     return after;
   }
 
-  type CreateProxySSGHelpers = ProtectedIntersection<
+  type CreateSSGHelpers = ProtectedIntersection<
     {
       queryClient: QueryClient;
       dehydrate: (opts?: DehydrateOptions) => DehydratedState;
@@ -108,7 +108,7 @@ export function createProxySSGHelpers<TRouter extends AnyRouter>(
     DecoratedProcedureSSGRecord<TRouter>
   >;
 
-  return createFlatProxy<CreateProxySSGHelpers>((key) => {
+  return createFlatProxy<CreateSSGHelpers>((key) => {
     if (key === 'queryClient') return queryClient;
     if (key === 'dehydrate') return _dehydrate;
 

--- a/packages/tests/server/react/ssg.test.ts
+++ b/packages/tests/server/react/ssg.test.ts
@@ -1,5 +1,5 @@
 import { InfiniteData } from '@tanstack/react-query';
-import { createProxySSGHelpers } from '@trpc/react-query/src/ssg/ssgProxy';
+import { createProxySSGHelpers } from '@trpc/react-query/src/ssg';
 import { initTRPC } from '@trpc/server/src';
 import { expectTypeOf } from 'expect-type';
 import { z } from 'zod';

--- a/packages/tests/server/react/ssg.test.ts
+++ b/packages/tests/server/react/ssg.test.ts
@@ -1,5 +1,5 @@
 import { InfiniteData } from '@tanstack/react-query';
-import { createProxySSGHelpers } from '@trpc/react-query/src/ssg';
+import { createSSGHelpers } from '@trpc/react-query/src/ssg';
 import { initTRPC } from '@trpc/server/src';
 import { expectTypeOf } from 'expect-type';
 import { z } from 'zod';
@@ -26,14 +26,14 @@ const appRouter = t.router({
 });
 
 test('fetch', async () => {
-  const ssg = createProxySSGHelpers({ router: appRouter, ctx: {} });
+  const ssg = createSSGHelpers({ router: appRouter, ctx: {} });
 
   const post = await ssg.post.byId.fetch({ id: '1' });
   expectTypeOf<'__result'>(post);
 });
 
 test('fetchInfinite', async () => {
-  const ssg = createProxySSGHelpers({ router: appRouter, ctx: {} });
+  const ssg = createSSGHelpers({ router: appRouter, ctx: {} });
 
   const post = await ssg.post.list.fetchInfinite({});
   expectTypeOf<InfiniteData<'__infResult'>>(post);
@@ -42,7 +42,7 @@ test('fetchInfinite', async () => {
 });
 
 test('prefetch and dehydrate', async () => {
-  const ssg = createProxySSGHelpers({ router: appRouter, ctx: {} });
+  const ssg = createSSGHelpers({ router: appRouter, ctx: {} });
   await ssg.post.byId.prefetch({ id: '1' });
 
   const data = JSON.stringify(ssg.dehydrate());
@@ -50,7 +50,7 @@ test('prefetch and dehydrate', async () => {
 });
 
 test('prefetchInfinite and dehydrate', async () => {
-  const ssg = createProxySSGHelpers({ router: appRouter, ctx: {} });
+  const ssg = createSSGHelpers({ router: appRouter, ctx: {} });
   await ssg.post.list.prefetchInfinite({});
 
   const data = JSON.stringify(ssg.dehydrate());


### PR DESCRIPTION
continue on #3513

rename `createProxySSGHelpers` to `createSSGHelpers` - but keep an alias marked deprecated so there's no breaking changes