### PR TITLE
docs: fix broken react-query links and link to correct version

### DIFF
--- a/examples/.interop/next-prisma-starter/src/pages/_app.tsx
+++ b/examples/.interop/next-prisma-starter/src/pages/_app.tsx
@@ -71,7 +71,7 @@ export default withTRPC<AppRouter>({
        */
       transformer: superjson,
       /**
-       * @link https://react-query.tanstack.com/reference/QueryClient
+       * @link https://tanstack.com/query/v4/docs/react/reference/QueryClient
        */
       // queryClientConfig: { defaultOptions: { queries: { staleTime: 60 } } },
     };

--- a/examples/next-prisma-starter/src/utils/trpc.ts
+++ b/examples/next-prisma-starter/src/utils/trpc.ts
@@ -88,7 +88,7 @@ export const trpc = createTRPCNext<AppRouter, SSRContext>({
         }),
       ],
       /**
-       * @link https://react-query.tanstack.com/reference/QueryClient
+       * @link https://tanstack.com/query/v4/docs/react/reference/QueryClient
        */
       // queryClientConfig: { defaultOptions: { queries: { staleTime: 60 } } },
     };

--- a/examples/next-prisma-todomvc/src/utils/trpc.ts
+++ b/examples/next-prisma-todomvc/src/utils/trpc.ts
@@ -54,7 +54,7 @@ export const trpc = createTRPCNext<AppRouter>({
         }),
       ],
       /**
-       * @link https://react-query.tanstack.com/reference/QueryClient
+       * @link https://tanstack.com/query/v4/docs/react/reference/QueryClient
        */
       // queryClientConfig: { defaultOptions: { queries: { staleTime: 60 } } },
     };

--- a/examples/next-prisma-websockets-starter/src/utils/trpc.ts
+++ b/examples/next-prisma-websockets-starter/src/utils/trpc.ts
@@ -69,7 +69,7 @@ export const trpc = createTRPCNext<AppRouter>({
        */
       transformer: superjson,
       /**
-       * @link https://react-query.tanstack.com/reference/QueryClient
+       * @link https://tanstack.com/query/v4/docs/react/reference/QueryClient
        */
       queryClientConfig: { defaultOptions: { queries: { staleTime: 60 } } },
     };

--- a/packages/react-query/src/internals/context.tsx
+++ b/packages/react-query/src/internals/context.tsx
@@ -226,7 +226,7 @@ export interface TRPCContextState<
   ): Promise<void>;
 
   /**
-   * @link https://react-query.tanstack.com/guides/query-cancellation
+   * @link https://tanstack.com/query/v4/docs/react/guides/query-cancellation
    */
   cancelQuery: <
     TPath extends keyof TRouter['_def']['queries'] & string,

--- a/packages/react-query/src/internals/context.tsx
+++ b/packages/react-query/src/internals/context.tsx
@@ -92,7 +92,7 @@ export const contextProps: (keyof ProxyTRPCContextProps<any, any>)[] = [
 /** @internal */
 type TRPCContextResetQueries<TRouter extends AnyRouter> =
   /**
-   * @link https://react-query.tanstack.com/reference/QueryClient#queryclientresetqueries
+   * @link https://tanstack.com/query/v4/docs/react/reference/QueryClient#queryclientresetqueries
    */
   (<
     TPath extends keyof TRouter['_def']['queries'] & string,
@@ -103,7 +103,7 @@ type TRPCContextResetQueries<TRouter extends AnyRouter> =
     options?: ResetOptions,
   ) => Promise<void>) &
     /**
-     * @link https://react-query.tanstack.com/reference/QueryClient#queryclientresetqueries
+     * @link https://tanstack.com/query/v4/docs/react/reference/QueryClient#queryclientresetqueries
      */
     ((filters?: ResetQueryFilters, options?: ResetOptions) => Promise<void>);
 
@@ -201,12 +201,12 @@ export interface TRPCContextState<
   ) => Promise<void>;
 
   /**
-   * @link https://react-query.tanstack.com/reference/QueryClient#queryclientresetqueries
+   * @link https://tanstack.com/query/v4/docs/react/reference/QueryClient#queryclientresetqueries
    */
   resetQueries: TRPCContextResetQueries<TRouter>;
 
   /**
-   * @link https://react-query.tanstack.com/reference/QueryClient#queryclientrefetchqueries
+   * @link https://tanstack.com/query/v4/docs/react/reference/QueryClient#queryclientrefetchqueries
    */
   refetchQueries<
     TPath extends keyof TRouter['_def']['queries'] & string,
