### PR TITLE
refactor: remove GnClass workaround

### DIFF
--- a/packages/react-query/src/shared/hooks/deprecated/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/deprecated/createHooksInternal.tsx
@@ -584,33 +584,13 @@ function __createHooksInternal<
 }
 
 /**
- * Hack to infer the type of `createReactQueryHooks`
- * @link https://stackoverflow.com/a/59072991
- */
-class GnClass<TRouter extends AnyRouter, TSSRContext = unknown> {
-  fn() {
-    return __createHooksInternal<TRouter, TSSRContext>();
-  }
-}
-
-type returnTypeInferer<TType> = TType extends (
-  a: Record<string, string>,
-) => infer U
-  ? U
-  : never;
-type fooType<TRouter extends AnyRouter, TSSRContext = unknown> = GnClass<
-  TRouter,
-  TSSRContext
->['fn'];
-
-/**
  * Infer the type of a `createReactQueryHooks` function
  * @internal
  */
 export type CreateReactQueryHooks<
   TRouter extends AnyRouter,
   TSSRContext = unknown,
-> = returnTypeInferer<fooType<TRouter, TSSRContext>>;
+> = ReturnType<typeof __createHooksInternal<TRouter, TSSRContext>>;
 
 /**
  * Create strongly typed react hooks


### PR DESCRIPTION
## 🎯 Changes

removes the workaround in `./packages/react-query/src/shared/hooks/deprecated/createHooksInternal.tsx` to pass generics into `__createHooksInternal` by using [instantiation expressions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#instantiation-expressions) however this requires typescript 4.7



What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
