### PR TITLE
docs: fix copying code in safari

### DIFF
--- a/www/src/theme/CodeBlock/index.js
+++ b/www/src/theme/CodeBlock/index.js
@@ -11,7 +11,7 @@ const CodeBlock = ({ children, ...props }) => {
 
   const handleCopyCode = () => {
     if (pre.current) {
-      navigator.clipboard.writeText(
+      void navigator.clipboard.writeText(
         Array.from(pre.current.querySelectorAll('code div.line'))
           .map((el) => el.textContent)
           .join('\n'),

--- a/www/src/theme/CodeBlock/index.js
+++ b/www/src/theme/CodeBlock/index.js
@@ -1,0 +1,57 @@
+// Based on https://github.com/facebook/docusaurus/blob/ed9d2a26f5a7b8096804ae1b3a4fffc504f8f90d/packages/docusaurus-theme-classic/src/theme/CodeBlock/index.tsx
+// which is under MIT License as per the banner
+
+import './styles.css';
+import Translate, { translate } from '@docusaurus/Translate';
+import React, { useRef, useState } from 'react';
+
+const CodeBlock = ({ children, ...props }) => {
+  const pre = useRef(null);
+  const [showCopied, setShowCopied] = useState(false);
+
+  const handleCopyCode = () => {
+    if (pre.current) {
+      navigator.clipboard.writeText(
+        Array.from(pre.current.querySelectorAll('code div.line'))
+          .map((el) => el.textContent)
+          .join('\n'),
+      );
+    }
+    setShowCopied(true);
+    setTimeout(() => setShowCopied(false), 2000);
+  };
+
+  return (
+    <pre {...props} ref={pre}>
+      {children}
+      <button
+        type="button"
+        aria-label={translate({
+          id: 'theme.CodeBlock.copyButtonAriaLabel',
+          message: 'Copy code to clipboard',
+          description: 'The ARIA label for copy code blocks button',
+        })}
+        className="copy-button"
+        onClick={handleCopyCode}
+      >
+        {showCopied ? (
+          <Translate
+            id="theme.CodeBlock.copied"
+            description="The copied button label on code blocks"
+          >
+            Copied
+          </Translate>
+        ) : (
+          <Translate
+            id="theme.CodeBlock.copy"
+            description="The copy button label on code blocks"
+          >
+            Copy
+          </Translate>
+        )}
+      </button>
+    </pre>
+  );
+};
+
+export default CodeBlock;

--- a/www/src/theme/CodeBlock/styles.css
+++ b/www/src/theme/CodeBlock/styles.css
@@ -1,0 +1,291 @@
+pre.shiki > .code-title {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  width: 100%;
+
+  font-family: var(--ifm-font-family-base);
+  font-size: var(--ifm-code-font-size);
+  font-weight: 500;
+
+  color: var(--ifm-color-emphasis-900);
+  border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  padding: 0 var(--ifm-pre-padding);
+
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+}
+
+pre.shiki.with-title {
+  padding-top: 2.5rem;
+}
+
+/** 
+  * Copy-to-Clipboard Button
+  * Taken from https://github.com/facebook/docusaurus/blob/ed9d2a26f5a7b8096804ae1b3a4fffc504f8f90d/packages/docusaurus-theme-classic/src/theme/CodeBlock/styles.module.css
+  * which is under MIT License as per the banner
+  */
+
+pre.shiki .copy-button {
+  appearance: none;
+  border: none;
+  cursor: pointer;
+
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: var(--ifm-global-radius);
+  color: var(--ifm-color-white);
+  opacity: 0;
+  user-select: none;
+  padding: 0.4rem 0.5rem;
+  position: absolute;
+  right: calc(var(--ifm-pre-padding) / 2);
+  top: calc(var(--ifm-pre-padding) / 2);
+  transition: opacity 200ms ease-in-out;
+}
+
+pre.shiki.with-title .copy-button {
+  top: calc(2.5rem + var(--ifm-pre-padding) / 2);
+}
+
+pre.shiki:hover > .copy-button,
+.copy-button:focus {
+  opacity: 1;
+}
+
+/* Base */
+pre.shiki {
+  overflow: visible;
+  position: relative;
+  padding: 0;
+}
+
+/* Sets a horizontal padding for all the lines */
+pre.shiki div.line,
+pre.shiki div.meta-line {
+  padding-left: var(--ifm-pre-padding);
+  padding-right: var(--ifm-pre-padding);
+}
+
+/* Sets vertical padding for the container */
+pre.shiki > .code-container {
+  padding: var(--ifm-pre-padding) 0;
+}
+
+/* Border for light themes, dark themes don't usually require borders */
+pre.shiki {
+  border: 1px solid transparent;
+}
+
+[data-theme='light'] pre.shiki {
+  border-color: var(--ifm-color-emphasis-300);
+}
+
+/* Hide language identifiers */
+pre.shiki .language-id {
+  display: none;
+}
+
+/* Line highlighting */
+pre.shiki:hover .dim {
+  opacity: 1;
+  filter: none;
+}
+
+pre.shiki div.dim {
+  opacity: 0.5;
+  filter: grayscale(1);
+  transition: opacity 200ms ease-in-out;
+}
+
+pre.shiki div.dim,
+pre.shiki div.highlight {
+  margin: 0;
+  /* To avoid flickering on the highlighted lines focus */
+  border-left: 2px solid transparent;
+}
+
+pre.shiki div.highlight {
+  opacity: 1;
+  transition: background-color 200ms ease-in-out;
+}
+
+pre.shiki:hover div.highlight {
+  background-color: var(--ifm-hover-overlay);
+  border-left: 2px solid var(--ifm-color-primary);
+  width: 100%;
+}
+
+pre.shiki div.line {
+  min-height: 1rem;
+}
+
+/** When you mouse over the pre, show the underlines */
+pre.twoslash:hover data-lsp {
+  border-color: var(--ifm-color-emphasis-400);
+}
+
+/** The tooltip-like which provides the LSP response */
+pre.twoslash data-lsp:hover::before {
+  content: attr(lsp);
+  position: absolute;
+  transform: translate(0, 1.5rem);
+
+  background-color: #3f3f3f;
+  color: #fff;
+  text-align: left;
+  padding: 5px 8px;
+  border-radius: 2px;
+  font-size: 85%;
+  white-space: pre-wrap;
+  z-index: 100;
+}
+
+pre .code-container {
+  overflow: auto;
+}
+
+pre code {
+  white-space: pre;
+  -webkit-overflow-scrolling: touch;
+}
+
+pre code a {
+  text-decoration: none;
+}
+
+/* Error */
+pre data-err {
+  /* Extracted from VS Code */
+  background: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20viewBox%3D'0%200%206%203'%20enable-background%3D'new%200%200%206%203'%20height%3D'3'%20width%3D'6'%3E%3Cg%20fill%3D'%23c94824'%3E%3Cpolygon%20points%3D'5.5%2C0%202.5%2C3%201.1%2C3%204.1%2C0'%2F%3E%3Cpolygon%20points%3D'4%2C0%206%2C2%206%2C0.6%205.4%2C0'%2F%3E%3Cpolygon%20points%3D'0%2C2%201%2C3%202.4%2C3%200%2C0.6'%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E")
+    repeat-x bottom left;
+  padding-bottom: 3px;
+}
+
+pre .query {
+  margin-bottom: 10px;
+  color: var(--ifm-color-primary);
+  display: inline-block;
+}
+
+/** 
+  * In order to have the 'popped out' style design and to not break the layout
+  * we need to place a fake and un-selectable copy of the error which _isn't_ broken out
+  * behind the actual error message.
+  * This sections keeps both of those two in in sync  
+  */
+
+pre .error,
+pre .error-behind {
+  margin-top: 8px;
+  padding: 6px;
+  padding-left: 14px;
+  width: 100%;
+  white-space: pre-wrap;
+  display: block;
+}
+
+pre .error {
+  position: absolute;
+  background-color: #fee;
+  border-left: 2px solid var(--ifm-color-danger-dark);
+  /* Give the space to the error code */
+  display: flex;
+  align-items: center;
+  color: black;
+}
+
+pre .error .code {
+  display: none;
+}
+
+pre .error-behind {
+  user-select: none;
+  color: #fee;
+}
+
+/* Queries */
+pre .arrow {
+  /* Transparent background */
+  background-color: var(--ifm-color-emphasis-200);
+  position: relative;
+  top: -7px;
+  margin-left: 0.1rem;
+  /* Edges */
+  border-left: 1px solid var(--ifm-color-emphasis-200);
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+  transform: translateY(25%) rotate(45deg);
+  /* Size */
+  height: 8px;
+  width: 8px;
+}
+
+pre .popover {
+  margin-bottom: 10px;
+  background-color: var(--ifm-color-emphasis-200);
+  display: inline-block;
+  padding: 0 0.5rem 0.3rem;
+  margin-top: 10px;
+  border-radius: 3px;
+}
+
+/* Completion */
+pre .inline-completions ul.dropdown {
+  display: inline-block;
+  position: absolute;
+  width: 240px;
+  background-color: var(--ifm-color-emphasis-200);
+  padding-top: 5px;
+  font-family: var(--code-font);
+  margin: 0 0 0 3px;
+  padding: 0;
+  border-left: 2px solid var(--ifm-color-primary);
+}
+
+pre .inline-completions ul.dropdown::before {
+  background-color: var(--ifm-color-primary);
+  width: 2px;
+  position: absolute;
+  top: -1.2rem;
+  left: -2px;
+  content: ' ';
+}
+
+pre .inline-completions ul.dropdown li {
+  overflow-x: hidden;
+  padding-left: 4px;
+  margin-bottom: 4px;
+}
+
+pre .inline-completions ul.dropdown li.deprecated {
+  text-decoration: line-through;
+}
+
+pre .inline-completions ul.dropdown li span.result-found {
+  color: var(--ifm-color-primary);
+}
+
+pre .inline-completions ul.dropdown li span.result {
+  width: 100px;
+  color: black;
+  display: inline-block;
+}
+
+data-lsp {
+  /* Ensures there's no 1px jump when the hover happens */
+  border-bottom: 1px dotted transparent;
+  /* Fades in unobtrusively */
+  transition-timing-function: ease;
+  transition: border-color 0.3s;
+}
+
+/* Respect people's wishes to not have animations */
+@media (prefers-reduced-motion: reduce) {
+  data-lsp,
+  pre .code-container > a,
+  pre.shiki div.dim,
+  pre.shiki div.highlight {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Closes #4019

## 🎯 Changes

Use the [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard) instead of `copy-text-to-clipboard`. Unfortunately this means we have to eject from twoslash's `CodeBlock` component ([which hasn't been updated in two years anyway](https://github.com/shikijs/twoslash/blob/f3a2683d1bd7fe64f424a808dcbdbc77b686c896/packages/docusaurus-preset-shiki-twoslash/docusaurus-theme-shiki-twoslash/theme/CodeBlock/index.js#L10)).