### PR TITLE
chore: add 'unstable_' prefix to 'onHead' and 'onChunk' adapter callbacks

### DIFF
--- a/packages/server/src/adapters/fastify/fastifyRequestHandler.ts
+++ b/packages/server/src/adapters/fastify/fastifyRequestHandler.ts
@@ -52,7 +52,7 @@ export async function fastifyRequestHandler<
   let resolve: (value: FastifyReply) => void;
   const promise = new Promise<FastifyReply>((r) => (resolve = r));
 
-  const onHead = (head: HTTPResponse) => {
+  const unstable_onHead = (head: HTTPResponse) => {
     if (!opts.res.statusCode || opts.res.statusCode === 200) {
       opts.res.statusCode = head.status;
     }
@@ -68,7 +68,7 @@ export async function fastifyRequestHandler<
   let isStream = false;
   let stream: Readable;
   const formatter = getBatchStreamFormatter();
-  const onChunk = ([index, string]: ResponseChunk) => {
+  const unstable_onChunk = ([index, string]: ResponseChunk) => {
     if (index === -1) {
       // full response, no streaming
       resolve(opts.res.send(string));
@@ -100,8 +100,8 @@ export async function fastifyRequestHandler<
     onError(o) {
       opts?.onError?.({ ...o, req: opts.req });
     },
-    onHead,
-    onChunk,
+    unstable_onHead,
+    unstable_onChunk,
   })
     .then(() => {
       if (isStream) {

--- a/packages/server/src/adapters/fetch/fetchRequestHandler.ts
+++ b/packages/server/src/adapters/fetch/fetchRequestHandler.ts
@@ -34,7 +34,7 @@ export async function fetchRequestHandler<TRouter extends AnyRouter>(
   const promise = new Promise<Response>((r) => (resolve = r));
   let status = 200;
 
-  const onHead = (head: HTTPResponse) => {
+  const unstable_onHead = (head: HTTPResponse) => {
     for (const [key, value] of Object.entries(head.headers ?? {})) {
       /* istanbul ignore if -- @preserve */
       if (typeof value === 'undefined') {
@@ -55,7 +55,7 @@ export async function fetchRequestHandler<TRouter extends AnyRouter>(
   let controller: ReadableStreamController<any>;
   let encoder: TextEncoder;
   const formatter = getBatchStreamFormatter();
-  const onChunk = ([index, string]: ResponseChunk) => {
+  const unstable_onChunk = ([index, string]: ResponseChunk) => {
     if (index === -1) {
       // full response, no streaming
       const response = new Response(string || null, {
@@ -94,8 +94,8 @@ export async function fetchRequestHandler<TRouter extends AnyRouter>(
     onError(o) {
       opts?.onError?.({ ...o, req: opts.req });
     },
-    onHead,
-    onChunk,
+    unstable_onHead,
+    unstable_onChunk,
   })
     .then(() => {
       if (isStream) {

--- a/packages/server/src/adapters/node-http/nodeHTTPRequestHandler.ts
+++ b/packages/server/src/adapters/node-http/nodeHTTPRequestHandler.ts
@@ -64,7 +64,7 @@ export async function nodeHTTPRequestHandler<
       body: bodyResult.ok ? bodyResult.data : undefined,
     };
 
-    const onHead = (head: HTTPResponse) => {
+    const unstable_onHead = (head: HTTPResponse) => {
       if (
         'status' in head &&
         (!opts.res.statusCode || opts.res.statusCode === 200)
@@ -82,7 +82,7 @@ export async function nodeHTTPRequestHandler<
 
     const formatter = getBatchStreamFormatter();
     let isStream = false;
-    const onChunk = ([index, string]: ResponseChunk) => {
+    const unstable_onChunk = ([index, string]: ResponseChunk) => {
       if (index === -1) {
         /**
          * Full response, no streaming. This can happen
@@ -120,8 +120,8 @@ export async function nodeHTTPRequestHandler<
         });
       },
       contentTypeHandler,
-      onHead,
-      onChunk,
+      unstable_onHead,
+      unstable_onChunk,
     });
 
     if (!isStream) {


### PR DESCRIPTION
Closes #

## 🎯 Changes

Add `unstable_` prefix to `onHead` and `onChunk` callbacks used in `resolveHTTPResponse` from the adapters. Adapters are part of the public API, so while `httpBatchStreamLink` is considered unstable, these callbacks should be too.

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
