### PR TITLE
fix: do not leak `UnsetMarker` to query input

### DIFF
--- a/packages/server/src/core/internals/utils.ts
+++ b/packages/server/src/core/internals/utils.ts
@@ -43,7 +43,9 @@ export type UnsetMarker = typeof unsetMarker;
  */
 export interface ResolveOptions<TParams extends ProcedureParams> {
   ctx: TParams['_ctx_out'];
-  input: TParams['_input_out'];
+  input: TParams['_input_out'] extends UnsetMarker
+    ? undefined
+    : TParams['_input_out'];
 }
 
 /**

--- a/packages/tests/server/input.test.ts
+++ b/packages/tests/server/input.test.ts
@@ -159,6 +159,7 @@ test('no input', async () => {
 
   const proc = t.procedure.query(({ input }) => {
     expectTypeOf(input).toBeUndefined();
+    expect(input).toBeUndefined();
     return input;
   });
 

--- a/packages/tests/server/input.test.ts
+++ b/packages/tests/server/input.test.ts
@@ -5,6 +5,7 @@ import {
   inferProcedureParams,
   initTRPC,
 } from '@trpc/server';
+import { UnsetMarker } from '@trpc/server/core/internals/utils';
 import { expectTypeOf } from 'expect-type';
 import { konn } from 'konn';
 import { ZodError, z } from 'zod';
@@ -151,6 +152,32 @@ test('only allow double input validator for object-like inputs', () => {
   } catch {
     // whatever
   }
+});
+
+test('no input', async () => {
+  const t = initTRPC.create();
+
+  const proc = t.procedure.query(({ input }) => {
+    expectTypeOf(input).toBeUndefined();
+    return input;
+  });
+
+  type ProcType = inferProcedureParams<typeof proc>;
+
+  expectTypeOf<ProcType['_input_in']>().toEqualTypeOf<UnsetMarker>();
+  expectTypeOf<ProcType['_input_out']>().toEqualTypeOf<UnsetMarker>();
+  expectTypeOf<ProcType['_output_in']>().toBeUndefined();
+  expectTypeOf<ProcType['_output_out']>().toBeUndefined();
+
+  const router = t.router({
+    proc,
+  });
+
+  const opts = routerToServerAndClientNew(router);
+
+  await expect(opts.proxy.proc.query()).resolves.toBeUndefined();
+
+  await opts.close();
 });
 
 test('zod default() string', async () => {

--- a/packages/tests/server/validators.test.ts
+++ b/packages/tests/server/validators.test.ts
@@ -12,7 +12,7 @@ test('no validator', async () => {
 
   const router = t.router({
     hello: t.procedure.query(({ input }) => {
-      expectTypeOf(input).toBeSymbol();
+      expectTypeOf(input).toBeUndefined();
       return 'test';
     }),
   });


### PR DESCRIPTION
Relates to #3609

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
