### PR TITLE
chore: add `rollup-plugin-analyzer` for monitoring bundle size

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,12 +54,12 @@ jobs:
         uses: dawidd6/action-download-artifact@v2
         with:
           name: bundle-analysis
-          # branch: main # once this workflow is merged, uncomment this: we should always only compare with `main`, not current branch
+          branch: main
           path: ./downloads/previous-bundle-analysis
           if_no_artifact_found: ignore
 
       - name: Build
-        run: pnpm turbo --filter "@trpc/*" build --force # temporarily forcing cache bypass for debugging purposes
+        run: pnpm turbo --filter "@trpc/*" build
 
       - name: Test
         run: pnpm turbo --filter tests test-ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,10 +51,12 @@ jobs:
         run: pnpm --filter "@trpc/*" --filter root install
 
       - name: Download previous bundle analysis
-        uses: actions/download-artifact@v3
+        uses: dawidd6/action-download-artifact@v2
         with:
           name: bundle-analysis
+          # branch: main # once this workflow is merged, uncomment this: we should always only compare with `main`, not self
           path: ~/download/previous-bundle-analysis
+          if_no_artifact_found: ignore
 
       - name: Build
         run: pnpm turbo --filter "@trpc/*" build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,12 @@ jobs:
       - name: Install deps (with cache)
         run: pnpm --filter "@trpc/*" --filter root install
 
+      - name: Download previous bundle analysis
+        uses: actions/download-artifact@v3
+        with:
+          name: bundle-analysis
+          path: ~/download/previous-bundle-analysis
+
       - name: Build
         run: pnpm turbo --filter "@trpc/*" build
 
@@ -60,3 +66,9 @@ jobs:
         with:
           # token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
           directory: ./packages
+
+      - name: Upload new bundle analysis
+        uses: actions/upload-artifact@v3
+        with:
+          name: bundle-analysis
+          path: packages/**/dist/bundle-analysis.json

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
           if_no_artifact_found: ignore
 
       - name: Build
-        run: pnpm turbo --filter "@trpc/*" build
+        run: pnpm turbo --filter "@trpc/*" build --force # temporarily forcing cache bypass for debugging purposes
 
       - name: Test
         run: pnpm turbo --filter tests test-ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v2
         with:
           name: bundle-analysis
-          # branch: main # once this workflow is merged, uncomment this: we should always only compare with `main`, not self
+          # branch: main # once this workflow is merged, uncomment this: we should always only compare with `main`, not current branch
           path: ~/download/previous-bundle-analysis
           if_no_artifact_found: ignore
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           name: bundle-analysis
           # branch: main # once this workflow is merged, uncomment this: we should always only compare with `main`, not current branch
-          path: ~/download/previous-bundle-analysis
+          path: ./downloads/previous-bundle-analysis
           if_no_artifact_found: ignore
 
       - name: Build

--- a/package.json
+++ b/package.json
@@ -91,5 +91,8 @@
       "@examples/legacy-next-starter>prisma": "https://registry.npmjs.com/prisma/-/prisma-4.12.0.tgz?id=%40exampleslegacy-next-starter",
       "@types/testing-library__jest-dom": "link:./packages/tests/vendor/@types/testing-library__jest-dom"
     }
+  },
+  "devDependencies": {
+    "rollup-plugin-analyzer": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "prettier": "^2.8.8",
     "prettier-plugin-tailwindcss": "^0.2.8",
     "rollup": "^2.79.1",
+    "rollup-plugin-analyzer": "^4.0.0",
     "rollup-plugin-delete": "^2.0.0",
     "rollup-plugin-multi-input": "^1.4.1",
     "rollup-plugin-node-externals": "^5.1.3",
@@ -91,8 +92,5 @@
       "@examples/legacy-next-starter>prisma": "https://registry.npmjs.com/prisma/-/prisma-4.12.0.tgz?id=%40exampleslegacy-next-starter",
       "@types/testing-library__jest-dom": "link:./packages/tests/vendor/@types/testing-library__jest-dom"
     }
