### PR TITLE
fix(`react-query`): fix `useInfiniteQuery` `placeholderData` types

### DIFF
--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -103,41 +103,35 @@ export type DecorateProcedure<
       useQuery: ProcedureUseQuery<TProcedure, TPath>;
     } & (inferProcedureInput<TProcedure> extends { cursor?: any }
       ? {
-          useInfiniteQuery: <
-            _TQueryFnData = inferTransformedProcedureOutput<TProcedure>,
-            TData = inferTransformedProcedureOutput<TProcedure>,
-          >(
+          useInfiniteQuery: (
             input: Omit<inferProcedureInput<TProcedure>, 'cursor'>,
             opts?: UseTRPCInfiniteQueryOptions<
               TPath,
               inferProcedureInput<TProcedure>,
-              TData,
+              inferTransformedProcedureOutput<TProcedure>,
               TRPCClientErrorLike<TProcedure>
             >,
           ) => UseTRPCInfiniteQueryResult<
-            TData,
+            inferTransformedProcedureOutput<TProcedure>,
             TRPCClientErrorLike<TProcedure>
           >;
         } & (TFlags extends 'ExperimentalSuspense'
           ? {
-              useSuspenseInfiniteQuery: <
-                _TQueryFnData = inferTransformedProcedureOutput<TProcedure>,
-                TData = inferTransformedProcedureOutput<TProcedure>,
-              >(
+              useSuspenseInfiniteQuery: (
                 input: Omit<inferProcedureInput<TProcedure>, 'cursor'>,
                 opts?: Omit<
                   UseTRPCInfiniteQueryOptions<
                     TPath,
                     inferProcedureInput<TProcedure>,
-                    TData,
+                    inferTransformedProcedureOutput<TProcedure>,
                     TRPCClientErrorLike<TProcedure>
                   >,
                   'enabled' | 'suspense'
                 >,
               ) => [
-                InfiniteData<TData>,
+                InfiniteData<inferTransformedProcedureOutput<TProcedure>>,
                 UseTRPCInfiniteQuerySuccessResult<
-                  TData,
+                  inferTransformedProcedureOutput<TProcedure>,
                   TRPCClientErrorLike<TProcedure>
                 >,
               ];

--- a/packages/tests/server/regression/issue-4360-useInfiniteQuery-placeHolderData.test.tsx
+++ b/packages/tests/server/regression/issue-4360-useInfiniteQuery-placeHolderData.test.tsx
@@ -1,6 +1,6 @@
 import { ignoreErrors } from '../___testHelpers';
 import { getServerAndReactClient } from '../react/__reactHelpers';
-import { initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 import { z } from 'zod';
 

--- a/packages/tests/server/regression/issue-4360-useInfiniteQuery-placeHolderData.test.tsx
+++ b/packages/tests/server/regression/issue-4360-useInfiniteQuery-placeHolderData.test.tsx
@@ -1,6 +1,6 @@
 import { ignoreErrors } from '../___testHelpers';
 import { getServerAndReactClient } from '../react/__reactHelpers';
-import { initTRPC } from '@trpc/server';
+import { initTRPC } from '@trpc/server/src';
 import { konn } from 'konn';
 import { z } from 'zod';
 

--- a/packages/tests/server/regression/issue-4360-useInfiniteQuery-placeHolderData.test.tsx
+++ b/packages/tests/server/regression/issue-4360-useInfiniteQuery-placeHolderData.test.tsx
@@ -1,0 +1,85 @@
+import { ignoreErrors } from '../___testHelpers';
+import { getServerAndReactClient } from '../react/__reactHelpers';
+import { initTRPC } from '@trpc/server/src';
+import { konn } from 'konn';
+import { z } from 'zod';
+
+const fixtureData = ['1', '2'];
+
+const ctx = konn()
+  .beforeEach(() => {
+    const t = initTRPC.create();
+
+    const appRouter = t.router({
+      post: t.router({
+        list: t.procedure
+          .input(
+            z.object({
+              cursor: z.number().default(0),
+              foo: z.literal('bar').optional().default('bar'),
+            }),
+          )
+          .query(({ input }) => {
+            return {
+              items: fixtureData.slice(input.cursor, input.cursor + 1),
+              next:
+                input.cursor + 1 > fixtureData.length
+                  ? undefined
+                  : input.cursor + 1,
+            };
+          }),
+      }),
+    });
+
+    return getServerAndReactClient(appRouter);
+  })
+  .afterEach(async (ctx) => {
+    await ctx?.close?.();
+  })
+  .done();
+
+test('with input', async () => {
+  const { proxy } = ctx;
+
+  ignoreErrors(() => {
+    proxy.post.list.useInfiniteQuery(
+      { foo: 'bar' },
+      {
+        // @ts-expect-error can't return page data that doesn't match the output type
+        placeholderData() {
+          return {
+            pageParams: [undefined],
+            pages: [undefined],
+          };
+        },
+        getNextPageParam(lastPage) {
+          return lastPage.next;
+        },
+        onSuccess: (data) => {
+          if (data.pages[0]?.next) {
+          }
+        },
+      },
+    );
+
+    proxy.post.list.useSuspenseInfiniteQuery(
+      { foo: 'bar' },
+      {
+        // @ts-expect-error can't return page data that doesn't match the output type
+        placeholderData() {
+          return {
+            pageParams: [undefined],
+            pages: [undefined],
+          };
+        },
+        getNextPageParam(lastPage) {
+          return lastPage.next;
+        },
+        onSuccess: (data) => {
+          if (data.pages[0]?.next) {
+          }
+        },
+      },
+    );
+  });
+});

--- a/packages/tests/server/regression/issue-4360-useInfiniteQuery-placeHolderData.test.tsx
+++ b/packages/tests/server/regression/issue-4360-useInfiniteQuery-placeHolderData.test.tsx
@@ -83,3 +83,32 @@ test('with input', async () => {
     );
   });
 });
+
+test('good placeholderData', () => {
+  const { proxy } = ctx;
+
+  ignoreErrors(() => {
+    proxy.post.list.useInfiniteQuery(
+      { foo: 'bar' },
+      {
+        placeholderData() {
+          return {
+            pageParams: [undefined],
+            pages: [
+              {
+                items: ['1', '2', '3'],
+              },
+            ],
+          };
+        },
+        getNextPageParam(lastPage) {
+          return lastPage.next;
+        },
+        onSuccess: (data) => {
+          if (data.pages[0]?.next) {
+          }
+        },
+      },
+    );
+  });
+});


### PR DESCRIPTION
Ensure that `useInfiniteQuery` and `useSuspenseInfiniteQuery` use explicit types rather than inferred generic types.

Closes #4360 
Bounty: /claim #4360

## 🎯 Changes

### Problem

This problem looks to be the result of our relying on a default generic parameter (e.g.):

```ts
function myFunction<Generic = string>() {}
```

The problem is that the way the default parameter seems to be working is that TypeScript uses the default (i.e. `string`) _unless_ it can infer the type by some other means.

In this case, we set the default value of `TData` to `inferTransformedProcedureOutput<TProcedure>`, however, by returning a _different_ type from the `placeholderData`, TypeScript tries to help us out and _infer_ the type from what it returns. This inference supersedes the default parameter type `inferTransformedProcedureOutput<TProcedure>`.

I put together a [minimal example using the TS Playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBA8mwEsD2A7AzgHgOIRRATggMZQC8UArigNYpIDuKAfGVAN4BQUUYANgIZEIACyS8AJgQAi-YPwD8ALigAKAJRkWbHvwDmENMoCC+fPxDZcBYiwC+Abi5RUAZQpEhaNEtXjZ-ZRw8QiINUhYANyQEcUcHDg4AMyoiRFQoYANgABVwA0tg4lY0YEIUXSYVJHhkdGU4NPQC6yImDTZbBIB6LqgAAyCWvqgENBGURIJ8CHEoACMQDOFoaeAKfBQMvOdE-r5BETFJfBk5PoAaDh6oNCQoPzl5iCIkAFsDfqpJRIQ8cWHfktRlAiPw0BAAHQcTIlXKQNAqTjcfZCUQSaT+dTsJzca4APXkOKgq3Wm20YD0BmUAG0vhAfn8ALpQeLcWyXbiudyeQy+fxhLSdXG9AkcWxqRxXXoDKwhYaglAAcmAT3Gk1MM3mi2Ay2JEDWGy2kB2ewEqKOGLOl2uc2e-Ao4JGwEVYzoKu+vxm5xudxlhSIw2+9t4wDGwF9JTKuj6Uqg9GExGEUFe-GoHx10Ae-H6kd+0agYLjEF4vHGQLGoPBUJhOTyCKRzhQbg8Bl5KizAvYQqg+MJ4sl1wA6tAIAAPPjEBDAXiLcEqv1DDJ3bN9FAUV62-DDW5QOEQFxEQjwe5IAxK4CxvCa8MZfDau6-dVOqCJfBvJbQPoow7ok7+C4+vc-ixvQCAlgWvD0OYYy2v0a4bgQAKbDqwKVpC0JZHumDwZulQNt+aLHKc-BYg2wpQKK3DcCShrkpSvK0igHpMiyjhshyjbNjyyjtvymhdk4vZihKHBAA) to help illustrate what I mean. Essentially, TypeScript only uses the default parameter if it _can't infer_ another type by some other means.

### Solution

I'm making a bit of an assumption here which is why I'm opening this PR as a draft PR, so that a discussion can be started. Based on the idea that TRPC is intended to help create type safety by inferring types off of the router, I'm not sure there's a reason we would want to allow the types for these hooks to be overridden.

For example, I'm not sure we would expect to see the following:

```tsx
type CustomData = {};

function MyComponent() {
  // Does it make sense to explicitly pass types to the hook if we're expecting the hook to infer types from the router?
  trpc.post.list.useInfiniteQuery<CustomData, CustomData>(input, opts);
}
```

Assuming that's true, then the question is _why_ do we use generic types for the hooks. My thought is that there are two advantages:
1. Reduces duplication because you can reuse the same name in multiple places
2. Somewhat serves as documentation because we can rename a type _before_ passing it to React Query which helps show how we intend to use the type

I'm not sure how important the above two points are, but if we prefer to keep them, then an alternative solution would be to explicitly constrain the generic parameter so that invalid types can't be inferred from the `placeholderData` return:

```tsx
type Example = {
  useInfiniteQuery: <
    _TQueryFnData = inferTransformedProcedureOutput<TProcedure>,
    // The `extends` makes sure you can't return invalid data from the `placeholderData`
    TData extends inferTransformedProcedureOutput<
      TProcedure
    > = inferTransformedProcedureOutput<TProcedure>
  >(
    input: Omit<inferProcedureInput<TProcedure>, "cursor">,
    opts?: UseTRPCInfiniteQueryOptions<
      TPath,
      inferProcedureInput<TProcedure>,
      TData,
      TRPCClientErrorLike<TProcedure>
    >
  ) => UseTRPCInfiniteQueryResult<TData, TRPCClientErrorLike<TProcedure>>;
};
```

I also noticed that the `useQuery` hook _also_ allows you to return anything from the `placeholderData`. I would think that we'd want to restrict this so you have to return the correct type for the `placeholderData` for all of the query types. That said, I held off on making more changes until we can confirm a path forward.

**Note:** If my initial assumption is wrong and we actually _do_ want to be able to use any type for the hook's generic parameter (i.e. `trpc.post.list.useInfiniteQuery<CustomData, CustomData>(input, opts);`), then neither of these proposed changes will work.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
