### PR TITLE
feat(next): allow `withTRPC()`-HOC on individual pages

### DIFF
--- a/packages/next/src/withTRPC.tsx
+++ b/packages/next/src/withTRPC.tsx
@@ -120,10 +120,15 @@ export function withTRPC<
       });
 
       const { queryClient, trpcClient, ssrState, ssrContext } = prepassProps;
-      const hydratedState = trpc.useDehydratedState(
-        trpcClient,
-        props.pageProps.trpcState,
-      );
+
+      // allow normal components to be wrapped, not just app/pages
+      let hydratedState: DehydratedState | undefined;
+      if (props.pageProps) {
+        hydratedState = trpc.useDehydratedState(
+          trpcClient,
+          props.pageProps.trpcState,
+        );
+      }
 
       return (
         <trpc.Provider

--- a/packages/tests/server/react/withTRPC.test.tsx
+++ b/packages/tests/server/react/withTRPC.test.tsx
@@ -487,4 +487,64 @@ describe('withTRPC()', () => {
       });
     });
   });
+
+  describe('individual pages', () => {
+    test('useQuery', async () => {
+      // @ts-ignore
+      const { window } = global;
+
+      // @ts-ignore
+      delete global.window;
+      const { trpc, trpcClientOptions } = ctx;
+      const App = () => {
+        const query = trpc.allPosts.useQuery();
+        return <>{JSON.stringify(query.data)}</>;
+      };
+
+      const Wrapped = withTRPC({
+        config: () => trpcClientOptions,
+      })(App);
+
+      // @ts-ignore
+      global.window = window;
+
+      const utils = render(<Wrapped />);
+      expect(utils.container).not.toHaveTextContent('first post');
+
+      // should eventually be fetched
+      await waitFor(() => {
+        expect(utils.container).toHaveTextContent('first post');
+      });
+    });
+    test('useQuery - ssr', async () => {
+      // @ts-ignore
+      const { window } = global;
+
+      // @ts-ignore
+      delete global.window;
+      const { trpc, trpcClientOptions } = ctx;
+      const App = () => {
+        const query = trpc.allPosts.useQuery();
+        return <>{JSON.stringify(query.data)}</>;
+      };
+
+      const Wrapped = withTRPC({
+        config: () => trpcClientOptions,
+        ssr: true,
+      })(App);
+
+      // @ts-ignore
+      global.window = window;
+
+      // ssr should not work
+
+      const utils = render(<Wrapped />);
+      expect(utils.container).not.toHaveTextContent('first post');
+
+      // should eventually be fetched
+      await waitFor(() => {
+        expect(utils.container).toHaveTextContent('first post');
+      });
+    });
+  });
 });


### PR DESCRIPTION
Closes #3936

## 🎯 Changes

`withTRPC` now doesn't attempt to hydrate the page if `pageProps` is missing from the given component - this lets random components, like indivdual pages, be wrapped by the HOC to get access to the context providers.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
