### PR TITLE
preparsedBody flag for resolveHTTPResponse

### DIFF
--- a/packages/server/src/adapters/next.ts
+++ b/packages/server/src/adapters/next.ts
@@ -53,6 +53,7 @@ export function createNextApiHandler<TRouter extends AnyRouter>(
 
     await nodeHTTPRequestHandler({
       ...opts,
+      preparsedBody: opts.preparsedBody ?? true,
       req,
       res,
       path,

--- a/packages/server/src/adapters/node-http/nodeHTTPRequestHandler.ts
+++ b/packages/server/src/adapters/node-http/nodeHTTPRequestHandler.ts
@@ -67,6 +67,7 @@ export async function nodeHTTPRequestHandler<
       router: opts.router,
       req,
       error: bodyResult.ok ? null : bodyResult.error,
+      preparsedBody: opts.preparsedBody,
       onError(o) {
         opts?.onError?.({
           ...o,

--- a/packages/server/src/adapters/node-http/types.ts
+++ b/packages/server/src/adapters/node-http/types.ts
@@ -64,6 +64,7 @@ export type NodeHTTPHandlerOptions<
    */
   middleware?: ConnectMiddleware;
   maxBodySize?: number;
+  preparsedBody?: boolean;
 } & NodeHTTPCreateContextOption<TRouter, TRequest, TResponse>;
 
 export type NodeHTTPCreateContextFnOptions<TRequest, TResponse> = {

--- a/packages/tests/server/regression/issue-4243-serialize-string.test.ts
+++ b/packages/tests/server/regression/issue-4243-serialize-string.test.ts
@@ -55,7 +55,7 @@ function mockRes() {
   return { res, json, setHeader, end };
 }
 
-test('string stringified', async () => {
+test('string input is properly serialized and deserialized', async () => {
   const t = initTRPC.create();
 
   const router = t.router({

--- a/packages/tests/server/regression/issue-4243-serialize-string.test.ts
+++ b/packages/tests/server/regression/issue-4243-serialize-string.test.ts
@@ -1,0 +1,93 @@
+import { initTRPC } from '@trpc/server';
+import * as trpcNext from '@trpc/server/src/adapters/next';
+import EventEmitter from 'events';
+import { z } from 'zod';
+
+function mockReq({
+  query,
+  method = 'GET',
+  headers = {},
+  body,
+}: {
+  query: Record<string, any>;
+  headers?: Record<string, string>;
+  method?:
+    | 'CONNECT'
+    | 'DELETE'
+    | 'GET'
+    | 'HEAD'
+    | 'OPTIONS'
+    | 'POST'
+    | 'PUT'
+    | 'TRACE';
+  body?: any;
+}) {
+  const req = new EventEmitter() as any;
+
+  req.method = method;
+  req.query = query;
+  if (
+    'content-type' in headers &&
+    headers['content-type'] === 'application/json'
+  ) {
+    req.body = JSON.parse(body);
+  } else {
+    req.body = body;
+  }
+
+  const socket = {
+    destroy: vi.fn(),
+  };
+  req.socket = socket;
+
+  return { req, socket };
+}
+function mockRes() {
+  const res = new EventEmitter() as any;
+
+  const json = vi.fn(() => res);
+  const setHeader = vi.fn(() => res);
+  const end = vi.fn(() => res);
+  res.json = json;
+  res.setHeader = setHeader;
+  res.end = end;
+
+  return { res, json, setHeader, end };
+}
+
+test('string stringified', async () => {
+  const t = initTRPC.create();
+
+  const router = t.router({
+    doSomething: t.procedure.input(z.string()).mutation((opts) => {
+      return `did ${opts.input}` as const;
+    }),
+  });
+
+  const handler = trpcNext.createNextApiHandler({
+    router,
+    maxBodySize: 1,
+  });
+
+  const { req } = mockReq({
+    query: {
+      trpc: ['doSomething'],
+    },
+    headers: {
+      'content-type': 'application/json',
+    },
+    method: 'POST',
+    body: JSON.stringify('something'),
+  });
+  const { res, end } = mockRes();
+  await handler(req, res);
+  const json: any = JSON.parse((end.mock.calls[0] as any)[0]);
+  expect(res.statusCode).toBe(200);
+  expect(json).toMatchInlineSnapshot(`
+  Object {
+    "result": Object {
+      "data": "did something",
+    },
+  }
+`);
+});

--- a/www/docs/nextjs/setup.mdx
+++ b/www/docs/nextjs/setup.mdx
@@ -307,3 +307,14 @@ export const trpc = createTRPCNext<AppRouter>({
 Browse the rest of the docs to learn more about things like [authorization](/docs/server/authorization), [middlewares](/docs/server/middlewares), and [error handling](/docs/server/error-handling).
 
 You can also find information about [queries](/docs/reactjs/usequery) and [mutations](/docs/reactjs/usemutation) now that you're using `@trpc/react-query`.
+
+If you for some reason want to disable bodyParser in your next.js route, you need to pass the following parameter to createNextApiHandler:
+
+```ts
+export default trpcNext.createNextApiHandler({
+  router: appRouter,
+  createContext: () => ({}),
+  // Body is preparsed by default, this tells hadler it needs to be parsed
+  preparsedBody: false,
+});
+```


### PR DESCRIPTION
Closes #4243

## 🎯 Changes
Added flag `preparsedBody`, that defaults to falsey value, so that it doesn't break anything existent, but for next.js adapter it defaults to `true`, so it avoids parsing body. 

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