@@ -218,7 +218,7 @@ export interface TRPCContextState<
   ): Promise<void>;
 
   /**
-   * @link https://react-query.tanstack.com/reference/QueryClient#queryclientrefetchqueries
+   * @link https://tanstack.com/query/v4/docs/react/reference/QueryClient#queryclientrefetchqueries
    */
   refetchQueries(
     filters?: RefetchQueryFilters,
@@ -237,7 +237,7 @@ export interface TRPCContextState<
   ) => Promise<void>;
 
   /**
-   * @link https://react-query.tanstack.com/reference/QueryClient#queryclientsetquerydata
+   * @link https://tanstack.com/query/v4/docs/react/reference/QueryClient#queryclientsetquerydata
    */
   setQueryData: <
     TPath extends keyof TRouter['_def']['queries'] & string,
@@ -252,7 +252,7 @@ export interface TRPCContextState<
   ) => void;
 
   /**
-   * @link https://react-query.tanstack.com/reference/QueryClient#queryclientgetquerydata
+   * @link https://tanstack.com/query/v4/docs/react/reference/QueryClient#queryclientgetquerydata
    */
   getQueryData: <
     TPath extends keyof TRouter['_def']['queries'] & string,
@@ -265,7 +265,7 @@ export interface TRPCContextState<
   ) => TOutput | undefined;
 
   /**
-   * @link https://react-query.tanstack.com/reference/QueryClient#queryclientsetquerydata
+   * @link https://tanstack.com/query/v4/docs/react/reference/QueryClient#queryclientsetquerydata
    */
   setInfiniteQueryData: <
     TPath extends keyof TRouter['_def']['queries'] & string,
@@ -283,7 +283,7 @@ export interface TRPCContextState<
   ) => void;
 
   /**
-   * @link https://react-query.tanstack.com/reference/QueryClient#queryclientgetquerydata
+   * @link https://tanstack.com/query/v4/docs/react/reference/QueryClient#queryclientgetquerydata
    */
   getInfiniteQueryData: <
     TPath extends keyof TRouter['_def']['queries'] & string,

--- a/packages/react-query/src/internals/context.tsx
+++ b/packages/react-query/src/internals/context.tsx
@@ -189,7 +189,7 @@ export interface TRPCContextState<
   ) => Promise<TOutput>;
 
   /**
-   * @link https://react-query.tanstack.com/guides/query-invalidation
+   * @link https://tanstack.com/query/v4/docs/react/guides/query-invalidation
    */
   invalidateQueries: <
     TPath extends keyof TRouter['_def']['queries'] & string,

--- a/packages/react-query/src/internals/context.tsx
+++ b/packages/react-query/src/internals/context.tsx
@@ -146,7 +146,7 @@ export interface TRPCContextState<
   ) => Promise<InfiniteData<TOutput>>;
 
   /**
-   * @link https://react-query.tanstack.com/guides/prefetching
+   * @link https://tanstack.com/query/v4/docs/react/guides/prefetching
    */
   prefetchQuery: <
     TPath extends keyof TRouter['_def']['queries'] & string,

--- a/packages/react-query/src/server/ssgProxy.ts
+++ b/packages/react-query/src/server/ssgProxy.ts
@@ -22,26 +22,26 @@ import { CreateSSGHelpersOptions } from './types';
 
 type DecorateProcedure<TProcedure extends AnyProcedure> = {
   /**
-   * @link https://react-query.tanstack.com/guides/prefetching
+   * @link https://tanstack.com/query/v4/docs/react/guides/prefetching
    */
   fetch(
     ...args: inferHandlerInput<TProcedure>
   ): Promise<inferTransformedProcedureOutput<TProcedure>>;
 
   /**
-   * @link https://react-query.tanstack.com/guides/prefetching
+   * @link https://tanstack.com/query/v4/docs/react/guides/prefetching
    */
   fetchInfinite(
     ...args: inferHandlerInput<TProcedure>
   ): Promise<InfiniteData<inferTransformedProcedureOutput<TProcedure>>>;
 
   /**
-   * @link https://react-query.tanstack.com/guides/prefetching
+   * @link https://tanstack.com/query/v4/docs/react/guides/prefetching
    */
   prefetch(...args: inferHandlerInput<TProcedure>): Promise<void>;
 
   /**
-   * @link https://react-query.tanstack.com/guides/prefetching
+   * @link https://tanstack.com/query/v4/docs/react/guides/prefetching
    */
   prefetchInfinite(...args: inferHandlerInput<TProcedure>): Promise<void>;
 };