-  },
-  "devDependencies": {
-    "rollup-plugin-analyzer": "^4.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,10 @@ importers:
       typescript:
         specifier: ^4.8.3
         version: 4.8.3
+    devDependencies:
+      rollup-plugin-analyzer:
+        specifier: ^4.0.0
+        version: 4.0.0
 
   examples/.experimental/next-app-dir:
     dependencies:
@@ -2059,6 +2063,7 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.1.1
       '@jridgewell/trace-mapping': 0.3.17
+    dev: true
 
   /@ampproject/remapping@2.2.1:
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
@@ -2883,6 +2888,7 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/core@7.21.8:
     resolution: {integrity: sha512-YeM22Sondbo523Sz0+CirSPnbj9bG3P0CdHcBZdqUuaeOaYEFbOLoGU7lebvGP6P5J/WE9wOn7u7C4J9HvS1xQ==}
@@ -2913,6 +2919,7 @@ packages:
       '@babel/types': 7.21.5
       '@jridgewell/gen-mapping': 0.3.3
       jsesc: 2.5.2
+    dev: true
 
   /@babel/generator@7.20.4:
     resolution: {integrity: sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==}
@@ -2921,6 +2928,7 @@ packages:
       '@babel/types': 7.20.7
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
+    dev: true
 
   /@babel/generator@7.21.5:
     resolution: {integrity: sha512-SrKK/sRv8GesIW1bDagf9cCG38IOMYZusoe1dfg0D8aiUe3Amvoj1QtjTPAWcfrZFvIwlleLb0gxzQidL9w14w==}
@@ -2955,6 +2963,7 @@ packages:
       '@babel/helper-validator-option': 7.18.6
       browserslist: 4.21.4
       semver: 6.3.0
+    dev: true
 
   /@babel/helper-compilation-targets@7.20.0(@babel/core@7.21.8):
     resolution: {integrity: sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==}
@@ -3209,6 +3218,7 @@ packages:
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/helper-module-transforms@7.21.5:
     resolution: {integrity: sha512-bI2Z9zBGY2q5yMHoBvJ2a9iX3ZOAzJPm7Q8Yz6YeoUjU/Cvhmi2G4QyTNyPBqqXSgTjUxRg3L0xV45HvkNWWBw==}
@@ -3345,6 +3355,7 @@ packages:
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/helpers@7.21.5:
     resolution: {integrity: sha512-BSY+JSlHxOmGsPTydUkPf1MdMQ3M81x5xGCOVgWM3G8XH77sJ292Y2oqcp0CbbgxhqBuI46iUz1tT7hqP7EfgA==}
@@ -3370,6 +3381,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.21.5
+    dev: true
 
   /@babel/parser@7.20.3:
     resolution: {integrity: sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==}
@@ -3377,6 +3389,7 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.20.7
+    dev: true
 
   /@babel/parser@7.21.8:
     resolution: {integrity: sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==}
@@ -5226,6 +5239,7 @@ packages:
       '@babel/code-frame': 7.18.6
       '@babel/parser': 7.20.15
       '@babel/types': 7.20.7
+    dev: true
 
   /@babel/template@7.20.7:
     resolution: {integrity: sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==}
@@ -5251,6 +5265,7 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/traverse@7.20.13:
     resolution: {integrity: sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==}
@@ -5268,6 +5283,7 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/traverse@7.21.5:
     resolution: {integrity: sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==}
@@ -7358,6 +7374,7 @@ packages:
     dependencies:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
 
   /@jridgewell/gen-mapping@0.3.2:
     resolution: {integrity: sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==}
@@ -7366,6 +7383,7 @@ packages:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
       '@jridgewell/trace-mapping': 0.3.18
+    dev: true
 
   /@jridgewell/gen-mapping@0.3.3:
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
@@ -7401,6 +7419,7 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
 
   /@jridgewell/trace-mapping@0.3.18:
     resolution: {integrity: sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==}
@@ -16776,6 +16795,7 @@ packages:
     resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}
     engines: {node: '>=6'}
     hasBin: true
+    dev: true
 
   /json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -17888,7 +17908,7 @@ packages:
       '@panva/hkdf': 1.0.2
       cookie: 0.5.0
       jose: 4.14.4
-      next: 13.3.4(@babel/core@7.20.2)(react-dom@18.2.0)(react@18.2.0)
+      next: 13.3.4(@babel/core@7.21.8)(react-dom@18.2.0)(react@18.2.0)
       oauth: 0.9.15
       openid-client: 5.4.2
       preact: 10.11.3
@@ -17963,6 +17983,7 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+    dev: true
 
   /next@13.3.4(@babel/core@7.21.8)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-sod7HeokBSvH5QV0KB+pXeLfcXUlLrGnVUXxHpmhilQ+nQYT3Im2O8DswD5e4uqbR8Pvdu9pcWgb1CbXZQZlmQ==}
@@ -20981,6 +21002,11 @@ packages:
     dependencies:
       glob: 7.2.3
 
