### PR TITLE
fix(child-repos): ci failing due to missing pipeline step

### DIFF
--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - fix-subtree-repo-ci
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -17,9 +18,9 @@ jobs:
             #
             next-prisma-starter,
             next-prisma-websockets-starter,
-            next-prisma-todomvc,
-            next-minimal-starter,
-            next-big-router,
+            # next-prisma-todomvc,
+            # next-minimal-starter,
+            # next-big-router,
           ]
 
     name: Update downstream ${{ matrix.path }} package

--- a/examples/next-prisma-starter/.github/workflows/main.yml
+++ b/examples/next-prisma-starter/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
           key: ${{ runner.os }}-${{ runner.node }}-${{ hashFiles('**/pnpm-lock.yaml') }}-nextjs
 
       - name: Build and test
-        run: pnpm build-sqlite && pnpm test-start && pnpm test-dev
+        run: pnpm prep-sqlite && build-sqlite && pnpm test-start && pnpm test-dev
 
       - name: Upload test results
         if: ${{ always() }}

--- a/examples/next-prisma-websockets-starter/.github/workflows/main.yml
+++ b/examples/next-prisma-websockets-starter/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
           key: ${{ runner.os }}-${{ runner.node }}-${{ hashFiles('**/pnpm-lock.yaml') }}-nextjs
 
       - name: Build and test
-        run: pnpm build-sqlite && pnpm test-start && pnpm test-dev
+        run: pnpm prep-sqlite && build-sqlite && pnpm test-start && pnpm test-dev
 
       - name: Upload test results
         if: ${{ always() }}


### PR DESCRIPTION
Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

The `prep-sqlite` step is part of the turbo pipeline, thus it's run before the build step in trpc's CI. This is not the case for the CI in each child repos causing it to fail due to the db not working. This adds that missing step as an explicit job

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
