### PR TITLE
fix(renovate): disable node and pnpm updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", ":preserveSemverRanges"],
   "ignorePaths": ["**/node_modules/**", "**/examples/**"],
+  "ignoreDeps": ["node", "pnpm"],
   "updateInternalDeps": true,
   "npm": {
     "rollbackPrs": false


### PR DESCRIPTION
Closes #4456

## 🎯 Changes
Disable `node` and `pnpm` updates by Renovate Bot.

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.

/claim #4456