### PR TITLE
feat: lock peerDependencies between @trpc/*-packages 

### DIFF
--- a/scripts/postversion.ts
+++ b/scripts/postversion.ts
@@ -24,9 +24,10 @@ for (const name of packages) {
   const content = fs.readFileSync(packageJSON).toString();
 
   const version = JSON.parse(content).version;
+
   // matches `"@trpc/*: ".*"` and replaces it with `"@trpc/*: "${version}""`
   const newContent = content.replace(
-    /\"@trpc\/(\w+)\": "([^"]|\\")*"/g,
+    /\"@trpc\/([\w-]+)\": "([^"]|\\")*"/g,
     `"@trpc/$1": "${version}"`,
   );
   fs.writeFileSync(packageJSON, newContent);


### PR DESCRIPTION
Closes #3553

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

From what I could gather, the regex was matching @trpc/client but not @trpc/react-query, because it was using `\w` which is only alphanumeric characters or underscores. This changes the regex to include hyphens

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
