### PR TITLE
chore: add .npmrc to fix render.com blueprint on next-prisma-starter

### DIFF
--- a/examples/next-prisma-starter/.npmrc
+++ b/examples/next-prisma-starter/.npmrc
@@ -1,0 +1,1 @@
+enable-pre-post-scripts=true


### PR DESCRIPTION
## 🎯 Changes

Right now, the build process on the application depends on running the `prebuild` script, which generates the Prisma client and executes the migrations.

However, by default `pnpm` [does not run pre/post scripts](https://github.com/pnpm/pnpm/issues/2891). To fix that, we could move the `prebuild` script to `build`, or, create this `.npmrc` file with this content:

```
enable-pre-post-scripts=true
```

This PR adds this file. I think it doesn't make sense to move away from pre/post scripts since it's what everyone is kinda used to.

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
