### PR TITLE
fix(client): enable instrumenting fetch

### DIFF
--- a/packages/client/src/getFetch.ts
+++ b/packages/client/src/getFetch.ts
@@ -4,11 +4,6 @@ type AnyFn = (...args: any[]) => unknown;
 
 const isFunction = (fn: unknown): fn is AnyFn => typeof fn === 'function';
 
-function _bind(fn: AnyFn, thisArg: unknown): AnyFn {
-  // eslint-disable-next-line @typescript-eslint/unbound-method
-  return isFunction(fn.bind) ? fn.bind(thisArg) : fn;
-}
-
 export function getFetch(
   customFetchImpl?: FetchEsque | NativeFetchEsque,
 ): FetchEsque {
@@ -17,11 +12,11 @@ export function getFetch(
   }
 
   if (typeof window !== 'undefined' && isFunction(window.fetch)) {
-    return _bind(window.fetch, window) as FetchEsque;
+    return window.fetch as FetchEsque;
   }
 
   if (typeof globalThis !== 'undefined' && isFunction(globalThis.fetch)) {
-    return _bind(globalThis.fetch, globalThis) as FetchEsque;
+    return globalThis.fetch as FetchEsque;
   }
 
   throw new Error('No fetch implementation found');

--- a/packages/client/src/links/internals/httpUtils.ts
+++ b/packages/client/src/links/internals/httpUtils.ts
@@ -29,7 +29,7 @@ export interface HTTPLinkBaseOptions {
 
 export interface ResolvedHTTPLinkOptions {
   url: string;
-  fetch: FetchEsque;
+  fetch?: FetchEsque;
   AbortController: AbortControllerEsque | null;
 }
 
@@ -38,7 +38,7 @@ export function resolveHTTPLinkOptions(
 ): ResolvedHTTPLinkOptions {
   return {
     url: opts.url,
-    fetch: getFetch(opts.fetch),
+    fetch: opts.fetch,
     AbortController: getAbortController(opts.AbortController),
   };
 }
@@ -164,7 +164,7 @@ export async function fetchHTTPResponse(
     ...resolvedHeaders,
   };
 
-  return opts.fetch(url, {
+  return getFetch(opts.fetch)(url, {
     method: METHOD[type],
     signal: ac?.signal,
     body: body,


### PR DESCRIPTION
Closes https://github.com/trpc/trpc/issues/4589

## 🎯 Changes

This is a suggested fix to enable third party (like DataDog) to instrument fetch. We do this by avoiding to bind window or globalThis to fetch.

If we go this direction then why not just get rid of `resolveHTTPLinkOptions`?

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
