### PR TITLE
remove use of `eval`

### DIFF
--- a/www/docs/server/data-transformers.md
+++ b/www/docs/server/data-transformers.md
@@ -86,7 +86,7 @@ export const transformer = {
   input: superjson,
   output: {
     serialize: (object) => uneval(object),
-    deserialize: (object) => eval(`(${object})`),
+    deserialize: (object) => JSON.parse(object),
   },
 };
 ```


### PR DESCRIPTION
## 🎯 Changes

I'm not sure if the suggested change is equivalent to what was documented before. However, I think it's important documentation does not suggest using `eval` due to the inherent security risks associated with the method.

Even if the example was included for simplicity and not as a "best practice", people are prone to copy-paste as a starting point, potentially never fixing the usage to something more robust after the fact.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [N/A] I have added or updated the tests related to the changes made.
