### PR TITLE
docs: add pitfall section for merging routers

### DIFF
--- a/www/docs/server/merging-routers.md
+++ b/www/docs/server/merging-routers.md
@@ -101,7 +101,7 @@ const appRouter = router({
 
 :::info
 
-We recommend you to only define inline sub-routers within a file, and to keep the exported routers as a `t.router` object. This makes any potential type errors show up in the file they originate from, and not at the place where you merge them.
+We recommend you always export routers via `t.router`, as opposed to exporting objects with procedures attached. This ensures that type errors show up in the file they originate from, instead of the place where you merge them.
 
 <details style={{ marginTop: "1rem" }}>
 <summary>See a deep dive here</summary>

--- a/www/docs/server/merging-routers.md
+++ b/www/docs/server/merging-routers.md
@@ -106,7 +106,7 @@ We recommend you to only define inline sub-routers within a file, and to keep th
 <details style={{ marginTop: "1rem" }}>
 <summary>See a deep dive here</summary>
 
-When defining a router as a plain object, any keys are valid. This means you can define a router like this:
+When defining a router as a plain object, any key is valid. This means you can define a router like this, without any errors being shown. But when you try to merge this router somewhere else, things will blow up:
 
 ```ts twoslash title="routers/user.ts"
 export const userRouter = {
@@ -118,9 +118,7 @@ export const userRouter = {
 
 <br />
 
-without any errors being shown. But when you try to merge this router somewhere else, things will blow up:
-
-```ts twoslash title="routers/user.ts"
+```ts twoslash title="routers/_app.ts"
 import { initTRPC } from '@trpc/server';
 
 const t = initTRPC.create();

--- a/www/docs/server/merging-routers.md
+++ b/www/docs/server/merging-routers.md
@@ -99,7 +99,7 @@ const appRouter = router({
 });
 ```
 
-:::caution
+:::info
 
 We recommend you to only define inline sub-routers within a file, and to keep the exported routers as a `t.router` object. This makes any potential type errors show up in the file they originate from, and not at the place where you merge them.
 


### PR DESCRIPTION
Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

Link: https://www-git-router-pitfall-trpc.vercel.app/docs/merging-routers#defining-an-inline-sub-router

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
