### PR TITLE
feat: Overwrite util type is unnecessarily expensive

### DIFF
--- a/packages/server/src/core/internals/utils.ts
+++ b/packages/server/src/core/internals/utils.ts
@@ -4,7 +4,13 @@ import { ProcedureParams } from '../procedure';
 /**
  * @internal
  */
-export type Overwrite<TType, TWith> = Omit<TType, keyof TWith> & TWith;
+export type Overwrite<TType, TWith> = {
+  [K in keyof TType | keyof TWith]: K extends keyof TWith
+    ? TWith[K]
+    : K extends keyof TType
+    ? TType[K]
+    : never;
+};
 /**
  * @internal
  */


### PR DESCRIPTION
Closes #4203

## 🎯 Changes

Replaced `type Overwrite<TType, TWith> = Omit<TType, keyof TWith> & TWith` with @Nick-Lucas' `MergeLightObjects`

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
