### PR TITLE
feat: Add ability to configure custom inputEncoder and inputDecoder

### DIFF
--- a/packages/server/src/adapters/fastify/fastifyRequestHandler.ts
+++ b/packages/server/src/adapters/fastify/fastifyRequestHandler.ts
@@ -52,6 +52,7 @@ export async function fastifyRequestHandler<
     path: opts.path,
     router: opts.router,
     batching: opts.batching,
+    inputDecoder: opts.inputDecoder,
     responseMeta: opts.responseMeta,
     onError(o) {
       opts?.onError?.({ ...o, req: opts.req });

--- a/packages/server/src/adapters/fetch/fetchRequestHandler.ts
+++ b/packages/server/src/adapters/fetch/fetchRequestHandler.ts
@@ -32,6 +32,7 @@ export async function fetchRequestHandler<TRouter extends AnyRouter>(
     path,
     router: opts.router,
     batching: opts.batching,
+    inputDecoder: opts.inputDecoder,
     responseMeta: opts.responseMeta,
     onError(o) {
       opts?.onError?.({ ...o, req: opts.req });

--- a/packages/server/src/adapters/node-http/nodeHTTPRequestHandler.ts
+++ b/packages/server/src/adapters/node-http/nodeHTTPRequestHandler.ts
@@ -45,6 +45,7 @@ export async function nodeHTTPRequestHandler<
   };
   const result = await resolveHTTPResponse({
     batching: opts.batching,
+    inputDecoder: opts.inputDecoder,
     responseMeta: opts.responseMeta,
     path,
     createContext,

--- a/packages/server/src/http/internals/types.ts
+++ b/packages/server/src/http/internals/types.ts
@@ -11,6 +11,7 @@ import { Dict } from '../../types';
 import { ResponseMeta } from '../types';
 
 export type HTTPHeaders = Dict<string | string[]>;
+export type InputDecoder = (input: string) => unknown;
 
 export interface HTTPResponse {
   status: number;
@@ -50,4 +51,8 @@ export interface HTTPBaseHandlerOptions<TRouter extends AnyRouter, TRequest>
    * @link https://trpc.io/docs/caching
    */
   responseMeta?: ResponseMetaFn<TRouter>;
+  /**
+   * Custom encoder to be used for the input.
+   */
+  inputDecoder?: InputDecoder;
 }

--- a/www/docs/client/links/httpBatchLink.md
+++ b/www/docs/client/links/httpBatchLink.md
@@ -58,6 +58,10 @@ export interface HTTPLinkOptions {
    * @link http://trpc.io/docs/v10/header
    */
   headers?: HTTPHeaders | (() => HTTPHeaders | Promise<HTTPHeaders>);
+  /**
+   * Custom encoder to be used when serializing the input into a query string entry.
+   */
+  inputEncoder?: InputEncoder;
 }
 ```
 
@@ -139,6 +143,43 @@ export const trpc = createTRPCNext<AppRouter>({
       ],
     };
   },
+});
+```
+
+## Using a custom input encoder/decoder pair
+
+This option can be helpful when your server has a hard limits on the URL length, yet you want to sqeeze as much data as possible.
+It supports any string-based format like Base64, [Zipson](https://jgranstrom.github.io/zipson/) or [JSURL2](https://github.com/wmertens/jsurl2).
+
+### 1. Configure `inputDecoder` on your server:
+
+```ts title="server.ts"
+import { createHTTPServer } from '@trpc/server/adapters/standalone';
+
+createHTTPServer({
+  inputDecoder: (input) => {
+    const decoded = decompress(input);
+    return JSON.parse(decoded);
+  },
+});
+```
+
+### 2. Configure `inputEncoder` with [`httpBatchLink`](./httpBatchLink.md) in your tRPC Client
+
+```ts title="client/index.ts"
+import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
+import type { AppRouter } from '../server';
+
+const client = createTRPCProxyClient<AppRouter>({
+  links: [
+    httpBatchLink({
+      url: 'http://localhost:3000',
+      inputEncoder: (input) => {
+        const encoded = JSON.stringify(input);
+        return compress(encoded);
+      },
+    }),
+  ],
 });
 ```
 


### PR DESCRIPTION
Closes https://github.com/trpc/trpc/issues/3590

## 🎯 Changes

This change introduces a new pair of options, `inputEncoder` to the client and `inputDecoder` to the server,
that allows you to change how input is serialized/deserialized prior to sending an HTTP request.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
