### PR TITLE
docs: Fix API endpoint url in Step 3 of landing page

### DIFF
--- a/www/docs/landing-intro/Step3.md
+++ b/www/docs/landing-intro/Step3.md
@@ -31,7 +31,7 @@ import type { AppRouter } from './server';
 const trpc = createTRPCProxyClient<AppRouter>({
   links: [
     httpBatchLink({
-      url: 'http://localhost:3000/trpc',
+      url: 'http://localhost:3000',
     }),
   ],
 });


### PR DESCRIPTION
Closes https://github.com/trpc/trpc/issues/4059

## 🎯 Changes

Landing page instructions are using a standalone server, which is listening on the root path `/`, and not `/trpc`.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
