### PR TITLE
Shift from using `fromWeb`/`toWeb`

### DIFF
--- a/examples/.experimental/next-formdata/src/utils/writeFileToDisk.ts
+++ b/examples/.experimental/next-formdata/src/utils/writeFileToDisk.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { Readable } from 'node:stream';
 
 export async function writeFileToDisk(file: File) {
   const rootDir = __dirname + '/../../../../..';
@@ -9,19 +9,13 @@ export async function writeFileToDisk(file: File) {
   const fileDir = path.resolve(`${rootDir}/public/uploads/${nonce}`);
 
   if (!fs.existsSync(fileDir)) {
-    fs.mkdirSync(fileDir, { recursive: true });
+    await mkdir(fileDir, { recursive: true });
   }
   console.log('Writing', file.name, 'to', fileDir);
-  const fd = fs.createWriteStream(path.resolve(`${fileDir}/${file.name}`));
-
-  const fileStream = Readable.fromWeb(
-    // @ts-expect-error - unsure why this is not working
-    file.stream(),
+  await writeFile(
+    path.resolve(`${fileDir}/${file.name}`),
+    new DataView(await file.arrayBuffer()),
   );
-  for await (const chunk of fileStream) {
-    fd.write(chunk);
-  }
-  fd.end();
 
   return {
     url: `/uploads/${nonce}/${file.name}`,

--- a/packages/server/src/adapters/node-http/content-type/form-data/fileUploadHandler.ts
+++ b/packages/server/src/adapters/node-http/content-type/form-data/fileUploadHandler.ts
@@ -10,12 +10,13 @@
 /**
  * @see https://github.com/remix-run/remix/blob/0bcb4a304dd2f08f6032c3bf0c3aa7eb5b976901/packages/remix-node/upload/fileUploadHandler.ts
  */
+
 import { randomBytes } from 'node:crypto';
 import { createReadStream, createWriteStream, statSync } from 'node:fs';
 import { mkdir, rm, stat as statAsync, unlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { basename, dirname, extname, resolve as resolvePath } from 'node:path';
-import { Readable, finished } from 'node:stream';
+import { finished, type Readable } from 'node:stream';
 import { promisify } from 'node:util';
 import { streamSlice } from './streamSlice';
 import { MaxPartSizeExceededError, UploadHandler } from './uploadHandler';
@@ -240,15 +241,15 @@ export class NodeOnDiskFile implements File {
     });
   }
 
-  stream(): ReadableStream<any>;
+  stream(): ReadableStream;
   stream(): NodeJS.ReadableStream;
-  stream(): ReadableStream<any> | NodeJS.ReadableStream {
+  stream(): ReadableStream | NodeJS.ReadableStream {
     let stream: Readable = createReadStream(this.filepath);
     if (this.slicer) {
       stream = stream.pipe(streamSlice(this.slicer.start, this.slicer.end));
     }
 
-    return Readable.toWeb(stream);
+    return stream;
   }
 
   async text(): Promise<string> {

--- a/packages/server/src/adapters/node-http/content-type/form-data/index.ts
+++ b/packages/server/src/adapters/node-http/content-type/form-data/index.ts
@@ -10,7 +10,6 @@
  */
 import { CombinedDataTransformer } from '@trpc/server/transformer';
 import { streamMultipart } from '@web3-storage/multipart-parser';
-import { Readable } from 'node:stream';
 import { createNodeHTTPContentTypeHandler } from '../../internals/contentType';
 import { NodeHTTPRequest } from '../../types';
 import { UploadHandler, UploadHandlerPart } from './uploadHandler';
@@ -34,7 +33,7 @@ async function parseMultipartFormData(
 
   const formData = new FormData();
   const parts: AsyncIterable<UploadHandlerPart & { done?: true }> =
-    streamMultipart(Readable.toWeb(request), boundary);
+    streamMultipart(request.body, boundary);
 
   for await (const part of parts) {
     if (part.done) break;

--- a/packages/server/src/adapters/node-http/content-type/form-data/streamSlice.ts
+++ b/packages/server/src/adapters/node-http/content-type/form-data/streamSlice.ts
@@ -1,4 +1,4 @@
-import { Transform, TransformCallback } from 'node:stream';
+import { Transform, type TransformCallback } from 'node:stream';
 
 class SliceStream extends Transform {
   #start: number;


### PR DESCRIPTION
Closes https://github.com/trpc/trpc/issues/4322

## 🎯 Changes

Replaces uses of `Readable.fromWeb`/`Readable.toWeb` with approaches that are compatible NodeJS 16.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
