### PR TITLE
docs: Fix grammar error in statement about custom validator

### DIFF
--- a/www/docs/server/validators.md
+++ b/www/docs/server/validators.md
@@ -125,7 +125,7 @@ export const appRouter = t.router({
 You can define a validator without any 3rd party dependencies, with a function.
 
 :::info
-We don't recommend doing making a custom validator unless you have a specific need, but it's important to understand that there's no magic here - it's _just typescript_!
+We don't recommend making a custom validator unless you have a specific need, but it's important to understand that there's no magic here - it's _just typescript_!
 
 In most cases we recommend you use a [validation library](#library-integrations)
 :::


### PR DESCRIPTION
This pull request fixes a grammatical error in the statement about custom validator. The word "doing" was removed since it was redundant. This change improves the clarity and readability of the codebase, and should have no impact on the functionality of the code. 

The corrected statement would be: "We don't recommend making a custom validator unless you have a specific need, but it's important to understand that there's no magic here - it's just TypeScript!"

Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
