### PR TITLE
docs: remove unused import in the usage with next.js documentation

### DIFF
--- a/www/docs/nextjs/introduction.mdx
+++ b/www/docs/nextjs/introduction.mdx
@@ -101,7 +101,7 @@ Initialize your tRPC backend using the `initTRPC` function and create your first
 <details><summary>View sample backend</summary>
 
 ```ts title='server/trpc.ts'
-import { TRPCError, initTRPC } from '@trpc/server';
+import { initTRPC } from '@trpc/server';
 
 // Avoid exporting the entire t-object
 // since it's not very descriptive.


### PR DESCRIPTION
Closes  #3741

## 🎯 Changes

- removed an unused import in the usage with next.js in the backend sample

```diff
- import { TRPCError, initTRPC } from "@trpc/server";
+ import { initTRPC } from '@trpc/server';

// Avoid exporting the entire t-object
// since it's not very descriptive.
// For instance, the use of a t variable
// is common in i18n libraries.
const t = initTRPC.create();

// Base router and procedure helpers
export const router = t.router;
export const procedure = t.procedure;
```



## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
