### PR TITLE
docs(`useInfiniteQuery`): Add a clarification in the `useInfiniteQuery` docs

### DIFF
--- a/www/docs/reactjs/useInfiniteQuery.md
+++ b/www/docs/reactjs/useInfiniteQuery.md
@@ -7,7 +7,7 @@ slug: /reactjs/useinfinitequery
 
 :::info
 
-- Your procedure needs to accept a `cursor` input of any type (`string`, `number`, etc)
+- Your procedure needs to accept a `cursor` input of any type (`string`, `number`, etc) to expose this hook.
 - For more details on infinite queries read the [react-query docs](https://react-query.tanstack.com/reference/useInfiniteQuery)
 - In this example we're using Prisma - see their docs on [cursor-based pagination](https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination)
 


### PR DESCRIPTION
## 🎯 Changes
Extends the note about the `cursor` input so it will be more clear that the hook would not be exposed **at all** if the procedure's input type is unsuitable.

[See current docs](https://trpc.io/docs/reactjs/useinfinitequery)

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
