### PR TITLE
Try adding sandpack for our needs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1131,6 +1131,8 @@ importers:
       '@algolia/client-search': ^4.9.1
       '@babel/core': ^7.18.6
       '@babel/preset-env': ^7.18.6
+      '@codesandbox/nodebox': ^0.1.6
+      '@codesandbox/sandpack-react': ^2.1.3
       '@docusaurus/core': 2.3.1
       '@docusaurus/module-type-aliases': 2.3.1
       '@docusaurus/plugin-content-docs': 2.3.1
@@ -1179,6 +1181,8 @@ importers:
       zod: ^3.0.0
     dependencies:
       '@algolia/client-search': 4.14.2
+      '@codesandbox/nodebox': 0.1.6
+      '@codesandbox/sandpack-react': 2.1.3_biqbaboplfbrettd7655fr4n2y
       '@docusaurus/core': 2.3.1_eifaucn3awwobbso7nlgjimoxe
       '@docusaurus/plugin-content-docs': 2.3.1_hvwp2hfr42m3u4fhckttgf5oni
       '@docusaurus/preset-classic': 2.3.1_7xhr2uwtczhx7d2nas4xlfomti
@@ -4780,6 +4784,151 @@ packages:
   /@cloudflare/workers-types/4.20230215.0:
     resolution: {integrity: sha512-s71gaGwtEIxjSu6l0cekbXm9AwjrmrFVcHPNx9tHidG2dnqamYf5Nms/KgMYZf7gnjdKOp/ZChYFeJJkNv3QfA==}
 
