### PR TITLE
feat(`client`): add HTTP response object to `TRPCClientError.meta`

### DIFF
--- a/packages/client/src/TRPCClientError.ts
+++ b/packages/client/src/TRPCClientError.ts
@@ -24,8 +24,15 @@ export interface TRPCClientErrorBase<TShape extends DefaultErrorShape> {
 export type TRPCClientErrorLike<TRouterOrProcedure extends ErrorInferrable> =
   TRPCClientErrorBase<inferErrorShape<TRouterOrProcedure>>;
 
-function isTRPCClientError(cause: unknown): cause is TRPCClientError<any> {
-  return cause instanceof Error && cause.name === 'TRPCClientError';
+function isTRPCClientError(cause: Error): cause is TRPCClientError<any> {
+  return (
+    cause instanceof TRPCClientError ||
+    /**
+     * @deprecated
+     * Delete in next major
+     */
+    cause.name === 'TRPCClientError'
+  );
 }
 
 export class TRPCClientError<TRouterOrProcedure extends ErrorInferrable>
@@ -80,12 +87,14 @@ export class TRPCClientError<TRouterOrProcedure extends ErrorInferrable>
         },
       );
     }
-    if (isTRPCClientError(cause) && opts.meta) {
-      // Decorate with meta error data
-      cause.meta = {
-        ...opts.meta,
-        ...cause.meta,
-      };
+    if (isTRPCClientError(cause)) {
+      if (opts.meta) {
+        // Decorate with meta error data
+        cause.meta = {
+          ...opts.meta,
+          ...cause.meta,
+        };
+      }
       return cause;
     }
 

--- a/packages/client/src/TRPCClientError.ts
+++ b/packages/client/src/TRPCClientError.ts
@@ -24,6 +24,10 @@ export interface TRPCClientErrorBase<TShape extends DefaultErrorShape> {
 export type TRPCClientErrorLike<TRouterOrProcedure extends ErrorInferrable> =
   TRPCClientErrorBase<inferErrorShape<TRouterOrProcedure>>;
 
+function isTRPCClientError(cause: unknown): cause is TRPCClientError<any> {
+  return cause instanceof Error && cause.name === 'TRPCClientError';
+}
+
 export class TRPCClientError<TRouterOrProcedure extends ErrorInferrable>
   extends Error
   implements TRPCClientErrorBase<inferErrorShape<TRouterOrProcedure>>
@@ -76,7 +80,7 @@ export class TRPCClientError<TRouterOrProcedure extends ErrorInferrable>
         },
       );
     }
