### PR TITLE
docs: comment out inlining sub-routers

### DIFF
--- a/www/docs/server/merging-routers.md
+++ b/www/docs/server/merging-routers.md
@@ -66,6 +66,8 @@ export const userRouter = router({
 
 ```
 
+<!--
+
 ### Defining an inline sub-router
 
 When you define an inline sub-router, you can represent your router as a plain object.
@@ -177,6 +179,8 @@ export const appRouter = router({
 </details>
 
 :::
+
+-->
 
 ## Merging with `t.mergeRouters`
 


### PR DESCRIPTION
It's not working (cc @Nsttt, see #4007)