### PR TITLE
docs: example next-prisma-websockets-starter setup

### DIFF
--- a/examples/next-prisma-websockets-starter/README.md
+++ b/examples/next-prisma-websockets-starter/README.md
@@ -18,10 +18,10 @@ Try demo http://websockets.trpc.io/
 ## Setup
 
 ```bash
-yarn create next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-starter-websockets trpc-prisma-starter-websockets
-cd trpc-prisma-starter-websockets
-yarn
-yarn dx
+pnpm create next-app --example https://github.com/trpc/trpc --example-path examples/next-prisma-websockets-starter trpc-prisma-websockets-starter
+cd trpc-prisma-websockets-starter
+pnpm i
+pnpm dx
 ```
 
 ## Deployment


### PR DESCRIPTION
## 🎯 Changes

Update documentation for example next-prisma-websockets-starter. The directory in the setup bash was incorrect.

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