+  /@code-hike/classer/0.0.0-e48fa74_react@18.2.0:
+    resolution: {integrity: sha512-CyPYvfl4K5Hp9uyhLhUemul56eiGOF0FNXh5ALzzK9VNhRmRmj1O0mKtLDpoccI8W90r9kQES/nW2FC8jVVieg==}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      react: 18.2.0
+    dev: false
+
+  /@codemirror/autocomplete/6.4.2:
+    resolution: {integrity: sha512-8WE2xp+D0MpWEv5lZ6zPW1/tf4AGb358T5GWYiKEuCP8MvFfT3tH2mIF9Y2yr2e3KbHuSvsVhosiEyqCpiJhZQ==}
+    dependencies:
+      '@codemirror/language': 6.6.0
+      '@codemirror/state': 6.2.0
+      '@codemirror/view': 6.9.2
+      '@lezer/common': 1.0.2
+    dev: false
+
+  /@codemirror/commands/6.2.2:
+    resolution: {integrity: sha512-s9lPVW7TxXrI/7voZ+HmD/yiAlwAYn9PH5SUVSUhsxXHhv4yl5eZ3KLntSoTynfdgVYM0oIpccQEWRBQgmNZyw==}
+    dependencies:
+      '@codemirror/language': 6.6.0
+      '@codemirror/state': 6.2.0
+      '@codemirror/view': 6.9.2
+      '@lezer/common': 1.0.2
+    dev: false
+
+  /@codemirror/lang-css/6.1.1:
+    resolution: {integrity: sha512-P6jdNEHyRcqqDgbvHYyC9Wxkek0rnG3a9aVSRi4a7WrjPbQtBTaOmvYpXmm13zZMAatO4Oqpac+0QZs7sy+LnQ==}
+    dependencies:
+      '@codemirror/autocomplete': 6.4.2
+      '@codemirror/language': 6.6.0
+      '@codemirror/state': 6.2.0
+      '@lezer/css': 1.1.1
+    dev: false
+
+  /@codemirror/lang-html/6.4.2:
+    resolution: {integrity: sha512-bqCBASkteKySwtIbiV/WCtGnn/khLRbbiV5TE+d9S9eQJD7BA4c5dTRm2b3bVmSpilff5EYxvB4PQaZzM/7cNw==}
+    dependencies:
+      '@codemirror/autocomplete': 6.4.2
+      '@codemirror/lang-css': 6.1.1
+      '@codemirror/lang-javascript': 6.1.4
+      '@codemirror/language': 6.6.0
+      '@codemirror/state': 6.2.0
+      '@codemirror/view': 6.9.2
+      '@lezer/common': 1.0.2
+      '@lezer/css': 1.1.1
+      '@lezer/html': 1.3.3
+    dev: false
+
+  /@codemirror/lang-javascript/6.1.4:
+    resolution: {integrity: sha512-OxLf7OfOZBTMRMi6BO/F72MNGmgOd9B0vetOLvHsDACFXayBzW8fm8aWnDM0yuy68wTK03MBf4HbjSBNRG5q7A==}
+    dependencies:
+      '@codemirror/autocomplete': 6.4.2
+      '@codemirror/language': 6.6.0
+      '@codemirror/lint': 6.2.0
+      '@codemirror/state': 6.2.0
+      '@codemirror/view': 6.9.2
+      '@lezer/common': 1.0.2
+      '@lezer/javascript': 1.4.1
+    dev: false
+
+  /@codemirror/language/6.6.0:
+    resolution: {integrity: sha512-cwUd6lzt3MfNYOobdjf14ZkLbJcnv4WtndYaoBkbor/vF+rCNguMPK0IRtvZJG4dsWiaWPcK8x1VijhvSxnstg==}
+    dependencies:
+      '@codemirror/state': 6.2.0
+      '@codemirror/view': 6.9.2
+      '@lezer/common': 1.0.2
+      '@lezer/highlight': 1.1.3
+      '@lezer/lr': 1.3.3
+      style-mod: 4.0.0
+    dev: false
+
+  /@codemirror/lint/6.2.0:
+    resolution: {integrity: sha512-KVCECmR2fFeYBr1ZXDVue7x3q5PMI0PzcIbA+zKufnkniMBo1325t0h1jM85AKp8l3tj67LRxVpZfgDxEXlQkg==}
+    dependencies:
+      '@codemirror/state': 6.2.0
+      '@codemirror/view': 6.9.2
+      crelt: 1.0.5
+    dev: false
+
+  /@codemirror/state/6.2.0:
+    resolution: {integrity: sha512-69QXtcrsc3RYtOtd+GsvczJ319udtBf1PTrr2KbLWM/e2CXUPnh0Nz9AUo8WfhSQ7GeL8dPVNUmhQVgpmuaNGA==}
+    dev: false
+
+  /@codemirror/view/6.9.2:
+    resolution: {integrity: sha512-ci0r/v6aKOSlzOs7/STMTYP3jX/+YMq2dAfAJcLIB6uom4ThtrUlzeuS7GTRGNqJJ+qAJR1vGWfXgu4CO/0myQ==}
+    dependencies:
+      '@codemirror/state': 6.2.0
+      style-mod: 4.0.0
+      w3c-keyname: 2.2.6
+    dev: false
+
+  /@codesandbox/nodebox/0.1.4:
+    resolution: {integrity: sha512-+MR7JibjGjTRDmyQbL8Mliej6wakQP7q99+wGL/nOzd0Q3s+YWGQfv0QpYKbdMClKUTFJGvwzwOeqHVTkpWNCQ==}
+    dependencies:
+      outvariant: 1.3.0
+      strict-event-emitter: 0.4.6
+    dev: false
+
+  /@codesandbox/nodebox/0.1.6:
+    resolution: {integrity: sha512-+ECJ7MT7Jbn3XmXuIotCTWK4sQIh3qwm8wKDrJLJHq7mfGio2T53tArSu8W1JqiGWBthtUNp+4mC6zj8rqdTXg==}
+    dependencies:
+      outvariant: 1.3.0
+      strict-event-emitter: 0.4.6
+    dev: false
+
+  /@codesandbox/sandpack-client/2.1.0:
+    resolution: {integrity: sha512-/z3EbaYaatd45DWAOvhU+8M7cMaDlmBEjyQaahNXRDY7keSraMZnsdImmASlU9qqLm6vQpAu1ZXtOMeL7dkMww==}
+    dependencies:
+      '@codesandbox/nodebox': 0.1.4
+      buffer: 6.0.3
+      dequal: 2.0.3
+      outvariant: 1.3.0
+    dev: false
+
+  /@codesandbox/sandpack-react/2.1.3_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-DV/t0esOi9nalUIZd/TBIiHv7IyYOegGnXkp483fj7GL+tmVjOEZAsxqjkyLTJGWuo0a0JS7tp2RFq6mGtm1kw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18
+      react-dom: ^16.8.0 || ^17 || ^18
+    dependencies:
+      '@code-hike/classer': 0.0.0-e48fa74_react@18.2.0
+      '@codemirror/autocomplete': 6.4.2
+      '@codemirror/commands': 6.2.2
+      '@codemirror/lang-css': 6.1.1
+      '@codemirror/lang-html': 6.4.2
+      '@codemirror/lang-javascript': 6.1.4
+      '@codemirror/language': 6.6.0
+      '@codemirror/state': 6.2.0
+      '@codemirror/view': 6.9.2
+      '@codesandbox/sandpack-client': 2.1.0
+      '@lezer/highlight': 1.1.3
+      '@react-hook/intersection-observer': 3.1.1_react@18.2.0
+      '@stitches/core': 1.2.8
+      ansi-to-react: 6.1.6_biqbaboplfbrettd7655fr4n2y
+      clean-set: 1.1.2
+      codesandbox-import-util-types: 2.2.3
+      dequal: 2.0.3
+      lz-string: 1.4.4
+      react: 18.2.0
+      react-devtools-inline: 4.4.0
+      react-dom: 18.2.0_react@18.2.0
+      react-is: 17.0.2
+    dev: false
+
   /@colors/colors/1.5.0:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
