### PR TITLE
fix: export 'Router' for dts files generation

### DIFF
--- a/examples/.test/internal-types-export/src/server.ts
+++ b/examples/.test/internal-types-export/src/server.ts
@@ -13,10 +13,18 @@ export function genericRouter<S extends (value: any) => unknown>(schema: S) {
   });
 }
 
+const routerA = t.router({
+  a: t.procedure.query(() => 'a'),
+});
+const routerB = t.router({
+  b: t.procedure.query(() => 'b'),
+});
+
 const appRouter = t.router({
   foo: t.procedure.query(() => 'bar'),
   hello: t.procedure.use(someMiddleware).query(() => 'hello'),
   generic: genericRouter((value: string) => value.toUpperCase()),
-})
+  merged: t.mergeRouters(routerA, routerB),
+});
 
 export type AppRouter = typeof appRouter;

--- a/packages/server/src/core/index.ts
+++ b/packages/server/src/core/index.ts
@@ -3,6 +3,7 @@ export type {
   ProcedureRecord,
   ProcedureRouterRecord,
   CreateRouterInner,
+  Router,
 } from './router';
 export { callProcedure } from './router';
 export type {


### PR DESCRIPTION
## 🎯 Changes

A follow up to work by @jgoux  in #3774 and myself in #3831. This PR fixes a `.d.ts` generation issue when exporting merged routers.

The fixture project for time inference testing has been updated and will fail if `Router` isn't exported.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
