### PR TITLE
chore: change npm specifiers to esm.sh for deno deploy

### DIFF
--- a/examples/deno-deploy/README.md
+++ b/examples/deno-deploy/README.md
@@ -13,6 +13,8 @@ Run the client in another terminal:
 deno run --allow-net ./src/client.ts
 ```
 
+Note: Deno Deploy does [not currently support npm specifiers](https://github.com/denoland/deploy_feedback/issues/314). 
+
 ---
 
 Created by [tomlienard](https://github.com/quiibz).

--- a/examples/deno-deploy/README.md
+++ b/examples/deno-deploy/README.md
@@ -13,7 +13,7 @@ Run the client in another terminal:
 deno run --allow-net ./src/client.ts
 ```
 
-Note: Deno Deploy does [not currently support npm specifiers](https://github.com/denoland/deploy_feedback/issues/314). 
+Note: Deno Deploy does [not currently support npm specifiers](https://github.com/denoland/deploy_feedback/issues/314).
 
 ---
 

--- a/examples/deno-deploy/src/client.ts
+++ b/examples/deno-deploy/src/client.ts
@@ -2,7 +2,7 @@ import {
   createTRPCProxyClient,
   httpBatchLink,
   loggerLink,
-} from 'npm:@trpc/client';
+} from 'https://esm.sh/@trpc/client';
 import type { AppRouter } from './router.ts';
 
 const sleep = (ms = 100) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/examples/deno-deploy/src/index.ts
+++ b/examples/deno-deploy/src/index.ts
@@ -1,5 +1,5 @@
 import { serve } from 'https://deno.land/std@0.140.0/http/server.ts';
-import { fetchRequestHandler } from 'npm:@trpc/server/adapters/fetch';
+import { fetchRequestHandler } from 'https://esm.sh/@trpc/server/adapters/fetch';
 import { appRouter } from './router.ts';
 
 function handler(request) {

--- a/examples/deno-deploy/src/router.ts
+++ b/examples/deno-deploy/src/router.ts
@@ -1,5 +1,5 @@
-import { initTRPC } from 'npm:@trpc/server';
-import { z } from 'npm:zod';
+import { initTRPC } from 'https://esm.sh/@trpc/server';
+import { z } from 'https://esm.sh/zod';
 
 let id = 0;
 


### PR DESCRIPTION
## 🎯 Changes

Change npm specifiers to esm.sh for deno deploy example. Deploy does not currently support npm specifiers so the previous example would not run.
