### PR TITLE
docs: add fetch polyfill to make sample runnable

### DIFF
--- a/examples/express-server/package.json
+++ b/examples/express-server/package.json
@@ -19,6 +19,7 @@
     "@trpc/react-query": "^10.13.0",
     "@trpc/server": "^10.13.0",
     "express": "^4.17.1",
+    "node-fetch": "^3.3.0",
     "zod": "^3.0.0"
   },
   "alias": {

--- a/examples/express-server/src/client.ts
+++ b/examples/express-server/src/client.ts
@@ -1,6 +1,11 @@
 import { createTRPCProxyClient, httpBatchLink, loggerLink } from '@trpc/client';
 import { tap } from '@trpc/server/observable';
+import fetch from 'node-fetch';
 import type { AppRouter } from './server';
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+globalThis.fetch = fetch;
 
 const sleep = (ms = 100) => new Promise((resolve) => setTimeout(resolve, ms));
 


### PR DESCRIPTION
Closes #

## 🎯 Changes

Noticed that the express-server example wasn't working with following error:
```
Error: No fetch implementation found
[dev:client]     at getFetch (file:///Users/patrickullrich/Src/trpc/examples/express-server/node_modules/@trpc/client/dist/httpUtils-24d9ee59.mjs:11:11)
[dev:client]     at resolveHTTPLinkOptions (file:///Users/patrickullrich/Src/trpc/examples/express-server/node_modules/@trpc/client/dist/httpUtils-24d9ee59.mjs:31:16)
[dev:client]     at httpBatchLink (file:///Users/patrickullrich/Src/trpc/examples/express-server/node_modules/@trpc/client/dist/links/httpBatchLink.mjs:127:26)
[dev:client]     at null.main (/Users/patrickullrich/Src/trpc/examples/express-server/src/client.ts:24:7)
[dev:client]     at null.<anonymous> (/Users/patrickullrich/Src/trpc/examples/express-server/src/client.ts:74:1)
[dev:client]     at ModuleJob.run (node:internal/modules/esm/module_job:195:25)
[dev:client]     at async Promise.all (index 0)
[dev:client]     at async ESMLoader.import (node:internal/modules/esm/loader:337:24)
[dev:client]     at async loadESM (node:internal/process/esm_loader:88:5)
[dev:client]     at async handleMainPromise (node:internal/modules/run_main:61:12)
```

This polyfills fetch and it makes the sample run both in codesandbox and locally.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
