### PR TITLE
fix: TextDecoder in parseJsonStream's global scope causes unsupported…

### DIFF
--- a/packages/client/src/links/internals/parseJSONStream.ts
+++ b/packages/client/src/links/internals/parseJSONStream.ts
@@ -36,6 +36,8 @@ export async function parseJSONStream<TReturn>(opts: {
   parse?: (text: string) => TReturn;
   signal?: AbortSignal;
 }): Promise<void> {
+  const textDecoder = new TextDecoder();
+
   const parse = opts.parse ?? JSON.parse;
 
   const onLine = (line: string) => {
@@ -55,10 +57,8 @@ export async function parseJSONStream<TReturn>(opts: {
     opts.onSingle(Number(indexAsStr), parse(text));
   };
 
-  await readLines(opts.readableStream, onLine);
+  await readLines(opts.readableStream, onLine, textDecoder);
 }
-
-const textDecoder = new TextDecoder();
 
 /**
  * Handle transforming a stream of bytes into lines of text.
@@ -71,6 +71,7 @@ const textDecoder = new TextDecoder();
 async function readLines(
   readableStream: ReadableStream<Uint8Array> | NodeJS.ReadableStream,
   onLine: (line: string) => void,
+  textDecoder: TextDecoder,
 ) {
   let partOfLine = '';
 


### PR DESCRIPTION
… environments to crash

This is a hotfix to prevent React Native clients from crashing, by putting the `const textDecoder = newTextDecoder()` within the parseJsonStream function itself we prevent it from always being initialized, and people who use React Native can opt out of using this batch stream link.

Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
