### PR TITLE
docs: fix typo on the aborting-procedures page

### DIFF
--- a/www/docs/client/aborting-procedures.md
+++ b/www/docs/client/aborting-procedures.md
@@ -35,7 +35,7 @@ import { trpc } from '~/utils/trpc';
 
 const PostViewPage: NextPageWithLayout = () => {
   const id = useRouter().query.id as string;
-  const postQuery = trpc.post.byId.useQuery({ id }, { trpc: abortOnUnmount: true });
+  const postQuery = trpc.post.byId.useQuery({ id }, { trpc: { abortOnUnmount: true } });
 
   return (...)
 }


### PR DESCRIPTION
## 🎯 Changes

This PR fixes a typo in the code block on the aborting-procedures page.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
