### PR TITLE
css: remove smooth scroll

### DIFF
--- a/www/src/components/Preview.tsx
+++ b/www/src/components/Preview.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { handleSmoothScrollToSection } from '../utils/handleSmoothScrollToSection';
 
 export const Preview = () => {
   return (
@@ -23,6 +24,7 @@ export const Preview = () => {
           href="#try-it-out"
           className="hidden rounded-lg border-[20px] border-neutral-900 bg-neutral-900 shadow-[0px_-24px_300px_0px_rgba(57,140,203,0.15)] transition hover:shadow-[0px_-24px_150px_0px_rgba(57,140,203,0.3)] md:block"
           title="Click to try it out"
+          onClick={handleSmoothScrollToSection}
         >
           <video
             autoPlay

--- a/www/src/css/custom.css
+++ b/www/src/css/custom.css
@@ -43,7 +43,7 @@
 }
 
 html {
-  @apply scroll-smooth selection:bg-sky-500/75 selection:text-white;
+  @apply selection:bg-sky-500/75 selection:text-white;
 }
 
 div[class^='announcementBar_'] {

--- a/www/src/utils/handleSmoothScrollToSection.ts
+++ b/www/src/utils/handleSmoothScrollToSection.ts
@@ -1,0 +1,24 @@
+const handleSmoothScrollToSection = (
+  e: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
+) => {
+  const isModifiedEvent = !!(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey);
+
+  const shouldProcessLinkClick =
+    e.button === 0 && // Ignore everything but left clicks
+    !isModifiedEvent; // Ignore clicks with modifier keys ;
+
+  if (shouldProcessLinkClick) {
+    e.preventDefault();
+
+    const href = e.currentTarget.href;
+
+    const id = href.split('#')[1];
+
+    const section = document.getElementById(id);
+    section?.scrollIntoView({ behavior: 'smooth' });
+
+    window.history.pushState(null, '', href);
+  }
+};
+
+export { handleSmoothScrollToSection };


### PR DESCRIPTION
Closes #4646

## 🎯 Changes

Remove smooth scroll behaviour from custom css.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
 I did write e2e test when I was fixing this bug locally, but don't think its good idea to have real browser running in a ci/cd just for this one test,
<details>

<summary>code</summary>

````ts
import { expect, test } from "@playwright/test";

test("should scroll to top on first visit navigation", async ({ page }) => {
  await page.goto("http://localhost:3000/docs/quickstart");

  await page.evaluate(() => window.scrollTo({ top: 400 }));

  await page.waitForTimeout(500);

  const conceptsLink = page
    .getByLabel("Docs sidebar")
    .getByRole("link", { name: "Concepts" });

  await conceptsLink.click();

  await page.waitForURL("**/docs/concepts");

  await page.waitForTimeout(500);

  const scrollTop = await page.evaluate(
    () => document.documentElement.scrollTop
  );

  console.log({ scrollTop });

  // await expect(scrollTop).toBe(0);
});
````

</details>
