### PR TITLE
fix: concat type inference

### DIFF
--- a/packages/tests/server/concat.test.ts
+++ b/packages/tests/server/concat.test.ts
@@ -73,16 +73,15 @@ const ctx = konn()
 
 test('decorate independently', async () => {
   const result = await ctx.proxy.getContext.mutate();
-  // This is correct
+
   expect(result).toEqual({
     user: mockUser,
     foo: 'bar',
   });
 
-  // This is not correct
-  expectTypeOf(result).toMatchTypeOf<{
-    // TODO FIXME: this is a bug in the type inference
-    // user: User;
+  expectTypeOf(result).toEqualTypeOf<{
+    user: User | null;
+
     foo: 'bar';
   }>();
 });


### PR DESCRIPTION
Closes #

## 🎯 Changes

This is a bugfix for concat test.
What was happening is that the "result" type was different from "User". 

## ✅ Checklist

- [ X ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ X ] If necessary, I have added documentation related to the changes made.
- [ X ] I have added or updated the tests related to the changes made.
