### PR TITLE
fix(`@trpc/next`): set `next` peer dependency to `*`

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -47,7 +47,7 @@
     "@trpc/client": "10.14.0",
     "@trpc/react-query": "10.14.0",
     "@trpc/server": "10.14.0",
-    "next": "^13.0.0",
+    "next": "*",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   },


### PR DESCRIPTION
I think we don't need to be strict to 13 [yet], do we? 

I have problems upgrading my app at work b/c trpc now forces me to update the whole universe
