### PR TITLE
docs: Fix incorrect example of `createServerSideHelpers` usage + add details

### DIFF
--- a/www/docs/nextjs/ssg.md
+++ b/www/docs/nextjs/ssg.md
@@ -30,7 +30,7 @@ import { trpc } from 'utils/trpc';
 export async function getStaticProps(
   context: GetStaticPropsContext<{ id: string }>,
 ) {
-  const ssg = await createServerSideHelpers({
+  const helpers = createServerSideHelpers({
     router: appRouter,
     ctx: {},
     transformer: superjson, // optional - adds superjson serialization
@@ -38,11 +38,11 @@ export async function getStaticProps(
   const id = context.params?.id as string;
 
   // prefetch `post.byId`
-  await ssg.post.byId.prefetch({ id });
+  await helpers.post.byId.prefetch({ id });
 
   return {
     props: {
-      trpcState: ssg.dehydrate(),
+      trpcState: helpers.dehydrate(),
       id,
     },
     revalidate: 1,

--- a/www/docs/server/context.md
+++ b/www/docs/server/context.md
@@ -67,12 +67,12 @@ const caller = appRouter.createCaller(await createContext());
 ```
 
 ```ts
-// 3. SSG helper
+// 3. servers-side helpers
 import { createServerSideHelpers } from '@trpc/react-query/server';
 import { createContext } from './context';
 import { appRouter } from './router';
 
-const ssg = createServerSideHelpers({
+const helpers = createServerSideHelpers({
   router: appRouter,
   ctx: await createContext(),
 });


### PR DESCRIPTION
## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

I made a slight error adding examples of `createServerSideHelpers` to the SSR page in the docs - this PR fixes it, and makes the example more instructive while it's at it since it shows an example of using `fetch`.

So that other people don't make the same mistake, I also elaborated on the difference between `prefetch` and `fetch` on the cSSH page.

Also:
 - Changed the variable name `createServerSideHelpers()` is assigned to in examples from `ssg` to `helpers`.
 - Removed await from `createServerSideHelpers` in examples since it's not a promise

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