--- a/packages/react-query/src/shared/proxy/utilsProxy.ts
+++ b/packages/react-query/src/shared/proxy/utilsProxy.ts
@@ -193,7 +193,7 @@ type DecorateRouter = {
   /**
    * Invalidate the full router
    * @link https://trpc.io/docs/v10/useContext#query-invalidation
-   * @link https://react-query.tanstack.com/guides/query-invalidation
+   * @link https://tanstack.com/query/v4/docs/react/guides/query-invalidation
    */
   invalidate(
     input?: undefined,

--- a/www/blog/2023-01-14-typescript-performance-lessons.md
+++ b/www/blog/2023-01-14-typescript-performance-lessons.md
@@ -91,7 +91,7 @@ type DecorateProcedure<
   TProcedure extends AnyQueryProcedure,
 > = {
   /**
-   * @link https://react-query.tanstack.com/guides/query-invalidation
+   * @link https://tanstack.com/query/v4/docs/react/guides/query-invalidation
    */
   invalidate(
     input?: inferProcedureInput<TProcedure>,

--- a/www/docs/nextjs/server-side-helpers.md
+++ b/www/docs/nextjs/server-side-helpers.md
@@ -25,7 +25,7 @@ const ssg = createServerSideHelpers({
 For a full example, see our [E2E SSG test example](https://github.com/trpc/trpc/tree/main/examples/.test/ssg)
 :::
 
-The returned functions are all wrappers around react-query functions. Please check out [their docs](https://react-query.tanstack.com/overview) to learn more about them.
+The returned functions are all wrappers around react-query functions. Please check out [their docs](https://tanstack.com/query/v4/docs/react/overview) to learn more about them.
 
 ## Next.js Example
 

--- a/www/docs/reactjs/useInfiniteQuery.md
+++ b/www/docs/reactjs/useInfiniteQuery.md
@@ -8,7 +8,7 @@ slug: /reactjs/useinfinitequery
 :::info
 
 - Your procedure needs to accept a `cursor` input of any type (`string`, `number`, etc) to expose this hook.
-- For more details on infinite queries read the [react-query docs](https://react-query.tanstack.com/reference/useInfiniteQuery)
+- For more details on infinite queries read the [react-query docs](https://tanstack.com/query/v4/docs/react/reference/useInfiniteQuery)
 - In this example we're using Prisma - see their docs on [cursor-based pagination](https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination)
 
 :::

--- a/www/docs/reactjs/useMutation.md
+++ b/www/docs/reactjs/useMutation.md
@@ -6,10 +6,10 @@ slug: /reactjs/usemutation
 ---
 
 :::note
-The hooks provided by `@trpc/react-query` are a thin wrapper around @tanstack/react-query. For in-depth information about options and usage patterns, refer to their docs on [mutations](https://react-query.tanstack.com/guides/mutations).
+The hooks provided by `@trpc/react-query` are a thin wrapper around @tanstack/react-query. For in-depth information about options and usage patterns, refer to their docs on [mutations](https://tanstack.com/query/v4/docs/react/guides/mutations).
 :::
 
-Works like react-query's mutations - [see their docs](https://react-query.tanstack.com/guides/mutations).
+Works like react-query's mutations - [see their docs](https://tanstack.com/query/v4/docs/react/guides/mutations).
 
 ### Example
 

--- a/www/versioned_docs/version-9.x/main/quickstart.mdx
+++ b/www/versioned_docs/version-9.x/main/quickstart.mdx
@@ -23,7 +23,7 @@ For making typesafe API calls from your client. Install in your client codebase 
 
 `npm install @trpc/react react-query@3`
 
-For generating a powerful set of React hooks for querying your tRPC API. Powered by [react-query](https://tanstack.com/query/v4/docs/react/overview).
+For generating a powerful set of React hooks for querying your tRPC API. Powered by [react-query](https://tanstack.com/query/v3/docs/react/overview).
 
 `npm install @trpc/next`
 

--- a/www/versioned_docs/version-9.x/main/quickstart.mdx
+++ b/www/versioned_docs/version-9.x/main/quickstart.mdx
@@ -23,7 +23,7 @@ For making typesafe API calls from your client. Install in your client codebase 
 
 `npm install @trpc/react react-query@3`
 
-For generating a powerful set of React hooks for querying your tRPC API. Powered by [react-query](https://react-query.tanstack.com/).
+For generating a powerful set of React hooks for querying your tRPC API. Powered by [react-query](https://tanstack.com/query/v4/docs/react/overview).
 
 `npm install @trpc/next`
 

--- a/www/versioned_docs/version-9.x/nextjs/introduction.md
+++ b/www/versioned_docs/version-9.x/nextjs/introduction.md
@@ -48,7 +48,7 @@ Recommended but not enforced file structure. This is what you get when starting 
 yarn add @trpc/client @trpc/server @trpc/react @trpc/next zod react-query@3
 ```
 
-- React Query: `@trpc/react` provides a thin wrapper over [@tanstack/react-query](https://tanstack.com/query/v4/docs/react/overview). It is required as a peer dependency.
+- React Query: `@trpc/react` provides a thin wrapper over [@tanstack/react-query](https://tanstack.com/query/v3/docs/react/overview). It is required as a peer dependency.
 - Zod: most examples use [Zod](https://github.com/colinhacks/zod) for input validation and we highly recommended it, though it isn't required. You can use a validation library of your choice ([Yup](https://github.com/jquense/yup), [Superstruct](https://github.com/ianstormtaylor/superstruct), [io-ts](https://github.com/gcanti/io-ts), etc). In fact, any object containing a `parse`, `create` or `validateSync` method will work.
 
 ### 2. Enable strict mode
@@ -153,7 +153,7 @@ export default withTRPC<AppRouter>({
     return {
       url,
       /**
-       * @link https://tanstack.com/query/v4/docs/react/reference/QueryClient
+       * @link https://tanstack.com/query/v3/docs/react/reference/QueryClient
        */
       // queryClientConfig: { defaultOptions: { queries: { staleTime: 60 } } },
     };
@@ -195,7 +195,7 @@ The `config`-argument is a function that returns an object that configures the t
   - `links` to customize the flow of data between tRPC Client and the tRPC-server. [Read more](../client/links.md).
 
 - Optional:
-  - `queryClientConfig`: a configuration object for the React Query `QueryClient` used internally by the tRPC React hooks: [QueryClient docs](https://tanstack.com/query/v4/docs/react/reference/QueryClient)
+  - `queryClientConfig`: a configuration object for the React Query `QueryClient` used internally by the tRPC React hooks: [QueryClient docs](https://tanstack.com/query/v3/docs/react/reference/QueryClient)
   - `headers`: an object or a function that returns an object of outgoing tRPC requests
   - `transformer`: a transformer applied to outgoing payloads. Read more about [Data Transformers](data-transformers)
   - `fetch`: customize the implementation of `fetch` used by tRPC internally

--- a/www/versioned_docs/version-9.x/nextjs/introduction.md
+++ b/www/versioned_docs/version-9.x/nextjs/introduction.md
@@ -48,7 +48,7 @@ Recommended but not enforced file structure. This is what you get when starting 
 yarn add @trpc/client @trpc/server @trpc/react @trpc/next zod react-query@3
 ```
 
-- React Query: `@trpc/react` provides a thin wrapper over [@tanstack/react-query](https://react-query.tanstack.com/overview). It is required as a peer dependency.
+- React Query: `@trpc/react` provides a thin wrapper over [@tanstack/react-query](https://tanstack.com/query/v4/docs/react/overview). It is required as a peer dependency.
 - Zod: most examples use [Zod](https://github.com/colinhacks/zod) for input validation and we highly recommended it, though it isn't required. You can use a validation library of your choice ([Yup](https://github.com/jquense/yup), [Superstruct](https://github.com/ianstormtaylor/superstruct), [io-ts](https://github.com/gcanti/io-ts), etc). In fact, any object containing a `parse`, `create` or `validateSync` method will work.
 
 ### 2. Enable strict mode

--- a/www/versioned_docs/version-9.x/nextjs/introduction.md
+++ b/www/versioned_docs/version-9.x/nextjs/introduction.md
@@ -153,7 +153,7 @@ export default withTRPC<AppRouter>({
     return {
       url,
       /**
-       * @link https://react-query.tanstack.com/reference/QueryClient
+       * @link https://tanstack.com/query/v4/docs/react/reference/QueryClient
        */
       // queryClientConfig: { defaultOptions: { queries: { staleTime: 60 } } },
     };
@@ -195,7 +195,7 @@ The `config`-argument is a function that returns an object that configures the t
   - `links` to customize the flow of data between tRPC Client and the tRPC-server. [Read more](../client/links.md).
 
 - Optional:
-  - `queryClientConfig`: a configuration object for the React Query `QueryClient` used internally by the tRPC React hooks: [QueryClient docs](https://react-query.tanstack.com/reference/QueryClient)
+  - `queryClientConfig`: a configuration object for the React Query `QueryClient` used internally by the tRPC React hooks: [QueryClient docs](https://tanstack.com/query/v4/docs/react/reference/QueryClient)
   - `headers`: an object or a function that returns an object of outgoing tRPC requests
   - `transformer`: a transformer applied to outgoing payloads. Read more about [Data Transformers](data-transformers)
   - `fetch`: customize the implementation of `fetch` used by tRPC internally

--- a/www/versioned_docs/version-9.x/nextjs/ssg-helpers.md
+++ b/www/versioned_docs/version-9.x/nextjs/ssg-helpers.md
@@ -24,7 +24,7 @@ const {
 });
 ```
 
-The returned functions are all wrappers around react-query functions. Please check out [their docs](https://react-query.tanstack.com/overview) to learn more about them.
+The returned functions are all wrappers around react-query functions. Please check out [their docs](https://tanstack.com/query/v4/docs/react/overview) to learn more about them.
 
 ## Next.js Example
 

--- a/www/versioned_docs/version-9.x/nextjs/ssg-helpers.md
+++ b/www/versioned_docs/version-9.x/nextjs/ssg-helpers.md
@@ -24,7 +24,7 @@ const {
 });
 ```
 
-The returned functions are all wrappers around react-query functions. Please check out [their docs](https://tanstack.com/query/v4/docs/react/overview) to learn more about them.
+The returned functions are all wrappers around react-query functions. Please check out [their docs](https://tanstack.com/query/v3/docs/react/overview) to learn more about them.
 
 ## Next.js Example
 

--- a/www/versioned_docs/version-9.x/reactjs/invalidateQueries.md
+++ b/www/versioned_docs/version-9.x/reactjs/invalidateQueries.md
@@ -5,7 +5,7 @@ sidebar_label: invalidateQueries()
 slug: /invalidateQueries
 ---
 
-A typesafe wrapper around calling `queryClient.invalidateQueries()`, all it does is to call `queryClient.invalidateQueries()` with the passed args. [See react-query docs](https://react-query.tanstack.com/guides/query-invalidation) if you want more fine-grained control.
+A typesafe wrapper around calling `queryClient.invalidateQueries()`, all it does is to call `queryClient.invalidateQueries()` with the passed args. [See react-query docs](https://tanstack.com/query/v4/docs/react/guides/query-invalidation) if you want more fine-grained control.
 
 ## Example code
 

--- a/www/versioned_docs/version-9.x/reactjs/invalidateQueries.md
+++ b/www/versioned_docs/version-9.x/reactjs/invalidateQueries.md
@@ -5,7 +5,7 @@ sidebar_label: invalidateQueries()
 slug: /invalidateQueries
 ---
 
-A typesafe wrapper around calling `queryClient.invalidateQueries()`, all it does is to call `queryClient.invalidateQueries()` with the passed args. [See react-query docs](https://tanstack.com/query/v4/docs/react/guides/query-invalidation) if you want more fine-grained control.
+A typesafe wrapper around calling `queryClient.invalidateQueries()`, all it does is to call `queryClient.invalidateQueries()` with the passed args. [See react-query docs](https://tanstack.com/query/v3/docs/react/guides/query-invalidation) if you want more fine-grained control.
 
 ## Example code
 

--- a/www/versioned_docs/version-9.x/reactjs/useInfiniteQuery.md
+++ b/www/versioned_docs/version-9.x/reactjs/useInfiniteQuery.md
@@ -8,7 +8,7 @@ slug: /useInfiniteQuery
 :::info
 
 - Your procedure needs to accept a `cursor` input of `any` type
-- For more details on infinite queries read the [react-query docs](https://react-query.tanstack.com/reference/useInfiniteQuery)
+- For more details on infinite queries read the [react-query docs](https://tanstack.com/query/v4/docs/react/reference/useInfiniteQuery)
 - In this example we're using Prisma - see their docs on [cursor-based pagination](https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination)
 
 :::

--- a/www/versioned_docs/version-9.x/reactjs/useInfiniteQuery.md
+++ b/www/versioned_docs/version-9.x/reactjs/useInfiniteQuery.md
@@ -8,7 +8,7 @@ slug: /useInfiniteQuery
 :::info
 
 - Your procedure needs to accept a `cursor` input of `any` type
-- For more details on infinite queries read the [react-query docs](https://tanstack.com/query/v4/docs/react/reference/useInfiniteQuery)
+- For more details on infinite queries read the [react-query docs](https://tanstack.com/query/v3/docs/react/reference/useInfiniteQuery)
 - In this example we're using Prisma - see their docs on [cursor-based pagination](https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination)
 
 :::

--- a/www/versioned_docs/version-9.x/reactjs/useMutation.md
+++ b/www/versioned_docs/version-9.x/reactjs/useMutation.md
@@ -5,9 +5,9 @@ sidebar_label: useMutation()
 slug: /react-mutations
 ---
 
-> The hooks provided by `@trpc/react` are a thin wrapper around React Query. For in-depth information about options and usage patterns, refer to their docs on [Mutations](https://tanstack.com/query/v4/docs/react/guides/mutations).
+> The hooks provided by `@trpc/react` are a thin wrapper around React Query. For in-depth information about options and usage patterns, refer to their docs on [Mutations](https://tanstack.com/query/v3/docs/react/guides/mutations).
 
-Works like react-query's mutations - [see their docs](https://tanstack.com/query/v4/docs/react/guides/mutations).
+Works like react-query's mutations - [see their docs](https://tanstack.com/query/v3/docs/react/guides/mutations).
 
 ### Example
 

--- a/www/versioned_docs/version-9.x/reactjs/useMutation.md
+++ b/www/versioned_docs/version-9.x/reactjs/useMutation.md
@@ -5,9 +5,9 @@ sidebar_label: useMutation()
 slug: /react-mutations
 ---
 
-> The hooks provided by `@trpc/react` are a thin wrapper around React Query. For in-depth information about options and usage patterns, refer to their docs on [Mutations](https://react-query.tanstack.com/guides/mutations).
+> The hooks provided by `@trpc/react` are a thin wrapper around React Query. For in-depth information about options and usage patterns, refer to their docs on [Mutations](https://tanstack.com/query/v4/docs/react/guides/mutations).
 
-Works like react-query's mutations - [see their docs](https://react-query.tanstack.com/guides/mutations).
+Works like react-query's mutations - [see their docs](https://tanstack.com/query/v4/docs/react/guides/mutations).
 
 ### Example
 

--- a/www/versioned_docs/version-9.x/reactjs/useQuery.md
+++ b/www/versioned_docs/version-9.x/reactjs/useQuery.md
@@ -5,7 +5,7 @@ sidebar_label: useQuery()
 slug: /react-queries
 ---
 
-> The hooks provided by `@trpc/react` are a thin wrapper around React Query. For in-depth information about options and usage patterns, refer to their docs on [Queries](https://react-query.tanstack.com/guides/queries).
+> The hooks provided by `@trpc/react` are a thin wrapper around React Query. For in-depth information about options and usage patterns, refer to their docs on [Queries](https://tanstack.com/query/v4/docs/react/guides/queries).
 
 ```tsx
 function useQuery(

--- a/www/versioned_docs/version-9.x/reactjs/useQuery.md
+++ b/www/versioned_docs/version-9.x/reactjs/useQuery.md
@@ -5,7 +5,7 @@ sidebar_label: useQuery()
 slug: /react-queries
 ---
 
-> The hooks provided by `@trpc/react` are a thin wrapper around React Query. For in-depth information about options and usage patterns, refer to their docs on [Queries](https://tanstack.com/query/v4/docs/react/guides/queries).
+> The hooks provided by `@trpc/react` are a thin wrapper around React Query. For in-depth information about options and usage patterns, refer to their docs on [Queries](https://tanstack.com/query/v3/docs/react/guides/queries).
 
 ```tsx
 function useQuery(


### PR DESCRIPTION
Closes #4165 

These are not a globbed find/replace, they are a find, look up closest doc in the v4 docs, then replace. Not too much risk of a broken link 😄 

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
