### PR TITLE
chore: add `@deprecated` on some internal types

### DIFF
--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -248,6 +248,10 @@ export function createBuilder<TConfig extends AnyRootConfig>(
         meta: meta as Record<string, unknown>,
       }) as AnyProcedureBuilder;
     },
+    /**
+     * @deprecated
+     * This functionality is deprecated and will be removed in the next major version.
+     */
     unstable_concat(builder) {
       return createNewBuilder(_def, builder._def) as any;
     },

--- a/packages/server/src/core/router.ts
+++ b/packages/server/src/core/router.ts
@@ -24,6 +24,9 @@ import {
 /** @internal **/
 export type ProcedureRecord = Record<string, AnyProcedure>;
 
+/**
+ * @deprecated
+ */
 export interface ProcedureRouterRecord {
   [key: string]: AnyProcedure | AnyRouter;
 }
@@ -173,7 +176,11 @@ const reservedWords = [
 export type CreateRouterInner<
   TConfig extends AnyRootConfig,
   TProcRouterRecord extends ProcedureRouterRecord,
-> = Router<RouterDef<TConfig, TProcRouterRecord>> & TProcRouterRecord;
+> = Router<RouterDef<TConfig, TProcRouterRecord>> &
+  /**
+   * This should be deleted in v11
+   * @deprecated
+   */ TProcRouterRecord;
 
 /**
  * @internal

--- a/packages/server/src/subscription.ts
+++ b/packages/server/src/subscription.ts
@@ -1,6 +1,10 @@
 import { getTRPCErrorFromUnknown } from './error/utils';
 import { Observable, Observer, observable } from './observable';
 
+/**
+ * @deprecated
+ * This functionality is deprecated and will be removed in the next major version.
+ */
 export function subscriptionPullFactory<TOutput>(opts: {
   /**
    * The interval of how often the function should run

--- a/packages/tests/server/callRouter.test.ts
+++ b/packages/tests/server/callRouter.test.ts
@@ -1,0 +1,20 @@
+import './___packages';
+import { initTRPC } from '@trpc/server';
+
+test('deprecated: call proc directly', async () => {
+  const t = initTRPC.create();
+  const router = t.router({
+    sub: t.router({
+      hello: t.procedure.query(() => 'hello'),
+    }),
+  });
+
+  const result = await router.sub.hello({
+    ctx: {},
+    path: 'asd',
+    type: 'query',
+    rawInput: {},
+  });
+
+  expect(result).toBe('hello');
+});


### PR DESCRIPTION
Add `@deprecated` on some types that aren't intended to be used that I had forgotten about