@@ -7153,6 +7302,44 @@ packages:
       write-file-atomic: 4.0.2
     dev: false
 
+  /@lezer/common/1.0.2:
+    resolution: {integrity: sha512-SVgiGtMnMnW3ActR8SXgsDhw7a0w0ChHSYAyAUxxrOiJ1OqYWEKk/xJd84tTSPo1mo6DXLObAJALNnd0Hrv7Ng==}
+    dev: false
+
+  /@lezer/css/1.1.1:
+    resolution: {integrity: sha512-mSjx+unLLapEqdOYDejnGBokB5+AiJKZVclmud0MKQOKx3DLJ5b5VTCstgDDknR6iIV4gVrN6euzsCnj0A2gQA==}
+    dependencies:
+      '@lezer/highlight': 1.1.3
+      '@lezer/lr': 1.3.3
+    dev: false
+
+  /@lezer/highlight/1.1.3:
+    resolution: {integrity: sha512-3vLKLPThO4td43lYRBygmMY18JN3CPh9w+XS2j8WC30vR4yZeFG4z1iFe4jXE43NtGqe//zHW5q8ENLlHvz9gw==}
+    dependencies:
+      '@lezer/common': 1.0.2
+    dev: false
+
+  /@lezer/html/1.3.3:
+    resolution: {integrity: sha512-04Fyvu66DjV2EjhDIG1kfDdktn5Pfw56SXPrzKNQH5B2m7BDfc6bDsz+ZJG8dLS3kIPEKbyyq1Sm2/kjeG0+AA==}
+    dependencies:
+      '@lezer/common': 1.0.2
+      '@lezer/highlight': 1.1.3
+      '@lezer/lr': 1.3.3
+    dev: false
+
+  /@lezer/javascript/1.4.1:
+    resolution: {integrity: sha512-Hqx36DJeYhKtdpc7wBYPR0XF56ZzIp0IkMO/zNNj80xcaFOV4Oj/P7TQc/8k2TxNhzl7tV5tXS8ZOCPbT4L3nA==}
+    dependencies:
+      '@lezer/highlight': 1.1.3
+      '@lezer/lr': 1.3.3
+    dev: false
+
+  /@lezer/lr/1.3.3:
+    resolution: {integrity: sha512-JPQe3mwJlzEVqy67iQiiGozhcngbO8QBgpqZM6oL1Wj/dXckrEexpBLeFkq0edtW5IqnPRFxA24BHJni8Js69w==}
+    dependencies:
+      '@lezer/common': 1.0.2
+    dev: false
+
   /@manypkg/cli/0.20.0:
     resolution: {integrity: sha512-xOAyzHp4cF6+1VxCeVi14k4WJBbKAExuYVA+wXlCHPLoTUv64D2HQrLUOFO8bXtzW9KFhGhdP2xGFq9n9rSDiw==}
     engines: {node: '>=14.18.0'}
@@ -8249,6 +8436,24 @@ packages:
     resolution: {integrity: sha512-B3tcTxjx196nuAu1GOTKO9cGPUgTFHYRdkPkTS4m5ptb2cejyBlH9X7GOfSt3xlI7p4zAJDshJP4JJivCg9ouA==}
     requiresBuild: true
 
+  /@react-hook/intersection-observer/3.1.1_react@18.2.0:
+    resolution: {integrity: sha512-OTDx8/wFaRvzFtKl1dEUEXSOqK2zVJHporiTTdC2xO++0e9FEx9wIrPis5q3lqtXeZH9zYGLbk+aB75qNFbbuw==}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      '@react-hook/passive-layout-effect': 1.2.1_react@18.2.0
+      intersection-observer: 0.10.0
+      react: 18.2.0
+    dev: false
+
+  /@react-hook/passive-layout-effect/1.2.1_react@18.2.0:
+    resolution: {integrity: sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      react: 18.2.0
+    dev: false
+
   /@resvg/resvg-wasm/2.0.0-alpha.4:
     resolution: {integrity: sha512-pWIG9a/x1ky8gXKRhPH1OPKpHFoMN1ISLbJ+O+gPXQHIAKhNd5I28RlWf7q576hAOQA9JZTlo3p/M2uyLzJmmw==}
     engines: {node: '>= 10'}
@@ -8445,6 +8650,10 @@ packages:
       eval: 0.1.8
       p-map: 4.0.0
       webpack-sources: 3.2.3
+    dev: false
+
+  /@stitches/core/1.2.8:
+    resolution: {integrity: sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==}
     dev: false
 
   /@svgr/babel-plugin-add-jsx-attribute/6.5.1_@babel+core@7.20.12:
@@ -9801,6 +10010,10 @@ packages:
       '@algolia/transporter': 4.14.2
     dev: false
 
+  /anser/1.4.10:
+    resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
+    dev: false
+
   /ansi-align/3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
     dependencies:
@@ -9854,6 +10067,18 @@ packages:
   /ansi-styles/6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
+
+  /ansi-to-react/6.1.6_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-+HWn72GKydtupxX9TORBedqOMsJRiKTqaLUKW8txSBZw9iBpzPKLI8KOu4WzwD4R7hSv1zEspobY6LwlWvwZ6Q==}
+    peerDependencies:
+      react: ^16.3.2 || ^17.0.0
+      react-dom: ^16.3.2 || ^17.0.0
+    dependencies:
+      anser: 1.4.10
+      escape-carriage: 1.3.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+    dev: false
 
   /anymatch/3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -10821,6 +11046,10 @@ packages:
       escape-string-regexp: 1.0.5
     dev: false
 
+  /clean-set/1.1.2:
+    resolution: {integrity: sha512-cA8uCj0qSoG9e0kevyOWXwPaELRPVg5Pxp6WskLMwerx257Zfnh8Nl0JBH59d7wQzij2CK7qEfJQK3RjuKKIug==}
+    dev: false
+
   /clean-stack/2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
@@ -10961,6 +11190,10 @@ packages:
 
   /code-block-writer/11.0.3:
     resolution: {integrity: sha512-NiujjUFB4SwScJq2bwbYUtXbZhBSlY6vYzm++3Q6oC+U+injTqfPYFK8wS9COOmb2lueqp0ZRB4nK1VYeHgNyw==}
+    dev: false
+
+  /codesandbox-import-util-types/2.2.3:
+    resolution: {integrity: sha512-Qj00p60oNExthP2oR3vvXmUGjukij+rxJGuiaKM6tyUmSyimdZsqHI/TUvFFClAffk9s7hxGnQgWQ8KCce27qQ==}
     dev: false
 
   /collapse-white-space/1.0.6:
@@ -11377,6 +11610,10 @@ packages:
       crc-32: 1.2.2
       readable-stream: 3.6.0
     dev: true
+
+  /crelt/1.0.5:
+    resolution: {integrity: sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA==}
+    dev: false
 
   /cron-parser/3.5.0:
     resolution: {integrity: sha512-wyVZtbRs6qDfFd8ap457w3XVntdvqcwBGxBoTvJQH9KGVKL/fB+h2k3C8AqiVxvUQKN1Ps/Ns46CNViOpVDhfQ==}
@@ -11822,7 +12059,6 @@ packages:
     dependencies:
       es5-ext: 0.10.62
       type: 1.2.0
-    dev: true
 
   /d3-hierarchy/1.1.9:
     resolution: {integrity: sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ==}
@@ -12146,6 +12382,11 @@ packages:
 
   /deprecation/2.3.1:
     resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
+
+  /dequal/2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+    dev: false
 
   /desm/1.3.0:
     resolution: {integrity: sha512-RvlHN2gfYA0BpCfjpWzCdQeR6p5U+84f5DzcirLow86UA/OcpwuOqXRC4Oz0bG9rzcJPVtMT6ZgNtjp4qh+uqA==}
@@ -12615,7 +12856,6 @@ packages:
       es6-iterator: 2.0.3
       es6-symbol: 3.1.3
       next-tick: 1.1.0
-    dev: true
 
   /es6-iterator/2.0.3:
     resolution: {integrity: sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==}
@@ -12623,7 +12863,6 @@ packages:
       d: 1.0.1
       es5-ext: 0.10.62
       es6-symbol: 3.1.3
-    dev: true
 
   /es6-set/0.1.6:
     resolution: {integrity: sha512-TE3LgGLDIBX332jq3ypv6bcOpkLO0AslAQo7p2VqX/1N46YNsvIWgvjojjSEnWEGWMhr1qUbYeTSir5J6mFHOw==}
@@ -12642,7 +12881,6 @@ packages:
     dependencies:
       d: 1.0.1
       ext: 1.7.0
-    dev: true
 
   /es6-weak-map/2.0.3:
     resolution: {integrity: sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==}
@@ -13112,6 +13350,10 @@ packages:
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
+
+  /escape-carriage/1.3.0:
+    resolution: {integrity: sha512-ATWi5MD8QlAGQOeMgI8zTp671BG8aKvAC0M7yenlxU4CRLGO/sKthxVUyjiOFKjHdIo+6dZZUNFgHFeVEaKfGQ==}
+    dev: false
 
   /escape-goat/2.1.1:
     resolution: {integrity: sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==}
@@ -13655,7 +13897,6 @@ packages:
     resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
     dependencies:
       type: 2.7.2
-    dev: true
 
   /extend-shallow/2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -15200,6 +15441,10 @@ packages:
   /interpret/1.4.0:
     resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
     engines: {node: '>= 0.10'}
+    dev: false
+
+  /intersection-observer/0.10.0:
+    resolution: {integrity: sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ==}
     dev: false
 
   /invariant/2.2.4:
@@ -16954,7 +17199,7 @@ packages:
       '@panva/hkdf': 1.0.2
       cookie: 0.5.0
       jose: 4.11.1
-      next: 13.2.1_biqbaboplfbrettd7655fr4n2y
+      next: 13.2.1_mqvh5p7ejg4taogoj6tpk3gd5a
       oauth: 0.9.15
       openid-client: 5.3.0
       preact: 10.11.3
@@ -16965,7 +17210,6 @@ packages:
 
   /next-tick/1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
-    dev: true
 
   /next/13.2.1_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-qhgJlDtG0xidNViJUPeQHLGJJoT4zDj/El7fP3D3OzpxJDUfxsm16cK4WTMyvSX1ciIfAq05u+0HqFAa+VJ+Hg==}
