### PR TITLE
refactor: use `Deno.serve()` in `deno-deploy` example

### DIFF
--- a/examples/deno-deploy/src/index.ts
+++ b/examples/deno-deploy/src/index.ts
@@ -1,20 +1,19 @@
-import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
-import { serve } from 'std/http/server.ts';
-import { appRouter } from './router.ts';
+import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
+import { appRouter } from "./router.ts";
 
 function handler(request: Request) {
   // Only used for start-server-and-test package that
   // expects a 200 OK to start testing the server
-  if (request.method === 'HEAD') {
+  if (request.method === "HEAD") {
     return new Response();
   }
 
   return fetchRequestHandler({
-    endpoint: '/trpc',
+    endpoint: "/trpc",
     req: request,
     router: appRouter,
     createContext: () => ({}),
   });
 }
 
-serve(handler);
+Deno.serve(handler);

--- a/examples/deno-deploy/src/index.ts
+++ b/examples/deno-deploy/src/index.ts
@@ -1,15 +1,15 @@
-import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
-import { appRouter } from "./router.ts";
+import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
+import { appRouter } from './router.ts';
 
 function handler(request: Request) {
   // Only used for start-server-and-test package that
   // expects a 200 OK to start testing the server
-  if (request.method === "HEAD") {
+  if (request.method === 'HEAD') {
     return new Response();
   }
 
   return fetchRequestHandler({
-    endpoint: "/trpc",
+    endpoint: '/trpc',
     req: request,
     router: appRouter,
     createContext: () => ({}),

--- a/www/docs/server/adapters/fetch.mdx
+++ b/www/docs/server/adapters/fetch.mdx
@@ -338,7 +338,6 @@ import { FetchCreateContextFnOptions } from 'npm:@trpc/server/adapters/fetch';
 #### Create Deno Deploy Function
 
 ```ts title='server.ts'
-import { serve } from 'https://deno.land/std@0.140.0/http/server.ts';
 import { fetchRequestHandler } from 'npm:@trpc/server/adapters/fetch';
 import { createContext } from './context.ts';
 import { appRouter } from './router.ts';
@@ -352,7 +351,7 @@ function handler(request) {
   });
 }
 
-serve(handler);
+Deno.serve(handler);
 ```
 
 Run `deno run --allow-net=:8000 --allow-env ./server.ts` and your endpoints will be available via HTTP!


### PR DESCRIPTION
## 🎯 Changes

[`Deno.serve()` is now supported on Deno Deploy.
](https://twitter.com/lcasdev/status/1677673531809701889?s=20)
## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
