### PR TITLE
feat(react-query): Add support for QueryClient.ensureQueryData and ensureData helper

### DIFF
--- a/examples/.interop/next-prisma-starter/package.json
+++ b/examples/.interop/next-prisma-starter/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@prisma/client": "^4.10.1",
-    "@tanstack/react-query": "^4.3.8",
+    "@tanstack/react-query": "^4.18.0",
     "@trpc/client": "^10.15.0",
     "@trpc/next": "^10.15.0",
     "@trpc/react-query": "^10.15.0",

--- a/examples/.test/big-router-declaration/package.json
+++ b/examples/.test/big-router-declaration/package.json
@@ -9,7 +9,7 @@
     "postinstall": "tsx scripts/codegen"
   },
   "dependencies": {
-    "@tanstack/react-query": "^4.3.8",
+    "@tanstack/react-query": "^4.18.0",
     "@trpc/client": "^10.15.0",
     "@trpc/next": "^10.15.0",
     "@trpc/react-query": "^10.15.0",

--- a/examples/.test/ssg/package.json
+++ b/examples/.test/ssg/package.json
@@ -12,7 +12,7 @@
     "test-start": "start-server-and-test start http://127.0.0.1:3000 test:e2e"
   },
   "dependencies": {
-    "@tanstack/react-query": "^4.3.8",
+    "@tanstack/react-query": "^4.18.0",
     "@trpc/client": "^10.15.0",
     "@trpc/next": "^10.15.0",
     "@trpc/react-query": "^10.15.0",

--- a/examples/minimal-react/client/package.json
+++ b/examples/minimal-react/client/package.json
@@ -10,7 +10,7 @@
     "start": "vite preview"
   },
   "dependencies": {
-    "@tanstack/react-query": "^4.3.8",
+    "@tanstack/react-query": "^4.18.0",
     "@trpc/client": "^10.15.0",
     "@trpc/react-query": "^10.15.0",
     "@trpc/server": "^10.15.0",

--- a/examples/next-big-router/package.json
+++ b/examples/next-big-router/package.json
@@ -10,7 +10,7 @@
     "postinstall": "tsx scripts/codegen"
   },
   "dependencies": {
-    "@tanstack/react-query": "^4.3.8",
+    "@tanstack/react-query": "^4.18.0",
     "@trpc/client": "^10.15.0",
     "@trpc/next": "^10.15.0",
     "@trpc/react-query": "^10.15.0",

--- a/examples/next-edge-runtime/package.json
+++ b/examples/next-edge-runtime/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@tanstack/react-query": "^4.3.8",
+    "@tanstack/react-query": "^4.18.0",
     "@trpc/client": "^10.15.0",
     "@trpc/next": "^10.15.0",
     "@trpc/react-query": "^10.15.0",

--- a/examples/next-minimal-starter/package.json
+++ b/examples/next-minimal-starter/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@tanstack/react-query": "^4.3.8",
+    "@tanstack/react-query": "^4.18.0",
     "@trpc/client": "^10.15.0",
     "@trpc/next": "^10.15.0",
     "@trpc/react-query": "^10.15.0",

--- a/examples/next-prisma-starter/package.json
+++ b/examples/next-prisma-starter/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@prisma/client": "^4.10.1",
-    "@tanstack/react-query": "^4.3.8",
+    "@tanstack/react-query": "^4.18.0",
     "@trpc/client": "^10.15.0",
     "@trpc/next": "^10.15.0",
     "@trpc/react-query": "^10.15.0",

--- a/examples/next-prisma-todomvc/package.json
+++ b/examples/next-prisma-todomvc/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@prisma/client": "^4.10.1",
-    "@tanstack/react-query": "^4.3.8",
+    "@tanstack/react-query": "^4.18.0",
     "@trpc/client": "^10.15.0",
     "@trpc/next": "^10.15.0",
     "@trpc/react-query": "^10.15.0",

--- a/examples/next-prisma-websockets-starter/package.json
+++ b/examples/next-prisma-websockets-starter/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@prisma/client": "^4.10.1",
-    "@tanstack/react-query": "^4.3.8",
+    "@tanstack/react-query": "^4.18.0",
     "@trpc/client": "^10.15.0",
     "@trpc/next": "^10.15.0",
     "@trpc/react-query": "^10.15.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   },
   "pnpm": {
     "overrides": {
+      "@tanstack/react-query": "4.18.0",
       "@trpc/client": "link:./packages/client",
       "@trpc/next": "link:./packages/next",
       "@trpc/react-query": "link:./packages/react-query",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
   },
   "pnpm": {
     "overrides": {
-      "@tanstack/react-query": "4.6.0",
       "@trpc/client": "link:./packages/client",
       "@trpc/next": "link:./packages/next",
       "@trpc/react-query": "link:./packages/react-query",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -43,7 +43,7 @@
     "package.json"
   ],
   "peerDependencies": {
-    "@tanstack/react-query": "^4.3.8",
+    "@tanstack/react-query": "^4.18.0",
     "@trpc/client": "10.15.0",
     "@trpc/react-query": "10.15.0",
     "@trpc/server": "10.15.0",
@@ -55,7 +55,7 @@
     "react-ssr-prepass": "^1.5.0"
   },
   "devDependencies": {
-    "@tanstack/react-query": "^4.3.8",
+    "@tanstack/react-query": "^4.18.0",
     "@trpc/client": "^10.15.0",
     "@trpc/react-query": "^10.15.0",
     "@trpc/server": "^10.15.0",

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -56,14 +56,14 @@
     }
   },
   "peerDependencies": {
-    "@tanstack/react-query": "^4.3.8",
+    "@tanstack/react-query": "^4.18.0",
     "@trpc/client": "10.15.0",
     "@trpc/server": "10.15.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   },
   "devDependencies": {
-    "@tanstack/react-query": "^4.3.8",
+    "@tanstack/react-query": "^4.18.0",
     "@trpc/client": "^10.15.0",
     "@trpc/server": "^10.15.0",
     "@types/express": "^4.17.12",

--- a/packages/react-query/src/internals/context.tsx
+++ b/packages/react-query/src/internals/context.tsx
@@ -126,6 +126,7 @@ export interface TRPCContextState<
     pathAndInput: [path: TPath, ...args: inferHandlerInput<TProcedure>],
     opts?: TRPCFetchQueryOptions<TInput, TRPCClientError<TRouter>, TOutput>,
   ) => Promise<TOutput>;
+
   /**
    * @link https://tanstack.com/query/v4/docs/reference/QueryClient#queryclientfetchinfinitequery
    */
@@ -142,6 +143,7 @@ export interface TRPCContextState<
       TOutput
     >,
   ) => Promise<InfiniteData<TOutput>>;
+
   /**
    * @link https://react-query.tanstack.com/guides/prefetching
    */
@@ -173,6 +175,19 @@ export interface TRPCContextState<
   ) => Promise<void>;
 
   /**
+   * @link https://tanstack.com/query/v4/docs/react/reference/QueryClient#queryclientensurequerydata
+   */
+  ensureQueryData: <
+    TPath extends keyof TRouter['_def']['queries'] & string,
+    TProcedure extends TRouter['_def']['queries'][TPath],
+    TOutput extends inferTransformedProcedureOutput<TProcedure>,
+    TInput extends inferProcedureInput<TProcedure>,
+  >(
+    pathAndInput: [path: TPath, ...args: inferHandlerInput<TProcedure>],
+    opts?: TRPCFetchQueryOptions<TInput, TRPCClientError<TRouter>, TOutput>,
+  ) => Promise<TOutput>;
+
+  /**
    * @link https://react-query.tanstack.com/guides/query-invalidation
    */
   invalidateQueries: <
@@ -200,6 +215,7 @@ export interface TRPCContextState<
     filters?: RefetchQueryFilters,
     options?: RefetchOptions,
   ): Promise<void>;