+  /rollup-plugin-analyzer@4.0.0:
+    resolution: {integrity: sha512-LL9GEt3bkXp6Wa19SNR5MWcvHNMvuTFYg+eYBZN2OIFhSWN+pEJUQXEKu5BsOeABob3x9PDaLKW7w5iOJnsESQ==}
+    engines: {node: '>=8.0.0'}
+    dev: true
+
   /rollup-plugin-delete@2.0.0:
     resolution: {integrity: sha512-/VpLMtDy+8wwRlDANuYmDa9ss/knGsAgrDhM+tEwB1npHwNu4DYNmDfUL55csse/GHs9Q+SMT/rw9uiaZ3pnzA==}
     engines: {node: '>=10'}
@@ -22111,6 +22137,7 @@ packages:
       '@babel/core': 7.20.2
       client-only: 0.0.1
       react: 18.2.0
+    dev: true
 
   /styled-jsx@5.1.1(@babel/core@7.21.8)(react@18.2.0):
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       rollup:
         specifier: ^2.79.1
         version: 2.79.1
+      rollup-plugin-analyzer:
+        specifier: ^4.0.0
+        version: 4.0.0
       rollup-plugin-delete:
         specifier: ^2.0.0
         version: 2.0.0
@@ -123,10 +126,6 @@ importers:
       typescript:
         specifier: ^4.8.3
         version: 4.8.3
-    devDependencies:
-      rollup-plugin-analyzer:
-        specifier: ^4.0.0
-        version: 4.0.0
 
   examples/.experimental/next-app-dir:
     dependencies:
@@ -2063,7 +2062,6 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.1.1
       '@jridgewell/trace-mapping': 0.3.17
-    dev: true
 
   /@ampproject/remapping@2.2.1:
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
@@ -2888,7 +2886,6 @@ packages:
       semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/core@7.21.8:
     resolution: {integrity: sha512-YeM22Sondbo523Sz0+CirSPnbj9bG3P0CdHcBZdqUuaeOaYEFbOLoGU7lebvGP6P5J/WE9wOn7u7C4J9HvS1xQ==}
@@ -2919,7 +2916,6 @@ packages:
       '@babel/types': 7.21.5
       '@jridgewell/gen-mapping': 0.3.3
       jsesc: 2.5.2
-    dev: true
 
   /@babel/generator@7.20.4:
     resolution: {integrity: sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==}
@@ -2928,7 +2924,6 @@ packages:
       '@babel/types': 7.20.7
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
-    dev: true
 
   /@babel/generator@7.21.5:
     resolution: {integrity: sha512-SrKK/sRv8GesIW1bDagf9cCG38IOMYZusoe1dfg0D8aiUe3Amvoj1QtjTPAWcfrZFvIwlleLb0gxzQidL9w14w==}
@@ -2963,7 +2958,6 @@ packages:
       '@babel/helper-validator-option': 7.18.6
       browserslist: 4.21.4
       semver: 6.3.0
-    dev: true
 
   /@babel/helper-compilation-targets@7.20.0(@babel/core@7.21.8):
     resolution: {integrity: sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==}
@@ -3218,7 +3212,6 @@ packages:
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helper-module-transforms@7.21.5:
     resolution: {integrity: sha512-bI2Z9zBGY2q5yMHoBvJ2a9iX3ZOAzJPm7Q8Yz6YeoUjU/Cvhmi2G4QyTNyPBqqXSgTjUxRg3L0xV45HvkNWWBw==}
@@ -3355,7 +3348,6 @@ packages:
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/helpers@7.21.5:
     resolution: {integrity: sha512-BSY+JSlHxOmGsPTydUkPf1MdMQ3M81x5xGCOVgWM3G8XH77sJ292Y2oqcp0CbbgxhqBuI46iUz1tT7hqP7EfgA==}
@@ -3381,7 +3373,6 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.21.5
-    dev: true
 
   /@babel/parser@7.20.3:
     resolution: {integrity: sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==}
@@ -3389,7 +3380,6 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.20.7
-    dev: true
 
   /@babel/parser@7.21.8:
     resolution: {integrity: sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==}
@@ -5239,7 +5229,6 @@ packages:
       '@babel/code-frame': 7.18.6
       '@babel/parser': 7.20.15
       '@babel/types': 7.20.7
-    dev: true
 
   /@babel/template@7.20.7:
     resolution: {integrity: sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==}
@@ -5265,7 +5254,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/traverse@7.20.13:
     resolution: {integrity: sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==}
