### PR TITLE
feat(react-query): relax `useInfiniteQuery` to allow optional objects containing `cursor: any`

### DIFF
--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -101,7 +101,7 @@ export type DecorateProcedure<
         type?: QueryType,
       ) => QueryKey;
       useQuery: ProcedureUseQuery<TProcedure, TPath>;
-    } & ({ cursor?: any } extends inferProcedureInput<TProcedure>
+    } & (inferProcedureInput<TProcedure> extends { cursor?: any }
       ? {
           useInfiniteQuery: <
             _TQueryFnData = inferTransformedProcedureOutput<TProcedure>,

--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -101,7 +101,7 @@ export type DecorateProcedure<
         type?: QueryType,
       ) => QueryKey;
       useQuery: ProcedureUseQuery<TProcedure, TPath>;
-    } & (inferProcedureInput<TProcedure> extends { cursor?: any }
+    } & ({ cursor?: any } extends inferProcedureInput<TProcedure>
       ? {
           useInfiniteQuery: <
             _TQueryFnData = inferTransformedProcedureOutput<TProcedure>,

--- a/packages/tests/server/react/__testHelpers.tsx
+++ b/packages/tests/server/react/__testHelpers.tsx
@@ -68,13 +68,16 @@ export function createAppRouter() {
     }),
     paginatedPosts: t.procedure
       .input(
-        z.object({
-          limit: z.number().min(1).max(100).nullish(),
-          cursor: z.number().nullish(),
-        }),
+        z
+          .object({
+            limit: z.number().min(1).max(100).nullish(),
+            cursor: z.number().nullish(),
+          })
+          .optional(),
       )
-      .query(({ input }) => {
+      .query((opts) => {
         const items: typeof db.posts = [];
+        const input = opts.input ?? {};
         const limit = input.limit ?? 50;
         const { cursor } = input;
         let nextCursor: typeof cursor = null;

--- a/packages/tests/server/react/infiniteQuery.test.tsx
+++ b/packages/tests/server/react/infiniteQuery.test.tsx
@@ -1,3 +1,4 @@
+import { ignoreErrors } from '../___testHelpers';
 import { createQueryClient } from '../__queryClient';
 import { Post, createAppRouter } from './__testHelpers';
 import { QueryClientProvider } from '@tanstack/react-query';
@@ -390,5 +391,16 @@ describe('Infinite Query', () => {
       expect(data).toContain('first post');
       expect(data).toContain('second post');
     }
+  });
+
+  test('cant useInfiniteQuery on on procedures that do not have a cursor', () => {
+    ignoreErrors(() => {
+      const { trpc } = factory;
+      trpc.allPosts.useQuery();
+      // @ts-expect-error cursor is not defined
+      trpc.allPosts.useInfiniteQuery();
+      // this is cool:
+      trpc.paginatedPosts.useInfiniteQuery({});
+    });
   });
 });

--- a/packages/tests/server/react/infiniteQuery.test.tsx
+++ b/packages/tests/server/react/infiniteQuery.test.tsx
@@ -393,14 +393,24 @@ describe('Infinite Query', () => {
     }
   });
 
-  test('cant useInfiniteQuery on on procedures that do not have a cursor', () => {
+  test('type tests', () => {
     ignoreErrors(() => {
       const { trpc } = factory;
       trpc.allPosts.useQuery();
       // @ts-expect-error cursor is not defined
       trpc.allPosts.useInfiniteQuery();
       // this is cool:
-      trpc.paginatedPosts.useInfiniteQuery({});
+      trpc.paginatedPosts.useInfiniteQuery({
+        limit: 2,
+      });
+
+      // @ts-expect-error too wide
+      trpc.paginatedPosts.useInfiniteQuery(
+        {
+          // does not exist
+          foo: 'bar',
+        },
+      });
     });
   });
 });


### PR DESCRIPTION
Relates to #4236 and previous questions

## 🎯 Changes

Allow you to have an optional object with a cursor

```ts
t.procedure
  .input(
    z
      .object({
        limit: z.number().min(1).max(100).nullish(),
        cursor: z.number().nullish(),
      })
      .optional() // <-- this would make tRPC regard it as being not an infinite query even if `cursor` is on the input
  )
  .query((opts) => {
    // ...
  })
```

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
