### PR TITLE
chore: break circular dependencies between internal files

### DIFF
--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -26,7 +26,7 @@ import {
 import {
   CreateReactQueryHooks,
   createHooksInternal,
-} from './shared/hooks/createHooksInternal';
+} from './shared/hooks/createRootHooks';
 import {
   CreateClient,
   DefinedUseTRPCQueryOptions,

--- a/packages/react-query/src/interop.ts
+++ b/packages/react-query/src/interop.ts
@@ -5,7 +5,7 @@ import { CreateTRPCReactOptions } from './shared';
 import {
   CreateReactQueryHooks,
   createHooksInternal,
-} from './shared/hooks/createHooksInternal';
+} from './shared/hooks/createRootHooks';
 
 /**
  * @deprecated use `createTRPCReact` instead

--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -512,9 +512,3 @@ export function createRootHooks<
     useInfiniteQuery,
   };
 }
-
-/**
- * @deprecated
- * DELETE ME
- */
-export * from './deprecated/createHooksInternal';

--- a/packages/react-query/src/shared/hooks/createRootHooks.tsx
+++ b/packages/react-query/src/shared/hooks/createRootHooks.tsx
@@ -1,0 +1,10 @@
+// NOTE: This indirection is only needed to break a circular-reference.
+// After removal of `hooks/deprecated/createHooksInternal` file,
+// `hooks/createHooksInternal` can be swapped for all `createRootHooks` imports.
+export { createRootHooks } from './createHooksInternal';
+
+/**
+ * @deprecated
+ * DELETE ME
+ */
+export * from './deprecated/createHooksInternal';

--- a/packages/react-query/src/shared/index.ts
+++ b/packages/react-query/src/shared/index.ts
@@ -6,7 +6,7 @@ export type {
   DecorateProcedure,
 } from '../createTRPCReact';
 export type { TRPCUseQueries } from '../internals/useQueries';
-export * from './hooks/createHooksInternal';
+export * from './hooks/createRootHooks';
 export * from './queryClient';
 export * from './types';
 export * from './hooks/types';

--- a/packages/react-query/src/shared/proxy/decorationProxy.ts
+++ b/packages/react-query/src/shared/proxy/decorationProxy.ts
@@ -2,7 +2,7 @@ import { AnyRouter } from '@trpc/server';
 import { createRecursiveProxy } from '@trpc/server/shared';
 import { getArrayQueryKey } from '../../internals/getArrayQueryKey';
 import { getQueryKeyInternal } from '../../internals/getQueryKey';
