### PR TITLE
#typo fix in code sample for multiple procedures

### DIFF
--- a/www/docs/server/procedures.md
+++ b/www/docs/server/procedures.md
@@ -212,7 +212,10 @@ import { initTRPC } from '@trpc/server';
 
 export const t = initTRPC.create();
 
-export const appRouter = t.router({
+const router = t.router;
+const publicProcedure = t.procedure;
+
+export const appRouter = router({
   hello: publicProcedure.query(() => {
     return {
       text: 'hello world',

--- a/www/docs/server/procedures.md
+++ b/www/docs/server/procedures.md
@@ -212,7 +212,7 @@ import { initTRPC } from '@trpc/server';
 
 export const t = initTRPC.create();
 
-export const appRouter = router({
+export const appRouter = t.router({
   hello: publicProcedure.query(() => {
     return {
       text: 'hello world',


### PR DESCRIPTION
change router to t.router(...) on line 215. Other examples import router, but in this example the t instance is instantiated in same file, line 213.

Closes #

## 🎯 Changes

fix typo

## ✅ Checklist

- [X ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [X ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