+
   /**
    * @link https://react-query.tanstack.com/reference/QueryClient#queryclientrefetchqueries
    */
@@ -218,6 +234,7 @@ export interface TRPCContextState<
     pathAndInput: [TPath, TInput?],
     options?: CancelOptions,
   ) => Promise<void>;
+
   /**
    * @link https://react-query.tanstack.com/reference/QueryClient#queryclientsetquerydata
    */
@@ -232,6 +249,7 @@ export interface TRPCContextState<
     updater: Updater<TOutput | undefined, TOutput | undefined>,
     options?: SetDataOptions,
   ) => void;
+
   /**
    * @link https://react-query.tanstack.com/reference/QueryClient#queryclientgetquerydata
    */
@@ -244,6 +262,7 @@ export interface TRPCContextState<
   >(
     pathAndInput: [TPath, TInput?],
   ) => TOutput | undefined;
+
   /**
    * @link https://react-query.tanstack.com/reference/QueryClient#queryclientsetquerydata
    */
@@ -261,6 +280,7 @@ export interface TRPCContextState<
     >,
     options?: SetDataOptions,
   ) => void;
+
   /**
    * @link https://react-query.tanstack.com/reference/QueryClient#queryclientgetquerydata
    */

--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -130,6 +130,17 @@ export function createRootHooks<
             },
             [client, queryClient],
           ),
