### PR TITLE
feat: added batch capabilities to procedures

### DIFF
--- a/examples/batch-example/Readme.md
+++ b/examples/batch-example/Readme.md
@@ -1,0 +1,20 @@
+Batch Example.
+Run by starting the server with npm run dev in the ./server directory and starting the client by running dev in the ./client directory. This should start a project that shows several ways of using trpc to collect a Name and an Email in a solid.js client app (solid.js only being used as an example here but similar patterns are avialable is all modern frameworks and very common using context API's in certain cases).
+
+There are 4 differnt patterns showns. I'll describe the Pro's and Con's as follows:
+
+1. This is labeled the Naive approach. It follows a pattern of Inputs bound with updaters to the data which they update. They implement the data updaters using TRPC in this case. Trpc automatically batches the API calls into one request but the server operates on those requests individually. This is often fine for most usecases, especially early on in the lifecycle of an application and any deviation from this would be considered an optimization (likely to happen later in the lifecycle of an application if ever needed at all)
+
+2. This uses the new Batch functionaly that I'm proposing. Note that the front-end client code can stay exactly the same, but the server code needs to be updated to add the expected batching functionality. The types automatically reflect this needed change on the server while allows the front-end to remain as it was. A benefit there being that this is a completely opt in optimization only neccesarry when the app grows to a complexity where NOT doing this would be an issue (likely fairly late in the development cycle)
+
+3. This uses a manual batching operation (changing the input type to an array of updates). This requires the same change that number 2 does to take advantage of this batching but also requires significant changes to the client code. Whether this client code is better or worse is IMO up to interpritation and style. The key point is that it does require a significant change to the client code in this situation and while this code is simple in more mature codebases the refactor may be non-trivial.
+
+4. This seeks to essentially use the inteface from number 3 but provide a DX similar to number 2. The main drawback here is that this type of code is complex to maintain and replicates essentially very similar code to what TRPC is already doing under the hood to batch requests at the HTTP level.
+
+There are also solutions to the optimization issues present in example 1 which could theoretically be solved via more copmlex data layers. Some datalayers can provide this optimization out of the box or with very little configuration, but many others don't provide any level of optimization here and would require a complete handrolling of your own solutions (like if your data layer was 3rd party API's for instance).
+
+Ultimately the proposed batching functionality is both a pure optimization and not functionality critical for any use cases and an optimization which could be performed at different levels (data layer, UI layer, etc.). That being said for certain usecases I think an optimization at this level is both the easiest to implement and leaves other layers the the most clean.
+
+That ALSO being said if this either isn't the direction the core team wants to take the API (implicit data transformation) or even this work isn't worth the effort to maintain it (seeing as how this is a non-existential optimization path) I'm more than fine calling it here and closing this feature path.
+
+Thanks again for taking the time to reivew this PR and double thanks on providing such a great piece of tech as OSS!

--- a/examples/batch-example/client/api.ts
+++ b/examples/batch-example/client/api.ts
@@ -1,0 +1,13 @@
+import {
+  createTRPCProxyClient,
+  httpBatchLink,
+} from '../../../packages/client/dist';
+import { AppRouter } from '../server';
+
+export const g = createTRPCProxyClient<AppRouter>({
+  links: [
+    httpBatchLink({
+      url: 'http://localhost:3200',
+    }),
+  ],
+});

