### PR TITLE
fix(`client`): add minimal `WebReadableStreamEsque` for compatibility across envs

### DIFF
--- a/packages/client/src/internals/types.ts
+++ b/packages/client/src/internals/types.ts
@@ -73,11 +73,19 @@ export interface RequestInitEsque {
 }
 
 /**
+ * A subset of the standard ReadableStream properties needed by tRPC internally.
+ * @see ReadableStream from lib.dom.d.ts
+ */
+export type WebReadableStreamEsque = {
+  getReader: () => ReadableStreamDefaultReader<Uint8Array>;
+};
+
+/**
  * A subset of the standard Response properties needed by tRPC internally.
  * @see Response from lib.dom.d.ts
  */
 export interface ResponseEsque {
-  readonly body?: ReadableStream<Uint8Array> | NodeJS.ReadableStream | null;
+  readonly body?: WebReadableStreamEsque | NodeJS.ReadableStream | null;
   /**
    * @remarks
    * The built-in Response::json() method returns Promise<any>, but

--- a/packages/client/src/links/internals/parseJSONStream.ts
+++ b/packages/client/src/links/internals/parseJSONStream.ts
@@ -1,6 +1,6 @@
 // Stream parsing adapted from https://www.loginradius.com/blog/engineering/guest-post/http-streaming-with-nodejs-and-fetch-api/
-
 import { TRPCResponse } from '@trpc/server/rpc';
+import { WebReadableStreamEsque } from '../../internals/types';
 import { HTTPHeaders } from '../types';
 import {
   fetchHTTPResponse,
@@ -26,7 +26,7 @@ export async function parseJSONStream<TReturn>(opts: {
   /**
    * As given by `(await fetch(url)).body`
    */
-  readableStream: ReadableStream<Uint8Array> | NodeJS.ReadableStream;
+  readableStream: WebReadableStreamEsque | NodeJS.ReadableStream;
   /**
    * Called for each line of the stream
    */
@@ -69,7 +69,7 @@ export async function parseJSONStream<TReturn>(opts: {
  * @param onLine will be called for every line ('\n' delimited) in the stream
  */
 async function readLines(
-  readableStream: ReadableStream<Uint8Array> | NodeJS.ReadableStream,
+  readableStream: WebReadableStreamEsque | NodeJS.ReadableStream,
   onLine: (line: string) => void,
   textDecoder: TextDecoderEsque,
 ) {
@@ -119,7 +119,7 @@ function readNodeChunks(
  * Handle WebAPI stream
  */
 async function readStandardChunks(
-  stream: ReadableStream<Uint8Array>,
+  stream: WebReadableStreamEsque,
   onChunk: (chunk: Uint8Array) => void,
 ) {
   const reader = stream.getReader();


### PR DESCRIPTION
Closes https://github.com/trpc/trpc/issues/4504

## 🎯 Changes

- Create `WebReadableStreamEsque` type for "web api response body", with the minimal subset of properties actually used by tRPC. This should improve compatibility across client-side environments (incl. undici fetch, like in the issue mentioned above)
- apply this new type to `ResponseEsque` type and in `parseJSONStream` functions

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
