### PR TITLE
Transformers must be able to roundtrip through JSON stringify/parse

### DIFF
--- a/packages/server/src/transformer.ts
+++ b/packages/server/src/transformer.ts
@@ -2,30 +2,34 @@
  * @public
  */
 export interface DataTransformer {
-  serialize(object: any): any;
-  deserialize(object: any): any;
+  serialize(object: any): JsonParseable;
+  deserialize(object: JsonParseable): any;
 }
+
+type JsonParseable =  boolean | number | string | null | JsonArray | JsonMap;
+interface JsonMap {  [key: string]: AnyJson; }
+interface JsonArray extends Array<AnyJson> {}
 
 interface InputDataTransformer extends DataTransformer {
   /**
    * This function runs **on the client** before sending the data to the server.
    */
-  serialize(object: any): any;
+  serialize(object: any): JsonParseable;
   /**
    * This function runs **on the server** to transform the data before it is passed to the resolver
    */
-  deserialize(object: any): any;
+  deserialize(object: JsonParseable): any;
 }
 
 interface OutputDataTransformer extends DataTransformer {
   /**
    * This function runs **on the server** before sending the data to the client.
    */
-  serialize(object: any): any;
+  serialize(object: any): JsonParseable;
   /**
    * This function runs **only on the client** to transform the data sent from the server.
    */
-  deserialize(object: any): any;
+  deserialize(object: JsonParseable): any;
 }
 
 /**


### PR DESCRIPTION
I tried to use msgpackr as transformer. But msgpackr serializes to Uint8Array which is not able to round-trip through
```
JSON.stringify(JSON.parse(XXX))
```

This commit attempts to clarify that requirement.

Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
