### PR TITLE
chore(fetch adapter): update fetch adapter documentation

### DIFF
--- a/www/docs/server/adapters/fetch.mdx
+++ b/www/docs/server/adapters/fetch.mdx
@@ -218,6 +218,11 @@ export const all: APIRoute = (opts) => {
     createContext,
   });
 };
+
+export const getStaticPaths = () =>
+  Object.keys(appRouter._def.procedures).map((procedure) => ({
+    params: { trpc: procedure },
+  }));
 ```
 
 ### Cloudflare Worker


### PR DESCRIPTION
Hi, I had a little trouble getting TRPC fetch adapter to work on the latest Astro version. It warned me about missing `getStaticPaths`. Here's an updated documentation how to pass all the procedure dynamic routes to API router.

## 🎯 Changes

- Added `getStaticPaths` definition to Astro Fetch Adapter example.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