@@ -17058,7 +17302,6 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
-    dev: true
 
   /nice-try/1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
@@ -17611,6 +17854,10 @@ packages:
 
   /outdent/0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
+    dev: false
+
+  /outvariant/1.3.0:
+    resolution: {integrity: sha512-yeWM9k6UPfG/nzxdaPlJkB2p08hCg4xP6Lx99F+vP8YF7xyZVfTmJjrrNalkmzudD4WFvNLVudQikqUmF8zhVQ==}
     dev: false
 
   /p-cancelable/1.1.0:
@@ -19561,6 +19808,12 @@ packages:
       - vue-template-compiler
     dev: false
 
+  /react-devtools-inline/4.4.0:
+    resolution: {integrity: sha512-ES0GolSrKO8wsKbsEkVeiR/ZAaHQTY4zDh1UW8DImVmm8oaGLl3ijJDvSGe+qDRKPZdPRnDtWWnSvvrgxXdThQ==}
+    dependencies:
+      es6-symbol: 3.1.3
+    dev: false
+
   /react-dom/18.2.0_react@18.2.0:
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
     peerDependencies:
@@ -21088,6 +21341,10 @@ packages:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
 
+  /strict-event-emitter/0.4.6:
+    resolution: {integrity: sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==}
+    dev: false
+
   /string-width/4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -21251,6 +21508,10 @@ packages:
       peek-readable: 4.1.0
     dev: true
 
