### PR TITLE
chore: Ignore packages/coverage from prettier formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,4 +7,5 @@ dist/
 examples/next-big-router/src/server/routers/*.ts
 packages/server/test/__packages.ts
 packages/tests/server/___packages.ts
+packages/coverage/
 pnpm-lock.yaml


### PR DESCRIPTION
Removes unnecessary matches from `packages/coverage`, as it's ignored in `.gitignore` and never committed anyway.