--- a/examples/batch-example/client/app.tsx
+++ b/examples/batch-example/client/app.tsx
@@ -1,0 +1,72 @@
+import { render, Switch } from "solid-js/web";
+import { Match } from "solid-js";
+import { OptionModule } from "./unimportant";
+import { Email as NaiveEmail, Name as NaiveName } from "./forms/naive";
+import { Name as BatchedName, Email as BatchedEmail } from "./forms/batched";
+import { User } from "./forms/manual";
+import {
+  Name as ComplexName,
+  Email as ComplexEmail,
+} from "./forms/manualComplex";
+
+const App = () => {
+  const { option, dom } = OptionModule();
+  const [N, E] = [NaiveName(), NaiveEmail()];
+  const [bN, bE] = [BatchedName(), BatchedEmail()];
+  const [cN, cE] = [ComplexName(), ComplexEmail()];
+  const {
+    dom: { Name: mN, Email: mE },
+    save,
+  } = User();
+  return (
+    <div style={{ display: "flex", "flex-direction": "column" }}>
+      <h1>Data Collection Application</h1>
+      {dom}
+      <Switch>
+        <Match when={option() === 1}>
+          {N.dom}
+          {E.dom}
+          <button
+            onClick={() => {
+              N.save();
+              E.save();
+            }}
+          >
+            Save
+          </button>
+        </Match>
+        <Match when={option() === 2}>
+          {bN.dom}
+          {bE.dom}
+          <button
+            onClick={() => {
+              bN.save();
+              bE.save();
+            }}
+          >
+            Save
+          </button>
+        </Match>
+        <Match when={option() === 3}>
+          {mN}
+          {mE}
+          <button onClick={save}>Save</button>
+        </Match>
+        <Match when={option() === 4}>
+          {cN.dom}
+          {cE.dom}
+          <button
+            onClick={() => {
+              cN.save();
+              cE.save();
+            }}
+          >
+            Save
+          </button>
+        </Match>
+      </Switch>
+    </div>
+  );
+};
+
+render(() => <App></App>, document.body);

