### PR TITLE
fix(server): allow overriding root context in nested middleware

### DIFF
--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -256,7 +256,7 @@ export function createBuilder<TConfig extends AnyRootConfig>(
           : [middlewareBuilderOrFn];
 
       return createNewBuilder(_def, {
-        middlewares,
+        middlewares: middlewares as ProcedureBuilderMiddleware[],
       }) as AnyProcedureBuilder;
     },
     query(resolver) {

--- a/packages/server/src/core/internals/utils.ts
+++ b/packages/server/src/core/internals/utils.ts
@@ -53,7 +53,9 @@ export type UnsetMarker = typeof unsetMarker;
  * @internal
  */
 export interface ResolveOptions<TParams extends ProcedureParams> {
-  ctx: Simplify<TParams['_ctx_out']>;
+  ctx: Simplify<
+    Overwrite<TParams['_config']['$types']['ctx'], TParams['_ctx_out']>
+  >;
   input: TParams['_input_out'] extends UnsetMarker
     ? undefined
     : TParams['_input_out'];

--- a/packages/server/src/core/middleware.ts
+++ b/packages/server/src/core/middleware.ts
@@ -114,7 +114,8 @@ type CreateMiddlewareReturnInput<
  */
 type deriveParamsFromConfig<TConfig extends AnyRootConfig> = {
   _config: TConfig;
-  _ctx_out: TConfig['$types']['ctx'];
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  _ctx_out: {};
   _input_out: unknown;
   _input_in: unknown;
   _output_in: unknown;
@@ -129,7 +130,9 @@ export type MiddlewareFunction<
   TParamsAfter extends ProcedureParams,
 > = {
   (opts: {
-    ctx: Simplify<TParams['_ctx_out']>;
+    ctx: Simplify<
+      Overwrite<TParams['_config']['$types']['ctx'], TParams['_ctx_out']>
+    >;
     type: ProcedureType;
     path: string;
     input: TParams['_input_out'];
@@ -146,6 +149,7 @@ export type MiddlewareFunction<
           _output_in: TParams['_output_in'];
           _output_out: TParams['_output_out'];
           _meta: TParams['_meta'];
+          _return: $Context;
         }>
       >;
       (opts: { rawInput: unknown }): Promise<MiddlewareResult<TParams>>;

--- a/packages/server/src/core/middleware.ts
+++ b/packages/server/src/core/middleware.ts
@@ -149,7 +149,6 @@ export type MiddlewareFunction<
           _output_in: TParams['_output_in'];
           _output_out: TParams['_output_out'];
           _meta: TParams['_meta'];
-          _return: $Context;
         }>
       >;
       (opts: { rawInput: unknown }): Promise<MiddlewareResult<TParams>>;

--- a/packages/server/src/core/procedure.ts
+++ b/packages/server/src/core/procedure.ts
@@ -62,15 +62,6 @@ export interface ProcedureParams<
 /**
  * @internal
  */
-export type MiddlewareParams<
-  TOptions extends ProcedureParams & {
-    _return: unknown;
-  } = ProcedureParams & { _return: unknown },
-> = TOptions;
-
-/**
- * @internal
- */
 export type ProcedureArgs<TParams extends ProcedureParams> =
   TParams['_input_in'] extends UnsetMarker
     ? [input?: undefined | void, opts?: ProcedureOptions]

--- a/packages/server/src/core/procedure.ts
+++ b/packages/server/src/core/procedure.ts
@@ -62,6 +62,15 @@ export interface ProcedureParams<
 /**
  * @internal
  */
+export type MiddlewareParams<
+  TOptions extends ProcedureParams & {
+    _return: unknown;
+  } = ProcedureParams & { _return: unknown },
+> = TOptions;
+
+/**
+ * @internal
+ */
 export type ProcedureArgs<TParams extends ProcedureParams> =
   TParams['_input_in'] extends UnsetMarker
     ? [input?: undefined | void, opts?: ProcedureOptions]

--- a/packages/tests/server/regression/issue-4527-nested-middleware-root-context.test.ts
+++ b/packages/tests/server/regression/issue-4527-nested-middleware-root-context.test.ts
@@ -36,7 +36,7 @@ test('root context override on nested middlewares', () => {
     )
     .query(async (opts) => {
       expectTypeOf<{
-        req: Request | undefined;
+        req?: Request;
         apiKey: string;
       }>(opts.ctx);
 
@@ -52,7 +52,7 @@ test('root context override on nested middlewares', () => {
     )
     .query(async (opts) => {
       expectTypeOf<{
-        req: Request | undefined;
+        req?: Request;
         apiKey: string;
       }>(opts.ctx);
 

--- a/packages/tests/server/regression/issue-4527-nested-middleware-root-context.test.ts
+++ b/packages/tests/server/regression/issue-4527-nested-middleware-root-context.test.ts
@@ -1,0 +1,55 @@
+import { initTRPC, TRPCError } from '@trpc/server/src';
+import { z } from 'zod';
+
+test('root context override on nested middlewares', () => {
+  const t = initTRPC
+    .context<{
+      apiKey?: string | null;
+      req?: Request;
+    }>()
+    .create();
+
+  const enforceApiKey = t.middleware(async ({ ctx, next }) => {
+    if (!ctx.apiKey) {
+      throw new TRPCError({ code: 'UNAUTHORIZED' });
+    }
+
+    return next({ ctx: { apiKey: ctx.apiKey } });
+  });
+
+  const formDataMiddleware = t.middleware(async ({ next }) => {
+    return next({ rawInput: new FormData() });
+  });
+
+  const protectedApiProcedure = t.procedure.use(enforceApiKey);
+  const protectedApiFormDataProcedure = t.procedure
+    .use(formDataMiddleware)
+    .use(enforceApiKey);
+
+  // root context -> enforceApiKey -> formDataMiddleware
+  protectedApiProcedure
+    .use(formDataMiddleware)
+    .input(
+      z.object({
+        somehash: z.string(),
+      }),
+    )
+    .query(async (opts) => {
+      expectTypeOf<string>(opts.ctx.apiKey);
+
+      return { status: 'ok' };
+    });
+
+  // root context -> formDataMiddleware -> enforceApiKey
+  protectedApiFormDataProcedure
+    .input(
+      z.object({
+        somehash: z.string(),
+      }),
+    )
+    .query(async (opts) => {
+      expectTypeOf<string>(opts.ctx.apiKey);
+
+      return { status: 'ok' };
+    });
+});

--- a/packages/tests/server/regression/issue-4527-nested-middleware-root-context.test.ts
+++ b/packages/tests/server/regression/issue-4527-nested-middleware-root-context.test.ts
@@ -21,13 +21,9 @@ test('root context override on nested middlewares', () => {
     return next({ rawInput: new FormData() });
   });
 
-  const protectedApiProcedure = t.procedure.use(enforceApiKey);
-  const protectedApiFormDataProcedure = t.procedure
-    .use(formDataMiddleware)
-    .use(enforceApiKey);
-
   // root context -> enforceApiKey -> formDataMiddleware
-  protectedApiProcedure
+  t.procedure
+    .use(enforceApiKey)
     .use(formDataMiddleware)
     .input(
       z.object({
@@ -44,7 +40,9 @@ test('root context override on nested middlewares', () => {
     });
 
   // root context -> formDataMiddleware -> enforceApiKey
-  protectedApiFormDataProcedure
+  t.procedure
+    .use(formDataMiddleware)
+    .use(enforceApiKey)
     .input(
       z.object({
         somehash: z.string(),

--- a/packages/tests/server/regression/issue-4527-nested-middleware-root-context.test.ts
+++ b/packages/tests/server/regression/issue-4527-nested-middleware-root-context.test.ts
@@ -35,7 +35,10 @@ test('root context override on nested middlewares', () => {
       }),
     )
     .query(async (opts) => {
-      expectTypeOf<string>(opts.ctx.apiKey);
+      expectTypeOf<{
+        req: Request | undefined;
+        apiKey: string;
+      }>(opts.ctx);
 
       return { status: 'ok' };
     });
@@ -48,7 +51,10 @@ test('root context override on nested middlewares', () => {
       }),
     )
     .query(async (opts) => {
-      expectTypeOf<string>(opts.ctx.apiKey);
+      expectTypeOf<{
+        req: Request | undefined;
+        apiKey: string;
+      }>(opts.ctx);
 
       return { status: 'ok' };
     });


### PR DESCRIPTION
Closes #4527
Closes T-108

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?
Merge the root context into the actual output of the middlewares only when necessary (function inputs like opts.ctx, used in t.middleware, t.use, t.procedure.query, t.procedure.mutation, t.procedure.subscription). This allows the proper order of overrides from root context -> middlewares instead of each middleware including the root context in it's `_ctx_out` type and preventing overriding the root context with nested middleware.