### PR TITLE
feat: add operations in `httpLink`/`httpBatchLink` `headers`-callback function

### DIFF
--- a/packages/client/src/internals/types.ts
+++ b/packages/client/src/internals/types.ts
@@ -124,3 +124,8 @@ export interface ResponseEsque {
    */
   json(): Promise<unknown>;
 }
+
+/**
+ * @internal
+ */
+export type NonEmptyArray<TItem> = [TItem, ...TItem[]];

--- a/packages/client/src/links/httpBatchLink.ts
+++ b/packages/client/src/links/httpBatchLink.ts
@@ -34,27 +34,50 @@ export function httpBatchLink<TRouter extends AnyRouter>(
           // escape hatch for quick calcs
           return true;
         }
+        const path = batchOps.map((op) => op.path).join(',');
         const inputs = batchOps.map((op) => op.input);
+
+        // TODO: dry this up
+        const resolveHeaders = () => {
+          const { headers } = opts;
+          if (typeof headers === 'function') {
+            return headers({ ops: batchOps });
+          }
+          return {};
+        };
 
         const url = getUrl({
           ...resolvedOpts,
           runtime,
           type,
+          path,
           inputs,
-          ops: batchOps,
+          resolveHeaders,
         });
+
         return url.length <= maxURLLength;
       };
 
       const fetch = (batchOps: BatchOperation[]) => {
+        const path = batchOps.map((op) => op.path).join(',');
         const inputs = batchOps.map((op) => op.input);
+
+        // TODO: dry this up
+        const resolveHeaders = () => {
+          const { headers } = opts;
+          if (typeof headers === 'function') {
+            return headers({ ops: batchOps });
+          }
+          return {};
+        };
 
         const { promise, cancel } = httpRequest({
           ...resolvedOpts,
           runtime,
           type,
+          path,
           inputs,
-          ops: batchOps,
+          resolveHeaders,
         });
 
         return {

--- a/packages/client/src/links/httpBatchLink.ts
+++ b/packages/client/src/links/httpBatchLink.ts
@@ -12,6 +12,8 @@ import {
 import { transformResult } from './internals/transformResult';
 import { Operation, TRPCLink } from './types';
 
+type BatchOperation = Operation;
+
 export interface HttpBatchLinkOptions extends HTTPLinkOptions {
   maxURLLength?: number;
 }
@@ -22,8 +24,6 @@ export function httpBatchLink<TRouter extends AnyRouter>(
   const resolvedOpts = resolveHTTPLinkOptions(opts);
   // initialized config
   return (runtime) => {
-    type BatchOperation = { id: number; path: string; input: unknown };
-
     const maxURLLength = opts.maxURLLength || Infinity;
 
     const batchLoader = (type: ProcedureType) => {

--- a/packages/client/src/links/httpBatchLink.ts
+++ b/packages/client/src/links/httpBatchLink.ts
@@ -5,10 +5,10 @@ import { dataLoader } from '../internals/dataLoader';
 import {
   HTTPLinkOptions,
   HTTPResult,
+  createResolveHeaders,
   getUrl,
   httpRequest,
   resolveHTTPLinkOptions,
-  resolveHeaders,
 } from './internals/httpUtils';
 import { transformResult } from './internals/transformResult';
 import { Operation, TRPCLink } from './types';
@@ -57,7 +57,7 @@ export function httpBatchLink<TRouter extends AnyRouter>(
           type,
           path,
           inputs,
-          headers: resolveHeaders({
+          resolveHeaders: createResolveHeaders({
             ops: batchOps,
             headers: opts.headers,
           }),

--- a/packages/client/src/links/httpBatchLink.ts
+++ b/packages/client/src/links/httpBatchLink.ts
@@ -34,31 +34,27 @@ export function httpBatchLink<TRouter extends AnyRouter>(
           // escape hatch for quick calcs
           return true;
         }
-        const path = batchOps.map((op) => op.path).join(',');
         const inputs = batchOps.map((op) => op.input);
 
         const url = getUrl({
           ...resolvedOpts,
           runtime,
           type,
-          path,
           inputs,
-          ops: batchOps as Operation[], // FIXME: is a BatchOperation just an Operation?
+          ops: batchOps,
         });
         return url.length <= maxURLLength;
       };
 
       const fetch = (batchOps: BatchOperation[]) => {
-        const path = batchOps.map((op) => op.path).join(',');
         const inputs = batchOps.map((op) => op.input);
 
         const { promise, cancel } = httpRequest({
           ...resolvedOpts,
           runtime,
           type,
-          path,
           inputs,
-          ops: batchOps as Operation[],
+          ops: batchOps,
         });
 
         return {

--- a/packages/client/src/links/httpBatchLink.ts
+++ b/packages/client/src/links/httpBatchLink.ts
@@ -10,7 +10,7 @@ import {
   resolveHTTPLinkOptions,
 } from './internals/httpUtils';
 import { transformResult } from './internals/transformResult';
-import { TRPCLink } from './types';
+import { Operation, TRPCLink } from './types';
 
 export interface HttpBatchLinkOptions extends HTTPLinkOptions {
   maxURLLength?: number;
@@ -28,6 +28,8 @@ export function httpBatchLink<TRouter extends AnyRouter>(
 
     const batchLoader = (type: ProcedureType) => {
       const validate = (batchOps: BatchOperation[]) => {
+        // DRY this up?
+
         if (maxURLLength === Infinity) {
           // escape hatch for quick calcs
           return true;
@@ -41,6 +43,7 @@ export function httpBatchLink<TRouter extends AnyRouter>(
           type,
           path,
           inputs,
+          ops: batchOps as Operation[], // FIXME: is a BatchOperation just an Operation?
         });
         return url.length <= maxURLLength;
       };
@@ -55,6 +58,7 @@ export function httpBatchLink<TRouter extends AnyRouter>(
           type,
           path,
           inputs,
+          ops: batchOps as Operation[],
         });
 
         return {

--- a/packages/client/src/links/httpBatchLink.ts
+++ b/packages/client/src/links/httpBatchLink.ts
@@ -69,10 +69,9 @@ export function httpBatchLink<TRouter extends AnyRouter>(
               return {};
             }
             if (typeof opts.headers === 'function') {
-              const headers = opts.headers({
+              return opts.headers({
                 opList: batchOps as NonEmptyArray<Operation>,
               });
-              return headers;
             }
             return opts.headers;
           },

--- a/packages/client/src/links/httpLink.ts
+++ b/packages/client/src/links/httpLink.ts
@@ -17,13 +17,23 @@ export function httpLink<TRouter extends AnyRouter>(
     ({ op }) =>
       observable((observer) => {
         const { path, input, type } = op;
+
+        // TODO: share this with batch link
+        const resolveHeaders = () => {
+          const { headers } = opts;
+          if (typeof headers === 'function') {
+            return headers({ ops: [op] });
+          }
+          return {};
+        };
+
         const { promise, cancel } = httpRequest({
           ...resolvedOpts,
           runtime,
           type,
           path,
           input,
-          ops: [op],
+          resolveHeaders,
         });
         promise
           .then((res) => {

--- a/packages/client/src/links/httpLink.ts
+++ b/packages/client/src/links/httpLink.ts
@@ -23,6 +23,7 @@ export function httpLink<TRouter extends AnyRouter>(
           type,
           path,
           input,
+          ops: [op],
         });
         promise
           .then((res) => {

--- a/packages/client/src/links/httpLink.ts
+++ b/packages/client/src/links/httpLink.ts
@@ -3,9 +3,9 @@ import { observable } from '@trpc/server/observable';
 import { TRPCClientError } from '../TRPCClientError';
 import {
   HTTPLinkOptions,
+  createResolveHeaders,
   httpRequest,
   resolveHTTPLinkOptions,
-  resolveHeaders,
 } from './internals/httpUtils';
 import { transformResult } from './internals/transformResult';
 import { TRPCLink } from './types';
@@ -25,7 +25,7 @@ export function httpLink<TRouter extends AnyRouter>(
           type,
           path,
           input,
-          headers: resolveHeaders({
+          resolveHeaders: createResolveHeaders({
             ops: [op],
             headers: opts.headers,
           }),

--- a/packages/client/src/links/httpLink.ts
+++ b/packages/client/src/links/httpLink.ts
@@ -39,10 +39,9 @@ export function httpLink<TRouter extends AnyRouter>(
               return {};
             }
             if (typeof opts.headers === 'function') {
-              const headers = opts.headers({
+              return opts.headers({
                 op,
               });
-              return headers;
             }
             return opts.headers;
           },

--- a/packages/client/src/links/httpLink.ts
+++ b/packages/client/src/links/httpLink.ts
@@ -5,6 +5,7 @@ import {
   HTTPLinkOptions,
   httpRequest,
   resolveHTTPLinkOptions,
+  resolveHeaders,
 } from './internals/httpUtils';
 import { transformResult } from './internals/transformResult';
 import { TRPCLink } from './types';
@@ -18,23 +19,18 @@ export function httpLink<TRouter extends AnyRouter>(
       observable((observer) => {
         const { path, input, type } = op;
 
-        // TODO: share this with batch link
-        const resolveHeaders = () => {
-          const { headers } = opts;
-          if (typeof headers === 'function') {
-            return headers({ ops: [op] });
-          }
-          return {};
-        };
-
         const { promise, cancel } = httpRequest({
           ...resolvedOpts,
           runtime,
           type,
           path,
           input,
-          resolveHeaders,
+          headers: resolveHeaders({
+            ops: [op],
+            headers: opts.headers,
+          }),
         });
+
         promise
           .then((res) => {
             const transformed = transformResult(res.json, runtime);

--- a/packages/client/src/links/internals/httpUtils.ts
+++ b/packages/client/src/links/internals/httpUtils.ts
@@ -7,7 +7,12 @@ import {
   FetchEsque,
   ResponseEsque,
 } from '../../internals/types';
-import { HTTPHeaders, Operation, PromiseAndCancel, TRPCClientRuntime } from '../types';
+import {
+  HTTPHeaders,
+  Operation,
+  PromiseAndCancel,
+  TRPCClientRuntime,
+} from '../types';
 
 export interface HTTPLinkOptions {
   url: string;
@@ -23,7 +28,9 @@ export interface HTTPLinkOptions {
    * Headers to be set on outgoing requests or a callback that of said headers
    * @link http://trpc.io/docs/v10/header
    */
-  headers?: HTTPHeaders | ((opts: {ops: Operation[]}) => HTTPHeaders | Promise<HTTPHeaders>);
+  headers?:
+    | HTTPHeaders
+    | ((opts: { ops: Operation[] }) => HTTPHeaders | Promise<HTTPHeaders>);
 }
 
 export interface ResolvedHTTPLinkOptions {
@@ -34,7 +41,7 @@ export interface ResolvedHTTPLinkOptions {
    * Headers to be set on outgoing request
    * @link http://trpc.io/docs/v10/header
    */
-  headers: (opts: {ops: Operation[]}) => HTTPHeaders | Promise<HTTPHeaders>;
+  headers: (opts: { ops: Operation[] }) => HTTPHeaders | Promise<HTTPHeaders>;
 }
 
 export function resolveHTTPLinkOptions(

--- a/packages/client/src/links/internals/httpUtils.ts
+++ b/packages/client/src/links/internals/httpUtils.ts
@@ -93,12 +93,12 @@ function getInput(opts: GetInputOptions) {
 export type HTTPRequestOptions = ResolvedHTTPLinkOptions &
   GetInputOptions & {
     type: ProcedureType;
-    path: string;
     ops: Operation[]; // TODO: if we do this, then we should get rid of type and path
   };
 
 export function getUrl(opts: HTTPRequestOptions) {
-  let url = opts.url + '/' + opts.path;
+  const path = opts.ops.map((op) => op.path).join(',');
+  let url = opts.url + '/' + path;
   const queryParts: string[] = [];
   if ('inputs' in opts) {
     queryParts.push('batch=1');

--- a/packages/tests/server/headers.test.tsx
+++ b/packages/tests/server/headers.test.tsx
@@ -54,7 +54,7 @@ describe('pass headers', () => {
           url: httpUrl,
           headers() {
             return {
-              'X-Special': 'special header',
+              'x-special': 'special header',
             };
           },
         }),
@@ -74,7 +74,7 @@ Object {
           url: httpUrl,
           async headers() {
             return {
-              'X-Special': 'async special header',
+              'x-special': 'async special header',
             };
           },
         }),
@@ -88,14 +88,19 @@ Object {
   });
 
   test('custom headers with context using httpBatchLink', async () => {
+    type LinkContext = {
+      headers: Dict<string | string[]>;
+    };
     const client = createTRPCProxyClient<AppRouter>({
       links: [
         httpBatchLink({
           url: httpUrl,
-          headers({ ops }) {
+          headers(opts) {
             return new Promise((resolve) => {
               resolve({
-                'X-Special': (ops[0] as any).context.headers['x-special'],
+                'x-special': (opts.opList[0].context as LinkContext).headers[
+                  'x-special'
+                ],
               });
             });
           },
@@ -119,13 +124,18 @@ Object {
   });
 
   test('custom headers with context using httpLink', async () => {
+    type LinkContext = {
+      headers: Dict<string | string[]>;
+    };
     const client = createTRPCProxyClient<AppRouter>({
       links: [
         httpLink({
           url: httpUrl,
-          headers({ ops }) {
+          headers(opts) {
             return {
-              'X-Special': (ops[0] as any).context.headers['x-special'],
+              'x-special': (opts.op.context as LinkContext).headers[
+                'x-special'
+              ],
             };
           },
         }),

--- a/www/docs/client/links/httpBatchLink.md
+++ b/www/docs/client/links/httpBatchLink.md
@@ -57,7 +57,9 @@ export interface HTTPLinkOptions {
    * Headers to be set on outgoing requests or a callback that of said headers
    * @link http://trpc.io/docs/v10/header
    */
-  headers?: HTTPHeaders | (() => HTTPHeaders | Promise<HTTPHeaders>);
+  headers?:
+    | HTTPHeaders
+    | ((opts: { ops: Operation[] }) => HTTPHeaders | Promise<HTTPHeaders>);
 }
 ```
 

--- a/www/docs/client/links/httpBatchLink.md
+++ b/www/docs/client/links/httpBatchLink.md
@@ -59,7 +59,7 @@ export interface HTTPLinkOptions {
    */
   headers?:
     | HTTPHeaders
-    | ((opts: { ops: Operation[] }) => HTTPHeaders | Promise<HTTPHeaders>);
+    | ((opts: { opList: Operation[] }) => HTTPHeaders | Promise<HTTPHeaders>);
 }
 ```
 

--- a/www/docs/client/links/httpLink.md
+++ b/www/docs/client/links/httpLink.md
@@ -47,7 +47,7 @@ export interface HTTPLinkOptions {
    */
   headers?:
     | HTTPHeaders
-    | ((opts: { ops: Operation[] }) => HTTPHeaders | Promise<HTTPHeaders>);
+    | ((opts: { op: Operation }) => HTTPHeaders | Promise<HTTPHeaders>);
 }
 ```
 

--- a/www/docs/client/links/httpLink.md
+++ b/www/docs/client/links/httpLink.md
@@ -45,7 +45,9 @@ export interface HTTPLinkOptions {
    * Headers to be set on outgoing requests or a callback that of said headers
    * @link http://trpc.io/docs/v10/header
    */
-  headers?: HTTPHeaders | (() => HTTPHeaders | Promise<HTTPHeaders>);
+  headers?:
+    | HTTPHeaders
+    | ((opts: { ops: Operation[] }) => HTTPHeaders | Promise<HTTPHeaders>);
 }
 ```
 


### PR DESCRIPTION
Closes https://github.com/trpc/trpc/issues/4071

## 🎯 Changes

This PR adds support for using operations in as part of the `HTTPLinkOptions.headers` used by `httpLink` and `httpBatchLink`. 

The API changes are non-breaking:
```diff
export interface HTTPLinkOptions {
  url: string;
  /**
   * Add ponyfill for fetch
   */
  fetch?: typeof fetch;
  /**
   * Add ponyfill for AbortController
   */
  AbortController?: typeof AbortController | null;
  /**
   * Headers to be set on outgoing requests or a callback that of said headers
   * @link http://trpc.io/docs/v10/header
   */
  headers?: 
    | HTTPHeaders 
-   | (()                           => HTTPHeaders | Promise<HTTPHeaders>);
+   | ((opts: { ops: Operation[] }) => HTTPHeaders | Promise<HTTPHeaders>);
}
```

Questions:
- Are we okay returning a list of operations when using the `httpLink`? If not how do we go about making the change non breaking? From a user point of view I actually like that both headers functions takes a list, this means I can share a headers function.  
- it seems we usually use abbreviations like `op` instead of `operations` in the external facing API (at least when building a custom link). I would prefer to be explicit here and use `operations`, but consistency is also a concern.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
