### PR TITLE
docs: fix wsLink args

### DIFF
--- a/www/docs/client/links/wsLink.md
+++ b/www/docs/client/links/wsLink.md
@@ -20,7 +20,7 @@ const wsClient = createWSClient({
 });
 
 const trpcClient = createTRPCProxyClient<AppRouter>({
-  links: [wsLink<AppRouter>(wsClient)],
+  links: [wsLink<AppRouter>({ client: wsClient })],
 });
 ```
 


### PR DESCRIPTION
## 🎯 Changes

Args for `wsLink` were incorrect on this docs page. It takes an object with the client as a key, not just the client itself. All other docs pages already have the correct args format.

<img width="455" alt="image" src="https://user-images.githubusercontent.com/8353666/210936051-b3a19ff9-a231-4c52-8f3d-fd0da257e19c.png">

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
