### PR TITLE
docs: Export type `Context` for use in `initTRPC`

### DIFF
--- a/www/docs/server/authorization.md
+++ b/www/docs/server/authorization.md
@@ -38,14 +38,14 @@ export async function createContext({
     user,
   };
 }
-type Context = inferAsyncReturnType<typeof createContext>;
+export type Context = inferAsyncReturnType<typeof createContext>;
 ```
 
 ## Option 1: Authorize using resolver
 
 ```ts title='server/routers/_app.ts'
 import { TRPCError, initTRPC } from '@trpc/server';
-import { Context } from '../context';
+import type { Context } from '../context';
 
 export const t = initTRPC.context<Context>().create();
 


### PR DESCRIPTION
## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

Changes to the [Authorization section in the v10 docs](https://trpc.io/docs/authorization). Namely:

In the docs, the type `Context` is declared in `server/context.ts`, without being exported. However it's then imported in the code snippet in `server/routers/_app.ts` that immediately follows, so for consistency and clarity I think the type declaration in `server/context.ts` needs to be exported. This PR does that.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