--- a/examples/batch-example/client/forms/batched.tsx
+++ b/examples/batch-example/client/forms/batched.tsx
@@ -1,8 +1,8 @@
-import { createSignal } from "solid-js";
-import { g } from "../api";
+import { createSignal } from 'solid-js';
+import { g } from '../api';
 
 export const Email = () => {
-  const [input, setInput] = createSignal("");
+  const [input, setInput] = createSignal('');
 
   return {
     dom: (
@@ -14,13 +14,13 @@ export const Email = () => {
       ></input>
     ),
     save: () => {
-      g.batched.mutate({ email: input() });
+      void g.batched.mutate({ email: input() });
     },
   };
 };
 
 export const Name = () => {
-  const [input, setInput] = createSignal("");
+  const [input, setInput] = createSignal('');
 
   return {
     dom: (
@@ -32,7 +32,7 @@ export const Name = () => {
       ></input>
     ),
     save: () => {
-      g.batched.mutate({ name: input() });
+      void g.batched.mutate({ name: input() });
     },
   };
 };

--- a/examples/batch-example/client/forms/batched.tsx
+++ b/examples/batch-example/client/forms/batched.tsx
@@ -1,0 +1,38 @@
+import { createSignal } from "solid-js";
+import { g } from "../api";
+
+export const Email = () => {
+  const [input, setInput] = createSignal("");
+
+  return {
+    dom: (
+      <input
+        placeholder="batched email"
+        type="text"
+        value={input()}
+        onChange={(e) => setInput(e.currentTarget.value)}
+      ></input>
+    ),
+    save: () => {
+      g.batched.mutate({ email: input() });
+    },
+  };
+};
+
+export const Name = () => {
+  const [input, setInput] = createSignal("");
+
+  return {
+    dom: (
+      <input
+        placeholder="batched name"
+        type="text"
+        value={input()}
+        onChange={(e) => setInput(e.currentTarget.value)}
+      ></input>
+    ),
+    save: () => {
+      g.batched.mutate({ name: input() });
+    },
+  };
+};

--- a/examples/batch-example/client/forms/manual.tsx
+++ b/examples/batch-example/client/forms/manual.tsx
@@ -1,0 +1,31 @@
+import { createSignal } from "solid-js";
+import { g } from "../api";
+
+export const User = () => {
+  const [inputE, setInputE] = createSignal("");
+  const [inputN, setInputN] = createSignal("");
+
+  return {
+    dom: {
+      Email: (
+        <input
+          placeholder="manual email"
+          type="text"
+          value={inputE()}
+          onChange={(e) => setInputE(e.currentTarget.value)}
+        ></input>
+      ),
+      Name: (
+        <input
+          placeholder="manual name"
+          type="text"
+          value={inputN()}
+          onChange={(e) => setInputN(e.currentTarget.value)}
+        ></input>
+      ),
+    },
+    save: () => {
+      g.manualBatch.mutate([{ email: inputE() }, { name: inputN() }]);
+    },
+  };
+};

--- a/examples/batch-example/client/forms/manual.tsx
+++ b/examples/batch-example/client/forms/manual.tsx
@@ -1,9 +1,9 @@
-import { createSignal } from "solid-js";
-import { g } from "../api";
+import { createSignal } from 'solid-js';
+import { g } from '../api';
 
 export const User = () => {
-  const [inputE, setInputE] = createSignal("");
-  const [inputN, setInputN] = createSignal("");
+  const [inputE, setInputE] = createSignal('');
+  const [inputN, setInputN] = createSignal('');
 
   return {
     dom: {
@@ -25,7 +25,7 @@ export const User = () => {
       ),
     },
     save: () => {
-      g.manualBatch.mutate([{ email: inputE() }, { name: inputN() }]);
+      void g.manualBatch.mutate([{ email: inputE() }, { name: inputN() }]);
     },
   };
 };

--- a/examples/batch-example/client/forms/manualComplex.tsx
+++ b/examples/batch-example/client/forms/manualComplex.tsx
@@ -1,23 +1,23 @@
-import { createSignal } from "solid-js";
-import { g } from "../api";
+import { createSignal } from 'solid-js';
+import { g } from '../api';
 
-type InferReturn<T> = T extends (input: infer U) => any ? U : never;
-type Unwrap<T> = T extends (infer U)[] ? U : T;
+type InferReturn<TInput> = TInput extends (input: infer U) => any ? U : never;
+type Unwrap<TInput> = TInput extends (infer U)[] ? U : TInput;
 
 let updates = [] as Unwrap<InferReturn<typeof g.manualBatch.mutate>>[];
 const manualClientMutateBatcher = (
-  input: Unwrap<InferReturn<typeof g.manualBatch.mutate>>
+  input: Unwrap<InferReturn<typeof g.manualBatch.mutate>>,
 ) => {
   updates.push(input);
   queueMicrotask(() => {
     if (updates.length === 0) return;
-    g.manualBatch.mutate(updates);
+    void g.manualBatch.mutate(updates);
     updates = [];
   });
 };
 
 export const Email = () => {
-  const [input, setInput] = createSignal("");
+  const [input, setInput] = createSignal('');
 
   return {
     dom: (
@@ -35,7 +35,7 @@ export const Email = () => {
 };
 
 export const Name = () => {
-  const [input, setInput] = createSignal("");
+  const [input, setInput] = createSignal('');
 
   return {
     dom: (

--- a/examples/batch-example/client/forms/manualComplex.tsx
+++ b/examples/batch-example/client/forms/manualComplex.tsx
@@ -1,0 +1,53 @@
+import { createSignal } from "solid-js";
+import { g } from "../api";
+
+type InferReturn<T> = T extends (input: infer U) => any ? U : never;
+type Unwrap<T> = T extends (infer U)[] ? U : T;
+
+let updates = [] as Unwrap<InferReturn<typeof g.manualBatch.mutate>>[];
+const manualClientMutateBatcher = (
+  input: Unwrap<InferReturn<typeof g.manualBatch.mutate>>
+) => {
+  updates.push(input);
+  queueMicrotask(() => {
+    if (updates.length === 0) return;
+    g.manualBatch.mutate(updates);
+    updates = [];
+  });
+};
+
+export const Email = () => {
+  const [input, setInput] = createSignal("");
+
+  return {
+    dom: (
+      <input
+        placeholder="batched email"
+        type="text"
+        value={input()}
+        onChange={(e) => setInput(e.currentTarget.value)}
+      ></input>
+    ),
+    save: () => {
+      manualClientMutateBatcher({ email: input() });
+    },
+  };
+};
+
+export const Name = () => {
+  const [input, setInput] = createSignal("");
+
+  return {
+    dom: (
+      <input
+        placeholder="batched name"
+        type="text"
+        value={input()}
+        onChange={(e) => setInput(e.currentTarget.value)}
+      ></input>
+    ),
+    save: () => {
+      manualClientMutateBatcher({ name: input() });
+    },
+  };
+};

--- a/examples/batch-example/client/forms/naive.tsx
+++ b/examples/batch-example/client/forms/naive.tsx
@@ -1,8 +1,8 @@
-import { createSignal } from "solid-js";
-import { g } from "../api";
+import { createSignal } from 'solid-js';
+import { g } from '../api';
 
 export const Email = () => {
-  const [input, setInput] = createSignal("");
+  const [input, setInput] = createSignal('');
 
   return {
     dom: (
@@ -14,13 +14,13 @@ export const Email = () => {
       ></input>
     ),
     save: () => {
-      g.naive.mutate({ email: input() });
+      void g.naive.mutate({ email: input() });
     },
   };
 };
 
 export const Name = () => {
-  const [input, setInput] = createSignal("");
+  const [input, setInput] = createSignal('');
 
   return {
     dom: (
@@ -32,7 +32,7 @@ export const Name = () => {
       ></input>
     ),
     save: () => {
-      g.naive.mutate({ name: input() });
+      void g.naive.mutate({ name: input() });
     },
   };
 };

--- a/examples/batch-example/client/forms/naive.tsx
+++ b/examples/batch-example/client/forms/naive.tsx
@@ -1,0 +1,38 @@
+import { createSignal } from "solid-js";
+import { g } from "../api";
+
+export const Email = () => {
+  const [input, setInput] = createSignal("");
+
+  return {
+    dom: (
+      <input
+        placeholder="naive email"
+        type="text"
+        value={input()}
+        onChange={(e) => setInput(e.currentTarget.value)}
+      ></input>
+    ),
+    save: () => {
+      g.naive.mutate({ email: input() });
+    },
+  };
+};
+
+export const Name = () => {
+  const [input, setInput] = createSignal("");
+
+  return {
+    dom: (
+      <input
+        placeholder="naive name"
+        type="text"
+        value={input()}
+        onChange={(e) => setInput(e.currentTarget.value)}
+      ></input>
+    ),
+    save: () => {
+      g.naive.mutate({ name: input() });
+    },
+  };
+};

--- a/examples/batch-example/client/index.html
+++ b/examples/batch-example/client/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<script type="module" src="./app.tsx"></script>
+	<title>Document</title>
+</head>
+
+<body>
+</body>
+
+</html>

--- a/examples/batch-example/client/package.json
+++ b/examples/batch-example/client/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "client",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "dev": "vite dev"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "solid-js": "^1.6.15",
+    "vite": "^4.1.4",
+    "vite-plugin-solid": "^2.6.1"
+  }
+}

--- a/examples/batch-example/client/tsconfig.json
+++ b/examples/batch-example/client/tsconfig.json
@@ -10,16 +10,15 @@
     "downlevelIteration": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    // so that if your project isn't using TypeScript, it still has autocomplete
-    "allowJs": true,
     "esModuleInterop": true,
     "types": [
-      "DOM"
     ],
+    "baseUrl": ".",
     "lib": [
       "dom",
       "ES2021"
     ],
   },
-  "include": ["./"]
+  "include": ["./"],
+  "exclude": ["node_modules"]
 }

--- a/examples/batch-example/client/tsconfig.json
+++ b/examples/batch-example/client/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "module": "esnext",
+    "target": "esnext",
+    "moduleResolution": "node",
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
+    "strict": true,
+    "downlevelIteration": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    // so that if your project isn't using TypeScript, it still has autocomplete
+    "allowJs": true,
+    "esModuleInterop": true,
+    "types": [
+      "DOM"
+    ],
+    "lib": [
+      "dom",
+      "ES2021"
+    ],
+  },
+  "include": ["./"]
+}

--- a/examples/batch-example/client/unimportant.tsx
+++ b/examples/batch-example/client/unimportant.tsx
@@ -1,0 +1,43 @@
+import { createSignal } from "solid-js";
+
+export const OptionModule = () => {
+  const [option, setOption] = createSignal(1);
+  const createOptionSelector = (option: number) => () => {
+    setOption(option);
+  };
+  return {
+    dom: (
+      <span>
+        <label for="1">Option 1</label>
+        <input
+          name="option"
+          type="radio"
+          id="1"
+          onChange={createOptionSelector(1)}
+        ></input>
+        <label for="2">Option 2</label>
+        <input
+          name="option"
+          type="radio"
+          id="2"
+          onChange={createOptionSelector(2)}
+        ></input>
+        <label for="3">Option 3</label>
+        <input
+          name="option"
+          type="radio"
+          id="3"
+          onChange={createOptionSelector(3)}
+        ></input>
+        <label for="4">Option 4</label>
+        <input
+          name="option"
+          type="radio"
+          id="4"
+          onChange={createOptionSelector(4)}
+        ></input>
+      </span>
+    ),
+    option,
+  };
+};

--- a/examples/batch-example/client/vite.config.ts
+++ b/examples/batch-example/client/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import solidPlugin from "vite-plugin-solid";
+
+export default defineConfig({
+  plugins: [solidPlugin()],
+});

--- a/examples/batch-example/server/index.ts
+++ b/examples/batch-example/server/index.ts
@@ -1,0 +1,56 @@
+import http from "http";
+import { createHTTPHandler } from "../trpc/packages/server/dist/adapters/standalone.mjs";
+import {
+  defaultTransformer,
+  initTRPC,
+} from "../trpc/packages/server/dist/index.js";
+import z from "zod";
+
+const user = z.object({
+  email: z.string(),
+  name: z.string(),
+});
+
+const t = initTRPC.context().create({
+  transformer: defaultTransformer,
+});
+
+export const appRouter = t.router({
+  batched: t.procedure
+    .input(user.partial())
+    .batch()
+    .mutation(({ input }) => {
+      console.log(input);
+      return input;
+    }),
+  manualBatch: t.procedure
+    .input(user.partial().array())
+    .mutation(({ input }) => {
+      console.log(input);
+      return input;
+    }),
+  naive: t.procedure.input(user.partial()).mutation(({ input }) => {
+    console.log("save operation: ", input);
+  }),
+});
+
+const trpcHandler = createHTTPHandler({
+  router: appRouter,
+});
+
+export type AppRouter = typeof appRouter;
+
+http
+  .createServer((req, res) => {
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader("Access-Control-Request-Method", "*");
+    res.setHeader("Access-Control-Allow-Methods", "*");
+    res.setHeader("Access-Control-Allow-Headers", "*");
+
+    if (req.method === "OPTIONS") {
+      res.writeHead(200);
+      return res.end();
+    }
+    trpcHandler(req, res);
+  })
+  .listen(3200);

--- a/examples/batch-example/server/index.ts
+++ b/examples/batch-example/server/index.ts
@@ -1,10 +1,10 @@
-import http from "http";
-import { createHTTPHandler } from "../trpc/packages/server/dist/adapters/standalone.mjs";
+import http from 'http';
+import z from 'zod';
+import { createHTTPHandler } from '../../../packages/server/dist/adapters/standalone.mjs';
 import {
   defaultTransformer,
   initTRPC,
-} from "../trpc/packages/server/dist/index.js";
-import z from "zod";
+} from '../../../packages/server/dist/index.js';
 
 const user = z.object({
   email: z.string(),
@@ -30,7 +30,7 @@ export const appRouter = t.router({
       return input;
     }),
   naive: t.procedure.input(user.partial()).mutation(({ input }) => {
-    console.log("save operation: ", input);
+    console.log('save operation: ', input);
   }),
 });
 
@@ -42,15 +42,15 @@ export type AppRouter = typeof appRouter;
 
 http
   .createServer((req, res) => {
-    res.setHeader("Access-Control-Allow-Origin", "*");
-    res.setHeader("Access-Control-Request-Method", "*");
-    res.setHeader("Access-Control-Allow-Methods", "*");
-    res.setHeader("Access-Control-Allow-Headers", "*");
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Request-Method', '*');
+    res.setHeader('Access-Control-Allow-Methods', '*');
+    res.setHeader('Access-Control-Allow-Headers', '*');
 
-    if (req.method === "OPTIONS") {
+    if (req.method === 'OPTIONS') {
       res.writeHead(200);
       return res.end();
     }
-    trpcHandler(req, res);
+    void trpcHandler(req, res);
   })
   .listen(3200);

--- a/examples/batch-example/server/package.json
+++ b/examples/batch-example/server/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "dev": "nodemon -e js,ts  --exec \"TS_NODE_FILES=true TS_NODE_TRANSPILE_ONLY=true ts-node --esm ./index.ts\""
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@trpc/server": "^10.16.0",
+    "nodemon": "^2.0.21",
+    "superjson": "^1.12.2",
+    "trpc": "^0.11.3",
+    "ts-node-dev": "^2.0.0",
+    "zod": "^3.21.4"
+  }
+}

--- a/examples/batch-example/server/tsconfig.json
+++ b/examples/batch-example/server/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "module": "esnext",
+    "target": "esnext",
+    "moduleResolution": "node",
+    "strict": true,
+    "downlevelIteration": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    // so that if your project isn't using TypeScript, it still has autocomplete
+    "allowJs": true,
+    "esModuleInterop": true,
+    "types": [
+      "node"
+    ],
+    "lib": [
+      "ESNext"
+    ],
+    "paths": {
+      "trpc/server": ["../trpc/packages/server"],
+      "test": ["../trpc/packages/server/adapters/standalone"]
+    }
+  },
+  "include": ["./"]
+}