+          ensureQueryData: useCallback(
+            (pathAndInput, opts) => {
+              return queryClient.ensureQueryData({
+                ...opts,
+                queryKey: getArrayQueryKey(pathAndInput, 'query'),
+                queryFn: () =>
+                  (client as any).query(...getClientArgs(pathAndInput, opts)),
+              });
+            },
+            [client, queryClient],
+          ),
           invalidateQueries: useCallback(
             (queryKey, filters, options) => {
               return queryClient.invalidateQueries(

--- a/packages/react-query/src/shared/hooks/deprecated/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/deprecated/createHooksInternal.tsx
@@ -169,6 +169,17 @@ function __createHooksInternal<
             },
             [client, queryClient],
           ),
+          ensureQueryData: useCallback(
+            (pathAndInput, opts) => {
+              return queryClient.ensureQueryData(
+                getArrayQueryKey(pathAndInput, 'query'),
+                () =>
+                  (client as any).query(...getClientArgs(pathAndInput, opts)),
+                opts,
+              );
+            },
+            [client, queryClient],
+          ),
           invalidateQueries: useCallback(
             (...args: any[]) => {
               const [queryKey, ...rest] = args;

--- a/packages/react-query/src/shared/proxy/utilsProxy.ts
+++ b/packages/react-query/src/shared/proxy/utilsProxy.ts
@@ -87,6 +87,18 @@ type DecorateProcedure<
   ): Promise<void>;
 
   /**
+   * @link https://tanstack.com/query/v4/docs/react/reference/QueryClient#queryclientensurequerydata
+   */
+  ensureData(
+    input: inferProcedureInput<TProcedure>,
+    opts?: TRPCFetchQueryOptions<
+      inferProcedureInput<TProcedure>,
+      TRPCClientError<TRouter>,
+      inferTransformedProcedureOutput<TProcedure>
+    >,
+  ): Promise<inferTransformedProcedureOutput<TProcedure>>;
+
+  /**
    * @link https://tanstack.com/query/v4/docs/reference/QueryClient#queryclientinvalidatequeries
    */
   invalidate(
@@ -275,6 +287,7 @@ export function createReactQueryUtilsProxy<
         prefetch: () => context.prefetchQuery(queryKey, ...rest),
         prefetchInfinite: () =>
           context.prefetchInfiniteQuery(queryKey, ...rest),
+        ensureData: () => context.ensureQueryData(queryKey, ...rest),
         invalidate: () => context.invalidateQueries(queryKey, ...rest),
         reset: () => context.resetQueries(queryKey, ...rest),
         refetch: () => context.refetchQueries(queryKey, ...rest),

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -127,7 +127,7 @@
   },
   "devDependencies": {
     "@fastify/websocket": "^7.1.2",
-    "@tanstack/react-query": "^4.3.8",
+    "@tanstack/react-query": "^4.18.0",
     "@types/aws-lambda": "^8.10.97",
     "@types/express": "^4.17.12",
     "@types/hash-sum": "^1.0.0",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -19,7 +19,7 @@
     "@cloudflare/workers-types": "^4.0.0",
     "@fastify/websocket": "^7.1.2",
     "@miniflare/core": "^2.9.0",
-    "@tanstack/react-query": "^4.3.8",
+    "@tanstack/react-query": "^4.18.0",
     "@testing-library/dom": "^9.0.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",

--- a/packages/tests/server/react/ensureQueryData.test.tsx
+++ b/packages/tests/server/react/ensureQueryData.test.tsx
@@ -1,0 +1,75 @@
+import { createQueryClient } from '../__queryClient';
+import { createAppRouter } from './__testHelpers';
+import { QueryClientProvider, useQueryClient } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import React, { useEffect, useState } from 'react';
+
+let factory: ReturnType<typeof createAppRouter>;
+beforeEach(() => {
+  factory = createAppRouter();
+});
+afterEach(async () => {
+  await factory.close();
+});
+
+describe('ensureQueryData()', () => {
+  test('with input', async () => {
+    const { trpc, client } = factory;
+    function MyComponent() {
+      const [state, setState] = useState<string>('nope');
+      const utils = trpc.useContext();
+      const queryClient = useQueryClient();
+
+      useEffect(() => {
+        async function prefetch() {
+          const initialQuery = await utils.postById.ensureData('1');
+          expect(initialQuery.title).toBe('first post');
+
+          const cachedQuery = await utils.postById.ensureData('1');
+          expect(cachedQuery.title).toBe('first post');
+
+          // Update data to invalidate the cache
+          utils.postById.setData('1', () => {
+            return {
+              id: 'id',
+              title: 'updated post',
+              createdAt: Date.now(),
+            };
+          });
+
+          const updatedQuery = await utils.postById.ensureData('1');
+          expect(updatedQuery.title).toBe('updated post');
+
+          setState(updatedQuery.title);
+        }
+        prefetch();
+      }, [queryClient, utils]);
+
+      return <>{JSON.stringify(state)}</>;
+    }
+    function App() {
+      const [queryClient] = useState(() => createQueryClient());
+      return (
+        <trpc.Provider {...{ queryClient, client }}>
+          <QueryClientProvider client={queryClient}>
+            <MyComponent />
+          </QueryClientProvider>
+        </trpc.Provider>
+      );
+    }
+
+    const utils = render(<App />);
+    await waitFor(() => {
+      expect(utils.container).toHaveTextContent('updated post');
+    });
+
+    // Because we are using `ensureData` here, it should always be only a single call
+    // as the first invocation will fetch and cache the data, and any consecutive calls
+    // will not go through `postById.fetch`, but rather get the data directly from cache.
+    //
+    // Calling `postById.setData` updates the cache as well, so even after update
+    // number of direct calls should still be 1.
+    expect(factory.resolvers.postById.mock.calls.length).toBe(1);
+    expect(factory.resolvers.postById.mock.calls[0]![0]).toBe('1');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,6 @@
 lockfileVersion: 5.4
 
 overrides:
-  '@tanstack/react-query': 4.6.0
   '@trpc/client': link:./packages/client
   '@trpc/next': link:./packages/next
   '@trpc/react-query': link:./packages/react-query
@@ -90,7 +89,7 @@ importers:
     specifiers:
       '@playwright/test': ^1.26.1
       '@prisma/client': https://registry.npmjs.com/@prisma/client/-/client-4.10.1.tgz?id=%40examples%2Flegacy-next-starter
-      '@tanstack/react-query': 4.6.0
+      '@tanstack/react-query': ^4.18.0
       '@tanstack/react-query-devtools': ^4.3.8
       '@trpc/client': link:../../../packages/client
       '@trpc/next': link:../../../packages/next
@@ -122,7 +121,7 @@ importers:
       zod: ^3.0.0
     dependencies:
       '@prisma/client': '@registry.npmjs.com/@prisma/client/-/client-4.10.1.tgz?id=%2540examples%252Flegacy-next-starter_prisma@4.10.1'
-      '@tanstack/react-query': 4.6.0_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
       '@trpc/client': link:../../../packages/client
       '@trpc/next': link:../../../packages/next
       '@trpc/react-query': link:../../../packages/react-query
@@ -135,7 +134,7 @@ importers:
       zod: 3.20.2
     devDependencies:
       '@playwright/test': 1.28.1
-      '@tanstack/react-query-devtools': 4.18.0_35w334xqtbzboqulr5pz522esm
+      '@tanstack/react-query-devtools': 4.18.0_brdhmlf72zuns3lsk66phyptty
       '@types/node': 18.7.20
       '@types/react': 18.0.25
       '@typescript-eslint/eslint-plugin': 5.47.0_jhaguxqfxx2v4alxps2nzei754
@@ -157,7 +156,7 @@ importers:
 
   examples/.test/big-router-declaration:
     specifiers:
-      '@tanstack/react-query': 4.6.0
+      '@tanstack/react-query': ^4.18.0
       '@trpc/client': link:../../../packages/client
       '@trpc/next': link:../../../packages/next
       '@trpc/react-query': link:../../../packages/react-query
@@ -173,7 +172,7 @@ importers:
       typescript: ^4.8.3
       zod: ^3.0.0
     dependencies:
-      '@tanstack/react-query': 4.6.0_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
       '@trpc/client': link:../../../packages/client
       '@trpc/next': link:../../../packages/next
       '@trpc/react-query': link:../../../packages/react-query
@@ -208,7 +207,7 @@ importers:
   examples/.test/ssg:
     specifiers:
       '@playwright/test': ^1.26.1
-      '@tanstack/react-query': 4.6.0
+      '@tanstack/react-query': ^4.18.0
       '@trpc/client': link:../../../packages/client
       '@trpc/next': link:../../../packages/next
       '@trpc/react-query': link:../../../packages/react-query
@@ -225,7 +224,7 @@ importers:
       typescript: ^4.8.3
       zod: ^3.0.0
     dependencies:
-      '@tanstack/react-query': 4.6.0_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
       '@trpc/client': link:../../../packages/client
       '@trpc/next': link:../../../packages/next
       '@trpc/react-query': link:../../../packages/react-query
@@ -437,7 +436,7 @@ importers:
 
   examples/minimal-react/client:
     specifiers:
-      '@tanstack/react-query': 4.6.0
+      '@tanstack/react-query': ^4.18.0
       '@trpc/client': link:../../../packages/client
       '@trpc/react-query': link:../../../packages/react-query
       '@trpc/server': link:../../../packages/server
@@ -450,7 +449,7 @@ importers:
       typescript: ^4.8.3
       vite: ^4.1.2
     dependencies:
-      '@tanstack/react-query': 4.6.0_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
       '@trpc/client': link:../../../packages/client
       '@trpc/react-query': link:../../../packages/react-query
       '@trpc/server': link:../../../packages/server
@@ -505,7 +504,7 @@ importers:
 
   examples/next-big-router:
     specifiers:
-      '@tanstack/react-query': 4.6.0
+      '@tanstack/react-query': ^4.18.0
       '@trpc/client': link:../../packages/client
       '@trpc/next': link:../../packages/next
       '@trpc/react-query': link:../../packages/react-query
@@ -521,7 +520,7 @@ importers:
       typescript: ^4.8.3
       zod: ^3.0.0
     dependencies:
-      '@tanstack/react-query': 4.6.0_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
       '@trpc/client': link:../../packages/client
       '@trpc/next': link:../../packages/next
       '@trpc/react-query': link:../../packages/react-query
@@ -540,7 +539,7 @@ importers:
 
   examples/next-edge-runtime:
     specifiers:
-      '@tanstack/react-query': 4.6.0
+      '@tanstack/react-query': ^4.18.0
       '@trpc/client': link:../../packages/client
       '@trpc/next': link:../../packages/next
       '@trpc/react-query': link:../../packages/react-query
@@ -555,7 +554,7 @@ importers:
       typescript: ^4.8.3
       zod: ^3.0.0
     dependencies:
-      '@tanstack/react-query': 4.6.0_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
       '@trpc/client': link:../../packages/client
       '@trpc/next': link:../../packages/next
       '@trpc/react-query': link:../../packages/react-query
@@ -573,7 +572,7 @@ importers:
 
   examples/next-minimal-starter:
     specifiers:
-      '@tanstack/react-query': 4.6.0
+      '@tanstack/react-query': ^4.18.0
       '@trpc/client': link:../../packages/client
       '@trpc/next': link:../../packages/next
       '@trpc/react-query': link:../../packages/react-query
@@ -588,7 +587,7 @@ importers:
       typescript: ^4.8.3
       zod: ^3.0.0
     dependencies:
-      '@tanstack/react-query': 4.6.0_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
       '@trpc/client': link:../../packages/client
       '@trpc/next': link:../../packages/next
       '@trpc/react-query': link:../../packages/react-query
@@ -608,7 +607,7 @@ importers:
     specifiers:
       '@playwright/test': ^1.26.1
       '@prisma/client': https://registry.npmjs.com/@prisma/client/-/client-4.10.1.tgz?id=%40examples%2Ftrpc-next-prisma-starter
-      '@tanstack/react-query': 4.6.0
+      '@tanstack/react-query': ^4.18.0
       '@trpc/client': link:../../packages/client
       '@trpc/next': link:../../packages/next
       '@trpc/react-query': link:../../packages/react-query
@@ -639,7 +638,7 @@ importers:
       zod: ^3.0.0
     dependencies:
       '@prisma/client': '@registry.npmjs.com/@prisma/client/-/client-4.10.1.tgz?id=%2540examples%252Ftrpc-next-prisma-starter_prisma@4.10.1'
-      '@tanstack/react-query': 4.6.0_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
       '@trpc/client': link:../../packages/client
       '@trpc/next': link:../../packages/next
       '@trpc/react-query': link:../../packages/react-query
@@ -675,7 +674,7 @@ importers:
     specifiers:
       '@playwright/test': ^1.26.1
       '@prisma/client': https://registry.npmjs.com/@prisma/client/-/client-4.10.1.tgz?id=%40examples%2Ftrpc-next-prisma-todomvc
-      '@tanstack/react-query': 4.6.0
+      '@tanstack/react-query': ^4.18.0
       '@tanstack/react-query-devtools': ^4.3.8
       '@trpc/client': link:../../packages/client
       '@trpc/next': link:../../packages/next
@@ -698,7 +697,7 @@ importers:
       zod: ^3.0.0
     dependencies:
       '@prisma/client': '@registry.npmjs.com/@prisma/client/-/client-4.10.1.tgz?id=%2540examples%252Ftrpc-next-prisma-todomvc_prisma@4.10.1'
-      '@tanstack/react-query': 4.6.0_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
       '@trpc/client': link:../../packages/client
       '@trpc/next': link:../../packages/next
       '@trpc/react-query': link:../../packages/react-query
@@ -713,7 +712,7 @@ importers:
       zod: 3.20.2
     devDependencies:
       '@playwright/test': 1.28.1
-      '@tanstack/react-query-devtools': 4.18.0_35w334xqtbzboqulr5pz522esm
+      '@tanstack/react-query-devtools': 4.18.0_brdhmlf72zuns3lsk66phyptty
       '@types/node': 18.7.20
       '@types/react': 18.0.25
       eslint: 8.30.0
@@ -726,7 +725,7 @@ importers:
     specifiers:
       '@playwright/test': ^1.26.1
       '@prisma/client': https://registry.npmjs.com/@prisma/client/-/client-4.10.1.tgz?id=%40examples%2Fnext-websockets-starter
-      '@tanstack/react-query': 4.6.0
+      '@tanstack/react-query': ^4.18.0
       '@tanstack/react-query-devtools': ^4.3.8
       '@trpc/client': link:../../packages/client
       '@trpc/next': link:../../packages/next
@@ -763,7 +762,7 @@ importers:
       zod: ^3.0.0
     dependencies:
       '@prisma/client': '@registry.npmjs.com/@prisma/client/-/client-4.10.1.tgz?id=%2540examples%252Fnext-websockets-starter_prisma@4.10.1'
-      '@tanstack/react-query': 4.6.0_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
       '@trpc/client': link:../../packages/client
       '@trpc/next': link:../../packages/next
       '@trpc/react-query': link:../../packages/react-query
@@ -779,7 +778,7 @@ importers:
       zod: 3.20.2
     devDependencies:
       '@playwright/test': 1.28.1
-      '@tanstack/react-query-devtools': 4.18.0_35w334xqtbzboqulr5pz522esm
+      '@tanstack/react-query-devtools': 4.18.0_brdhmlf72zuns3lsk66phyptty
       '@types/node': 18.7.20
       '@types/react': 18.0.25
       '@types/ws': 8.5.3
@@ -907,7 +906,7 @@ importers:
 
   packages/next:
     specifiers:
-      '@tanstack/react-query': 4.6.0
+      '@tanstack/react-query': ^4.18.0
       '@trpc/client': link:../client
       '@trpc/react-query': link:../react-query
       '@trpc/server': link:../server
@@ -927,7 +926,7 @@ importers:
     dependencies:
       react-ssr-prepass: 1.5.0_react@18.2.0
     devDependencies:
-      '@tanstack/react-query': 4.6.0_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
       '@trpc/client': link:../client
       '@trpc/react-query': link:../react-query
       '@trpc/server': link:../server
@@ -946,7 +945,7 @@ importers:
 
   packages/react-query:
     specifiers:
-      '@tanstack/react-query': 4.6.0
+      '@tanstack/react-query': ^4.18.0
       '@trpc/client': link:../client
       '@trpc/server': link:../server
       '@types/express': ^4.17.12
@@ -961,7 +960,7 @@ importers:
       tsx: ^3.12.3
       zod: ^3.0.0
     devDependencies:
-      '@tanstack/react-query': 4.6.0_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
       '@trpc/client': link:../client
       '@trpc/server': link:../server
       '@types/express': 4.17.14
@@ -979,7 +978,7 @@ importers:
   packages/server:
     specifiers:
       '@fastify/websocket': ^7.1.2
-      '@tanstack/react-query': 4.6.0
+      '@tanstack/react-query': ^4.18.0
       '@types/aws-lambda': ^8.10.97
       '@types/express': ^4.17.12
       '@types/hash-sum': ^1.0.0
@@ -1010,7 +1009,7 @@ importers:
       zod: ^3.0.0
     devDependencies:
       '@fastify/websocket': 7.1.2
-      '@tanstack/react-query': 4.6.0_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
       '@types/aws-lambda': 8.10.109
       '@types/express': 4.17.14
       '@types/hash-sum': 1.0.0
@@ -1045,7 +1044,7 @@ importers:
       '@cloudflare/workers-types': ^4.0.0
       '@fastify/websocket': ^7.1.2
       '@miniflare/core': ^2.9.0
-      '@tanstack/react-query': 4.6.0
+      '@tanstack/react-query': ^4.18.0
       '@testing-library/dom': ^9.0.0
       '@testing-library/jest-dom': ^5.16.5
       '@testing-library/react': ^14.0.0
@@ -1087,7 +1086,7 @@ importers:
       '@cloudflare/workers-types': 4.20230215.0
       '@fastify/websocket': 7.1.2
       '@miniflare/core': 2.11.0
-      '@tanstack/react-query': 4.6.0_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
       '@testing-library/dom': 9.0.0
       '@testing-library/jest-dom': 5.16.5
       '@testing-library/react': 14.0.0_biqbaboplfbrettd7655fr4n2y
@@ -8742,10 +8741,10 @@ packages:
       remove-accents: 0.4.2
     dev: true
 
-  /@tanstack/query-core/4.6.0:
-    resolution: {integrity: sha512-8b+vwooh8b4z1bIT3Ca7OVSyARM5JNbXi6F+g5VLYiflRd0AtJ+koqhin7UGhR11bbypmzVRKllWHwexWjKjDg==}
+  /@tanstack/query-core/4.26.1:
+    resolution: {integrity: sha512-Zrx2pVQUP4ndnsu6+K/m8zerXSVY8QM+YSbxA1/jbBY21GeCd5oKfYl92oXPK0hPEUtoNuunIdiq0ZMqLos+Zg==}
 
-  /@tanstack/react-query-devtools/4.18.0_35w334xqtbzboqulr5pz522esm:
+  /@tanstack/react-query-devtools/4.18.0_brdhmlf72zuns3lsk66phyptty:
     resolution: {integrity: sha512-L51D0AUqLTs7J+W7RypJrUEKXsS0y0eEhXAgO+rhcZH6i8jVrKLhcNZStQSnE+UpZqPm73uxt2e8TJgYfzz0nw==}
     peerDependencies:
       '@tanstack/react-query': 4.18.0
@@ -8753,15 +8752,15 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       '@tanstack/match-sorter-utils': 8.1.1
-      '@tanstack/react-query': 4.6.0_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       superjson: 1.11.0
       use-sync-external-store: 1.2.0_react@18.2.0
     dev: true
 
-  /@tanstack/react-query/4.6.0_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-ZIx8EfRBGagxw+3onFb//Fnv0hhXDj/UHIYovPGwHdancAG9ZL4D0ymUan4cXJib/L0rGPzYFvET/yTEIPPXAw==}
+  /@tanstack/react-query/4.26.1_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-i3dnz4TOARGIXrXQ5P7S25Zfi4noii/bxhcwPurh2nrf5EUCcAt/95TB2HSmMweUBx206yIMWUMEQ7ptd6zwDg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -8772,7 +8771,7 @@ packages:
       react-native:
         optional: true
     dependencies:
-      '@tanstack/query-core': 4.6.0
+      '@tanstack/query-core': 4.26.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       use-sync-external-store: 1.2.0_react@18.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,7 @@
 lockfileVersion: 5.4
 
 overrides:
+  '@tanstack/react-query': 4.18.0
   '@trpc/client': link:./packages/client
   '@trpc/next': link:./packages/next
   '@trpc/react-query': link:./packages/react-query
@@ -89,7 +90,7 @@ importers:
     specifiers:
       '@playwright/test': ^1.26.1
       '@prisma/client': https://registry.npmjs.com/@prisma/client/-/client-4.10.1.tgz?id=%40examples%2Flegacy-next-starter
-      '@tanstack/react-query': ^4.18.0
+      '@tanstack/react-query': 4.18.0
       '@tanstack/react-query-devtools': ^4.3.8
       '@trpc/client': link:../../../packages/client
       '@trpc/next': link:../../../packages/next
@@ -121,7 +122,7 @@ importers:
       zod: ^3.0.0
     dependencies:
       '@prisma/client': '@registry.npmjs.com/@prisma/client/-/client-4.10.1.tgz?id=%2540examples%252Flegacy-next-starter_prisma@4.10.1'
-      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.18.0_biqbaboplfbrettd7655fr4n2y
       '@trpc/client': link:../../../packages/client
       '@trpc/next': link:../../../packages/next
       '@trpc/react-query': link:../../../packages/react-query
@@ -134,7 +135,7 @@ importers:
       zod: 3.20.2
     devDependencies:
       '@playwright/test': 1.28.1
-      '@tanstack/react-query-devtools': 4.18.0_brdhmlf72zuns3lsk66phyptty
+      '@tanstack/react-query-devtools': 4.18.0_2ryzfomli4bbns3rdhwnpgjdhm
       '@types/node': 18.7.20
       '@types/react': 18.0.25
       '@typescript-eslint/eslint-plugin': 5.47.0_jhaguxqfxx2v4alxps2nzei754
@@ -156,7 +157,7 @@ importers:
 
   examples/.test/big-router-declaration:
     specifiers:
-      '@tanstack/react-query': ^4.18.0
+      '@tanstack/react-query': 4.18.0
       '@trpc/client': link:../../../packages/client
       '@trpc/next': link:../../../packages/next
       '@trpc/react-query': link:../../../packages/react-query
@@ -172,7 +173,7 @@ importers:
       typescript: ^4.8.3
       zod: ^3.0.0
     dependencies:
-      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.18.0_biqbaboplfbrettd7655fr4n2y
       '@trpc/client': link:../../../packages/client
       '@trpc/next': link:../../../packages/next
       '@trpc/react-query': link:../../../packages/react-query
@@ -207,7 +208,7 @@ importers:
   examples/.test/ssg:
     specifiers:
       '@playwright/test': ^1.26.1
-      '@tanstack/react-query': ^4.18.0
+      '@tanstack/react-query': 4.18.0
       '@trpc/client': link:../../../packages/client
       '@trpc/next': link:../../../packages/next
       '@trpc/react-query': link:../../../packages/react-query
@@ -224,7 +225,7 @@ importers:
       typescript: ^4.8.3
       zod: ^3.0.0
     dependencies:
-      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.18.0_biqbaboplfbrettd7655fr4n2y
       '@trpc/client': link:../../../packages/client
       '@trpc/next': link:../../../packages/next
       '@trpc/react-query': link:../../../packages/react-query
@@ -436,7 +437,7 @@ importers:
 
   examples/minimal-react/client:
     specifiers:
-      '@tanstack/react-query': ^4.18.0
+      '@tanstack/react-query': 4.18.0
       '@trpc/client': link:../../../packages/client
       '@trpc/react-query': link:../../../packages/react-query
       '@trpc/server': link:../../../packages/server
@@ -449,7 +450,7 @@ importers:
       typescript: ^4.8.3
       vite: ^4.1.2
     dependencies:
-      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.18.0_biqbaboplfbrettd7655fr4n2y
       '@trpc/client': link:../../../packages/client
       '@trpc/react-query': link:../../../packages/react-query
       '@trpc/server': link:../../../packages/server
@@ -504,7 +505,7 @@ importers:
 
   examples/next-big-router:
     specifiers:
-      '@tanstack/react-query': ^4.18.0
+      '@tanstack/react-query': 4.18.0
       '@trpc/client': link:../../packages/client
       '@trpc/next': link:../../packages/next
       '@trpc/react-query': link:../../packages/react-query
@@ -520,7 +521,7 @@ importers:
       typescript: ^4.8.3
       zod: ^3.0.0
     dependencies:
-      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.18.0_biqbaboplfbrettd7655fr4n2y
       '@trpc/client': link:../../packages/client
       '@trpc/next': link:../../packages/next
       '@trpc/react-query': link:../../packages/react-query
@@ -539,7 +540,7 @@ importers:
 
   examples/next-edge-runtime:
     specifiers:
-      '@tanstack/react-query': ^4.18.0
+      '@tanstack/react-query': 4.18.0
       '@trpc/client': link:../../packages/client
       '@trpc/next': link:../../packages/next
       '@trpc/react-query': link:../../packages/react-query
@@ -554,7 +555,7 @@ importers:
       typescript: ^4.8.3
       zod: ^3.0.0
     dependencies:
-      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.18.0_biqbaboplfbrettd7655fr4n2y
       '@trpc/client': link:../../packages/client
       '@trpc/next': link:../../packages/next
       '@trpc/react-query': link:../../packages/react-query
@@ -572,7 +573,7 @@ importers:
 
   examples/next-minimal-starter:
     specifiers:
-      '@tanstack/react-query': ^4.18.0
+      '@tanstack/react-query': 4.18.0
       '@trpc/client': link:../../packages/client
       '@trpc/next': link:../../packages/next
       '@trpc/react-query': link:../../packages/react-query
@@ -587,7 +588,7 @@ importers:
       typescript: ^4.8.3
       zod: ^3.0.0
     dependencies:
-      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.18.0_biqbaboplfbrettd7655fr4n2y
       '@trpc/client': link:../../packages/client
       '@trpc/next': link:../../packages/next
       '@trpc/react-query': link:../../packages/react-query
@@ -607,7 +608,7 @@ importers:
     specifiers:
       '@playwright/test': ^1.26.1
       '@prisma/client': https://registry.npmjs.com/@prisma/client/-/client-4.10.1.tgz?id=%40examples%2Ftrpc-next-prisma-starter
-      '@tanstack/react-query': ^4.18.0
+      '@tanstack/react-query': 4.18.0
       '@trpc/client': link:../../packages/client
       '@trpc/next': link:../../packages/next
       '@trpc/react-query': link:../../packages/react-query
@@ -638,7 +639,7 @@ importers:
       zod: ^3.0.0
     dependencies:
       '@prisma/client': '@registry.npmjs.com/@prisma/client/-/client-4.10.1.tgz?id=%2540examples%252Ftrpc-next-prisma-starter_prisma@4.10.1'
-      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.18.0_biqbaboplfbrettd7655fr4n2y
       '@trpc/client': link:../../packages/client
       '@trpc/next': link:../../packages/next
       '@trpc/react-query': link:../../packages/react-query
@@ -674,7 +675,7 @@ importers:
     specifiers:
       '@playwright/test': ^1.26.1
       '@prisma/client': https://registry.npmjs.com/@prisma/client/-/client-4.10.1.tgz?id=%40examples%2Ftrpc-next-prisma-todomvc
-      '@tanstack/react-query': ^4.18.0
+      '@tanstack/react-query': 4.18.0
       '@tanstack/react-query-devtools': ^4.3.8
       '@trpc/client': link:../../packages/client
       '@trpc/next': link:../../packages/next
@@ -697,7 +698,7 @@ importers:
       zod: ^3.0.0
     dependencies:
       '@prisma/client': '@registry.npmjs.com/@prisma/client/-/client-4.10.1.tgz?id=%2540examples%252Ftrpc-next-prisma-todomvc_prisma@4.10.1'
-      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.18.0_biqbaboplfbrettd7655fr4n2y
       '@trpc/client': link:../../packages/client
       '@trpc/next': link:../../packages/next
       '@trpc/react-query': link:../../packages/react-query
@@ -712,7 +713,7 @@ importers:
       zod: 3.20.2
     devDependencies:
       '@playwright/test': 1.28.1
-      '@tanstack/react-query-devtools': 4.18.0_brdhmlf72zuns3lsk66phyptty
+      '@tanstack/react-query-devtools': 4.18.0_2ryzfomli4bbns3rdhwnpgjdhm
       '@types/node': 18.7.20
       '@types/react': 18.0.25
       eslint: 8.30.0
@@ -725,7 +726,7 @@ importers:
     specifiers:
       '@playwright/test': ^1.26.1
       '@prisma/client': https://registry.npmjs.com/@prisma/client/-/client-4.10.1.tgz?id=%40examples%2Fnext-websockets-starter
-      '@tanstack/react-query': ^4.18.0
+      '@tanstack/react-query': 4.18.0
       '@tanstack/react-query-devtools': ^4.3.8
       '@trpc/client': link:../../packages/client
       '@trpc/next': link:../../packages/next
@@ -762,7 +763,7 @@ importers:
       zod: ^3.0.0
     dependencies:
       '@prisma/client': '@registry.npmjs.com/@prisma/client/-/client-4.10.1.tgz?id=%2540examples%252Fnext-websockets-starter_prisma@4.10.1'
-      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.18.0_biqbaboplfbrettd7655fr4n2y
       '@trpc/client': link:../../packages/client
       '@trpc/next': link:../../packages/next
       '@trpc/react-query': link:../../packages/react-query
@@ -778,7 +779,7 @@ importers:
       zod: 3.20.2
     devDependencies:
       '@playwright/test': 1.28.1
-      '@tanstack/react-query-devtools': 4.18.0_brdhmlf72zuns3lsk66phyptty
+      '@tanstack/react-query-devtools': 4.18.0_2ryzfomli4bbns3rdhwnpgjdhm
       '@types/node': 18.7.20
       '@types/react': 18.0.25
       '@types/ws': 8.5.3
@@ -906,7 +907,7 @@ importers:
 
   packages/next:
     specifiers:
-      '@tanstack/react-query': ^4.18.0
+      '@tanstack/react-query': 4.18.0
       '@trpc/client': link:../client
       '@trpc/react-query': link:../react-query
       '@trpc/server': link:../server
@@ -926,7 +927,7 @@ importers:
     dependencies:
       react-ssr-prepass: 1.5.0_react@18.2.0
     devDependencies:
-      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.18.0_biqbaboplfbrettd7655fr4n2y
       '@trpc/client': link:../client
       '@trpc/react-query': link:../react-query
       '@trpc/server': link:../server
@@ -945,7 +946,7 @@ importers:
 
   packages/react-query:
     specifiers:
-      '@tanstack/react-query': ^4.18.0
+      '@tanstack/react-query': 4.18.0
       '@trpc/client': link:../client
       '@trpc/server': link:../server
       '@types/express': ^4.17.12
@@ -960,7 +961,7 @@ importers:
       tsx: ^3.12.3
       zod: ^3.0.0
     devDependencies:
-      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.18.0_biqbaboplfbrettd7655fr4n2y
       '@trpc/client': link:../client
       '@trpc/server': link:../server
       '@types/express': 4.17.14
@@ -978,7 +979,7 @@ importers:
   packages/server:
     specifiers:
       '@fastify/websocket': ^7.1.2
-      '@tanstack/react-query': ^4.18.0
+      '@tanstack/react-query': 4.18.0
       '@types/aws-lambda': ^8.10.97
       '@types/express': ^4.17.12
       '@types/hash-sum': ^1.0.0
@@ -1009,7 +1010,7 @@ importers:
       zod: ^3.0.0
     devDependencies:
       '@fastify/websocket': 7.1.2
-      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.18.0_biqbaboplfbrettd7655fr4n2y
       '@types/aws-lambda': 8.10.109
       '@types/express': 4.17.14
       '@types/hash-sum': 1.0.0
@@ -1044,7 +1045,7 @@ importers:
       '@cloudflare/workers-types': ^4.0.0
       '@fastify/websocket': ^7.1.2
       '@miniflare/core': ^2.9.0
-      '@tanstack/react-query': ^4.18.0
+      '@tanstack/react-query': 4.18.0
       '@testing-library/dom': ^9.0.0
       '@testing-library/jest-dom': ^5.16.5
       '@testing-library/react': ^14.0.0
@@ -1086,7 +1087,7 @@ importers:
       '@cloudflare/workers-types': 4.20230215.0
       '@fastify/websocket': 7.1.2
       '@miniflare/core': 2.11.0
-      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.18.0_biqbaboplfbrettd7655fr4n2y
       '@testing-library/dom': 9.0.0
       '@testing-library/jest-dom': 5.16.5
       '@testing-library/react': 14.0.0_biqbaboplfbrettd7655fr4n2y
@@ -8741,10 +8742,10 @@ packages:
       remove-accents: 0.4.2
     dev: true
 
-  /@tanstack/query-core/4.26.1:
-    resolution: {integrity: sha512-Zrx2pVQUP4ndnsu6+K/m8zerXSVY8QM+YSbxA1/jbBY21GeCd5oKfYl92oXPK0hPEUtoNuunIdiq0ZMqLos+Zg==}
+  /@tanstack/query-core/4.18.0:
+    resolution: {integrity: sha512-PP4mG8MD08sq64RZCqMfXMYfaj7+Oulwg7xZ/fJoEOdTZNcPIgaOkHajZvUBsNLbi/0ViMvJB4cFkL2Jg2WPbw==}
 
-  /@tanstack/react-query-devtools/4.18.0_brdhmlf72zuns3lsk66phyptty:
+  /@tanstack/react-query-devtools/4.18.0_2ryzfomli4bbns3rdhwnpgjdhm:
     resolution: {integrity: sha512-L51D0AUqLTs7J+W7RypJrUEKXsS0y0eEhXAgO+rhcZH6i8jVrKLhcNZStQSnE+UpZqPm73uxt2e8TJgYfzz0nw==}
     peerDependencies:
       '@tanstack/react-query': 4.18.0
@@ -8752,15 +8753,15 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       '@tanstack/match-sorter-utils': 8.1.1
-      '@tanstack/react-query': 4.26.1_biqbaboplfbrettd7655fr4n2y
+      '@tanstack/react-query': 4.18.0_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       superjson: 1.11.0
       use-sync-external-store: 1.2.0_react@18.2.0
     dev: true
 
-  /@tanstack/react-query/4.26.1_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-i3dnz4TOARGIXrXQ5P7S25Zfi4noii/bxhcwPurh2nrf5EUCcAt/95TB2HSmMweUBx206yIMWUMEQ7ptd6zwDg==}
+  /@tanstack/react-query/4.18.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-s1kdbGMdVcfUIllzsHUqVUdktBT5uuIRgnvrqFNLjl9TSOXEoBSDrhjsGjao0INQZv8cMpQlgOh3YH9YtN6cKw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -8771,7 +8772,7 @@ packages:
       react-native:
         optional: true
     dependencies:
-      '@tanstack/query-core': 4.26.1
+      '@tanstack/query-core': 4.18.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       use-sync-external-store: 1.2.0_react@18.2.0

--- a/www/docs/reactjs/useContext.mdx
+++ b/www/docs/reactjs/useContext.mdx
@@ -87,6 +87,7 @@ These are the helpers you'll get access to via `useContext`. The table below wil
 | `prefetch`          | [`queryClient.prefetchQuery`](https://tanstack.com/query/v4/docs/guides/prefetching)                                             |
 | `fetchInfinite`     | [`queryClient.fetchInfiniteQuery`](https://tanstack.com/query/v4/docs/reference/QueryClient#queryclientfetchinfinitequery)       |
 | `prefetchInfinite`  | [`queryClient.prefetchInfiniteQuery`](https://tanstack.com/query/v4/docs/reference/QueryClient#queryclientprefetchinfinitequery) |
+| `ensureData`        | [`queryClient.ensureData`](https://tanstack.com/query/v4/docs/react/reference/QueryClient#queryclientensurequerydata)            |
 | `invalidate`        | [`queryClient.invalidateQueries`](https://tanstack.com/query/v4/docs/guides/query-invalidation)                                  |
 | `refetch`           | [`queryClient.refetchQueries`](https://tanstack.com/query/v4/docs/reference/QueryClient#queryclientrefetchqueries)               |
 | `cancel`            | [`queryClient.cancelQuery`](https://tanstack.com/query/v4/docs/guides/query-cancellation)                                        |


### PR DESCRIPTION
Closes https://github.com/trpc/trpc/issues/3933

## 🎯 Changes

- Added support for https://tanstack.com/query/v4/docs/react/reference/QueryClient#queryclientensurequerydata with a new `ensureData` context helper - https://trpc.io/docs/useContext#helpers
- Bumped `@tanstack/react-query` to `^4.18.0` as this is version where `ensureQueryData` was added
- Removed unnecessary `pnpm.overrides.overrides.@tanstack/react-query` which was initially set in https://github.com/trpc/trpc/pull/2852
- Moved `nextjs` and `react-query` `peerDep` to `^4.18.0`, however personally I'd rather change it to `4.x` instead. We've had plenty of reports about `peerDep` from various environments in Sentry SDK and after years of experimentation this seems to be the most reliable and flexible way, eg.
  - https://github.com/getsentry/sentry-javascript/blob/63ef40e5f856e29b344bb577036c88e00d0264d5/packages/nextjs/package.json#L39-L43
  - https://github.com/getsentry/sentry-javascript/blob/63ef40e5f856e29b344bb577036c88e00d0264d5/packages/react/package.json#L25-L27
  - https://github.com/getsentry/sentry-javascript/blob/63ef40e5f856e29b344bb577036c88e00d0264d5/packages/remix/package.json#L41-L45

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