+  /style-mod/4.0.0:
+    resolution: {integrity: sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==}
+    dev: false
+
   /style-to-object/0.3.0:
     resolution: {integrity: sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==}
     dependencies:
@@ -21273,7 +21534,6 @@ packages:
       '@babel/core': 7.20.2
       client-only: 0.0.1
       react: 18.2.0
-    dev: true
 
   /styled-jsx/5.1.1_react@18.2.0:
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
@@ -21969,11 +22229,9 @@ packages:
 
   /type/1.2.0:
     resolution: {integrity: sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==}
-    dev: true
 
   /type/2.7.2:
     resolution: {integrity: sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==}
-    dev: true
 
   /typedarray-to-buffer/3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
@@ -22695,6 +22953,10 @@ packages:
   /vscode-textmate/8.0.0:
     resolution: {integrity: sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==}
     dev: true
+
+  /w3c-keyname/2.2.6:
+    resolution: {integrity: sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg==}
+    dev: false
 
   /w3c-xmlserializer/4.0.0:
     resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}

--- a/www/docs/main/sandpack-example.mdx
+++ b/www/docs/main/sandpack-example.mdx
@@ -1,0 +1,10 @@
+---
+id: sandpack-example
+title: Sandpack Example
+sidebar_label: Sandpack Example
+slug: /sandpack-example
+---
+
+import { SandpackRoot } from '@site/src/components/Sandpack';
+
+<SandpackRoot />

