### PR TITLE
Add cloudflare-page-plugin-trpc into the Awesome tRPC collection list

### DIFF
--- a/www/docs/main/awesome-trpc.mdx
+++ b/www/docs/main/awesome-trpc.mdx
@@ -46,6 +46,7 @@ A collection of resources on tRPC.
 | trpc-koa-adapter - tRPC adapter for Koa server                                                      | https://github.com/BlairCurrey/trpc-koa-adapter                       |
 | tRPC - iron-session                                                                                 | https://github.com/parkgang/trpc-iron-session                         |
 | electron-trpc - Electron support for tRPC                                                           | https://github.com/jsonnull/electron-trpc                             |
+| cloudflare-pages-plugin-trpc - Quickly create a tRPC server with a Cloudflare Pages Function        | https://github.com/toyamarinyon/cloudflare-pages-plugin-trpc          |
 
 ### Extensions
 


### PR DESCRIPTION
## 🎯 Changes

Add [cloudflare-pages-plugin-trpc](https://github.com/toyamarinyon/cloudflare-pages-plugin-trpc) into the Library section on the Awesome tRPC collection.

demo: https://cloudflare-pages-plugin-trpc.pages.dev/

I think it is now of a quality that developers can use, and I would like to add it to the Awesome tRPC list.