### PR TITLE
feat(server): better way to export the fetch request handler

### DIFF
--- a/packages/server/src/adapters/fetch/fetchRequestHandler.ts
+++ b/packages/server/src/adapters/fetch/fetchRequestHandler.ts
@@ -114,8 +114,8 @@ export async function fetchRequestHandler<TRouter extends AnyRouter>(
   return promise;
 }
 
-export async function routeFetchRequestHandler<TRouter extends AnyRouter>(
-  opts: FetchHandlerRequestOptions<TRouter>,
+export function routeFetchRequestHandler<TRouter extends AnyRouter>(
+  opts: Omit<FetchHandlerRequestOptions<TRouter>, 'req'>,
 ) {
   return {
     GET: async (req: Request) => await fetchRequestHandler({ ...opts, req }),

--- a/packages/server/src/adapters/fetch/fetchRequestHandler.ts
+++ b/packages/server/src/adapters/fetch/fetchRequestHandler.ts
@@ -113,3 +113,12 @@ export async function fetchRequestHandler<TRouter extends AnyRouter>(
 
   return promise;
 }
+
+export async function routeFetchRequestHandler<TRouter extends AnyRouter>(
+  opts: FetchHandlerRequestOptions<TRouter>,
+) {
+  return {
+    GET: async (req: Request) => await fetchRequestHandler({ ...opts, req }),
+    POST: async (req: Request) => await fetchRequestHandler({ ...opts, req }),
+  };
+}


### PR DESCRIPTION
Closes #

## 🎯 Changes

This PR proposes a more concise syntax for the `fetchRequestHandler` export in `fetchRequestHandler.ts`. I made the change in a new function called routeFetchRequestHandler. However, it's worth considering adding this new function to the main fetchRequestHandler function (if this gonna be merged) in some way to avoid breaking current apps that use it. With this version, you no longer need to export GET and POST with as, and you don't need to pass the request object to the handler. Instead, the routeFetchRequestHandler function returns an object with GET and POST properties, each of which is an async function that calls fetchRequestHandler with the appropriate request method.

exmaple usage:
```ts
const {GET, POST} = routeFetchRequestHandler({
  endpoint: "/api/trpc",
  router: appRouter,
  createContext: () => createTRPCContext(),
});


```

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.