### PR TITLE
chore: add web build directories to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,8 @@
 __generated__/
+.docusaurus/
 .test/
+**/.next/
+**/www/build/
 dist/
 examples/next-big-router/src/server/routers/*.ts
 packages/server/test/__packages.ts

--- a/examples/next-minimal-starter/www/build/wat.js
+++ b/examples/next-minimal-starter/www/build/wat.js
@@ -1,0 +1,1 @@
+console.log(  'hi'   )

--- a/examples/next-minimal-starter/www/build/wat.js
+++ b/examples/next-minimal-starter/www/build/wat.js
@@ -1,1 +1,0 @@
-console.log(  'hi'   )


### PR DESCRIPTION
~Closes #~ Mentioned by @juliusmarminge and @KATT that Prettier is formatting things it doesn't need to.

## 🎯 Changes

Adds web build directories to the `.prettierignore` file:

* `.next/` for Next.js
* `.docusaurus/` and `www/build/` for Docusaurus

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
