### PR TITLE
protected intersection for vanilla client

### DIFF
--- a/packages/client/src/internals/TRPCUntypedClient.ts
+++ b/packages/client/src/internals/TRPCUntypedClient.ts
@@ -77,6 +77,17 @@ export type CreateTRPCClientOptions<TRouter extends AnyRouter> =
       links: TRPCLink<TRouter>[];
     };
 
+/** @internal */
+export type UntypedClientProperties =
+  | 'links'
+  | 'runtime'
+  | 'requestId'
+  | '$request'
+  | 'requestAsPromise'
+  | 'query'
+  | 'mutation'
+  | 'subscription';
+
 export class TRPCUntypedClient<TRouter extends AnyRouter> {
   private readonly links: OperationLink<AnyRouter>[];
   public readonly runtime: TRPCClientRuntime;

--- a/packages/react-query/src/internals/context.tsx
+++ b/packages/react-query/src/internals/context.tsx
@@ -16,9 +16,9 @@ import {
   Updater,
 } from '@tanstack/react-query';
 import {
+  CreateTRPCProxyClient,
   TRPCClient,
   TRPCRequestOptions,
-  inferRouterProxyClient,
 } from '@trpc/client';
 import { TRPCClientError } from '@trpc/client';
 import type { AnyRouter } from '@trpc/server';
@@ -70,7 +70,7 @@ export type DecoratedProxyTRPCContextProps<
   TRouter extends AnyRouter,
   TSSRContext,
 > = ProxyTRPCContextProps<TRouter, TSSRContext> & {
-  client: inferRouterProxyClient<TRouter>;
+  client: CreateTRPCProxyClient<TRouter>;
 };
 
 export interface TRPCContextProps<TRouter extends AnyRouter, TSSRContext>

--- a/packages/tests/server/react/regression/issue-3461-reserved-properties.test.tsx
+++ b/packages/tests/server/react/regression/issue-3461-reserved-properties.test.tsx
@@ -1,11 +1,25 @@
 import { getServerAndReactClient } from '../__reactHelpers';
 import { render } from '@testing-library/react';
+import { createTRPCProxyClient } from '@trpc/client';
 import { createProxySSGHelpers } from '@trpc/react-query/src/ssg';
 import { IntersectionError } from '@trpc/server';
 import { initTRPC } from '@trpc/server/src/core';
 import { expectTypeOf } from 'expect-type';
 import React from 'react';
 import { z } from 'zod';
+
+test('vanilla client', async () => {
+  const t = initTRPC.create();
+
+  const appRouter = t.router({
+    links: t.procedure.query(() => 'hello'),
+    a: t.procedure.query(() => 'a'),
+  });
+
+  const client = createTRPCProxyClient<typeof appRouter>({ links: [] });
+
+  expectTypeOf(client).toMatchTypeOf<IntersectionError<'links'>>();
+});
 
 test('utils client', async () => {
   const t = initTRPC.create();


### PR DESCRIPTION
Closes #3530

Naming a procedure something that conflicts with a `TRPCUntypedClient` property is now a type error.