### PR TITLE
docs: fixed incorrect link to trpc's tests directory in CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ pnpm test-watch
 pnpm test-watch --testPathPattern react
 ```
 
-Testing is currently coalesced in [./packages/server/test](./packages/server/test); we import the different libs from here, this makes it easier for us to do integration testing + getting test coverage on the whole codebase.
+Testing is currently coalesced in [./packages/tests](./packages/tests); we import the different libs from here, this makes it easier for us to do integration testing + getting test coverage on the whole codebase.
 
 ### Linting
 


### PR DESCRIPTION
Closes #

## 🎯 Changes

Trpc's contributing guide had incorrect link to tests directory. Fixed it.

## ✅ Checklist

- [✅ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
