### PR TITLE
docs: fix typo in procedures page

### DIFF
--- a/www/docs/server/procedures.md
+++ b/www/docs/server/procedures.md
@@ -5,7 +5,7 @@ sidebar_label: Define Procedures
 slug: /procedures
 ---
 
-Procedures in tRPC is a very flexible primitive to create backend functions; they use a builder patter which means you can create reusable base procedures for different parts fo your backend application.
+Procedures in tRPC is a very flexible primitive to create backend functions; they use a builder pattern which means you can create reusable base procedures for different parts of your backend application.
 
 :::tip
 


### PR DESCRIPTION
Closes #

## 🎯 Changes

Just a small fix for typos in "Define Procedures" page

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
