### PR TITLE
feat(client): allow UntypedClient direclty in server helpers

### DIFF
--- a/packages/client/src/createTRPCUntypedClient.ts
+++ b/packages/client/src/createTRPCUntypedClient.ts
@@ -13,5 +13,5 @@ export function createTRPCUntypedClient<TRouter extends AnyRouter>(
 export type {
   CreateTRPCClientOptions,
   TRPCRequestOptions,
-  TRPCUntypedClient,
 } from './internals/TRPCUntypedClient';
+export { TRPCUntypedClient } from './internals/TRPCUntypedClient';

--- a/packages/client/src/createTRPCUntypedClient.ts
+++ b/packages/client/src/createTRPCUntypedClient.ts
@@ -14,7 +14,4 @@ export type {
   CreateTRPCClientOptions,
   TRPCRequestOptions,
 } from './internals/TRPCUntypedClient';
-export {
-  /** @internal */
-  TRPCUntypedClient,
-} from './internals/TRPCUntypedClient';
+export { TRPCUntypedClient } from './internals/TRPCUntypedClient';

--- a/packages/client/src/createTRPCUntypedClient.ts
+++ b/packages/client/src/createTRPCUntypedClient.ts
@@ -14,4 +14,7 @@ export type {
   CreateTRPCClientOptions,
   TRPCRequestOptions,
 } from './internals/TRPCUntypedClient';
-export { TRPCUntypedClient } from './internals/TRPCUntypedClient';
+export {
+  /** @internal */
+  TRPCUntypedClient,
+} from './internals/TRPCUntypedClient';

--- a/packages/react-query/src/server/types.ts
+++ b/packages/react-query/src/server/types.ts
@@ -1,4 +1,8 @@
-import { inferRouterProxyClient } from '@trpc/client';
+import {
+  inferRouterProxyClient,
+  TRPCClient,
+  TRPCUntypedClient,
+} from '@trpc/client';
 import {
   AnyRouter,
   ClientDataTransformerOptions,
@@ -13,7 +17,10 @@ interface CreateSSGHelpersInternal<TRouter extends AnyRouter> {
 }
 
 interface CreateSSGHelpersExternal<TRouter extends AnyRouter> {
-  client: inferRouterProxyClient<TRouter>;
+  client:
+    | inferRouterProxyClient<TRouter>
+    | TRPCUntypedClient<TRouter>
+    | TRPCClient<TRouter>;
 }
 
 export type CreateServerSideHelpersOptions<TRouter extends AnyRouter> =

--- a/packages/react-query/src/server/types.ts
+++ b/packages/react-query/src/server/types.ts
@@ -20,6 +20,7 @@ interface CreateSSGHelpersExternal<TRouter extends AnyRouter> {
   client:
     | inferRouterProxyClient<TRouter>
     | TRPCUntypedClient<TRouter>
+    // FIXME: @deprecated
     | TRPCClient<TRouter>;
 }
 

--- a/packages/react-query/src/ssg/ssg.ts
+++ b/packages/react-query/src/ssg/ssg.ts
@@ -4,7 +4,7 @@ import {
   DehydrateOptions,
   InfiniteData,
 } from '@tanstack/react-query';
-import { getUntypedClient } from '@trpc/client';
+import { getUntypedClient, TRPCUntypedClient } from '@trpc/client';
 import {
   AnyRouter,
   callProcedure,
@@ -48,7 +48,10 @@ export function createSSGHelpers<TRouter extends AnyRouter>(
     }
 
     const { client } = opts;
-    const untypedClient = getUntypedClient(client);
+    const untypedClient =
+      client instanceof TRPCUntypedClient
+        ? client
+        : getUntypedClient(client as any);
 
     return {
       query: (queryOpts) =>

--- a/packages/tests/server/react/ssgExternal.test.ts
+++ b/packages/tests/server/react/ssgExternal.test.ts
@@ -95,3 +95,14 @@ test('prefetch faulty query and dehydrate', async () => {
   const data = JSON.stringify(ssg.dehydrate());
   expect(data).toContain('__error');
 });
+
+test('prefetch and dehydrate', async () => {
+  const { opts } = ctx;
+  const ssg = createServerSideHelpers({
+    client: ctx.proxy.createClient(opts.trpcClientOptions),
+  });
+  await ssg.post.byId.prefetch({ id: '1' });
+
+  const data = JSON.stringify(ssg.dehydrate());
+  expect(data).toContain('__result');
+});


### PR DESCRIPTION
Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

- allows passing an UntypedClient directly, and not just a proxy one, when creating server helpers
