### PR TITLE
ci: fix deno test

### DIFF
--- a/examples/deno-deploy/src/index.ts
+++ b/examples/deno-deploy/src/index.ts
@@ -3,6 +3,12 @@ import { fetchRequestHandler } from 'npm:@trpc/server/adapters/fetch';
 import { appRouter } from './router.ts';
 
 function handler(request) {
+  // Only used for start-server-and-test package that
+  // expects a 200 OK to start testing the server
+  if (request.method === 'HEAD') {
+    return new Response();
+  }
+
   return fetchRequestHandler({
     endpoint: '/trpc',
     req: request,


### PR DESCRIPTION
## 🎯 Changes

Fix the Deno test that has been failing since two days (due to a timeout). We use the `start-server-and-test` package and they released a [new version](https://github.com/bahmutov/start-server-and-test/releases/tag/v1.15.4) two days ago that fix a bug and expects to return a status code `200` in response to a `HEAD` request on `/`, to notify that the HTTP server is ready to be tested.

However, `/` always returns a `404` status code because the tRPC server listens on the `/trpc` endpoint. I've fixed this by returning an empty `Response` (which has a `200` status code) if the request method is `HEAD` (meaning when `start-server-and-test` checks if the HTTP server is ready to be tested)

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
