### PR TITLE
docs: fix scale-ts import statement

### DIFF
--- a/www/docs/server/procedures.md
+++ b/www/docs/server/procedures.md
@@ -144,7 +144,7 @@ export type AppRouter = typeof appRouter;
 
 ```tsx
 import { initTRPC } from '@trpc/server';
-import * as $ from 'scale-ts';
+import * as $ from 'scale-codec';
 
 export const t = initTRPC.create();
 


### PR DESCRIPTION
## 🎯 Changes

Changed import from `scale-ts` to `scale-codec` as shown in their [readme](https://github.com/paritytech/scale-ts#setup).
