### PR TITLE
fix(ci): fix lerna publish task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,34 +1,28 @@
 *.log
 .DS_Store
-dist
-.next
-.turbo
-.vercel
+dist/
+.next/
+.turbo/
+.vercel/
+.eslintcache
+*.tsbuildinfo
 
-node_modules
+node_modules/
 package-lock.json
 yarn.lock
-
 .yalc
 yalc.lock
 
 coverage/
-__generated__
+playwright/
+__generated__/
 
-*.tsbuildinfo
 
-# Barrel files
-## Ignore all folders
-packages/*/*
-## Dont ignore files
-!packages/*/*.*
-## Dont ignore src or test
-!packages/*/src
-!packages/tests/*
+# Ignore all folders except `src/` in every published package
+packages/*/*/
+!packages/*/src/
+# and all folders inside `tests` package, which is handled separately
+!packages/tests/*/
 packages/tests/node_modules
 
-.eslintcache
-
 examples/next-big-router/src/server/routers
-
-playwright

--- a/lerna.json
+++ b/lerna.json
@@ -1,10 +1,6 @@
 {
   "version": "10.29.1",
   "registry": "https://registry.npmjs.org/",
-  "publishConfig": {
-    "access": "public"
-  },
   "npmClient": "pnpm",
-  "packages": ["packages/*", "www", "www/og-image"],
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }


### PR DESCRIPTION
- `.gitignore` was for some reason preventing lerna from picking up the packages correctly. This change fixes it, but still preserves the behavior that code comments said it should enforce
- cleaned up the rest of `.gitignore` a bit, especially adding `/` which makes it obvious that we want to match only directories, and not files named like so
- `publishConfig` is deprecated and not valid according to lerna's json schema
- `packages` are redundant, as when `npmClient` is set to `pnpm`, it'll use `pnpm-workspace.yaml` instead