### PR TITLE
createAction from a "client"

### DIFF
--- a/examples/.experimental/next-app-dir/src/app/alt-server-action/_actions.ts
+++ b/examples/.experimental/next-app-dir/src/app/alt-server-action/_actions.ts
@@ -1,0 +1,5 @@
+'use server';
+
+import { api, createAction } from '~/trpc/server';
+
+export const createPostAction = createAction(api.createPost);

--- a/examples/.experimental/next-app-dir/src/app/alt-server-action/page.tsx
+++ b/examples/.experimental/next-app-dir/src/app/alt-server-action/page.tsx
@@ -1,0 +1,22 @@
+import { api } from '~/trpc/server';
+import { createPostAction } from './_actions';
+
+export default async function Page() {
+  const post = await api.getPost.query();
+
+  return (
+    <>
+      <h1>Post</h1>
+      <pre>{JSON.stringify(post, null, 4)}</pre>
+
+      <br />
+      <h1>Create post</h1>
+      <p>(Refresh the page after to see updated post)</p>
+      <form action={createPostAction}>
+        <input type="text" name="title" placeholder="title" />
+        <input type="text" name="content" placeholder="content" />
+        <button type="submit">Create</button>
+      </form>
+    </>
+  );
+}

--- a/examples/.experimental/next-app-dir/src/server/routers/_app.ts
+++ b/examples/.experimental/next-app-dir/src/server/routers/_app.ts
@@ -1,6 +1,13 @@
 import { z } from 'zod';
 import { publicProcedure, router } from '../trpc';
 
+let post = {
+  id: 1,
+  title: 'hello',
+  content: 'world',
+  created: new Date(),
+};
+
 export const createPost = publicProcedure
   .input(
     z.object({
@@ -9,8 +16,9 @@ export const createPost = publicProcedure
     }),
   )
   .mutation(async (opts) => {
-    return {
-      id: '1',
+    post = {
+      id: post.id + 1,
+      created: new Date(),
       ...opts.input,
     };
   });
@@ -28,6 +36,9 @@ export const appRouter = router({
     }),
 
   createPost,
+  getPost: publicProcedure.query(async (opts) => {
+    return post;
+  }),
 });
 
 export type AppRouter = typeof appRouter;

--- a/examples/.experimental/next-app-dir/src/server/trpc.ts
+++ b/examples/.experimental/next-app-dir/src/server/trpc.ts
@@ -25,7 +25,8 @@ const t = initTRPC.context<Context>().create({
 export const router = t.router;
 export const publicProcedure = t.procedure;
 
-export const createAction = experimental_createServerActionHandler(t, {
+export const createAction = experimental_createServerActionHandler({
+  t,
   createContext() {
     const newHeaders = new Map(headers());
 

--- a/packages/next/src/app-dir/types.ts
+++ b/packages/next/src/app-dir/types.ts
@@ -1,0 +1,39 @@
+import { Resolver } from '@trpc/client';
+import {
+  AnyMutationProcedure,
+  AnyProcedure,
+  AnyQueryProcedure,
+  AnyRouter,
+  AnySubscriptionProcedure,
+  ProcedureRouterRecord,
+} from '@trpc/server';
+
+export type DecorateProcedureServer<TProcedure extends AnyProcedure> =
+  TProcedure extends AnyQueryProcedure
+    ? {
+        query: Resolver<TProcedure>;
+        revalidate: (
+          input?: unknown,
+        ) => Promise<
+          { revalidated: true } | { revalidated: false; error: string }
+        >;
+      }
+    : TProcedure extends AnyMutationProcedure
+    ? {
+        mutate: Resolver<TProcedure>;
+      }
+    : TProcedure extends AnySubscriptionProcedure
+    ? {
+        subscribe: Resolver<TProcedure>;
+      }
+    : never;
+
+export type NextAppDirDecoratedProcedureRecord<
+  TProcedures extends ProcedureRouterRecord,
+> = {
+  [TKey in keyof TProcedures]: TProcedures[TKey] extends AnyRouter
+    ? NextAppDirDecoratedProcedureRecord<TProcedures[TKey]['_def']['record']>
+    : TProcedures[TKey] extends AnyProcedure
+    ? DecorateProcedureServer<TProcedures[TKey]>
+    : never;
+};


### PR DESCRIPTION
Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

- allows you to pass in a router instance to the `experimental_createServerActionHandler` and then creating actions from your client like `createAction(api.createPost)`

Needs #4375

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
