### PR TITLE
fix(client): make sure that `dom.iterable` types are included for `FormData`

### DIFF
--- a/packages/client/src/links/loggerLink.ts
+++ b/packages/client/src/links/loggerLink.ts
@@ -71,14 +71,6 @@ function isFormData(value: unknown): value is FormData {
   return value instanceof FormData;
 }
 
-function fromEntries(fd: FormData) {
-  const result: Record<string, unknown> = {};
-  for (const [key, value] of fd) {
-    result[key] = value;
-  }
-  return result;
-}
-
 // maybe this should be moved to it's own package
 const defaultLogger =
   <TRouter extends AnyRouter>(
@@ -90,7 +82,9 @@ const defaultLogger =
 
     const rawInput = props.input;
 
-    const input = isFormData(rawInput) ? fromEntries(rawInput) : rawInput;
+    const input = isFormData(rawInput)
+      ? Object.fromEntries(rawInput)
+      : rawInput;
 
     const css = `
     background-color: #${direction === 'up' ? light : dark}; 

--- a/packages/client/src/links/loggerLink.ts
+++ b/packages/client/src/links/loggerLink.ts
@@ -1,3 +1,10 @@
+/// <reference lib="dom.iterable" />
+
+// `dom.iterable` types are explicitly required for extracting `FormData` values,
+// as all implementations of `Symbol.iterable` are separated from the main `dom` types.
+// Using triple-slash directive makes sure that it will be available,
+// even if end-user `tsconfig.json` omits it in the `lib` array.
+
 import { AnyRouter } from '@trpc/server';
 import { observable, tap } from '@trpc/server/observable';
 import { TRPCClientError } from '..';


### PR DESCRIPTION
Closes https://github.com/trpc/trpc/issues/4339

## 🎯 Changes

```
// `dom.iterable` types are explicitly required for extracting `FormData` values,
// as all implementations of `Symbol.iterable` are separated from the main `dom` types.
// Using triple-slash directive makes sure that it will be available,
// even if end-user `tsconfig.json` omits it in the `lib` array.
```

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.

/claim #4339 (Feel free to skip the payout, I just wonder if it "just works" out of the box and how it works in the first place, never heard of Algora 🤔)