### PR TITLE
fix(client): use constant of websocket impl

### DIFF
--- a/packages/client/src/links/wsLink.ts
+++ b/packages/client/src/links/wsLink.ts
@@ -265,7 +265,7 @@ export function createWSClient(opts: WebSocketClientOptions) {
 
       callbacks?.complete?.();
       if (
-        activeConnection.readyState === WebSocket.OPEN &&
+        activeConnection.readyState === WebSocketImpl.OPEN &&
         op.type === 'subscription'
       ) {
         outgoing.push({


### PR DESCRIPTION
Closes #3539

## 🎯 Changes

Use the OPEN constant of the WebSocketImpl to prevent a type error in nodejs environments.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
