### PR TITLE
docs: fix typo in useMutation()

### DIFF
--- a/www/docs/reactjs/useMutation.md
+++ b/www/docs/reactjs/useMutation.md
@@ -52,7 +52,7 @@ export function MyComponent() {
   // This can either be a tuple ['login'] or string 'login'
   const mutation = trpc.login.useMutation();
 
-  const handleLogin = async () => {
+  const handleLogin = () => {
     const name = 'John Doe';
 
     mutation.mutate({ name });


### PR DESCRIPTION
Closes #3625 

## 🎯 Changes
`mutate()` from `useMutation()` does not return a promise. We don't need `async` in the example code.

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
