### PR TITLE
chore(server): (breaking) return an instance of `http.Server` from `createHTTPServer` in standalone adapter

### DIFF
--- a/examples/standalone-server/src/server.ts
+++ b/examples/standalone-server/src/server.ts
@@ -72,7 +72,7 @@ const appRouter = router({
 export type AppRouter = typeof appRouter;
 
 // http server
-const { server, listen } = createHTTPServer({
+const server = createHTTPServer({
   router: appRouter,
   createContext,
 });
@@ -88,4 +88,4 @@ applyWSSHandler<AppRouter>({
 // setInterval(() => {
 //   console.log('Connected clients', wss.clients.size);
 // }, 1000);
-listen(2022);
+server.listen(2022);

--- a/packages/server/src/adapters/standalone.ts
+++ b/packages/server/src/adapters/standalone.ts
@@ -19,14 +19,9 @@ export function createHTTPHandler<TRouter extends AnyRouter>(
   opts: CreateHTTPHandlerOptions<TRouter>,
 ) {
   return async (req: http.IncomingMessage, res: http.ServerResponse) => {
-    // if no hostname, set a dummy one
-    const href = req.url!.startsWith('/')
-      ? `http://127.0.0.1${req.url}`
-      : req.url!;
-
-    // get procedure path and remove the leading slash
-    // /procedure -> procedure
-    const path = new URL(href).pathname.slice(1);
+    // Get procedure path and remove the leading slash, `/procedure -> procedure`
+    // Use dummy hostname if one is not provided.
+    const path = new URL(req.url!, 'http://127.0.0.1').pathname.slice(1);
 
     await nodeHTTPRequestHandler({
       ...opts,
@@ -41,18 +36,5 @@ export function createHTTPServer<TRouter extends AnyRouter>(
   opts: CreateHTTPHandlerOptions<TRouter>,
 ) {
   const handler = createHTTPHandler(opts);
-  const server = http.createServer((req, res) => handler(req, res));
-
-  return {
-    server,
-    listen: (port?: number) => {
-      server.listen(port);
-      const actualPort =
-        port === 0 ? ((server.address() as any).port as number) : port;
-
-      return {
-        port: actualPort,
-      };
-    },
-  };
+  return http.createServer((req, res) => handler(req, res));
 }

--- a/packages/tests/server/___testHelpers.ts
+++ b/packages/tests/server/___testHelpers.ts
@@ -17,6 +17,7 @@ import {
   WSSHandlerOptions,
   applyWSSHandler,
 } from '@trpc/server/src/adapters/ws';
+import { AddressInfo } from 'net';
 import fetch from 'node-fetch';
 import ws from 'ws';
 
@@ -47,7 +48,8 @@ export function routerToServerAndClientNew<TRouter extends AnyNewRouter>(
       },
     }),
   });
-  const { port: httpPort } = httpServer.listen(0);
+  const server = httpServer.listen(0);
+  const httpPort = (server.address() as AddressInfo).port;
   const httpUrl = `http://localhost:${httpPort}`;
 
   // wss
@@ -84,7 +86,7 @@ export function routerToServerAndClientNew<TRouter extends AnyNewRouter>(
     proxy,
     close: async () => {
       await Promise.all([
-        new Promise((resolve) => httpServer.server.close(resolve)),
+        new Promise((resolve) => server.close(resolve)),
         new Promise((resolve) => {
           wss.clients.forEach((ws) => ws.close());
           wss.close(resolve);

--- a/packages/tests/server/adapters/standalone.test.ts
+++ b/packages/tests/server/adapters/standalone.test.ts
@@ -8,7 +8,9 @@ import {
   CreateHTTPHandlerOptions,
   createHTTPServer,
 } from '@trpc/server/src/adapters/standalone';
+import { AddressInfo } from 'net';
 import fetch from 'node-fetch';
+import { NetworkInterfaceInfo, networkInterfaces } from 'os';
 import { z } from 'zod';
 
 const t = initTRPC.create();
@@ -30,48 +32,65 @@ const router = t.router({
   }),
 });
 
-let app: ReturnType<typeof createHTTPServer>;
-async function startServer(opts: CreateHTTPHandlerOptions<any>) {
-  app = createHTTPServer(opts);
-  app.server.addListener('error', (err) => {
-    throw err;
-  });
+function findPossibleLocalAddress() {
+  const bestMatch = Object.values(networkInterfaces())
+    .flat()
+    .find((netInterface) => {
+      const info = netInterface as NetworkInterfaceInfo;
+      return info.family === 'IPv4' && !info.internal;
+    });
+  return bestMatch?.address;
+}
 
-  const { port } = app.listen(0);
-
-  const client = createTRPCProxyClient<typeof router>({
+function createClient(port: number, address: string) {
+  return createTRPCProxyClient<typeof router>({
     links: [
       httpBatchLink({
-        url: `http://localhost:${port}`,
+        url: `http://${address}:${port}`,
         AbortController,
         fetch: fetch as any,
       }),
     ],
   });
+}
 
-  return {
-    port,
-    router,
-    client,
-  };
+let server: ReturnType<typeof createHTTPServer>;
+
+async function startServer(
+  opts: CreateHTTPHandlerOptions<any> & { host?: string },
+): Promise<{
+  port: number;
+  address: string;
+}> {
+  server = createHTTPServer(opts);
+
+  // NOTE: Using custom hostname requires awaiting for `listening` event.
+  // Prior to this event, it's not possible to retrieve resolved `port` and `address` values.
+  return new Promise((resolve, reject) => {
+    server.addListener('error', (err) => reject(err));
+    server.addListener('listening', () =>
+      resolve({
+        ...(server.address() as AddressInfo),
+      }),
+    );
+    server.listen(0, opts.host || '127.0.0.1');
+  });
 }
 
 afterEach(async () => {
-  if (app) {
-    app.server.close();
+  if (server) {
+    server.close();
   }
 });
 
 test('simple query', async () => {
-  const t = await startServer({
+  const { port, address } = await startServer({
     router,
   });
+  const client = createClient(port, address);
 
-  expect(
-    await t.client.hello.query({
-      who: 'test',
-    }),
-  ).toMatchInlineSnapshot(`
+  const result = await client.hello.query({ who: 'test' });
+  expect(result).toMatchInlineSnapshot(`
     Object {
       "text": "hello test",
     }
@@ -79,19 +98,20 @@ test('simple query', async () => {
 });
 
 test('error query', async () => {
-  const t = await startServer({
+  const { port, address } = await startServer({
     router,
   });
+  const client = createClient(port, address);
 
   try {
-    await t.client.exampleError.query();
+    await client.exampleError.query();
   } catch (e) {
     expect(e).toStrictEqual(new TRPCClientError('Unexpected error'));
   }
 });
 
 test('middleware intercepts request', async () => {
-  const t = await startServer({
+  const { port, address } = await startServer({
     middleware: (_req, res, _next) => {
       res.statusCode = 419;
       res.end();
@@ -100,21 +120,37 @@ test('middleware intercepts request', async () => {
     router,
   });
 
-  const result = await fetch(`http://localhost:${t.port}`);
-
+  const result = await fetch(`http://${address}:${port}`);
   expect(result.status).toBe(419);
 });
 
 test('middleware passes the request', async () => {
-  const t = await startServer({
+  const { port, address } = await startServer({
     middleware: (_req, _res, next) => {
       return next();
     },
     router,
   });
+  const client = createClient(port, address);
 
-  const result = await t.client.hello.query({ who: 'test' });
+  const result = await client.hello.query({ who: 'test' });
+  expect(result).toMatchInlineSnapshot(`
+    Object {
+      "text": "hello test",
+    }
+  `);
+});
 
+test('custom host', async () => {
+  const { port, address } = await startServer({
+    host: findPossibleLocalAddress(),
+    router,
+  });
+  const client = createClient(port, address);
+
+  expect(address).not.toEqual('127.0.0.1');
+
+  const result = await client.hello.query({ who: 'test' });
   expect(result).toMatchInlineSnapshot(`
     Object {
       "text": "hello test",

--- a/packages/tests/showcase/tinyrpc.test.ts
+++ b/packages/tests/showcase/tinyrpc.test.ts
@@ -5,6 +5,7 @@ import '../server/___packages';
 import '@trpc/server';
 import { TRPCError, initTRPC } from '@trpc/server';
 import { createHTTPServer } from '@trpc/server/adapters/standalone';
+import { AddressInfo } from 'net';
 import { z } from 'zod';
 import { createTinyRPCClient } from './tinyrpc';
 
@@ -59,17 +60,18 @@ const appRouter = router({
 type AppRouter = typeof appRouter;
 
 function createServer() {
-  const app = createHTTPServer({
+  const server = createHTTPServer({
     router: appRouter,
   });
 
-  const { port } = app.listen(0);
+  server.listen(0);
+  const port = (server.address() as AddressInfo).port;
 
   return {
-    port: port!,
+    port: port,
     async close() {
       await new Promise((resolve) => {
-        app.server.close(resolve);
+        server.close(resolve);
       });
     },
   };

--- a/www/docs/server/adapters/standalone.md
+++ b/www/docs/server/adapters/standalone.md
@@ -130,7 +130,7 @@ The `middleware` option will accept any function which resembles a connect/node.
 
 ## Going further
 
-If `createHTTPServer` isn't enough you can also use the standalone adapter's `createHTTPHandler` function to create your own HTTP Server. For instance:
+`createHTTPServer` is returning an instance of Node's built-in `http.Server`(https://nodejs.org/api/http.html#class-httpserver), which means that you have an access to all it's properties and APIs. However, if `createHTTPServer` isn't enough for your usecase, you can also use the standalone adapter's `createHTTPHandler` function to create your own HTTP server. For instance:
 
 ```ts title='server.ts'
 import { inferAsyncReturnType, initTRPC } from '@trpc/server';


### PR DESCRIPTION
Closes https://github.com/trpc/trpc/issues/4004

## 🎯 Changes

Refactor `createHTTPServer` to return an instance of Node's `http.Server` directly, instead of through `.server` property with an additional `listen` method on top of it.
This way we'll be able to encourage users to use built-in API directly and allow for usecases like the one with custom host in #4004

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