-    if (cause instanceof TRPCClientError && opts.meta) {
+    if (isTRPCClientError(cause) && opts.meta) {
       // Decorate with meta error data
       cause.meta = {
         ...opts.meta,

--- a/packages/client/src/TRPCClientError.ts
+++ b/packages/client/src/TRPCClientError.ts
@@ -91,8 +91,8 @@ export class TRPCClientError<TRouterOrProcedure extends ErrorInferrable>
       if (opts.meta) {
         // Decorate with meta error data
         cause.meta = {
-          ...opts.meta,
           ...cause.meta,
+          ...opts.meta,
         };
       }
       return cause;

--- a/packages/client/src/TRPCClientError.ts
+++ b/packages/client/src/TRPCClientError.ts
@@ -86,6 +86,7 @@ export class TRPCClientError<TRouterOrProcedure extends ErrorInferrable>
         ...opts.meta,
         ...cause.meta,
       };
+      return cause;
     }
 
     return new TRPCClientError<TRouterOrProcedure>(cause.message, {

--- a/packages/client/src/TRPCClientError.ts
+++ b/packages/client/src/TRPCClientError.ts
@@ -31,7 +31,12 @@ export class TRPCClientError<TRouterOrProcedure extends ErrorInferrable>
   public readonly cause;
   public readonly shape: Maybe<inferErrorShape<TRouterOrProcedure>>;
   public readonly data: Maybe<inferErrorShape<TRouterOrProcedure>['data']>;
-  public readonly meta;
+
+  /**
+   * Additional meta data about the error
+   * In the case of HTTP-errors, we'll have `response` and potentially `responseJSON` here
+   */
+  public meta;
 
   constructor(
     message: string,
@@ -71,8 +76,12 @@ export class TRPCClientError<TRouterOrProcedure extends ErrorInferrable>
         },
       );
     }
-    if (cause.name === 'TRPCClientError') {
-      return cause as TRPCClientError<any>;
+    if (cause instanceof TRPCClientError && opts.meta) {
+      // Decorate with meta error data
+      cause.meta = {
+        ...opts.meta,
+        ...cause.meta,
+      };
     }
 
     return new TRPCClientError<TRouterOrProcedure>(cause.message, {

--- a/packages/client/src/links/httpLink.ts
+++ b/packages/client/src/links/httpLink.ts
@@ -4,6 +4,7 @@ import { transformResult } from '../shared/transformResult';
 import { TRPCClientError } from '../TRPCClientError';
 import {
   HTTPLinkBaseOptions,
+  HTTPResult,
   jsonHttpRequester,
   Requester,
   resolveHTTPLinkOptions,
@@ -48,14 +49,16 @@ export function httpLinkFactory(factoryOpts: { requester: Requester }) {
               return opts.headers;
             },
           });
+          let meta: HTTPResult['meta'] | undefined = undefined;
           promise
             .then((res) => {
+              meta = res.meta;
               const transformed = transformResult(res.json, runtime);
 
               if (!transformed.ok) {
                 observer.error(
                   TRPCClientError.from(transformed.error, {
-                    meta: res.meta,
+                    meta,
                   }),
                 );
                 return;
@@ -67,7 +70,7 @@ export function httpLinkFactory(factoryOpts: { requester: Requester }) {
               observer.complete();
             })
             .catch((cause) => {
-              observer.error(TRPCClientError.from(cause));
+              observer.error(TRPCClientError.from(cause, { meta }));
             });
 
           return () => {

--- a/packages/client/src/links/internals/createHTTPBatchLink.ts
+++ b/packages/client/src/links/internals/createHTTPBatchLink.ts
@@ -87,8 +87,10 @@ export function createHTTPBatchLink<TOptions extends HTTPBatchLinkOptions>(
           const loader = loaders[op.type];
           const { promise, cancel } = loader.load(op);
 
+          let _res = undefined as HTTPResult | undefined;
           promise
             .then((res) => {
+              _res = res;
               const transformed = transformResult(res.json, runtime);
 
               if (!transformed.ok) {
@@ -106,7 +108,11 @@ export function createHTTPBatchLink<TOptions extends HTTPBatchLinkOptions>(
               observer.complete();
             })
             .catch((err) => {
-              observer.error(TRPCClientError.from(err));
+              observer.error(
+                TRPCClientError.from(err, {
+                  meta: _res?.meta,
+                }),
+              );
             });
 
           return () => {

--- a/packages/client/src/links/internals/httpUtils.ts
+++ b/packages/client/src/links/internals/httpUtils.ts
@@ -9,6 +9,7 @@ import {
   RequestInitEsque,
   ResponseEsque,
 } from '../../internals/types';
+import { TRPCClientError } from '../../TRPCClientError';
 import { TextDecoderEsque } from '../internals/streamingUtils';
 import { HTTPHeaders, PromiseAndCancel, TRPCClientRuntime } from '../types';
 
@@ -62,6 +63,7 @@ export interface HTTPResult {
   json: TRPCResponse;
   meta: {
     response: ResponseEsque;
+    responseJSON?: unknown;
   };
 }
 
@@ -185,12 +187,15 @@ export function httpRequest(
         return _res.json();
       })
       .then((json) => {
+        meta.responseJSON = json;
         resolve({
           json: json as TRPCResponse,
           meta,
         });
       })
-      .catch(reject);
+      .catch((err) => {
+        reject(TRPCClientError.from(err, { meta }));
+      });
   });
   const cancel = () => {
     ac?.abort();

--- a/packages/client/src/links/wsLink.ts
+++ b/packages/client/src/links/wsLink.ts
@@ -338,7 +338,13 @@ export function wsLink<TRouter extends AnyRouter>(
               const transformed = transformResult(message, runtime);
 
               if (!transformed.ok) {
-                observer.error(TRPCClientError.from(transformed.error));
+                observer.error(
+                  TRPCClientError.from(transformed.error, {
+                    meta: {
+                      message,
+                    },
+                  }),
+                );
                 return;
               }
               observer.next({

--- a/packages/client/src/links/wsLink.ts
+++ b/packages/client/src/links/wsLink.ts
@@ -338,13 +338,7 @@ export function wsLink<TRouter extends AnyRouter>(
               const transformed = transformResult(message, runtime);
 
               if (!transformed.ok) {
-                observer.error(
-                  TRPCClientError.from(transformed.error, {
-                    meta: {
-                      message,
-                    },
-                  }),
-                );
+                observer.error(TRPCClientError.from(transformed.error));
                 return;
               }
               observer.next({

--- a/packages/client/src/shared/transformResult.ts
+++ b/packages/client/src/shared/transformResult.ts
@@ -6,7 +6,6 @@ import type {
 } from '@trpc/server/rpc';
 import type { TRPCClientRuntime } from '../links';
 import { isObject } from '../links/internals/isObject';
-import { TRPCClientError } from '../TRPCClientError';
 
 // FIXME:
 // - the generics here are probably unnecessary
@@ -41,6 +40,12 @@ function transformResultInner<TRouter extends AnyRouter, TOutput>(
   return { ok: true, result } as const;
 }
 
+class TransformResultError extends Error {
+  constructor() {
+    super('Unable to transform response from server');
+  }
+}
+
 /**
  * Transforms and validates that the result is a valid TRPCResponse
  * @internal
@@ -56,7 +61,7 @@ export function transformResult<TRouter extends AnyRouter, TOutput>(
     // Use the data transformers on the JSON-response
     result = transformResultInner(response, runtime);
   } catch (err) {
-    throw new TRPCClientError('Unable to transform response from server');
+    throw new TransformResultError();
   }
 
   // check that output of the transformers is a valid TRPCResponse
@@ -65,10 +70,10 @@ export function transformResult<TRouter extends AnyRouter, TOutput>(
     (!isObject(result.error.error) ||
       typeof result.error.error.code !== 'number')
   ) {
-    throw new TRPCClientError('Badly formatted response from server');
+    throw new TransformResultError();
   }
   if (result.ok && !isObject(result.result)) {
-    throw new TRPCClientError('Badly formatted response from server');
+    throw new TransformResultError();
   }
   return result;
 }

--- a/packages/tests/server/errors.test.ts
+++ b/packages/tests/server/errors.test.ts
@@ -386,7 +386,7 @@ test('retain stack trace', async () => {
   await close();
 });
 
-describe.only('links have meta data about http failures', async () => {
+describe('links have meta data about http failures', async () => {
   type Handler = (opts: {
     req: http.IncomingMessage;
     res: http.ServerResponse;

--- a/packages/tests/server/errors.test.ts
+++ b/packages/tests/server/errors.test.ts
@@ -1,12 +1,20 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
+import http from 'http';
 import { routerToServerAndClientNew, waitError } from './___testHelpers';
-import { TRPCClientError } from '@trpc/client/src';
+import {
+  createTRPCProxyClient,
+  httpBatchLink,
+  httpLink,
+  TRPCClientError,
+} from '@trpc/client/src';
+import { observable } from '@trpc/server/observable';
 import * as trpc from '@trpc/server/src';
 import { initTRPC } from '@trpc/server/src';
 import { CreateHTTPContextOptions } from '@trpc/server/src/adapters/standalone';
 import { TRPCError } from '@trpc/server/src/error/TRPCError';
 import { getMessageFromUnknownError } from '@trpc/server/src/error/utils';
 import { OnErrorFunction } from '@trpc/server/src/internals/types';
+import { konn } from 'konn';
 import fetch from 'node-fetch';
 import { z, ZodError } from 'zod';
 
@@ -376,4 +384,132 @@ test('retain stack trace', async () => {
   expect(stackParts[1]).toContain(__filename);
 
   await close();
+});
+
+describe.only('links have meta data about http failures', async () => {
+  type Handler = (opts: {
+    req: http.IncomingMessage;
+    res: http.ServerResponse;
+  }) => void;
+
+  function createServer(handler: Handler) {
+    const server = http.createServer((req, res) => {
+      handler({ req, res });
+    });
+    server.listen(0);
+
+    const port = (server.address() as any).port as number;
+
+    return {
+      url: `http://localhost:${port}`,
+      async close() {
+        await new Promise((resolve) => {
+          server.close(resolve);
+        });
+      },
+    };
+  }
+  const ctx = konn()
+    .beforeEach(() => {
+      return {
+        server: createServer(({ res }) => {
+          res.setHeader('content-type', 'application/json');
+          res.write(
+            JSON.stringify({
+              __error: {
+                foo: 'bar',
+              },
+            }),
+          );
+          res.end();
+        }),
+      };
+    })
+    .afterEach((opts) => {
+      opts.server?.close();
+    })
+    .done();
+  test('httpLink', async () => {
+    let meta = undefined as Record<string, unknown> | undefined;
+
+    const client: any = createTRPCProxyClient<any>({
+      links: [
+        () => {
+          return ({ next, op }) => {
+            return observable((observer) => {
+              const unsubscribe = next(op).subscribe({
+                error(err) {
+                  observer.error(err);
+                  meta = err.meta;
+                },
+              });
+              return unsubscribe;
+            });
+          };
+        },
+        httpLink({
+          url: ctx.server.url,
+          fetch: fetch as any,
+        }),
+      ],
+    });
+
+    const error = await waitError(client.test.query(), TRPCClientError);
+    expect(error).toMatchInlineSnapshot(
+      `[TRPCClientError: Unable to transform response from server]`,
+    );
+
+    expect(meta).not.toBeUndefined();
+    expect(meta?.responseJSON).not.toBeFalsy();
+    expect(meta?.responseJSON).not.toBeFalsy();
+    expect(meta?.responseJSON).toMatchInlineSnapshot(`
+      Object {
+        "__error": Object {
+          "foo": "bar",
+        },
+      }
+    `);
+  });
+
+  test('httpBatchLink', async () => {
+    let meta = undefined as Record<string, unknown> | undefined;
+
+    const client: any = createTRPCProxyClient<any>({
+      links: [
+        () => {
+          return ({ next, op }) => {
+            return observable((observer) => {
+              const unsubscribe = next(op).subscribe({
+                error(err) {
+                  observer.error(err);
+                  meta = err.meta;
+                },
+              });
+              return unsubscribe;
+            });
+          };
+        },
+        httpBatchLink({
+          url: ctx.server.url,
+          fetch: fetch as any,
+        }),
+      ],
+    });
+
+    const error = await waitError(client.test.query(), TRPCClientError);
+    expect(error).toMatchInlineSnapshot(
+      `[TRPCClientError: Unable to transform response from server]`,
+    );
+
+    expect(meta).not.toBeUndefined();
+    expect(meta?.responseJSON).not.toBeFalsy();
+    expect(meta?.responseJSON).not.toBeFalsy();
+    expect(meta?.responseJSON).toMatchInlineSnapshot(`
+      Object {
+        "__error": Object {
+          "foo": "bar",
+        },
+      }
+    `);
+  });
 });

--- a/packages/tests/server/interop/links.test.ts
+++ b/packages/tests/server/interop/links.test.ts
@@ -70,6 +70,11 @@ test('chainer', async () => {
     Object {
       "context": Object {
         "response": "[redacted]",
+        "responseJSON": Object {
+          "result": Object {
+            "data": "world",
+          },
+        },
       },
       "result": Object {
         "data": "world",
@@ -171,6 +176,18 @@ describe('batching', () => {
         Object {
           "context": Object {
             "response": "[redacted]",
+            "responseJSON": Array [
+              Object {
+                "result": Object {
+                  "data": "hello world",
+                },
+              },
+              Object {
+                "result": Object {
+                  "data": "hello alexdotjs",
+                },
+              },
+            ],
           },
           "result": Object {
             "data": "hello world",
@@ -180,6 +197,18 @@ describe('batching', () => {
         Object {
           "context": Object {
             "response": "[redacted]",
+            "responseJSON": Array [
+              Object {
+                "result": Object {
+                  "data": "hello world",
+                },
+              },
+              Object {
+                "result": Object {
+                  "data": "hello alexdotjs",
+                },
+              },
+            ],
           },
           "result": Object {
             "data": "hello alexdotjs",

--- a/packages/tests/server/links.test.ts
+++ b/packages/tests/server/links.test.ts
@@ -72,6 +72,11 @@ test('chainer', async () => {
     Object {
       "context": Object {
         "response": "[redacted]",
+        "responseJSON": Object {
+          "result": Object {
+            "data": "world",
+          },
+        },
       },
       "result": Object {
         "data": "world",
@@ -174,6 +179,18 @@ describe('batching', () => {
         Object {
           "context": Object {
             "response": "[redacted]",
+            "responseJSON": Array [
+              Object {
+                "result": Object {
+                  "data": "hello world",
+                },
+              },
+              Object {
+                "result": Object {
+                  "data": "hello alexdotjs",
+                },
+              },
+            ],
           },
           "result": Object {
             "data": "hello world",
@@ -183,6 +200,18 @@ describe('batching', () => {
         Object {
           "context": Object {
             "response": "[redacted]",
+            "responseJSON": Array [
+              Object {
+                "result": Object {
+                  "data": "hello world",
+                },
+              },
+              Object {
+                "result": Object {
+                  "data": "hello alexdotjs",
+                },
+              },
+            ],
           },
           "result": Object {
             "data": "hello alexdotjs",

--- a/packages/tests/server/regression/issue-3359-http-status-413-payload-too-large.test.ts
+++ b/packages/tests/server/regression/issue-3359-http-status-413-payload-too-large.test.ts
@@ -63,10 +63,10 @@ describe('server responds with 413 Payload Too Large', () => {
     const error = await waitError(client.test.query(), TRPCClientError);
 
     expect(error).toMatchInlineSnapshot(
-      `[TRPCClientError: Badly formatted response from server]`,
+      '[TRPCClientError: Unable to transform response from server]',
     );
     expect(error.message).toMatchInlineSnapshot(
-      `"Badly formatted response from server"`,
+      '"Unable to transform response from server"',
     );
 
     await server.close();
@@ -99,10 +99,10 @@ describe('server responds with 413 Payload Too Large', () => {
 
     const error = await waitError(client.test.query(), TRPCClientError);
     expect(error).toMatchInlineSnapshot(
-      `[TRPCClientError: Badly formatted response from server]`,
+      '[TRPCClientError: Unable to transform response from server]',
     );
     expect(error.message).toMatchInlineSnapshot(
-      `"Badly formatted response from server"`,
+      '"Unable to transform response from server"',
     );
 
     await server.close();


### PR DESCRIPTION
## 🎯 Changes

Allows you to access:

- `error.meta?.response`
- `error.meta?.responseJSON`

In for instance links etc
