### PR TITLE
chore: Add --list-different to format:write command

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "turbo lint",
     "lint-fix": "turbo lint -- --fix && manypkg fix",
     "format": "prettier \"**/*\" --ignore-unknown",
-    "format:write": "pnpm format --write",
+    "format:write": "pnpm format --write --list-different",
     "lint-prune": "! ts-prune | grep -v \"used in module\"",
     "clean": "find . -name node_modules -o -name .turbo -o -name .next -o -name dist -type d -prune | xargs rm -rf",
     "codegen:override-prisma": "tsx scripts/addPrismaOverrides.ts",


### PR DESCRIPTION
This option makes it so the command only spits out the names of files which it's actually made changes to. In my experience the command is also a bit faster to run without locking on the terminal for every file :)

Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
