### PR TITLE
docs: Add tRPC-SWR back to Library adapters

### DIFF
--- a/www/docs/community/awesome-trpc.mdx
+++ b/www/docs/community/awesome-trpc.mdx
@@ -59,6 +59,7 @@ A collection of resources on tRPC.
 | electron-trpc - Electron support for tRPC                                                           | https://github.com/jsonnull/electron-trpc                             |
 | cloudflare-pages-plugin-trpc - Quickly create a tRPC server with a Cloudflare Pages Function        | https://github.com/toyamarinyon/cloudflare-pages-plugin-trpc          |
 | ZenStack - Full-stack toolkit adds access control to Prisma and generates trpc routers from schema  | https://github.com/zenstackhq/zenstack                                |
+| tRPC-SWR - tRPC adapter for Vercel's SWR client                                                     | https://trpc-swr.vercel.app/                                          |
 
 ## 🍀 Starting points, example projects, etc
 


### PR DESCRIPTION
tRPC-SWR now has tRPC v10 support with all SWR api's

Closes #

## 🎯 Changes

Adds tRPC-SWR entry back into `awesome-trpc.mdx`. This was previously removed due to missing v10 support.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
