### PR TITLE
chore: remove the word “beta” from subscriptions docs

### DIFF
--- a/www/docs/main/introduction.mdx
+++ b/www/docs/main/introduction.mdx
@@ -94,6 +94,6 @@ tRPC is for full-stack TypeScript developers. It makes it easy to write endpoint
 - 🍃&nbsp; Light - tRPC has zero deps and a tiny client-side footprint.
 - 🐻&nbsp; For new and old projects - Easy to start with or add to your existing brownfield project.
 - 🔋&nbsp; Framework agnostic - The tRPC community has built [adapters](https://trpc.io/docs/awesome-trpc#-extensions--community-add-ons) for all of the most popular frameworks.
-- 🥃&nbsp; Subscriptions support (beta) - Add typesafe observability to your application.
+- 🥃&nbsp; Subscriptions support - Add typesafe observability to your application.
 - ⚡️&nbsp; Request batching - Requests made at the same time can be automatically combined into one.
 - 👀&nbsp; Examples - Check out an [example](example-apps.mdx) to learn with or use as a starting point.

--- a/www/versioned_docs/version-9.x/further/subscriptions.md
+++ b/www/versioned_docs/version-9.x/further/subscriptions.md
@@ -5,10 +5,6 @@ sidebar_label: Subscriptions / WebSockets
 slug: /subscriptions
 ---
 
-:::info
-Subscriptions & WebSockets are in beta, alpha & might change without a major version bump. However, feel free to use them and report any issue you may find on [GitHub](https://github.com/trpc/trpc)
-:::
-
 ## Using Subscriptions
 
 :::tip


### PR DESCRIPTION
We’ve not received any bug reports in a year. I think it is pretty stable.
