### PR TITLE
Update Docs: Move context within trpc

### DIFF
--- a/www/docs/client/links/splitLink.mdx
+++ b/www/docs/client/links/splitLink.mdx
@@ -58,8 +58,10 @@ const client = createTRPCProxyClient<AppRouter>({
 
 ```ts title='client.ts'
 const postResult = proxy.posts.query(null, {
-  context: {
-    skipBatch: true,
+  trpc: {
+    context: {
+      skipBatch: true,
+    },
   },
 });
 ```


### PR DESCRIPTION
## 🎯 Changes

Just an update to the [example docs](https://trpc.io/docs/client/links/splitLink#2-perform-request-without-batching)

The second example is right with `context` within the `trpc` object and the first example doesn't work

<img width="1038" alt="image" src="https://github.com/trpc/trpc/assets/3721449/6978d653-967b-44c7-a1af-33bd01ba38fe">


## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
