### PR TITLE
docs: Fix typo in /client/react/useContext : .useQuery -> .useQueries

### DIFF
--- a/www/docs/client/react/useContext.mdx
+++ b/www/docs/client/react/useContext.mdx
@@ -90,7 +90,7 @@ These are the helpers you'll get access to via `useContext`. The table below wil
 | `ensureData`        | [`queryClient.ensureData`](https://tanstack.com/query/v4/docs/react/reference/QueryClient#queryclientensurequerydata)            |
 | `invalidate`        | [`queryClient.invalidateQueries`](https://tanstack.com/query/v4/docs/guides/query-invalidation)                                  |
 | `refetch`           | [`queryClient.refetchQueries`](https://tanstack.com/query/v4/docs/reference/QueryClient#queryclientrefetchqueries)               |
-| `cancel`            | [`queryClient.cancelQuery`](https://tanstack.com/query/v4/docs/guides/query-cancellation)                                        |
+| `cancel`            | [`queryClient.cancelQueries`](https://tanstack.com/query/v4/docs/guides/query-cancellation)                                        |
 | `setData`           | [`queryClient.setQueryData`](https://tanstack.com/query/v4/docs/reference/QueryClient#queryclientsetquerydata)                   |
 | `getData`           | [`queryClient.getQueryData`](https://tanstack.com/query/v4/docs/reference/QueryClient#queryclientgetquerydata)                   |
 | `setInfiniteData`   | [`queryClient.setInfiniteQueryData`](https://tanstack.com/query/v4/docs/reference/QueryClient#queryclientsetquerydata)           |


### PR DESCRIPTION
useQuery doesn't exist in react-query and it caused me confusion so I changed it to the correct corresponding method

Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [x ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x ] If necessary, I have added documentation related to the changes made.
- [x ] I have added or updated the tests related to the changes made.
