### PR TITLE
fix: prioritize `globalThis` over `window`

### DIFF
--- a/packages/client/src/internals/fetchHelpers.ts
+++ b/packages/client/src/internals/fetchHelpers.ts
@@ -2,10 +2,13 @@ import { Maybe } from '@trpc/server';
 import { AbortControllerEsque } from './types';
 
 export function getWindow() {
+  if (typeof globalThis !== 'undefined') {
+    return globalThis; 
+  }
   if (typeof window !== 'undefined') {
     return window;
   }
-  return globalThis;
+  throw new Error('Could not resolve "globalThis"');
 }
 export function getAbortController(
   ac: Maybe<AbortControllerEsque>,


### PR DESCRIPTION
Closes #3848

We could just use `globalThis` directly too maybe? https://caniuse.com/?search=globalThis