@@ -5283,7 +5271,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/traverse@7.21.5:
     resolution: {integrity: sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==}
@@ -7374,7 +7361,6 @@ packages:
     dependencies:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
-    dev: true
 
   /@jridgewell/gen-mapping@0.3.2:
     resolution: {integrity: sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==}
@@ -7383,7 +7369,6 @@ packages:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
       '@jridgewell/trace-mapping': 0.3.18
-    dev: true
 
   /@jridgewell/gen-mapping@0.3.3:
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
@@ -7419,7 +7404,6 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
-    dev: true
 
   /@jridgewell/trace-mapping@0.3.18:
     resolution: {integrity: sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==}
@@ -16795,7 +16779,6 @@ packages:
     resolution: {integrity: sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==}
     engines: {node: '>=6'}
     hasBin: true
-    dev: true
 
   /json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -17908,7 +17891,7 @@ packages:
       '@panva/hkdf': 1.0.2
       cookie: 0.5.0
       jose: 4.14.4
-      next: 13.3.4(@babel/core@7.21.8)(react-dom@18.2.0)(react@18.2.0)
+      next: 13.3.4(@babel/core@7.20.2)(react-dom@18.2.0)(react@18.2.0)
       oauth: 0.9.15
       openid-client: 5.4.2
       preact: 10.11.3
@@ -17983,7 +17966,6 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
-    dev: true
 
   /next@13.3.4(@babel/core@7.21.8)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-sod7HeokBSvH5QV0KB+pXeLfcXUlLrGnVUXxHpmhilQ+nQYT3Im2O8DswD5e4uqbR8Pvdu9pcWgb1CbXZQZlmQ==}
@@ -21005,7 +20987,7 @@ packages:
   /rollup-plugin-analyzer@4.0.0:
     resolution: {integrity: sha512-LL9GEt3bkXp6Wa19SNR5MWcvHNMvuTFYg+eYBZN2OIFhSWN+pEJUQXEKu5BsOeABob3x9PDaLKW7w5iOJnsESQ==}
     engines: {node: '>=8.0.0'}
-    dev: true
+    dev: false
 
   /rollup-plugin-delete@2.0.0:
     resolution: {integrity: sha512-/VpLMtDy+8wwRlDANuYmDa9ss/knGsAgrDhM+tEwB1npHwNu4DYNmDfUL55csse/GHs9Q+SMT/rw9uiaZ3pnzA==}
@@ -22137,7 +22119,6 @@ packages:
       '@babel/core': 7.20.2
       client-only: 0.0.1
       react: 18.2.0
-    dev: true
 
   /styled-jsx@5.1.1(@babel/core@7.21.8)(react@18.2.0):
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}

--- a/scripts/analyzeSizeChange.ts
+++ b/scripts/analyzeSizeChange.ts
@@ -110,7 +110,7 @@ function logGithubMessage(
 }
 
 function difference(before: number, after: number) {
-  const percent = before ? (after / before) * 100 : after ? Infinity : 0;
+  const percent = before ? (after / before) * 100 - 100 : after ? Infinity : 0;
   const absolute = after - before;
   return { percent, absolute };
 }

