### PR TITLE
Add new index file for components

### DIFF
--- a/www/src/components/index.ts
+++ b/www/src/components/index.ts
@@ -1,0 +1,23 @@
+import { Button } from './Button';
+import { Features } from './Features';
+import { GithubSponsorButton } from './GithubSponsorButton';
+import { GithubStarsButton } from './GithubStarsButton';
+import { Preview } from './Preview';
+import { QuickIntro } from './QuickIntro';
+import { SectionTitle } from './SectionTitle';
+import { TwitterWall } from './TwitterWall';
+import { SponsorBubbles } from './sponsors/SponsorBubbles';
+import { TopSponsors } from './sponsors/TopSponsors';
+
+export {
+  Button,
+  Features,
+  GithubSponsorButton,
+  GithubStarsButton,
+  Preview,
+  QuickIntro,
+  SectionTitle,
+  TwitterWall,
+  SponsorBubbles,
+  TopSponsors,
+};

--- a/www/src/pages/index.tsx
+++ b/www/src/pages/index.tsx
@@ -4,16 +4,18 @@ import Layout from '@theme/Layout';
 import clsx from 'clsx';
 import React, { ComponentPropsWithoutRef, useState } from 'react';
 import { FiArrowRight } from 'react-icons/fi';
-import { Button } from '../components/Button';
-import { Features } from '../components/Features';
-import { GithubSponsorButton } from '../components/GithubSponsorButton';
-import { GithubStarsButton } from '../components/GithubStarsButton';
-import { Preview } from '../components/Preview';
-import { QuickIntro } from '../components/QuickIntro';
-import { SectionTitle } from '../components/SectionTitle';
-import { TwitterWall } from '../components/TwitterWall';
-import { SponsorBubbles } from '../components/sponsors/SponsorBubbles';
-import { TopSponsors } from '../components/sponsors/TopSponsors';
+import {
+  Button,
+  Features,
+  GithubSponsorButton,
+  GithubStarsButton,
+  Preview,
+  QuickIntro,
+  SectionTitle,
+  SponsorBubbles,
+  TopSponsors,
+  TwitterWall,
+} from '../components';
 import { searchParams } from '../utils/searchParams';
 
 const Iframe = (


### PR DESCRIPTION
Closes #

## 🎯 Changes

Added a new index.ts file for components so that we can reexport components. So it looks cleaner on the homepage where we import all these components.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
