### PR TITLE
fix: next-app-dir build fails

### DIFF
--- a/examples/.experimental/next-app-dir/next.config.js
+++ b/examples/.experimental/next-app-dir/next.config.js
@@ -6,8 +6,10 @@ const nextConfig = {
   experimental: {
     appDir: true,
     serverActions: true,
+    serverComponentsExternalPackages: ['@trpc/server'],
   },
   webpack: (config) => {
+    // This is only intended to pass CI and should be skiped in your app
     if (config.name === 'server')
       config.optimization.concatenateModules = false;
 


### PR DESCRIPTION
`Cannot get final name for export 'observable' of ....`

Fixes #4396

## 🎯 Changes
Revert the custom optimization configuration in webpack. Next.js provides support for [serverComponentsExternalPackages](https://nextjs.org/docs/app/api-reference/next-config-js/serverComponentsExternalPackages) to address this issue./
For me, `config.optimization.concatenateModules = false` causes some other strange errors.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