--- a/scripts/analyzeSizeChange.ts
+++ b/scripts/analyzeSizeChange.ts
@@ -1,0 +1,154 @@
+import { readFileSync, readdirSync, writeFile } from 'node:fs';
+import path from 'node:path';
+import analyze from 'rollup-plugin-analyzer';
+
+export default function analyzeSizeChange(packageDir: string) {
+  let analyzePluginIterations = 0;
+  return analyze({
+    summaryOnly: process.env.CI ? undefined : true,
+    skipFormatted: process.env.CI ? true : undefined,
+    onAnalysis: (analysis) => {
+      if (analyzePluginIterations > 0) {
+        throw ''; // We only want reports on the first output
+      }
+      analyzePluginIterations++;
+      if (process.env.CI) {
+        const { currentPath, prevPath, relativePath } =
+          resolveJsonPaths(packageDir);
+
+        writeFile(
+          currentPath,
+          JSON.stringify(analysis, undefined, 2),
+          () => {},
+        );
+
+        // Find previous analysis file on CI
+        try {
+          const prevStr = readFileSync(prevPath, 'utf8');
+          const prevAnalysis = JSON.parse(prevStr);
+          const change = difference(
+            prevAnalysis.bundleSize,
+            analysis.bundleSize,
+          );
+          logDifference(
+            'Total Bundle',
+            prevAnalysis.bundleSize,
+            analysis.bundleSize,
+          );
+          for (const module of analysis.modules) {
+            const prevModule = prevAnalysis.modules.find(
+              (m: any) => m.id === module.id,
+            );
+            if (prevModule) {
+              logDifference(
+                `Module '${module.id}'`,
+                prevModule.size,
+                module.size,
+              );
+            } else {
+              logNewModule(module.id, module.size);
+            }
+          }
+        } catch {
+          console.log('No previous bundle analysis found');
+        }
+      }
+    },
+  });
+}
+
+type GitHubLogType = 'debug' | 'notice' | 'warning' | 'error';
+
+type GitHubLogOptions = {
+  title?: string;
+  file?: string;
+  col?: number;
+  endColumn?: number;
+  line?: number;
+  endLine?: number;
+};
+
+function logNewModule(name: string, size: number) {
+  if (size < 100) {
+    return;
+  }
+  const type = 'notice';
+  const options = {
+    title: `New Module (${size} bytes in ${name})`,
+  };
+  const message = `${name} size: ${size} bytes`;
+  logGithubMessage(type, message, options);
+}
+
+function logDifference(name: string, before: number, after: number) {
+  const change = difference(before, after);
+  if (change.absolute < 100 && change.percent < 1) {
+    return;
+  }
+  const type = 'error';
+  const options = {
+    title: `Important Size Change (${change.absolute} bytes in ${name})`,
+  };
+  const message = `${name} size change: ${
+    change.absolute
+  } bytes (${change.percent.toFixed(2)}%)`;
+  logGithubMessage(type, message, options);
+}
+
+function logGithubMessage(
+  type: GitHubLogType,
+  message: string,
+  options: GitHubLogOptions = {},
+) {
+  console.log(
+    stripAnsiEscapes(
+      `::${type} ${formatGithubOptions(options)}::${formatGithubMessage(
+        message,
+      )}`,
+    ),
+  );
+}
+
+function difference(before: number, after: number) {
+  const percent = before ? (after / before) * 100 : after ? Infinity : 0;
+  const absolute = after - before;
+  return { percent, absolute };
+}
+
+function resolveJsonPaths(packageDir: string) {
+  const runnerRoot = '../..';
+  const analysisFilePath = 'dist/bundle-analysis.json';
+  const previousAnalysisDir = 'downloads/previous-bundle-analysis';
+  const currentPath = path.resolve(packageDir, analysisFilePath);
+  const relativePath = path.relative(
+    path.resolve(runnerRoot, 'packages'),
+    packageDir,
+  );
+  const prevPath = path.resolve(
+    runnerRoot,
+    previousAnalysisDir,
+    relativePath,
+    analysisFilePath,
+  );
+
+  return { currentPath, prevPath, relativePath };
+}
+
+const ansiRegex = new RegExp(
+  '([\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~])))',
+  'g',
+);
+
+function stripAnsiEscapes(str: string) {
+  return str.replace(ansiRegex, '');
+}
+
+function formatGithubOptions(options: Record<string, string>) {
+  return Object.entries(options)
+    .map(([key, option]) => `${key}=${option}`)
+    .join(',');
+}
+
+function formatGithubMessage(message: string) {
+  return message.replace(/\n/g, '%0A');
+}

