### PR TITLE
remove reference to resolve()

### DIFF
--- a/www/docs/further/subscriptions.md
+++ b/www/docs/further/subscriptions.md
@@ -29,7 +29,6 @@ const t = initTRPC.create();
 
 export const appRouter = t.router({
   onAdd: t.procedure.subscription(() => {
-    // `resolve()` is triggered for each client when they start subscribing `onAdd`
 
     // return an `observable` with a callback which is triggered immediately
     return observable<Post>((emit) => {

--- a/www/docs/further/subscriptions.md
+++ b/www/docs/further/subscriptions.md
@@ -29,7 +29,6 @@ const t = initTRPC.create();
 
 export const appRouter = t.router({
   onAdd: t.procedure.subscription(() => {
-
     // return an `observable` with a callback which is triggered immediately
     return observable<Post>((emit) => {
       const onAdd = (data: Post) => {


### PR DESCRIPTION
I couldnt find any other references to resolve(). it seems it might be a v9 concept that was removed in v10? I'm not sure because I've only ever used v10
