### PR TITLE
expose getQueryKey on mutation procedures

### DIFF
--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -168,6 +168,7 @@ export type DecorateProcedure<
         : object)
   : TProcedure extends AnyMutationProcedure
   ? {
+      getQueryKey: () => QueryKey;
       useMutation: <TContext = unknown>(
         opts?: UseTRPCMutationOptions<
           inferProcedureInput<TProcedure>,


### PR DESCRIPTION
## 🎯 Changes

In #3302 `getQueryKey` was exposed for all query procedures. I was hoping to be able to use the feature for `setMutationDefaults` - however the method was not exposed on mutation queries.

Happy New Year!

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
