### PR TITLE
Use ref to ensure opts stay sync'd with subscription

### DIFF
--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -12,7 +12,7 @@ import {
 import { TRPCClientErrorLike, createTRPCClient } from '@trpc/client';
 import type { AnyRouter } from '@trpc/server';
 import { Observable } from '@trpc/server/observable';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import { SSRState, TRPCContext } from '../../internals/context';
 import { TRPCContextState } from '../../internals/context';
 import { QueryType, getArrayQueryKey } from '../../internals/getArrayQueryKey';
@@ -371,6 +371,9 @@ export function createRootHooks<
     const queryKey = hashQueryKey(pathAndInput);
     const { client } = useContext();
 
+    const optsRef = useRef<typeof opts>(opts);
+    optsRef.current = opts;
+
     return useEffect(() => {
       if (!enabled) {
         return;
@@ -383,18 +386,18 @@ export function createRootHooks<
         {
           onStarted: () => {
             if (!isStopped) {
-              opts.onStarted?.();
+              optsRef.current.onStarted?.();
             }
           },
           onData: (data) => {
             if (!isStopped) {
               // FIXME this shouldn't be needed as both should be `unknown` in next major
-              opts.onData(data as any);
+              optsRef.current.onData(data as any);
             }
           },
           onError: (err) => {
             if (!isStopped) {
-              opts.onError?.(err);
+              optsRef.current.onError?.(err);
             }
           },
         },


### PR DESCRIPTION
Closes #

## 🎯 Changes

Bug fix. Currently if you update the `opts` parameter of a `useSubscription` call, they are not reflected in the downstream subscription except on the initial load. This leads to broken behavior (e.g. when the `onData` opt is updated with a new value).

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
