### PR TITLE
docs(useContext): Remove unstable info

### DIFF
--- a/www/docs/reactjs/useContext.mdx
+++ b/www/docs/reactjs/useContext.mdx
@@ -244,10 +244,6 @@ function MyComponent() {
 
 ### Invalidate full cache on every mutation
 
-:::info
-We have prefixed this as `unstable_` as it's a new API, but you're safe to use it! [Read more](/docs/faq#unstable).
-:::
-
 Keeping track of exactly what queries a mutation should invalidate is hard, therefore, it can be a pragmatic solution to invalidate the _full cache_ as a side-effect on any mutation. Since we have request batching, this invalidation will simply refetch all queries on the page you're looking at in one single request.
 
 We have added a feature to help with this:


### PR DESCRIPTION
Follow-up to #4268 that removes the "unstable" info.


