### PR TITLE
chore: update peers

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -69,7 +69,7 @@
     "links"
   ],
   "peerDependencies": {
-    "@trpc/server": "^10.8.0"
+    "@trpc/server": "10.13.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^9.0.0",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -44,10 +44,10 @@
   ],
   "peerDependencies": {
     "@tanstack/react-query": "^4.3.8",
-    "@trpc/client": "^10.8.0",
-    "@trpc/react-query": "^10.8.0",
-    "@trpc/server": "^10.8.0",
-    "next": "13.2.1",
+    "@trpc/client": "10.13.0",
+    "@trpc/react-query": "10.13.0",
+    "@trpc/server": "10.13.0",
+    "next": "^13.0.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   },

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -57,8 +57,8 @@
   },
   "peerDependencies": {
     "@tanstack/react-query": "^4.3.8",
-    "@trpc/client": "^10.8.0",
-    "@trpc/server": "^10.8.0",
+    "@trpc/client": "10.13.0",
+    "@trpc/server": "10.13.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   },


### PR DESCRIPTION
t3-app started breaking cause 10.13 required nextjs 13.2.1 (don't check the gitblame xdddd)

reverting that to be `^13.0.0` and also fixes all the trcp versions to eachother