-import { CreateReactQueryHooks } from '../hooks/createHooksInternal';
+import { CreateReactQueryHooks } from '../hooks/createRootHooks';
 
 /**
  * Create proxy for decorating procedures

--- a/packages/server/src/adapters/ws.ts
+++ b/packages/server/src/adapters/ws.ts
@@ -6,8 +6,8 @@ import {
   callProcedure,
   inferRouterContext,
 } from '../core';
-import { TRPCError } from '../error/TRPCError';
-import { getCauseFromUnknown, getTRPCErrorFromUnknown } from '../error/utils';
+import { TRPCError, getTRPCErrorFromUnknown } from '../error/TRPCError';
+import { getCauseFromUnknown } from '../error/utils';
 import { transformTRPCResponse } from '../internals/transformTRPCResponse';
 import { BaseHandlerOptions } from '../internals/types';
 import { Unsubscribable, isObservable } from '../observable';

--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -1,5 +1,4 @@
-import { TRPCError } from '../../error/TRPCError';
-import { getTRPCErrorFromUnknown } from '../../error/utils';
+import { TRPCError, getTRPCErrorFromUnknown } from '../../error/TRPCError';
 import { MaybePromise, Simplify } from '../../types';
 import {
   MiddlewareBuilder,

--- a/packages/server/src/deprecated/internals/procedure.ts
+++ b/packages/server/src/deprecated/internals/procedure.ts
@@ -1,8 +1,5 @@
-import { TRPCError } from '../../error/TRPCError';
-import {
-  getCauseFromUnknown,
-  getTRPCErrorFromUnknown,
-} from '../../error/utils';
+import { TRPCError, getTRPCErrorFromUnknown } from '../../error/TRPCError';
+import { getCauseFromUnknown } from '../../error/utils';
 import { InferLast } from '../../types';
 import { ProcedureType } from '../router';
 import {

--- a/packages/server/src/error/TRPCError.ts
+++ b/packages/server/src/error/TRPCError.ts
@@ -4,6 +4,26 @@ import {
 } from '../error/utils';
 import { TRPC_ERROR_CODE_KEY } from '../rpc/codes';
 
+export function getTRPCErrorFromUnknown(cause: unknown): TRPCError {
+  const error = getErrorFromUnknown(cause);
+  // this should ideally be an `instanceof TRPCError` but for some reason that isn't working
+  // ref https://github.com/trpc/trpc/issues/331
+  if (error.name === 'TRPCError') {
+    return cause as TRPCError;
+  }
+
+  const trpcError = new TRPCError({
+    code: 'INTERNAL_SERVER_ERROR',
+    cause: error,
+    message: error.message,
+  });
+
+  // Inherit stack from error
+  trpcError.stack = error.stack;
+
+  return trpcError;
+}
+
 export class TRPCError extends Error {
   public readonly cause?;
   public readonly code;

--- a/packages/server/src/error/utils.ts
+++ b/packages/server/src/error/utils.ts
@@ -1,5 +1,3 @@
-import { TRPCError } from './TRPCError';
-
 export function getMessageFromUnknownError(
   err: unknown,
   fallback: string,
@@ -7,7 +5,6 @@ export function getMessageFromUnknownError(
   if (typeof err === 'string') {
     return err;
   }
-
   if (err instanceof Error && typeof err.message === 'string') {
     return err.message;
   }
@@ -20,26 +17,6 @@ export function getErrorFromUnknown(cause: unknown): Error {
   }
   const message = getMessageFromUnknownError(cause, 'Unknown error');
   return new Error(message);
-}
-
-export function getTRPCErrorFromUnknown(cause: unknown): TRPCError {
-  const error = getErrorFromUnknown(cause);
-  // this should ideally be an `instanceof TRPCError` but for some reason that isn't working
-  // ref https://github.com/trpc/trpc/issues/331
-  if (error.name === 'TRPCError') {
-    return cause as TRPCError;
-  }
-
-  const trpcError = new TRPCError({
-    code: 'INTERNAL_SERVER_ERROR',
-    cause: error,
-    message: error.message,
-  });
-
-  // Inherit stack from error
-  trpcError.stack = error.stack;
-
-  return trpcError;
 }
 
 export function getCauseFromUnknown(cause: unknown) {

--- a/packages/server/src/http/resolveHTTPResponse.ts
+++ b/packages/server/src/http/resolveHTTPResponse.ts
@@ -6,8 +6,8 @@ import {
   inferRouterContext,
   inferRouterError,
 } from '../core';
-import { TRPCError } from '../error/TRPCError';
-import { getCauseFromUnknown, getTRPCErrorFromUnknown } from '../error/utils';
+import { TRPCError, getTRPCErrorFromUnknown } from '../error/TRPCError';
+import { getCauseFromUnknown } from '../error/utils';
 import { transformTRPCResponse } from '../internals/transformTRPCResponse';
 import { TRPCResponse } from '../rpc';
 import { Maybe } from '../types';

--- a/packages/server/src/subscription.ts
+++ b/packages/server/src/subscription.ts
@@ -1,4 +1,4 @@
-import { getTRPCErrorFromUnknown } from './error/utils';
+import { getTRPCErrorFromUnknown } from './error/TRPCError';
 import { Observable, Observer, observable } from './observable';
 
 /**


### PR DESCRIPTION
## 🎯 Changes

Fix circular dependency warnings emitted during every build job.

```
@trpc/react-query:build: (!) Circular dependency
@trpc/react-query:build: src/shared/hooks/createHooksInternal.tsx -> src/shared/hooks/deprecated/createHooksInternal.tsx -> src/shared/hooks/createHooksInternal.tsx

@trpc/server:build: (!) Circular dependency
@trpc/server:build: src/error/TRPCError.ts -> } -> src/error/TRPCError.ts
```

There were no functional changes to the API or public exports.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
