### PR TITLE
Add 'override' to 'cause' in TRPCError

### DIFF
--- a/packages/server/src/error/TRPCError.ts
+++ b/packages/server/src/error/TRPCError.ts
@@ -20,7 +20,7 @@ export function getTRPCErrorFromUnknown(cause: unknown): TRPCError {
 }
 
 export class TRPCError extends Error {
-  public readonly cause?: Error;
+  public override readonly cause?: Error;
   public readonly code;
 
   constructor(opts: {


### PR DESCRIPTION
Closes #

## 🎯 Changes

I was getting the following error with "@trpc/server@npm:10.32.0" and TypeScript 5

```
../../node_modules/@trpc/server/src/error/TRPCError.ts:23:19 - error TS4114: This member must have an 'override' modifier because it overrides a member in the base class 'Error'.

23   public readonly cause?: Error;
                     ~~~~~
```

so I fixed it by adding the `override` modifier, not sure why hasn't anyone complained yet.


## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
