### PR TITLE
fix: export more internals for dts files generation

### DIFF
--- a/packages/server/src/internals.ts
+++ b/packages/server/src/internals.ts
@@ -2,12 +2,12 @@
  * These types have to be exported so users can generate their own types definitions files
  */
 export type { DefaultErrorShape } from './error/formatter';
-export type { MergeRouters } from './core/internals/mergeRouters';
+export type { MergeRouters, mergeRouters } from './core/internals/mergeRouters';
 export type { RootConfig, AnyRootConfig } from './core/internals/config';
 export type {
   ProcedureBuilder,
   BuildProcedure,
 } from './core/internals/procedureBuilder';
 export type { Overwrite, unsetMarker } from './core/internals/utils';
-export type { MiddlewareFunction } from './core/middleware';
+export type { MiddlewareFunction, MiddlewareBuilder } from './core/middleware';
 export type { Router, RouterDef } from './core/router';


### PR DESCRIPTION
Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

I'm continuing my patches about exposing enough internal types to be able to have a correct inference when generating declaration files (necessary when using TS project references).

It fixes these errors:

<img width="1470" alt="image" src="https://user-images.githubusercontent.com/1443499/219054974-9a43293f-93d7-4520-94d0-b4fdf984b9d0.png">

Past PRs: https://github.com/trpc/trpc/pulls?q=is%3Apr+author%3Ajgoux+is%3Aclosed

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
