### PR TITLE
Update all internal peer-deps to 10.16.0

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -69,7 +69,7 @@
     "links"
   ],
   "peerDependencies": {
-    "@trpc/server": "10.15.0"
+    "@trpc/server": "10.16.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^9.0.0",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -44,9 +44,9 @@
   ],
   "peerDependencies": {
     "@tanstack/react-query": "^4.18.0",
-    "@trpc/client": "10.15.0",
-    "@trpc/react-query": "10.15.0",
-    "@trpc/server": "10.15.0",
+    "@trpc/client": "10.16.0",
+    "@trpc/react-query": "10.16.0",
+    "@trpc/server": "10.16.0",
     "next": "*",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -57,8 +57,8 @@
   },
   "peerDependencies": {
     "@tanstack/react-query": "^4.18.0",
-    "@trpc/client": "10.15.0",
-    "@trpc/server": "10.15.0",
+    "@trpc/client": "10.16.0",
+    "@trpc/server": "10.16.0",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   },


### PR DESCRIPTION
This will not fix the npm package, for that we need to cut a 10.16.1 release and make sure to get this bit right this time!

At least our CI builds can build with this fix though

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