--- a/scripts/getRollupConfig.ts
+++ b/scripts/getRollupConfig.ts
@@ -128,7 +128,9 @@ function lib({ input, packageDir }: Options): RollupOptions {
                 console.log(err)
                 console.log(prevStr)
                 console.log('cwd', process.cwd())
-                console.log(path.resolve('.'))
+                console.log('.', path.resolve('.'))
+                console.log('..', path.resolve('..'))
+                console.log('/', path.resolve('/'))
                 try {
                   const files = readdirSync(path.resolve('.', 'downloads', 'previous-bundle-analysis'))
                   console.log('artifact', ...files)
@@ -140,6 +142,14 @@ function lib({ input, packageDir }: Options): RollupOptions {
                 try {
                   const files = readdirSync(path.resolve('.'))
                   console.log('root', ...files)
+                } catch {}
+                try {
+                  const files = readdirSync(path.resolve('..'))
+                  console.log('..', ...files)
+                } catch {}
+                try {
+                  const files = readdirSync(path.resolve('../..'))
+                  console.log('../..', ...files)
                 } catch {}
               }
             }

--- a/scripts/getRollupConfig.ts
+++ b/scripts/getRollupConfig.ts
@@ -106,7 +106,7 @@ function lib({ input, packageDir }: Options): RollupOptions {
             writeFile(analysisFilePath, JSON.stringify(analysis, undefined, 2), () => {})
             if (process.env.CI) {
               // Find previous analysis file on CI
-              const previousAnalysisFilePath = path.resolve('~', 'download', 'previous-bundle-analysis', packageDir, 'dist', 'bundle-analysis.json');
+              const previousAnalysisFilePath = path.resolve('.', 'downloads', 'previous-bundle-analysis', packageDir, 'dist', 'bundle-analysis.json');
               let prevStr: string
               try {
                 prevStr = readFileSync(previousAnalysisFilePath, 'utf8')
@@ -127,14 +127,20 @@ function lib({ input, packageDir }: Options): RollupOptions {
                 console.log('packageDir', packageDir)
                 console.log(err)
                 console.log(prevStr)
-                {
-                  const files = readdirSync(path.resolve('~', 'download', 'previous-bundle-analysis'))
+                console.log('cwd', process.cwd())
+                console.log(path.resolve('.'))
+                try {
+                  const files = readdirSync(path.resolve('.', 'downloads', 'previous-bundle-analysis'))
                   console.log('artifact', ...files)
-                }
-                {
-                  const files = readdirSync(path.resolve('~', 'download'))
+                } catch {}
+                try {
+                  const files = readdirSync(path.resolve('.', 'downloads'))
                   console.log('downloads', ...files)
-                }
+                } catch {}
+                try {
+                  const files = readdirSync(path.resolve('.'))
+                  console.log('root', ...files)
+                } catch {}
               }
             }
           }

--- a/scripts/getRollupConfig.ts
+++ b/scripts/getRollupConfig.ts
@@ -103,7 +103,7 @@ function lib({ input, packageDir }: Options): RollupOptions {
             }
             analyzePluginIterations++;
             if (process.env.CI) {
-              const runnerRoot = '/home/runner/work/***/***'
+              const runnerRoot = '../..'
               const analysisFilePath = 'dist/bundle-analysis.json'
               const previousAnalysisDir = 'downloads/previous-bundle-analysis'
 

--- a/scripts/getRollupConfig.ts
+++ b/scripts/getRollupConfig.ts
@@ -107,8 +107,9 @@ function lib({ input, packageDir }: Options): RollupOptions {
             if (process.env.CI) {
               // Find previous analysis file on CI
               const previousAnalysisFilePath = path.resolve('~', 'download', 'previous-bundle-analysis', packageDir, 'dist', 'bundle-analysis.json');
+              let prevStr: string
               try {
-                const prevStr = readFileSync(previousAnalysisFilePath, 'utf8')
+                prevStr = readFileSync(previousAnalysisFilePath, 'utf8')
                 const prevAnalysis = JSON.parse(prevStr)
                 console.log(`Bundle size change: ${analysis.bundleSize - prevAnalysis.bundleSize} bytes`)
                 for (const module of analysis.modules) {
@@ -125,6 +126,7 @@ function lib({ input, packageDir }: Options): RollupOptions {
                 console.log('analysisFilePath', analysisFilePath)
                 console.log('packageDir', packageDir)
                 console.log(err)
+                console.log(prevStr)
               }
             }
           }

--- a/scripts/getRollupConfig.ts
+++ b/scripts/getRollupConfig.ts
@@ -108,7 +108,8 @@ function lib({ input, packageDir }: Options): RollupOptions {
               const previousAnalysisDir = 'downloads/previous-bundle-analysis'
 
               const currentPath = path.resolve(packageDir, analysisFilePath)
-              const prevPath = path.resolve(runnerRoot, previousAnalysisDir, path.relative(path.resolve(runnerRoot, 'packages'), packageDir), analysisFilePath)
+              const relative = path.relative(path.resolve(runnerRoot, 'packages'), packageDir)
+              const prevPath = path.resolve(runnerRoot, previousAnalysisDir, relative, analysisFilePath)
 
               writeFile(currentPath, JSON.stringify(analysis, undefined, 2), () => {})
               
@@ -136,6 +137,7 @@ function lib({ input, packageDir }: Options): RollupOptions {
                 console.log('..', path.resolve('..'))
                 console.log('/', path.resolve('/'))
                 console.log('currentPath', currentPath)
+                console.log('relative', relative)
                 console.log('prevPath', prevPath)
                 
                 try {
@@ -149,6 +151,14 @@ function lib({ input, packageDir }: Options): RollupOptions {
                 try {
                   const files = readdirSync(path.resolve('../../downloads/previous-bundle-analysis'))
                   console.log('../../downloads/previous-bundle-analysis', ...files)
+                } catch {}
+                try {
+                  const files = readdirSync(path.resolve(runnerRoot, previousAnalysisDir))
+                  console.log('runnerRoot/previousAnalysisDir', ...files)
+                } catch {}
+                try {
+                  const files = readdirSync(prevPath)
+                  console.log('prevPath', ...files)
                 } catch {}
               }
             }

--- a/scripts/getRollupConfig.ts
+++ b/scripts/getRollupConfig.ts
@@ -119,8 +119,9 @@ function lib({ input, packageDir }: Options): RollupOptions {
                     console.log(`New module '${module.id}': ${module.size} bytes`)
                   }
                 }
-              } catch {
-                console.log('No previous bundle analysis found')
+              } catch (err) {
+                console.log('No previous bundle analysis found', previousAnalysisFilePath, analysisFilePath)
+                console.log(err)
               }
             }
           }

--- a/scripts/getRollupConfig.ts
+++ b/scripts/getRollupConfig.ts
@@ -102,14 +102,17 @@ function lib({ input, packageDir }: Options): RollupOptions {
               throw ''; // We only want reports on the first output
             }
             analyzePluginIterations++;
-            const analysisFilePath = path.resolve(packageDir, 'dist', 'bundle-analysis.json');
-            writeFile(analysisFilePath, JSON.stringify(analysis, undefined, 2), () => {})
             if (process.env.CI) {
+              const runnerRoot = '/home/runner/work/***/***'
+              const analysisFilePath = 'dist/bundle-analysis.json'
+              const previousAnalysisDir = 'downloads/previous-bundle-analysis'
+
+              writeFile(path.resolve(packageDir, analysisFilePath), JSON.stringify(analysis, undefined, 2), () => {})
+              
               // Find previous analysis file on CI
-              const previousAnalysisFilePath = path.resolve('.', 'downloads', 'previous-bundle-analysis', packageDir, 'dist', 'bundle-analysis.json');
               let prevStr: string
               try {
-                prevStr = readFileSync(previousAnalysisFilePath, 'utf8')
+                prevStr = readFileSync(path.resolve(runnerRoot, previousAnalysisDir, packageDir, analysisFilePath), 'utf8')
                 const prevAnalysis = JSON.parse(prevStr)
                 console.log(`Bundle size change: ${analysis.bundleSize - prevAnalysis.bundleSize} bytes`)
                 for (const module of analysis.modules) {
@@ -122,8 +125,6 @@ function lib({ input, packageDir }: Options): RollupOptions {
                 }
               } catch (err) {
                 console.log('No previous bundle analysis found')
-                console.log('previousAnalysisFilePath', previousAnalysisFilePath)
-                console.log('analysisFilePath', analysisFilePath)
                 console.log('packageDir', packageDir)
                 console.log(err)
                 console.log(prevStr)
@@ -131,25 +132,18 @@ function lib({ input, packageDir }: Options): RollupOptions {
                 console.log('.', path.resolve('.'))
                 console.log('..', path.resolve('..'))
                 console.log('/', path.resolve('/'))
-                try {
-                  const files = readdirSync(path.resolve('.', 'downloads', 'previous-bundle-analysis'))
-                  console.log('artifact', ...files)
-                } catch {}
-                try {
-                  const files = readdirSync(path.resolve('.', 'downloads'))
-                  console.log('downloads', ...files)
-                } catch {}
-                try {
-                  const files = readdirSync(path.resolve('.'))
-                  console.log('root', ...files)
-                } catch {}
-                try {
-                  const files = readdirSync(path.resolve('..'))
-                  console.log('..', ...files)
-                } catch {}
+                path.relative(path.resolve('.'), path.resolve('/'))
                 try {
                   const files = readdirSync(path.resolve('../..'))
                   console.log('../..', ...files)
+                } catch {}
+                try {
+                  const files = readdirSync(path.resolve('../../downloads'))
+                  console.log('../../downloads', ...files)
+                } catch {}
+                try {
+                  const files = readdirSync(path.resolve('../../downloads/previous-bundle-analysis'))
+                  console.log('../../downloads/previous-bundle-analysis', ...files)
                 } catch {}
               }
             }

--- a/scripts/getRollupConfig.ts
+++ b/scripts/getRollupConfig.ts
@@ -8,7 +8,7 @@ import externals from 'rollup-plugin-node-externals';
 import { swc } from 'rollup-plugin-swc3';
 import typescript from 'rollup-plugin-typescript2';
 import analyze from 'rollup-plugin-analyzer'
-import { readFileSync, writeFile } from "fs"
+import { readFileSync, readdirSync, writeFile } from "fs"
 
 const isWatchMode = process.argv.includes('--watch');
 const extensions = ['.ts', '.tsx'];
@@ -127,6 +127,14 @@ function lib({ input, packageDir }: Options): RollupOptions {
                 console.log('packageDir', packageDir)
                 console.log(err)
                 console.log(prevStr)
+                {
+                  const files = readdirSync(path.resolve('~', 'download', 'previous-bundle-analysis'))
+                  console.log('artifact', ...files)
+                }
+                {
+                  const files = readdirSync(path.resolve('~', 'download'))
+                  console.log('downloads', ...files)
+                }
               }
             }
           }

--- a/scripts/getRollupConfig.ts
+++ b/scripts/getRollupConfig.ts
@@ -120,7 +120,10 @@ function lib({ input, packageDir }: Options): RollupOptions {
                   }
                 }
               } catch (err) {
-                console.log('No previous bundle analysis found', previousAnalysisFilePath, analysisFilePath)
+                console.log('No previous bundle analysis found')
+                console.log('previousAnalysisFilePath', previousAnalysisFilePath)
+                console.log('analysisFilePath', analysisFilePath)
+                console.log('packageDir', packageDir)
                 console.log(err)
               }
             }