--- a/www/package.json
+++ b/www/package.json
@@ -21,6 +21,8 @@
   },
   "dependencies": {
     "@algolia/client-search": "^4.9.1",
+    "@codesandbox/nodebox": "^0.1.6",
+    "@codesandbox/sandpack-react": "^2.1.3",
     "@docusaurus/core": "2.3.1",
     "@docusaurus/plugin-content-docs": "2.3.1",
     "@docusaurus/preset-classic": "2.3.1",

--- a/www/sidebars.js
+++ b/www/sidebars.js
@@ -12,6 +12,7 @@ module.exports = {
         'main/quickstart',
         'main/awesome-trpc',
         'main/example-apps',
+        'main/sandpack-example',
         'nextjs/introduction',
         'reactjs/introduction',
         'main/contributing',

--- a/www/src/components/Sandpack/index.tsx
+++ b/www/src/components/Sandpack/index.tsx
@@ -1,0 +1,195 @@
+import { Nodebox } from '@codesandbox/nodebox';
+import {
+  Sandpack,
+  SandpackCodeEditor,
+  SandpackConsole,
+  SandpackFileExplorer,
+  SandpackLayout,
+  SandpackPreview,
+  SandpackProvider,
+} from '@codesandbox/sandpack-react';
+import React, { useEffect, useRef, useState } from 'react';
+
+const BACKEND_FILES = {
+  '/package.json': {
+    code: JSON.stringify({
+      scripts: { start: 'node index.ts' },
+      main: 'index.ts',
+    }),
+  },
+  'index.ts': `
+console.log("Starting trpc...")
+import "./trpc.ts"
+console.log("Imported trpc")
+  `.trim(),
+  'appRouter.ts': `console.log('It\'s dead')`,
+  'trpc.ts': `
+import { initTRPC } from '@trpc/server';
+import { z } from 'zod';
+
+const t = initTRPC.create();
+
+const router = t.router;
+const publicProcedure = t.procedure;
+
+interface User {
+  id: string;
+  name: string;
+}
+
+const userList: User[] = [
+  {
+    id: '1',
+    name: 'KATT',
+  },
+];
+
+const appRouter = router({
+  userById: publicProcedure
+    .input((val: unknown) => {
+      if (typeof val === 'string') return val;
+      throw new Error(\`Invalid input: \${typeof val}\`);
+    })
+    .query((req) => {
+      const input = req.input;
+      const user = userList.find((it) => it.id === input);
+
+      return user;
+    }),
+  userCreate: publicProcedure
+    .input(z.object({ name: z.string() }))
+    .mutation((req) => {
+      const id = \`\${Math.random()}\`;
+
+      const user: User = {
+        id,
+        name: req.input.name,
+      };
+
+      userList.push(user);
+
+      return user;
+    }),
+});
+
+export type AppRouter = typeof appRouter;
+  `.trim(),
+};
+
+const FRONTEND_FILES = {
+  'index.tsx': `
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+const root = ReactDOM.createRoot(
+  document.getElementById('root') as HTMLElement
+)
+
+root.render(
+  <React.StrictMode>
+    <div>The Client is rendering!</div>
+  </React.StrictMode>,
+);
+  `.trim(),
+};
+
+export function SandpackRoot() {
+  const ref = useRef<HTMLIFrameElement>();
+  // const [_loaded, setLoaded] = useState(false);
+
+  // Probably don't need this stuff if the abstractions can do it
+  // useEffect(() => {
+  //   async function boot() {
+  //     const el = ref.current;
+  //     if (!el) {
+  //       return;
+  //     }
+
+  //     const emulator = new Nodebox({
+  //       iframe: el,
+  //     });
+
+  //     await emulator.connect();
+
+  //     await emulator.fs.init(BACKEND_FILES);
+
+  //     const shell = emulator.shell.create();
+
+  //     await shell.runCommand('node', ['index.js']);
+  //   }
+
+  //   boot()
+  //     .then(() => setLoaded(true))
+  //     .catch((err) => {
+  //       // TODO: handle this
+  //       console.error(err);
+  //     });
+  // }, []);
+
+  return (
+    <>
+      <iframe ref={ref as any} hidden />
+
+      {/* Run a backend */}
+      <SandpackProvider
+        files={BACKEND_FILES}
+        theme="dark"
+        customSetup={{
+          dependencies: {
+            '@trpc/server': '*',
+            '@trpc/client': '*',
+            '@trpc/react-query': '*',
+            '@tanstack/react-query': '*',
+            zod: '*',
+          },
+          entry: 'index.ts',
+          environment: 'node',
+        }}
+        options={{
+          visibleFiles: ['package.json', 'index.ts', 'trpc.ts'],
+          activeFile: 'index.ts',
+          initMode: 'user-visible',
+          autorun: true,
+        }}
+      >
+        <SandpackLayout>
+          <SandpackFileExplorer autoHiddenFiles />
+          <SandpackCodeEditor showTabs={false} />
+        </SandpackLayout>
+
+        <SandpackLayout>
+          <SandpackPreview />
+          <SandpackConsole />
+        </SandpackLayout>
+      </SandpackProvider>
+
+      {/* Run a frontend */}
+      {/* <SandpackProvider
+        files={FRONTEND_FILES}
+        theme="dark"
+        customSetup={{
+          dependencies: {
+            '@trpc/client': '*',
+            '@trpc/react-query': '*',
+            zod: '*',
+            react: '*',
+            'react-dom': '*',
+          },
+          entry: 'index.ts',
+        }}
+        options={{
+          visibleFiles: ['package.json', 'index.ts', 'trpc.ts'],
+          activeFile: 'index.ts',
+          initMode: 'user-visible',
+          autorun: true,
+        }}
+      >
+        <SandpackLayout>
+          <SandpackCodeEditor showTabs={false} />
+
+          <SandpackPreview />
+        </SandpackLayout>
+      </SandpackProvider> */}
+    </>
+  );
+}

--- a/www/src/components/Sandpack/index.tsx
+++ b/www/src/components/Sandpack/index.tsx
@@ -13,14 +13,14 @@ import React, { useEffect, useRef, useState } from 'react';
 const BACKEND_FILES = {
   '/package.json': {
     code: JSON.stringify({
-      dependencies: {
-        '@trpc/server': '*',
-        '@trpc/client': '*',
-        '@trpc/react-query': '*',
-        '@tanstack/react-query': '*',
-        zod: '*',
-      },
-      scripts: { start: 'node index.ts' },
+      // dependencies: {
+      //   '@trpc/server': '*',
+      //   '@trpc/client': '*',
+      //   '@trpc/react-query': '*',
+      //   '@tanstack/react-query': '*',
+      //   zod: '*',
+      // },
+      scripts: { start: 'ts-node index.ts' },
       main: 'index.ts',
     }),
   },
@@ -148,6 +148,8 @@ export function SandpackRoot() {
             '@trpc/react-query': '*',
             '@tanstack/react-query': '*',
             zod: '*',
+            typescript: '*',
+            'ts-node': '*',
           },
           entry: 'index.ts',
           environment: 'node',

--- a/www/src/components/Sandpack/index.tsx
+++ b/www/src/components/Sandpack/index.tsx
@@ -1,4 +1,4 @@
-import { Nodebox } from '@codesandbox/nodebox';
+// import { Nodebox } from '@codesandbox/nodebox';
 import {
   Sandpack,
   SandpackCodeEditor,
@@ -11,16 +11,28 @@ import {
 import React, { useEffect, useRef, useState } from 'react';
 
 const BACKEND_FILES = {
+  'tsconfig.json': {
+    code: JSON.stringify({
+      compilerOptions: {
+        target: 'ESNext',
+        useDefineForClassFields: true,
+        module: 'ESNext',
+        moduleResolution: 'Node',
+        strict: true,
+        jsx: 'preserve',
+        resolveJsonModule: true,
+        isolatedModules: true,
+        esModuleInterop: true,
+        lib: ['ESNext', 'DOM'],
+        skipLibCheck: true,
+        noEmit: true,
+      },
+      include: ['src/**/*.ts', 'src/**/*.d.ts', 'src/**/*.tsx', 'src/**/*.vue'],
+    }),
+  },
   '/package.json': {
     code: JSON.stringify({
-      // dependencies: {
-      //   '@trpc/server': '*',
-      //   '@trpc/client': '*',
-      //   '@trpc/react-query': '*',
-      //   '@tanstack/react-query': '*',
-      //   zod: '*',
-      // },
-      scripts: { start: 'ts-node index.ts' },
+      scripts: { start: 'tsc && node index.js' },
       main: 'index.ts',
     }),
   },
@@ -149,9 +161,8 @@ export function SandpackRoot() {
             '@tanstack/react-query': '*',
             zod: '*',
             typescript: '*',
-            'ts-node': '*',
           },
-          entry: 'index.ts',
+          entry: 'index.js',
           environment: 'node',
         }}
         options={{

--- a/www/src/components/Sandpack/index.tsx
+++ b/www/src/components/Sandpack/index.tsx
@@ -13,6 +13,13 @@ import React, { useEffect, useRef, useState } from 'react';
 const BACKEND_FILES = {
   '/package.json': {
     code: JSON.stringify({
+      dependencies: {
+        '@trpc/server': '*',
+        '@trpc/client': '*',
+        '@trpc/react-query': '*',
+        '@tanstack/react-query': '*',
+        zod: '*',
+      },
       scripts: { start: 'node index.ts' },
       main: 'index.ts',
     }),
@@ -97,7 +104,7 @@ export function SandpackRoot() {
   const ref = useRef<HTMLIFrameElement>();
   // const [_loaded, setLoaded] = useState(false);
 
-  // Probably don't need this stuff if the abstractions can do it
+  // TODO: Probably don't need this stuff if the abstractions can do it, but also might need to build it ourselves
   // useEffect(() => {
   //   async function boot() {
   //     const el = ref.current;


### PR DESCRIPTION
Closes #

Sandpack (from codesandbox) is what the React beta docs use to mount and run their code examples. It can be a nice extension to MDX/Code-blocks to create interactive environments. They also have an in-browser node environemt and support NextJS, so in theory we could mount tRPC and a React frontend in an instance and have a fully working code example. This would be fantastic for docs.

https://sandpack.codesandbox.io/docs/quickstart

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
