### PR TITLE
Fix: Set display to inline-block for code element

### DIFF
--- a/www/src/theme/CodeBlock/styles.css
+++ b/www/src/theme/CodeBlock/styles.css
@@ -148,6 +148,7 @@ pre .code-container {
 
 pre code {
   white-space: pre;
+  display: inline-block;
   -webkit-overflow-scrolling: touch;
 }
 


### PR DESCRIPTION
This change sets the `display` property of the `code` element to `inline-block`, which makes the right padding of its child `div` (class="line") elements effective and improves user experience expecially on mobile devices.

Before this change, the right padding of the `div` (class="line") elements inside the `code` element was not effective because the `code` element had a default `display` property of `inline`, which does not allow for width or height. This made some lines of code look like they were cut off especially on mobile devices since the padding-right wasn't effective. By setting the `display` property of the `code` element to `inline-block`, the element now has a width and height, and its child `div` (class="line") elements' padding is effective.

I tested this change locally by adding the `display: inline-block` property to the `code` element in the CSS file and verifying that the right padding of its child `div` (class="line") elements was effective.

## Screenshots

Below are screenshots of before and after fix

### Before Fix
Before setting the display property of code to inline-block, the padding-right of "line" class were not effective as seen in the two screenshot below.
![before-fix2](https://user-images.githubusercontent.com/99342564/237061345-49dc675c-e5d4-441f-a4ef-ec014df9a261.png)
![before-fix](https://user-images.githubusercontent.com/99342564/237061370-7793a5bb-2a3c-4767-b2ee-c16d41e47320.png)

### After Fix
After setting the display property of code to inline-block the padding are now effective as seen in the two screenshot below.
![after-fix2](https://user-images.githubusercontent.com/99342564/237061584-b0eb08d7-07c0-490b-b46a-12f3ed49756e.png)
![after-fix](https://user-images.githubusercontent.com/99342564/237061595-d3d4f76d-c9a7-45ba-b4de-cbabd06a0823.png)


Closes #

## 🎯 Changes

Set CSS display property of code element to inline-block.

What changes are made in this PR? Is it a feature or a bug fix?

The change is a bug fix.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
