### PR TITLE
fix(react-query): `useQueries()` no longer ignoring query options

### DIFF
--- a/packages/react-query/src/shared/proxy/useQueriesProxy.ts
+++ b/packages/react-query/src/shared/proxy/useQueriesProxy.ts
@@ -75,7 +75,7 @@ export function createUseQueriesProxy<TRouter extends AnyRouter>(
       queryFn: () => {
         return client.query(path, input);
       },
-      ...(rest[1] as any),
+      ...(rest[0] as any),
     };
 
     return options;

--- a/packages/tests/server/react/useQueries.test.tsx
+++ b/packages/tests/server/react/useQueries.test.tsx
@@ -126,3 +126,26 @@ test('mapping queries', async () => {
     expect(utils.container).toHaveTextContent(`__result3`);
   });
 });
+
+test('single query with options', async () => {
+  const { proxy, App } = ctx;
+  function MyComponent() {
+    const results = proxy.useQueries((t) => [
+      t.post.byId(
+        { id: '1' },
+        { enabled: false, placeholderData: '__result2' },
+      ),
+    ]);
+
+    return <pre>{JSON.stringify(results[0].data ?? 'n/a', null, 4)}</pre>;
+  }
+
+  const utils = render(
+    <App>
+      <MyComponent />
+    </App>,
+  );
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent(`__result2`);
+  });
+});


### PR DESCRIPTION
## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

Previously, the `useQueries` hook ignored the query options parameter. I fixed the typo that caused it and added a test.

Edit: made [this](https://github.com/HatulaPro/showing-usequeries-bug) to better explain the issue.

## ✅ Checklist

- [X] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [X] If necessary, I have added documentation related to the changes made.
- [X] I have added or updated the tests related to the changes made.
