### PR TITLE
feat: leverage mutationKey in mutations

### DIFF
--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -311,12 +311,12 @@ export function createRootHooks<
   ): UseTRPCMutationResult<unknown, TError, unknown, unknown> {
     const { client } = useContext();
     const queryClient = useQueryClient({ context: ReactQueryContext });
+    const actualPath = Array.isArray(path) ? path[0] : path;
 
     const hook = __useMutation({
       ...opts,
+      mutationKey: [actualPath.split('.')],
       mutationFn: (input) => {
-        const actualPath = Array.isArray(path) ? path[0] : path;
-
         return (client.mutation as any)(
           ...getClientArgs([actualPath, input], opts),
         );
@@ -334,7 +334,7 @@ export function createRootHooks<
     }) as UseTRPCMutationResult<unknown, TError, unknown, unknown>;
 
     hook.trpc = useHookResult({
-      path: Array.isArray(path) ? path[0] : path,
+      path: actualPath,
     });
 
     return hook;

--- a/packages/tests/server/react/mutationkey.test.tsx
+++ b/packages/tests/server/react/mutationkey.test.tsx
@@ -1,0 +1,76 @@
+import { getServerAndReactClient } from './__reactHelpers';
+import { useIsMutating, useQueryClient } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { initTRPC } from '@trpc/server';
+import { konn } from 'konn';
+import React from 'react';
+
+const ctx = konn()
+  .beforeEach(() => {
+    const t = initTRPC.create();
+
+    const appRouter = t.router({
+      post: t.router({
+        create: t.procedure.mutation(() => 'ok' as const),
+      }),
+    });
+
+    return getServerAndReactClient(appRouter);
+  })
+  .afterEach(async (ctx) => {
+    await ctx?.close?.();
+  })
+  .done();
+
+describe('mutation keys', () => {
+  test('can grab from cache using correct key', async () => {
+    const { proxy, App } = ctx;
+
+    function MyComponent() {
+      const postCreate = proxy.post.create.useMutation();
+
+      const mutationKey = [['post', 'create']]; // TODO: Maybe add a getter later?
+      const isMutating = useIsMutating({ mutationKey });
+
+      const queryClient = useQueryClient();
+      const mutationCache = queryClient.getMutationCache();
+
+      React.useEffect(() => {
+        postCreate.mutate();
+        const mutation = mutationCache.find({ mutationKey });
+        expect(mutation).not.toBeUndefined();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, []);
+
+      return (
+        <div>
+          <button onClick={() => postCreate.mutate()} data-testid="mutate" />
+          <pre data-testid="status">{isMutating}</pre>
+        </div>
+      );
+    }
+
+    const utils = render(
+      <App>
+        <MyComponent />
+      </App>,
+    );
+
+    // should be mutating due to effect
+    await waitFor(() => {
+      expect(utils.getByTestId('status')).toHaveTextContent('1');
+    });
+
+    // let the mutation finish
+    await waitFor(() => {
+      expect(utils.getByTestId('status')).toHaveTextContent('0');
+    });
+
+    // should be mutating after button press
+    userEvent.click(utils.getByTestId('mutate'));
+    await waitFor(() => {
+      expect(utils.getByTestId('status')).toHaveTextContent('1');
+    });
+  });
+});


### PR DESCRIPTION
Closes #3534

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

did in https://github.com/trpc/trpc/pull/3591 but figured it should prob be made here first

Keys will be similar to queryKeys, in that it's the array path inside a tuple, although since we don't have inputs / type here its just a single item in the tuple

we could also just have the path `['post', 'create']` (not nested `[['post', 'create']]`) but better to be consistent imo

this should unlock #3528 without any modifications to the getter - although maybe we want that to be named `getMutationKey`?

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