--- a/scripts/getRollupConfig.ts
+++ b/scripts/getRollupConfig.ts
@@ -7,7 +7,7 @@ import multiInput from 'rollup-plugin-multi-input';
 import externals from 'rollup-plugin-node-externals';
 import { swc } from 'rollup-plugin-swc3';
 import typescript from 'rollup-plugin-typescript2';
-import analyzeSizeChange from 'scripts/analyzeSizeChange';
+import analyzeSizeChange from './analyzeSizeChange';
 
 const isWatchMode = process.argv.includes('--watch');
 const extensions = ['.ts', '.tsx'];

--- a/scripts/getRollupConfig.ts
+++ b/scripts/getRollupConfig.ts
@@ -107,12 +107,15 @@ function lib({ input, packageDir }: Options): RollupOptions {
               const analysisFilePath = 'dist/bundle-analysis.json'
               const previousAnalysisDir = 'downloads/previous-bundle-analysis'
 
-              writeFile(path.resolve(packageDir, analysisFilePath), JSON.stringify(analysis, undefined, 2), () => {})
+              const currentPath = path.resolve(packageDir, analysisFilePath)
+              const prevPath = path.resolve(runnerRoot, previousAnalysisDir, path.relative(path.resolve(runnerRoot, 'packages'), packageDir), analysisFilePath)
+
+              writeFile(currentPath, JSON.stringify(analysis, undefined, 2), () => {})
               
               // Find previous analysis file on CI
               let prevStr: string
               try {
-                prevStr = readFileSync(path.resolve(runnerRoot, previousAnalysisDir, packageDir, analysisFilePath), 'utf8')
+                prevStr = readFileSync(prevPath, 'utf8')
                 const prevAnalysis = JSON.parse(prevStr)
                 console.log(`Bundle size change: ${analysis.bundleSize - prevAnalysis.bundleSize} bytes`)
                 for (const module of analysis.modules) {
@@ -132,7 +135,9 @@ function lib({ input, packageDir }: Options): RollupOptions {
                 console.log('.', path.resolve('.'))
                 console.log('..', path.resolve('..'))
                 console.log('/', path.resolve('/'))
-                path.relative(path.resolve('.'), path.resolve('/'))
+                console.log('currentPath', currentPath)
+                console.log('prevPath', prevPath)
+                
                 try {
                   const files = readdirSync(path.resolve('../..'))
                   console.log('../..', ...files)


### PR DESCRIPTION
❗️ This PR is **still a draft**, but was created as "ready for review" by mistake. Sorry for the spam to the people who were inadvertently subscribed to this ❗️

Related to https://github.com/trpc/trpc/pull/4347

## 🎯 Changes

- Adding `rollup-plugin-analyzer` as a rollup build step so we remain aware of the final size of the packages being distributed
- analysis duration is negligeable compared to the rest of the build
- adding artifact upload/download so that a PR can compare size differences in CI

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
