### PR TITLE
feat(server): stricter types for AnyRouter

### DIFF
--- a/packages/next/src/app-dir/shared.ts
+++ b/packages/next/src/app-dir/shared.ts
@@ -23,7 +23,9 @@ export type UseProcedureRecord<TRouter extends AnyRouter> = {
     AnyRouter | AnyQueryProcedure
   >]: TRouter['_def']['record'][TKey] extends AnyRouter
     ? UseProcedureRecord<TRouter['_def']['record'][TKey]>
-    : Resolver<TRouter['_def']['record'][TKey]>;
+    : TRouter['_def']['record'][TKey] extends AnyQueryProcedure
+    ? Resolver<TRouter['_def']['record'][TKey]>
+    : never;
 };
 
 export function createUseProxy<TRouter extends AnyRouter>(

--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -203,25 +203,41 @@ export type DecorateProcedure<
 /**
  * @internal
  */
+type IfEquals<TObj, TOther, TYes = unknown, TNo = never> = (<
+  TInner,
+>() => TInner extends TObj ? 1 : 2) extends <TInner>() => TInner extends TOther
+  ? 1
+  : 2
+  ? TYes
+  : TNo;
+
+/**
+ * @internal
+ */
 export type DecoratedProcedureRecord<
   TProcedures extends ProcedureRouterRecord,
   TFlags,
   TPath extends string = '',
 > = {
-  [TKey in keyof TProcedures]: TProcedures[TKey] extends AnyRouter
-    ? {
-        /**
-         * @deprecated - import `getQueryKey` from `@trpc/react-query` instead
-         */
-        getQueryKey: () => QueryKey;
-      } & DecoratedProcedureRecord<
-        TProcedures[TKey]['_def']['record'],
-        TFlags,
-        `${TPath}${TKey & string}.`
-      >
-    : TProcedures[TKey] extends AnyProcedure
-    ? DecorateProcedure<TProcedures[TKey], TFlags, `${TPath}${TKey & string}`>
-    : never;
+  [TKey in keyof TProcedures]: IfEquals<
+    TProcedures,
+    ProcedureRouterRecord,
+    unknown,
+    TProcedures[TKey] extends AnyRouter
+      ? {
+          /**
+           * @deprecated - import `getQueryKey` from `@trpc/react-query` instead
+           */
+          getQueryKey: () => QueryKey;
+        } & DecoratedProcedureRecord<
+          TProcedures[TKey]['_def']['record'],
+          TFlags,
+          `${TPath}${TKey & string}.`
+        >
+      : TProcedures[TKey] extends AnyProcedure
+      ? DecorateProcedure<TProcedures[TKey], TFlags, `${TPath}${TKey & string}`>
+      : never
+  >;
 };
 
 /**

--- a/packages/react-query/src/server/ssgProxy.ts
+++ b/packages/react-query/src/server/ssgProxy.ts
@@ -56,7 +56,9 @@ export type DecoratedProcedureSSGRecord<TRouter extends AnyRouter> = {
   >]: TRouter['_def']['record'][TKey] extends AnyRouter
     ? DecoratedProcedureSSGRecord<TRouter['_def']['record'][TKey]>
     : // utils only apply to queries
-      DecorateProcedure<TRouter['_def']['record'][TKey]>;
+    TRouter['_def']['record'][TKey] extends AnyQueryProcedure
+    ? DecorateProcedure<TRouter['_def']['record'][TKey]>
+    : never;
 };
 
 type AnyDecoratedProcedure = DecorateProcedure<any>;

--- a/packages/react-query/src/shared/proxy/useQueriesProxy.ts
+++ b/packages/react-query/src/shared/proxy/useQueriesProxy.ts
@@ -48,10 +48,12 @@ export type UseQueriesProcedureRecord<
         TRouter['_def']['record'][TKey],
         `${TPath}${TKey & string}.`
       >
-    : GetQueryOptions<
+    : TRouter['_def']['record'][TKey] extends AnyQueryProcedure
+    ? GetQueryOptions<
         TRouter['_def']['record'][TKey],
         `${TPath}${TKey & string}`
-      >;
+      >
+    : never;
 };
 
 /**

--- a/packages/react-query/src/shared/proxy/utilsProxy.ts
+++ b/packages/react-query/src/shared/proxy/utilsProxy.ts
@@ -213,7 +213,9 @@ export type DecoratedProcedureUtilsRecord<TRouter extends AnyRouter> = {
     ? DecoratedProcedureUtilsRecord<TRouter['_def']['record'][TKey]> &
         DecorateRouter
     : // utils only apply to queries
-      DecorateProcedure<TRouter['_def']['record'][TKey]>;
+    TRouter['_def']['record'][TKey] extends AnyQueryProcedure
+    ? DecorateProcedure<TRouter['_def']['record'][TKey]>
+    : never;
 } & DecorateRouter; // Add functions that should be available at utils root
 
 type AnyDecoratedProcedure = DecorateProcedure<any>;

--- a/packages/server/src/core/internals/utils.ts
+++ b/packages/server/src/core/internals/utils.ts
@@ -77,3 +77,14 @@ export type PickFirstDefined<TType, TPick> = undefined extends TType
     ? never
     : TPick
   : TType;
+
+/**
+ * @internal
+ */
+export type IfEquals<TObj, TOther, TYes = unknown, TNo = never> = (<
+  TInner,
+>() => TInner extends TObj ? 1 : 2) extends <TInner>() => TInner extends TOther
+  ? 1
+  : 2
+  ? TYes
+  : TNo;

--- a/packages/server/src/core/router.ts
+++ b/packages/server/src/core/router.ts
@@ -7,6 +7,7 @@ import { defaultTransformer } from '../transformer';
 import { AnyRootConfig } from './internals/config';
 import { omitPrototype } from './internals/omitPrototype';
 import { ProcedureCallOptions } from './internals/procedureBuilder';
+import { IfEquals } from './internals/utils';
 import {
   AnyMutationProcedure,
   AnyProcedure,
@@ -76,7 +77,7 @@ export interface RouterDef<
 export type AnyRouterDef<
   TConfig extends AnyRootConfig = AnyRootConfig,
   TOld extends DeprecatedProcedureRouterRecord = any,
-> = RouterDef<TConfig, any, TOld>;
+> = RouterDef<TConfig, ProcedureRouterRecord, TOld>;
 
 /**
  * @internal
@@ -97,11 +98,16 @@ type DecorateProcedure<TProcedure extends AnyProcedure> = (
  * @internal
  */
 type DecoratedProcedureRecord<TProcedures extends ProcedureRouterRecord> = {
-  [TKey in keyof TProcedures]: TProcedures[TKey] extends AnyRouter
-    ? DecoratedProcedureRecord<TProcedures[TKey]['_def']['record']>
-    : TProcedures[TKey] extends AnyProcedure
-    ? DecorateProcedure<TProcedures[TKey]>
-    : never;
+  [TKey in keyof TProcedures]: IfEquals<
+    TProcedures,
+    ProcedureRouterRecord,
+    unknown,
+    TProcedures[TKey] extends AnyRouter
+      ? DecoratedProcedureRecord<TProcedures[TKey]['_def']['record']>
+      : TProcedures[TKey] extends AnyProcedure
+      ? DecorateProcedure<TProcedures[TKey]>
+      : never
+  >;
 };
 
 /**

--- a/packages/tests/server/router.test.ts
+++ b/packages/tests/server/router.test.ts
@@ -1,5 +1,9 @@
 import './___packages';
-import { initTRPC } from '@trpc/server/src/core';
+import {
+  AnyRouter,
+  initTRPC,
+  ProcedureRouterRecord,
+} from '@trpc/server/src/core';
 
 const t = initTRPC.create();
 
@@ -33,5 +37,14 @@ describe('router', () => {
         }),
       }),
     ).toThrow('Duplicate key: foo..bar');
+  });
+
+  test('should have proper _def types', async () => {
+    expectTypeOf(t.router({})).not.toBeAny();
+
+    expectTypeOf((t.router({}) as AnyRouter)._def.procedures)
+      .toMatchTypeOf<ProcedureRouterRecord>;
+    expectTypeOf((t.router({}) as AnyRouter)._def.record)
+      .toMatchTypeOf<ProcedureRouterRecord>;
   });
 });


### PR DESCRIPTION
Closes #4257

## 🎯 Changes

`AnyRouter` now uses `ProcedureRouterRecord` instead of `any` as `TRecord`.
The other changes are typing fixes required because of the change.

P.S - I'm not too familiar with the codebase, but I think this does what you want :)

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