--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -118,8 +118,8 @@ export interface BatchProcedureBuilder<
       inferParser<$Parser>['out']
     >[];
 
-    _output_in: TParams['_output_in'];
-    _output_out: TParams['_output_out'];
+    _output_in: Unwrap<TParams['_output_in']>;
+    _output_out: Unwrap<TParams['_output_out']>;
   }>;
   /**
    * Add an output parser to the procedure.
@@ -242,7 +242,7 @@ export interface ProcedureBuilder<
     _input_in: TParams['_input_in'];
     _input_out: TParams['_input_out'][];
 
-    _output_in: TParams['_output_in'][];
+    _output_in: TParams['_output_in'];
     _output_out: TParams['_output_out'];
   }>;
   /**

--- a/packages/server/src/http/resolveHTTPResponse.ts
+++ b/packages/server/src/http/resolveHTTPResponse.ts
@@ -176,6 +176,7 @@ export async function resolveHTTPResponse<
       return input;
     };
     const inputs = getInputs();
+    paths = isBatchCall ? opts.path.split(',') : [opts.path];
     const batchMemos: Record<typeof paths[number], Promise<unknown[]>> = {};
     const batchIndexes: Record<typeof paths[number], number> = {};
     const batchRawInputs = paths.reduce((initialValue, path, i) => {
@@ -184,7 +185,6 @@ export async function resolveHTTPResponse<
         : { ...initialValue, [path]: [inputs[i]] };
     }, {} as Record<string, Array<typeof inputs[number]>>);
 
-    paths = isBatchCall ? opts.path.split(',') : [opts.path];
     const requestInfo: TRPCRequestInfo = {
       isBatchCall,
       calls: paths.map((path, idx) => ({

--- a/packages/server/src/http/resolveHTTPResponse.ts
+++ b/packages/server/src/http/resolveHTTPResponse.ts
@@ -180,7 +180,7 @@ export async function resolveHTTPResponse<
     const batchMemos: Record<typeof paths[number], Promise<unknown[]>> = {};
     const batchIndexes: Record<typeof paths[number], number> = {};
     const batchRawInputs = paths.reduce((initialValue, path, i) => {
-      return initialValue[path]
+      return Array.isArray(initialValue[path])
         ? { ...initialValue, [path]: [...initialValue[path]!, inputs[i]] }
         : { ...initialValue, [path]: [inputs[i]] };
     }, {} as Record<string, Array<typeof inputs[number]>>);


### PR DESCRIPTION
Note: Currently In progress. Opening this for feedback

## 🎯 Changes

This is a feature. I would like to add the ability to specify a procedure as a "batch" procedure. When a procedure is labeled a "batch" procedure (using the .batch()) function and the procedure builder. instead of getting just one input in the handler you will get an array of inputs. You will also be expected to return an array of the same length as the returned data to all the functions you called from the client. Currently the happy path works well as well as using it in conjunction with Input() and Output(). If there is interest I can clean up the last few things I'd need to handle before this code is ready for a merge.

In order to test this you can create a simple sandbox where you mark a procedure as batch like so:
![image](https://user-images.githubusercontent.com/46887906/225966535-f6413666-a5b7-4671-8ce8-d21752de8fcb.png)

## 💡 Rationale

The Rationale for this change is that with the automatic batch that is done on the client side often times it would be more performant to handle those requests all at once instead of one at a time for because you can batch API calls, database calls, etc. This would provide a very simplistic API so that you can continue to leverage the automatic batching done by TRPC on the client side while also taking advantage of it on the server side to get better performance or enable some other behavior that you may desire. This feature is completely opt in on the part of the user of course and should have no backwards breaking changes.


## ✅ Checklist

✅ I have followed the steps listed in the [Contributing guide (https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
- [ ] Handle error cases
- [ ] Clean up Procedure builder types

