### PR TITLE
chore: revert pnpm updrade as it breaks some example projects

### DIFF
--- a/.github/workflows/examples-old-nodes.yml
+++ b/.github/workflows/examples-old-nodes.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@v2
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@v2
 
       - uses: actions/setup-node@v3
         with:
@@ -122,7 +122,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@v2
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@v2
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@v2
 
       - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v3

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - maybe
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -15,15 +16,15 @@ jobs:
       matrix:
         path: [
             #
-            next-prisma-starter,
+            # next-prisma-starter,
             next-prisma-websockets-starter,
-            next-prisma-todomvc,
-            next-minimal-starter,
-            next-big-router,
-            minimal,
-            minimal-react,
-            .experimental/next-formdata,
-            .experimental/next-app-dir,
+            # next-prisma-todomvc,
+            # next-minimal-starter,
+            # next-big-router,
+            # minimal,
+            # minimal-react,
+            # .experimental/next-formdata,
+            # .experimental/next-app-dir,
           ]
 
     name: Update downstream ${{ matrix.path }} package

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Get the above output
         run: echo "The replaced value is ${{ steps.findandreplace.outputs.value }}"
 
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@v2
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -16,10 +16,10 @@ jobs:
       matrix:
         path: [
             #
-            # next-prisma-starter,
+            next-prisma-starter,
             next-prisma-websockets-starter,
             # next-prisma-todomvc,
-            # next-minimal-starter,
+            next-minimal-starter,
             # next-big-router,
             # minimal,
             # minimal-react,
@@ -71,3 +71,4 @@ jobs:
           path: 'examples/${{ matrix.path }}'
           deploy_key: ${{ secrets.TRPC_DEPLOY_TOKEN }}
           force: true # will force push to the downstream repository
+          branch: main # will push to the main branch of the downstream repository

--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - maybe
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -18,13 +17,13 @@ jobs:
             #
             next-prisma-starter,
             next-prisma-websockets-starter,
-            # next-prisma-todomvc,
+            next-prisma-todomvc,
             next-minimal-starter,
-            # next-big-router,
-            # minimal,
-            # minimal-react,
-            # .experimental/next-formdata,
-            # .experimental/next-app-dir,
+            next-big-router,
+            minimal,
+            minimal-react,
+            .experimental/next-formdata,
+            .experimental/next-app-dir,
           ]
 
     name: Update downstream ${{ matrix.path }} package

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 nodejs 18.16.0
-pnpm 8.6.0
+pnpm 8.5.1

--- a/examples/.interop/next-prisma-starter/.github/workflows/main.yml
+++ b/examples/.interop/next-prisma-starter/.github/workflows/main.yml
@@ -26,8 +26,6 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v2.2.2
-        with:
-          version: 7.12.0
 
       - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v3

--- a/examples/.interop/next-prisma-starter/.github/workflows/main.yml
+++ b/examples/.interop/next-prisma-starter/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v2.2.2
+        with:
+          version: 7.12.0
 
       - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v3

--- a/examples/next-prisma-starter/.github/workflows/main.yml
+++ b/examples/next-prisma-starter/.github/workflows/main.yml
@@ -25,9 +25,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v2.2.4
-        with:
-          version: 7.26.0
+      - uses: pnpm/action-setup@v2
 
       - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v3

--- a/examples/next-prisma-starter/.github/workflows/main.yml
+++ b/examples/next-prisma-starter/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v2
+        with:
+          version: 8.5.1
 
       - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v3

--- a/examples/next-prisma-starter/package.json
+++ b/examples/next-prisma-starter/package.json
@@ -25,6 +25,7 @@
     "test-start": "start-server-and-test start http://127.0.0.1:3000 test",
     "postinstall": "pnpm generate"
   },
+  "packageManager": "pnpm@8.6.0",
   "prisma": {
     "seed": "tsx prisma/seed.ts"
   },

--- a/examples/next-prisma-starter/package.json
+++ b/examples/next-prisma-starter/package.json
@@ -25,7 +25,7 @@
     "test-start": "start-server-and-test start http://127.0.0.1:3000 test",
     "postinstall": "pnpm generate"
   },
-  "packageManager": "pnpm@8.6.0",
+  "packageManager": "pnpm@8.5.0",
   "prisma": {
     "seed": "tsx prisma/seed.ts"
   },

--- a/examples/next-prisma-websockets-starter/.github/workflows/main.yml
+++ b/examples/next-prisma-websockets-starter/.github/workflows/main.yml
@@ -25,9 +25,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v2.2.4
-        with:
-          version: 7.26.0
+      - uses: pnpm/action-setup@v2
 
       - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v3

--- a/examples/next-prisma-websockets-starter/.github/workflows/main.yml
+++ b/examples/next-prisma-websockets-starter/.github/workflows/main.yml
@@ -26,6 +26,8 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v2
+        with:
+          version: 8.5.1
 
       - name: Use Node ${{ matrix.node }}
         uses: actions/setup-node@v3

--- a/examples/next-prisma-websockets-starter/package.json
+++ b/examples/next-prisma-websockets-starter/package.json
@@ -5,7 +5,6 @@
   "engines": {
     "node": "^18.15.0"
   },
-  "packageManager": "pnpm@8.6.0",
   "scripts": {
     "prebuild": "prisma generate && prisma migrate deploy",
     "build:1-next": "cross-env NODE_ENV=production next build",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "node": "^18.0.0",
     "pnpm": ">=8.0.0"
   },
-  "packageManager": "pnpm@8.6.0",
+  "packageManager": "pnpm@8.5.1",
   "scripts": {
     "build": "turbo --filter=\"@trpc/*\" --filter=\"!@trpc/tests\" build",
     "build-www": "turbo --filter www build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,4 @@
-lockfileVersion: '6.1'
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
+lockfileVersion: '6.0'
 
 overrides:
   '@tanstack/react-query': 4.18.0


### PR DESCRIPTION
new lockfiles from #4437 breaks deployments e.g.

https://github.com/trpc/examples-next-prisma-starter

#4456  - Would like for renovate to stop updating pnpm and node automatically, it's a bit more involved than what it is capable of