### PR TITLE
fix: add `Simplify<T>` to serialized output

### DIFF
--- a/packages/server/src/shared/jsonify.ts
+++ b/packages/server/src/shared/jsonify.ts
@@ -1,6 +1,7 @@
 import { AnyProcedure } from '../core';
 import { inferObservableValue } from '../observable';
 import { DefaultDataTransformer } from '../transformer';
+import { Simplify } from '../types';
 import type { Serialize } from './internal/serialize';
 
 /**
@@ -8,7 +9,7 @@ import type { Serialize } from './internal/serialize';
  */
 export type inferTransformedProcedureOutput<TProcedure extends AnyProcedure> =
   TProcedure['_def']['_config']['transformer'] extends DefaultDataTransformer
-    ? Serialize<TProcedure['_def']['_output_out']>
+    ? Simplify<Serialize<TProcedure['_def']['_output_out']>>
     : TProcedure['_def']['_output_out'];
 
 export type inferTransformedSubscriptionOutput<


### PR DESCRIPTION
Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

Simplifies output type when not using a transformer to get prettier output

Pre:
<img width="1354" alt="CleanShot 2023-02-13 at 08 59 04@2x" src="https://user-images.githubusercontent.com/51714798/218402225-2fb5b2f3-2ce3-4fac-83d3-a1f291faca49.png">

After:
<img width="1361" alt="CleanShot 2023-02-13 at 08 59 12@2x" src="https://user-images.githubusercontent.com/51714798/218402228-bcbf00eb-5f38-4e74-a1fe-d3c6733ba30b.png">


## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
