### PR TITLE
feat(server): add CORS support to nodeHTTPRequestHandler, add Standalone adapter documentation

### DIFF
--- a/examples/minimal-react/server/index.ts
+++ b/examples/minimal-react/server/index.ts
@@ -3,8 +3,8 @@
  * On a bigger app, you will probably want to split this file up into multiple files.
  */
 import { initTRPC } from '@trpc/server';
-import { createHTTPHandler } from '@trpc/server/adapters/standalone';
-import http from 'http';
+import { createHTTPServer } from '@trpc/server/adapters/standalone';
+import cors from 'cors';
 import { z } from 'zod';
 
 const t = initTRPC.create();
@@ -36,25 +36,12 @@ const appRouter = router({
 // None of the actual implementation is exposed to the client
 export type AppRouter = typeof appRouter;
 
-// create handler
-const handler = createHTTPHandler({
+// create server
+createHTTPServer({
+  cors: cors(),
   router: appRouter,
   createContext() {
     console.log('context 3');
     return {};
   },
-});
-
-const server = http.createServer((req, res) => {
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Request-Method', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'OPTIONS, GET');
-  res.setHeader('Access-Control-Allow-Headers', '*');
-  if (req.method === 'OPTIONS') {
-    res.writeHead(200);
-    return res.end();
-  }
-  handler(req, res);
-});
-
-server.listen(2022);
+}).listen(2022);

--- a/examples/minimal-react/server/index.ts
+++ b/examples/minimal-react/server/index.ts
@@ -38,7 +38,7 @@ export type AppRouter = typeof appRouter;
 
 // create server
 createHTTPServer({
-  cors: cors(),
+  middleware: cors(),
   router: appRouter,
   createContext() {
     console.log('context 3');

--- a/examples/minimal-react/server/package.json
+++ b/examples/minimal-react/server/package.json
@@ -10,9 +10,11 @@
   },
   "dependencies": {
     "@trpc/server": "^10.13.2",
+    "cors": "^2.8.5",
     "zod": "^3.0.0"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.13",
     "@types/node": "^18.7.20",
     "eslint": "^8.30.0",
     "tsx": "^3.12.3",

--- a/packages/server/src/adapters/node-http/nodeHTTPRequestHandler.ts
+++ b/packages/server/src/adapters/node-http/nodeHTTPRequestHandler.ts
@@ -28,7 +28,7 @@ export async function nodeHTTPRequestHandler<
   const handleViaMiddleware =
     opts.middleware ??
     ((_req, _res, next) => {
-      next();
+      return next();
     });
 
   return handleViaMiddleware(opts.req, opts.res, async (err) => {

--- a/packages/server/src/adapters/node-http/nodeHTTPRequestHandler.ts
+++ b/packages/server/src/adapters/node-http/nodeHTTPRequestHandler.ts
@@ -32,6 +32,23 @@ export async function nodeHTTPRequestHandler<
   };
   const { path, router } = opts;
 
+  if (opts.cors) {
+    await new Promise<void>((resolve, reject) => {
+      opts.cors!(opts.req, opts.res, (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+
+    if (opts.res.writableEnded) {
+      // cors handled the request
+      return;
+    }
+  }
+
   const bodyResult = await getPostBody(opts);
 
   const query = opts.req.query

--- a/packages/server/src/adapters/node-http/nodeHTTPRequestHandler.ts
+++ b/packages/server/src/adapters/node-http/nodeHTTPRequestHandler.ts
@@ -33,17 +33,21 @@ export async function nodeHTTPRequestHandler<
   const { path, router } = opts;
 
   if (opts.cors) {
-    await new Promise<void>((resolve, reject) => {
-      opts.cors!(opts.req, opts.res, (err) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve();
-        }
-      });
-    });
+    const corsStatus = await new Promise<'continue' | 'handled'>(
+      (resolve, reject) => {
+        opts.cors!(opts.req, opts.res, (err) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve('continue');
+          }
+        });
 
-    if (opts.res.writableEnded) {
+        resolve('handled');
+      },
+    );
+
+    if (corsStatus === 'handled') {
       // cors handled the request
       return;
     }

--- a/packages/server/src/adapters/node-http/nodeHTTPRequestHandler.ts
+++ b/packages/server/src/adapters/node-http/nodeHTTPRequestHandler.ts
@@ -26,7 +26,7 @@ export async function nodeHTTPRequestHandler<
   TResponse extends NodeHTTPResponse,
 >(opts: NodeHTTPRequestHandlerOptions<TRouter, TRequest, TResponse>) {
   const handleViaMiddleware =
-    opts.cors ??
+    opts.middleware ??
     ((_req, _res, next) => {
       next();
     });

--- a/packages/server/src/adapters/node-http/nodeHTTPRequestHandler.ts
+++ b/packages/server/src/adapters/node-http/nodeHTTPRequestHandler.ts
@@ -25,70 +25,72 @@ export async function nodeHTTPRequestHandler<
   TRequest extends NodeHTTPRequest,
   TResponse extends NodeHTTPResponse,
 >(opts: NodeHTTPRequestHandlerOptions<TRouter, TRequest, TResponse>) {
-  const createContext = async function _createContext(): Promise<
-    inferRouterContext<TRouter>
-  > {
-    return await opts.createContext?.(opts);
-  };
-  const { path, router } = opts;
+  const handleViaMiddleware =
+    opts.cors ??
+    ((_req, _res, next) => {
+      next();
+    });
 
-  if (opts.cors) {
-    const corsStatus = await new Promise<'continue' | 'handled'>(
-      (resolve, reject) => {
-        opts.cors!(opts.req, opts.res, (err) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve('continue');
-          }
+  return handleViaMiddleware(opts.req, opts.res, async (err) => {
+    if (err) {
+      throw err;
+    }
+
+    //
+    // Build tRPC dependencies
+
+    async function createContext(): Promise<inferRouterContext<TRouter>> {
+      return await opts.createContext?.(opts);
+    }
+
+    const bodyResult = await getPostBody(opts);
+
+    const query = opts.req.query
+      ? new URLSearchParams(opts.req.query as any)
+      : new URLSearchParams(opts.req.url!.split('?')[1]);
+
+    const req: HTTPRequest = {
+      method: opts.req.method!,
+      headers: opts.req.headers,
+      query,
+      body: bodyResult.ok ? bodyResult.data : undefined,
+    };
+
+    //
+    // Invoke tRPC
+
+    const result = await resolveHTTPResponse({
+      batching: opts.batching,
+      responseMeta: opts.responseMeta,
+      path: opts.path,
+      createContext,
+      router: opts.router,
+      req,
+      error: bodyResult.ok ? null : bodyResult.error,
+      onError(o) {
+        opts?.onError?.({
+          ...o,
+          req: opts.req,
         });
-
-        resolve('handled');
       },
-    );
+    });
 
-    if (corsStatus === 'handled') {
-      // cors handled the request
-      return;
+    //
+    // Handle result
+
+    const { res } = opts;
+    if ('status' in result && (!res.statusCode || res.statusCode === 200)) {
+      res.statusCode = result.status;
     }
-  }
 
-  const bodyResult = await getPostBody(opts);
+    for (const [key, value] of Object.entries(result.headers ?? {})) {
+      if (typeof value === 'undefined') {
+        continue;
+      }
 
-  const query = opts.req.query
-    ? new URLSearchParams(opts.req.query as any)
-    : new URLSearchParams(opts.req.url!.split('?')[1]);
-  const req: HTTPRequest = {
-    method: opts.req.method!,
-    headers: opts.req.headers,
-    query,
-    body: bodyResult.ok ? bodyResult.data : undefined,
-  };
-  const result = await resolveHTTPResponse({
-    batching: opts.batching,
-    responseMeta: opts.responseMeta,
-    path,
-    createContext,
-    router,
-    req,
-    error: bodyResult.ok ? null : bodyResult.error,
-    onError(o) {
-      opts?.onError?.({
-        ...o,
-        req: opts.req,
-      });
-    },
+      res.setHeader(key, value);
+    }
+
+    res.end(result.body);
   });
-
-  const { res } = opts;
-  if ('status' in result && (!res.statusCode || res.statusCode === 200)) {
-    res.statusCode = result.status;
-  }
-  for (const [key, value] of Object.entries(result.headers ?? {})) {
-    if (typeof value === 'undefined') {
-      continue;
-    }
-    res.setHeader(key, value);
-  }
-  res.end(result.body);
 }

--- a/packages/server/src/adapters/node-http/types.ts
+++ b/packages/server/src/adapters/node-http/types.ts
@@ -58,6 +58,9 @@ export type NodeHTTPHandlerOptions<
    *   cors: cors()
    * })
    * ```
+   *
+   * You can also use it for other needs which a connect/node.js compatible middleware can solve,
+   *  though you might wish to consider an alternative solution like the Express adapter if your needs are complex.
    */
   middleware?: ConnectMiddleware;
   maxBodySize?: number;

--- a/packages/server/src/adapters/node-http/types.ts
+++ b/packages/server/src/adapters/node-http/types.ts
@@ -36,6 +36,20 @@ export type NodeHTTPHandlerOptions<
   TRequest extends NodeHTTPRequest,
   TResponse extends NodeHTTPResponse,
 > = HTTPBaseHandlerOptions<TRouter, TRequest> & {
+  /**
+   * By default options requests are not handled and CORS headers are not returned.
+   *
+   * This can be used to handle them manually or via the `cors` npm package: https://www.npmjs.com/package/cors
+   *
+   * ```ts
+   * import cors from 'cors'
+   *
+   * nodeHTTPRequestHandler({
+   *   cors: cors()
+   * })
+   * ```
+   */
+  cors?: (req: TRequest, res: TResponse, next: (err?: any) => any) => void;
   maxBodySize?: number;
 } & NodeHTTPCreateContextOption<TRouter, TRequest, TResponse>;
 

--- a/packages/server/src/adapters/node-http/types.ts
+++ b/packages/server/src/adapters/node-http/types.ts
@@ -56,7 +56,7 @@ export type NodeHTTPHandlerOptions<
    * })
    * ```
    */
-  cors?: NodeMiddlewareLike;
+  middleware?: NodeMiddlewareLike;
   maxBodySize?: number;
 } & NodeHTTPCreateContextOption<TRouter, TRequest, TResponse>;
 

--- a/packages/server/src/adapters/node-http/types.ts
+++ b/packages/server/src/adapters/node-http/types.ts
@@ -31,6 +31,13 @@ export type NodeHTTPCreateContextOption<
       createContext: NodeHTTPCreateContextFn<TRouter, TRequest, TResponse>;
     };
 
+export interface NodeMiddlewareLike<
+  TRequest extends NodeHTTPRequest = NodeHTTPRequest,
+  TResponse extends NodeHTTPResponse = NodeHTTPResponse,
+> {
+  (req: TRequest, res: TResponse, next: (err?: any) => any): void;
+}
+
 export type NodeHTTPHandlerOptions<
   TRouter extends AnyRouter,
   TRequest extends NodeHTTPRequest,
@@ -49,7 +56,7 @@ export type NodeHTTPHandlerOptions<
    * })
    * ```
    */
-  cors?: (req: TRequest, res: TResponse, next: (err?: any) => any) => void;
+  cors?: NodeMiddlewareLike;
   maxBodySize?: number;
 } & NodeHTTPCreateContextOption<TRouter, TRequest, TResponse>;
 

--- a/packages/server/src/adapters/node-http/types.ts
+++ b/packages/server/src/adapters/node-http/types.ts
@@ -37,7 +37,7 @@ export type NodeHTTPHandlerOptions<
   TResponse extends NodeHTTPResponse,
 > = HTTPBaseHandlerOptions<TRouter, TRequest> & {
   /**
-   * By default options requests are not handled and CORS headers are not returned.
+   * By default, http `OPTIONS` requests are not handled, and CORS headers are not returned.
    *
    * This can be used to handle them manually or via the `cors` npm package: https://www.npmjs.com/package/cors
    *

--- a/packages/server/src/adapters/node-http/types.ts
+++ b/packages/server/src/adapters/node-http/types.ts
@@ -31,7 +31,10 @@ export type NodeHTTPCreateContextOption<
       createContext: NodeHTTPCreateContextFn<TRouter, TRequest, TResponse>;
     };
 
-export interface NodeMiddlewareLike<
+/**
+ * @internal
+ */
+interface ConnectMiddleware<
   TRequest extends NodeHTTPRequest = NodeHTTPRequest,
   TResponse extends NodeHTTPResponse = NodeHTTPResponse,
 > {
@@ -56,7 +59,7 @@ export type NodeHTTPHandlerOptions<
    * })
    * ```
    */
-  middleware?: NodeMiddlewareLike;
+  middleware?: ConnectMiddleware;
   maxBodySize?: number;
 } & NodeHTTPCreateContextOption<TRouter, TRequest, TResponse>;
 

--- a/packages/tests/server/adapters/next.test.ts
+++ b/packages/tests/server/adapters/next.test.ts
@@ -232,3 +232,59 @@ test('PUT request (fails)', async () => {
 
   expect(res.statusCode).toBe(405);
 });
+
+test('middleware intercepts request', async () => {
+  const t = initTRPC.create();
+
+  const router = t.router({
+    hello: t.procedure.query(() => 'world'),
+  });
+
+  const handler = trpcNext.createNextApiHandler({
+    middleware: (_req, res, _next) => {
+      res.statusCode = 419;
+      res.end();
+      return
+    },
+    router,
+  });
+
+  const { req } = mockReq({
+    query: {
+      trpc: [],
+    },
+    method: 'PUT',
+  });
+  const { res } = mockRes();
+
+  await handler(req, res);
+
+  expect(res.statusCode).toBe(419);
+})
+
+test('middleware passes the request', async () => {
+  const t = initTRPC.create();
+
+  const router = t.router({
+    hello: t.procedure.query(() => 'world'),
+  });
+
+  const handler = trpcNext.createNextApiHandler({
+    middleware: (_req, _res, next) => {
+      return next()
+    },
+    router,
+  });
+
+  const { req } = mockReq({
+    query: {
+      trpc: [],
+    },
+    method: 'PUT',
+  });
+  const { res } = mockRes();
+
+  await handler(req, res);
+
+  expect(res.statusCode).toBe(405);
+})

--- a/packages/tests/server/adapters/next.test.ts
+++ b/packages/tests/server/adapters/next.test.ts
@@ -244,7 +244,7 @@ test('middleware intercepts request', async () => {
     middleware: (_req, res, _next) => {
       res.statusCode = 419;
       res.end();
-      return
+      return;
     },
     router,
   });
@@ -260,7 +260,7 @@ test('middleware intercepts request', async () => {
   await handler(req, res);
 
   expect(res.statusCode).toBe(419);
-})
+});
 
 test('middleware passes the request', async () => {
   const t = initTRPC.create();
@@ -271,7 +271,7 @@ test('middleware passes the request', async () => {
 
   const handler = trpcNext.createNextApiHandler({
     middleware: (_req, _res, next) => {
-      return next()
+      return next();
     },
     router,
   });
@@ -287,4 +287,4 @@ test('middleware passes the request', async () => {
   await handler(req, res);
 
   expect(res.statusCode).toBe(405);
-})
+});

--- a/packages/tests/server/adapters/standalone.test.ts
+++ b/packages/tests/server/adapters/standalone.test.ts
@@ -1,0 +1,123 @@
+import { createHTTPServer, CreateHTTPHandlerOptions } from '@trpc/server/src/adapters/standalone';
+import {
+  TRPCClientError,
+  createTRPCProxyClient,
+  httpBatchLink,
+} from '@trpc/client/src';
+import fetch from 'node-fetch';
+import { initTRPC, TRPCError } from '@trpc/server';
+import { z } from 'zod';
+
+const t = initTRPC.create();
+const router = t.router({
+  hello: t.procedure
+    .input(
+      z
+        .object({
+          who: z.string().nullish(),
+        }),
+    )
+    .query(({ input }) => ({
+      text: `hello ${input?.who}`,
+    })),
+  exampleError: t.procedure.query(() => {
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Unexpected error',
+    });
+  }),
+});
+
+
+let app: ReturnType<typeof createHTTPServer>
+async function startServer(opts: CreateHTTPHandlerOptions<any>) {
+  app = createHTTPServer(opts)
+  app.server.addListener('error', (err) => {
+    throw err
+  })
+
+  const { port } = app.listen(0)
+
+  const client = createTRPCProxyClient<typeof router>({
+    links: [
+      httpBatchLink({
+        url: `http://localhost:${port}`,
+        AbortController,
+        fetch: fetch as any,
+      }),
+    ],
+  });
+
+  return {
+    port,
+    router,
+    client,
+  };
+}
+
+afterEach(async () => {
+  if (app) {
+    app.server.close()
+  }
+});
+
+test('simple query', async () => {
+  const t = await startServer({
+    router
+  })
+
+  expect(
+    await t.client.hello.query({
+      who: 'test',
+    }),
+  ).toMatchInlineSnapshot(`
+    Object {
+      "text": "hello test",
+    }
+  `);
+});
+
+test('error query', async () => {
+  const t = await startServer({
+    router
+  })
+
+  try {
+    await t.client.exampleError.query();
+  } catch (e) {
+    expect(e).toStrictEqual(new TRPCClientError('Unexpected error'));
+  }
+});
+
+
+test('middleware intercepts request', async () => {
+  const t = await startServer({
+    middleware: (_req, res, _next) => {
+      res.statusCode = 419;
+      res.end();
+      return
+    },
+    router
+  })
+
+  const result = await fetch(`http://localhost:${t.port}`)
+  
+  expect(result.status).toBe(419);
+})
+
+test('middleware passes the request', async () => {
+  const t = await startServer({
+    middleware: (_req, _res, next) => {
+      return next()
+    },
+    router
+  })
+  
+  const result = await t.client.hello.query({who: 'test'})  
+
+  expect(result).toMatchInlineSnapshot(`
+    Object {
+      "text": "hello test",
+    }
+  `);
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -462,15 +462,19 @@ importers:
   examples/minimal-react/server:
     specifiers:
       '@trpc/server': ^10.13.2
+      '@types/cors': ^2.8.13
       '@types/node': ^18.7.20
+      cors: ^2.8.5
       eslint: ^8.30.0
       tsx: ^3.12.3
       typescript: ^4.8.3
       zod: ^3.0.0
     dependencies:
       '@trpc/server': link:../../../packages/server
+      cors: 2.8.5
       zod: 3.20.2
     devDependencies:
+      '@types/cors': 2.8.13
       '@types/node': 18.7.20
       eslint: 8.30.0
       tsx: 3.12.3
@@ -8896,6 +8900,12 @@ packages:
     dependencies:
       '@types/node': 18.13.0
 
+  /@types/cors/2.8.13:
+    resolution: {integrity: sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==}
+    dependencies:
+      '@types/node': 18.13.0
+    dev: true
+
   /@types/d3-hierarchy/1.1.8:
     resolution: {integrity: sha512-AbStKxNyWiMDQPGDguG2Kuhlq1Sv539pZSxYbx4UZeYkutpPwXCcgyiRrlV4YH64nIOsKx7XVnOMy9O7rJsXkg==}
     dev: false
@@ -11302,6 +11312,14 @@ packages:
 
   /core-util-is/1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  /cors/2.8.5:
+    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+    dev: false
 
   /cosmiconfig/6.0.0:
     resolution: {integrity: sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==}

--- a/www/docs/server/adapter/standalone.md
+++ b/www/docs/server/adapter/standalone.md
@@ -68,7 +68,7 @@ The Standalone adapter runs a simple Node.js HTTP server.
 ```ts title='server.ts'
 import { inferAsyncReturnType, initTRPC } from '@trpc/server';
 import { createHTTPServer } from '@trpc/server/adapters/standalone';
-import { appRouter } from './appRouter.ts'
+import { appRouter } from './appRouter.ts';
 
 createHTTPServer({
   router: appRouter,
@@ -95,7 +95,6 @@ yarn add -D @types/cors
 ```
 
 For full information on how to configure this package, [check the docs](https://github.com/expressjs/cors#readme)
-
 
 ### 2. Configure the Standalone server
 
@@ -129,7 +128,7 @@ If `createHTTPServer` isn't enough you can also use the standalone adapter's `cr
 ```ts title='server.ts'
 import { inferAsyncReturnType, initTRPC } from '@trpc/server';
 import { createHTTPHandler } from '@trpc/server/adapters/standalone';
-import { createServer } from 'http'
+import { createServer } from 'http';
 
 const handler = createHTTPHandler({
   router: appRouter,
@@ -140,12 +139,12 @@ const handler = createHTTPHandler({
 
 createServer((req, res) => {
   /**
-   * Handle the request however you like, 
+   * Handle the request however you like,
    * just call the tRPC handler when you're ready
    */
 
-  handler(req, res)
-})
+  handler(req, res);
+});
 
-server.listen(3333)
+server.listen(3333);
 ```

--- a/www/docs/server/adapter/standalone.md
+++ b/www/docs/server/adapter/standalone.md
@@ -115,7 +115,7 @@ createHTTPServer({
 }).listen(3333);
 ```
 
-The `middleware` option will accept any function which resembles a node.js middleware, so it can be used for more than `cors` handling if you wish. It is, however, intended to be a simple escape hatch and as such won't on its own allow you to compose multiple middlewares together. If you want to do this then you could:
+The `middleware` option will accept any function which resembles a connect/node.js middleware, so it can be used for more than `cors` handling if you wish. It is, however, intended to be a simple escape hatch and as such won't on its own allow you to compose multiple middlewares together. If you want to do this then you could:
 
 1. Use an alternate adapter with more comprehensive middleware support, like the [Express adapter](/docs/express)
 2. Use a solution to compose middlewares such as [connect](https://github.com/senchalabs/connect)

--- a/www/docs/server/adapter/standalone.md
+++ b/www/docs/server/adapter/standalone.md
@@ -107,7 +107,7 @@ import { createHTTPServer } from '@trpc/server/adapters/standalone';
 import cors from 'cors';
 
 createHTTPServer({
-  cors: cors(),
+  middleware: cors(),
   router: appRouter,
   createContext() {
     console.log('context 3');
@@ -115,6 +115,12 @@ createHTTPServer({
   },
 }).listen(3333);
 ```
+
+The `middleware` option will accept any function which resembles a node.js middleware, so it can be used for more than `cors` handling if you wish. It is, however, intended to be a simple escape hatch and as such won't on its own allow you to compose multiple middlewares together. If you want to do this then you could:
+
+1. Use an alternate adapter with more comprehensive middleware support, like the [Express adapter](/docs/express)
+2. Use a solution to compose middlewares such as [connect](https://github.com/senchalabs/connect)
+3. Extend the Standalone `createHTTPHandler` with a custom http server (see below)
 
 ## Going further
 
@@ -134,7 +140,7 @@ const handler = createHTTPHandler({
 
 createServer((req, res) => {
   /**
-   * Handle the request however you like here, 
+   * Handle the request however you like, 
    * just call the tRPC handler when you're ready
    */
 

--- a/www/docs/server/adapter/standalone.md
+++ b/www/docs/server/adapter/standalone.md
@@ -1,0 +1,145 @@
+---
+id: standalone
+title: Standalone Usage
+sidebar_label: Standalone
+slug: /standalone
+---
+
+## Example app
+
+<table>
+  <thead>
+    <tr>
+      <th>Description</th>
+      <th>URL</th>
+      <th>Links</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Standalone tRPC Server with Node.js</td>
+      <td><em>n/a</em></td>
+      <td>
+        <ul>
+          <li><a href="https://githubbox.com/trpc/trpc/blob/main/examples/minimal">CodeSandbox</a></li>
+          <li><a href="https://github.com/trpc/trpc/blob/main/examples/minimal/server/index.ts">Source</a></li>
+        </ul>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Setting up a Standalone tRPC Server
+
+### 1. Implement your App Router
+
+Implement your tRPC router. For example:
+
+```ts title='appRouter.ts'
+import { initTRPC } from '@trpc/server';
+import { z } from 'zod';
+
+export const t = initTRPC.create();
+
+export const appRouter = t.router({
+  getUser: t.procedure.input(z.string()).query((req) => {
+    return { id: req.input, name: 'Bilbo' };
+  }),
+  createUser: t.procedure
+    .input(z.object({ name: z.string().min(5) }))
+    .mutation(async (req) => {
+      // use your ORM of choice
+      return await UserModel.create({
+        data: req.input,
+      });
+    }),
+});
+
+// export type definition of API
+export type AppRouter = typeof appRouter;
+```
+
+For more information you can look at the [quickstart guide](/docs/quickstart)
+
+### 2. Use the Standalone adapter
+
+The Standalone adapter runs a simple Node.js HTTP server.
+
+```ts title='server.ts'
+import { inferAsyncReturnType, initTRPC } from '@trpc/server';
+import { createHTTPServer } from '@trpc/server/adapters/standalone';
+import { appRouter } from './appRouter.ts'
+
+createHTTPServer({
+  router: appRouter,
+  createContext() {
+    console.log('context 3');
+    return {};
+  },
+}).listen(2022);
+```
+
+## Handling CORS & Options
+
+By default the standalone server will not respond to HTTP OPTIONS requests, or set any CORS headers.
+
+If you're not hosting in an environment which can handle this for you, like during local development, you may need to handle it.
+
+### 1. Install cors
+
+You can add support yourself with the popular `cors` package
+
+```bash
+yarn add cors
+yarn add -D @types/cors
+```
+
+For full information on how to configure this package, [check the docs](https://github.com/expressjs/cors#readme)
+
+
+### 2. Configure the Standalone server
+
+This example just throws open CORS to any request, which is useful for development, but you can and should configure it more strictly in a production environment.
+
+```ts title='server.ts'
+import { inferAsyncReturnType, initTRPC } from '@trpc/server';
+import { createHTTPServer } from '@trpc/server/adapters/standalone';
+import cors from 'cors';
+
+createHTTPServer({
+  cors: cors(),
+  router: appRouter,
+  createContext() {
+    console.log('context 3');
+    return {};
+  },
+}).listen(3333);
+```
+
+## Going further
+
+If `createHTTPServer` isn't enough you can also use the standalone adapter's `createHTTPHandler` function to create your own HTTP Server. For instance:
+
+```ts title='server.ts'
+import { inferAsyncReturnType, initTRPC } from '@trpc/server';
+import { createHTTPHandler } from '@trpc/server/adapters/standalone';
+import { createServer } from 'http'
+
+const handler = createHTTPHandler({
+  router: appRouter,
+  createContext() {
+    return {};
+  },
+});
+
+createServer((req, res) => {
+  /**
+   * Handle the request however you like here, 
+   * just call the tRPC handler when you're ready
+   */
+
+  handler(req, res)
+})
+
+server.listen(3333)
+```

--- a/www/docs/server/adapter/standalone.md
+++ b/www/docs/server/adapter/standalone.md
@@ -11,18 +11,25 @@ slug: /standalone
   <thead>
     <tr>
       <th>Description</th>
-      <th>URL</th>
       <th>Links</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td>Standalone tRPC Server with Node.js</td>
-      <td><em>n/a</em></td>
+      <td>Standalone tRPC Server</td>
       <td>
         <ul>
-          <li><a href="https://githubbox.com/trpc/trpc/blob/main/examples/minimal">CodeSandbox</a></li>
+          <li><a href="https://stackblitz.com/github/trpc/trpc/tree/main/examples/minimal">CodeSandbox</a></li>
           <li><a href="https://github.com/trpc/trpc/blob/main/examples/minimal/server/index.ts">Source</a></li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td>Standalone tRPC Server with CORS handling</td>
+      <td>
+        <ul>
+          <li><a href="https://stackblitz.com/github/trpc/trpc/tree/main/examples/minimal-react">CodeSandbox</a></li>
+          <li><a href="https://github.com/trpc/trpc/blob/main/examples/minimal-react/server/index.ts">Source</a></li>
         </ul>
       </td>
     </tr>

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -55,10 +55,10 @@ module.exports = {
           },
           items: [
             'server/adapter/aws-lambda',
-            'server/adapter/standalone',
             'server/adapter/express',
             'server/adapter/fastify',
             'server/adapter/fetch',
+            'server/adapter/standalone',
           ],
         },
       ],

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -55,6 +55,7 @@ module.exports = {
           },
           items: [
             'server/adapter/aws-lambda',
+            'server/adapter/standalone',
             'server/adapter/express',
             'server/adapter/fastify',
             'server/adapter/fetch',


### PR DESCRIPTION
Closes #3881 

Since this adds support to `nodeHTTPRequestHandler` directly, the change is also upstream of 
the express, next, and standalone, adapters.

I've implemented and run this against the minimal example and it works, though if the approach is acceptable some updates to documentation will probably be in order.

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
