### PR TITLE
docs: Add instructions for usage with Deno's `Oak`

### DIFF
--- a/www/docs/server/adapters/fetch.mdx
+++ b/www/docs/server/adapters/fetch.mdx
@@ -274,6 +274,79 @@ Run `wrangler dev server.ts` and your endpoints will be available via HTTP!
 | `getUser`    | `GET http://localhost:8787/trpc/getUserById?input=INPUT` <br/><br/>where `INPUT` is a URI-encoded JSON string. |
 | `createUser` | `POST http://localhost:8787/trpc/createUser` <br/><br/>with `req.body` of type `User`                          |
 
+### Deno Oak
+
+#### Install dependencies
+
+<Tabs>
+  <TabItem value="macOS / Linux" label="macOS / Linux" default>
+
+```sh
+curl -fsSL https://deno.land/x/install/install.sh | sh
+```
+
+  </TabItem>
+  <TabItem value="Windows" label="Windows">
+
+```sh
+irm https://deno.land/install.ps1 | iex
+```
+
+  </TabItem>
+</Tabs>
+
+#### Update the imports in `router.ts`
+
+```ts title='router.ts'
+import { initTRPC } from 'npm:@trpc/server';
+import { z } from 'npm:zod';
+import { Context } from './context.ts';
+```
+
+#### Update the imports in `context.ts`
+
+```ts title='context.ts'
+import { inferAsyncReturnType } from 'npm:@trpc/server';
+import { FetchCreateContextFnOptions } from 'npm:@trpc/server/adapters/fetch';
+```
+
+#### Use `fetchRequestHandler` with Oak in `app.ts`
+
+```ts title='app.ts'
+import { Application, Router } from 'https://deno.land/x/oak/mod.ts';
+import { fetchRequestHandler } from 'npm:@trpc/server/adapters/fetch';
+import { createContext } from './context.ts';
+import { appRouter } from './router.ts';
+
+const app = new Application();
+const router = new Router();
+
+router.all('/trpc/(.*)', async (ctx) => {
+  const res = await fetchRequestHandler({
+    endpoint: '/trpc',
+    req: new Request(ctx.request.url, {
+      headers: ctx.request.headers,
+      body:
+        ctx.request.method !== 'GET' && ctx.request.method !== 'HEAD'
+          ? ctx.request.body({ type: 'stream' }).value
+          : void 0,
+      method: ctx.request.method,
+    }),
+    router: appRouter,
+    createContext,
+  });
+
+  ctx.response.status = res.status;
+  ctx.response.headers = res.headers;
+  ctx.response.body = res.body;
+});
+
+app.use(router.routes());
+app.use(router.allowedMethods());
+
+await app.listen({ port: 3000 });
+```
+
 ### Deno Deploy
 
 #### Install dependencies


### PR DESCRIPTION
## 🎯 Changes

This adds documentation so consumers of tRPC can more easily integrate with Oak, a web framework for Deno. It's sufficiently different than Deno Deploy to warrant its own section. This code has worked well for a [project](https://github.com/quasipanacea) of mine for a few months, but of course feedback is always welcome.

Closes #3725

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
