### PR TITLE
fix: export even more internals for dts files generation

### DIFF
--- a/examples/.test/internal-types-export/src/server.ts
+++ b/examples/.test/internal-types-export/src/server.ts
@@ -3,9 +3,20 @@ import { initTRPC } from '@trpc/server';
 // needs to be exported for the test to be valid
 export const t = initTRPC.create();
 
+const someMiddleware = t.middleware(({ next }) => {
+  return next();
+});
+
+export function genericRouter<S extends (value: any) => unknown>(schema: S) {
+  return t.router({
+    foo: t.procedure.output(schema).query(() => 'bar'),
+  });
+}
 
 const appRouter = t.router({
   foo: t.procedure.query(() => 'bar'),
+  hello: t.procedure.use(someMiddleware).query(() => 'hello'),
+  generic: genericRouter((value: string) => value.toUpperCase()),
 })
 
 export type AppRouter = typeof appRouter;

--- a/packages/server/src/core/index.ts
+++ b/packages/server/src/core/index.ts
@@ -15,7 +15,7 @@ export type {
   ProcedureArgs,
   ProcedureOptions,
 } from './procedure';
-export { inferParser } from './parser';
+export type { inferParser } from './parser';
 export { createInputMiddleware, createOutputMiddleware } from './middleware';
 
 export { initTRPC } from './initTRPC';

--- a/packages/server/src/core/index.ts
+++ b/packages/server/src/core/index.ts
@@ -15,6 +15,7 @@ export type {
   ProcedureArgs,
   ProcedureOptions,
 } from './procedure';
+export { inferParser } from './parser';
 export { createInputMiddleware, createOutputMiddleware } from './middleware';
 
 export { initTRPC } from './initTRPC';

--- a/packages/server/src/internals.ts
+++ b/packages/server/src/internals.ts
@@ -8,5 +8,5 @@ export type {
   ProcedureBuilder,
   BuildProcedure,
 } from './core/internals/procedureBuilder';
-export type { unsetMarker } from './core/internals/utils';
+export type { Overwrite, unsetMarker } from './core/internals/utils';
 export type { MiddlewareFunction, MiddlewareBuilder } from './core/middleware';


### PR DESCRIPTION
Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

This extends work by @jgoux in #3774 by exposing more internal types to ensure declaration files can be generated. 

It fixes errors caused by the interaction of context and middleware ([stackblitz](https://stackblitz.com/edit/trpc-export-ts2742-jdz415?file=index.ts&view=editor)) and when routers are created within generic functions ([stackblitz](https://stackblitz.com/edit/trpc-export-ts2742-76uvre?file=index.ts&view=editor)).

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
