### PR TITLE
chore(sponsor-script): fix missing newline causing prettier errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Also, if your company using tRPC and want to support long-term maintenance of tR
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
+
 <!-- SPONSORS:LIST:END -->
 
 ## All contributors ✨

--- a/www/src/components/sponsors/script.push.ts
+++ b/www/src/components/sponsors/script.push.ts
@@ -256,7 +256,7 @@ for (const file of files) {
       '',
       '<!-- markdownlint-restore -->',
       '<!-- prettier-ignore-end -->',
-      '',
+      '\n',
     ].join('\n'),
   );
   fs.writeFileSync(file, newContents);

--- a/www/unversioned/_sponsors.mdx
+++ b/www/unversioned/_sponsors.mdx
@@ -117,4 +117,5 @@ Also, if your company using tRPC and want to support long-term maintenance of tR
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
+
 <!-- SPONSORS:LIST:END -->


### PR DESCRIPTION
Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

- After every `sync sponsor` commit, CI starts failing due to invalid formatting. This fixes that by adding the missing newline that prettier expects

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
