### PR TITLE
feat(server): simplify built procedure type

### DIFF
--- a/packages/client/src/TRPCClientError.ts
+++ b/packages/client/src/TRPCClientError.ts
@@ -1,5 +1,4 @@
 import {
-  AnyProcedure,
   AnyRouter,
   DefaultErrorShape,
   inferRouterError,
@@ -7,22 +6,18 @@ import {
 } from '@trpc/server';
 import { TRPCErrorResponse, TRPCErrorShape } from '@trpc/server/rpc';
 
-type ErrorInferrable = AnyProcedure | AnyRouter | TRPCErrorShape<number>;
+type ErrorInferrable = AnyRouter | TRPCErrorShape<number>;
 
 type inferErrorShape<TInferrable extends ErrorInferrable> =
-  TInferrable extends AnyRouter
-    ? inferRouterError<TInferrable>
-    : TInferrable extends AnyProcedure
-    ? TInferrable['_def']['_config']['$types']['errorShape']
-    : TInferrable;
+  TInferrable extends AnyRouter ? inferRouterError<TInferrable> : TInferrable;
 
 export interface TRPCClientErrorBase<TShape extends DefaultErrorShape> {
   readonly message: string;
   readonly shape: Maybe<TShape>;
   readonly data: Maybe<TShape['data']>;
 }
-export type TRPCClientErrorLike<TRouterOrProcedure extends ErrorInferrable> =
-  TRPCClientErrorBase<inferErrorShape<TRouterOrProcedure>>;
+export type TRPCClientErrorLike<TRouter extends ErrorInferrable> =
+  TRPCClientErrorBase<inferErrorShape<TRouter>>;
 
 function isTRPCClientError(cause: Error): cause is TRPCClientError<any> {
   return (
@@ -35,13 +30,13 @@ function isTRPCClientError(cause: Error): cause is TRPCClientError<any> {
   );
 }
 
-export class TRPCClientError<TRouterOrProcedure extends ErrorInferrable>
+export class TRPCClientError<TRouter extends ErrorInferrable>
   extends Error
-  implements TRPCClientErrorBase<inferErrorShape<TRouterOrProcedure>>
+  implements TRPCClientErrorBase<inferErrorShape<TRouter>>
 {
   public readonly cause;
-  public readonly shape: Maybe<inferErrorShape<TRouterOrProcedure>>;
-  public readonly data: Maybe<inferErrorShape<TRouterOrProcedure>['data']>;
+  public readonly shape: Maybe<inferErrorShape<TRouter>>;
+  public readonly data: Maybe<inferErrorShape<TRouter>['data']>;
 
   /**
    * Additional meta data about the error
@@ -52,7 +47,7 @@ export class TRPCClientError<TRouterOrProcedure extends ErrorInferrable>
   constructor(
     message: string,
     opts?: {
-      result?: Maybe<inferErrorShape<TRouterOrProcedure>>;
+      result?: Maybe<inferErrorShape<TRouter>>;
       cause?: Error;
       meta?: Record<string, unknown>;
     },

--- a/packages/next/src/app-dir/create-action-hook.tsx
+++ b/packages/next/src/app-dir/create-action-hook.tsx
@@ -105,10 +105,13 @@ export function experimental_serverActionLink<
 /**
  * @internal
  */
-export type inferActionResultProps<TProc extends AnyProcedure> = {
+export type inferActionResultProps<
+  TRouter extends AnyRouter,
+  TProc extends AnyProcedure,
+> = {
   input: inferHandlerInput<TProc>[0];
   output: TProc['_def']['_output_out'];
-  errorShape: TProc['_def']['_config']['$types']['errorShape'];
+  errorShape: TRouter['_def']['_config']['$types']['errorShape'];
 };
 
 interface UseTRPCActionOptions<TDef extends ActionHandlerDef> {

--- a/packages/next/src/app-dir/server.ts
+++ b/packages/next/src/app-dir/server.ts
@@ -89,9 +89,10 @@ export function experimental_createServerActionHandler<
   const transformer = config.transformer as CombinedDataTransformer;
 
   // TODO allow this to take a `TRouter` in addition to a `AnyProcedure`
-  return function createServerAction<TProc extends AnyProcedure>(
-    proc: TProc,
-  ): TRPCActionHandler<Simplify<inferActionDef<TProc>>> {
+  return function createServerAction<
+    TRouter extends AnyRouter,
+    TProc extends AnyProcedure,
+  >(proc: TProc): TRPCActionHandler<Simplify<inferActionDef<TRouter, TProc>>> {
     return async function actionHandler(
       rawInput: FormData | inferProcedureInput<TProc>,
     ) {
@@ -143,7 +144,7 @@ export function experimental_createServerActionHandler<
           error: shape,
         });
       }
-    } as TRPCActionHandler<inferActionDef<TProc>>;
+    } as TRPCActionHandler<inferActionDef<TRouter, TProc>>;
   };
 }
 

--- a/packages/next/src/app-dir/shared.ts
+++ b/packages/next/src/app-dir/shared.ts
@@ -7,7 +7,6 @@ import {
   AnyProcedure,
   AnyQueryProcedure,
   AnyRouter,
-  Filter,
   inferHandlerInput,
   ProtectedIntersection,
   ThenArg,
@@ -18,10 +17,11 @@ import { createRecursiveProxy } from '@trpc/server/shared';
  * @internal
  */
 export type UseProcedureRecord<TRouter extends AnyRouter> = {
-  [TKey in keyof Filter<
-    TRouter['_def']['record'],
-    AnyQueryProcedure | AnyRouter
-  >]: TRouter['_def']['record'][TKey] extends AnyRouter
+  [TKey in keyof TRouter['_def']['record'] as TRouter[TKey] extends
+    | AnyQueryProcedure
+    | AnyRouter
+    ? TKey
+    : never]: TRouter['_def']['record'][TKey] extends AnyRouter
     ? UseProcedureRecord<TRouter['_def']['record'][TKey]>
     : Resolver<TRouter['_def']['record'][TKey]>;
 };

--- a/packages/next/src/app-dir/shared.ts
+++ b/packages/next/src/app-dir/shared.ts
@@ -23,7 +23,7 @@ export type UseProcedureRecord<TRouter extends AnyRouter> = {
     ? TKey
     : never]: TRouter['_def']['record'][TKey] extends AnyRouter
     ? UseProcedureRecord<TRouter['_def']['record'][TKey]>
-    : Resolver<TRouter['_def']['record'][TKey]>;
+    : Resolver<TRouter, TRouter['_def']['record'][TKey]>;
 };
 
 export function createUseProxy<TRouter extends AnyRouter>(
@@ -92,8 +92,11 @@ export interface ActionHandlerDef {
 /**
  * @internal
  */
-export type inferActionDef<TProc extends AnyProcedure> = {
+export type inferActionDef<
+  TRouter extends AnyRouter,
+  TProc extends AnyProcedure,
+> = {
   input: inferHandlerInput<TProc>[0];
   output: TProc['_def']['_output_out'];
-  errorShape: TProc['_def']['_config']['$types']['errorShape'];
+  errorShape: TRouter['_def']['_config']['$types']['errorShape'];
 };

--- a/packages/next/src/app-dir/types.ts
+++ b/packages/next/src/app-dir/types.ts
@@ -5,35 +5,36 @@ import {
   AnyQueryProcedure,
   AnyRouter,
   AnySubscriptionProcedure,
-  ProcedureRouterRecord,
 } from '@trpc/server';
 
-export type DecorateProcedureServer<TProcedure extends AnyProcedure> =
-  TProcedure extends AnyQueryProcedure
-    ? {
-        query: Resolver<TProcedure>;
-        revalidate: (
-          input?: unknown,
-        ) => Promise<
-          { revalidated: false; error: string } | { revalidated: true }
-        >;
-      }
-    : TProcedure extends AnyMutationProcedure
-    ? {
-        mutate: Resolver<TProcedure>;
-      }
-    : TProcedure extends AnySubscriptionProcedure
-    ? {
-        subscribe: Resolver<TProcedure>;
-      }
-    : never;
+export type DecorateProcedureServer<
+  TRouter extends AnyRouter,
+  TProcedure extends AnyProcedure,
+> = TProcedure extends AnyQueryProcedure
+  ? {
+      query: Resolver<TRouter, TProcedure>;
+      revalidate: (
+        input?: unknown,
+      ) => Promise<
+        { revalidated: false; error: string } | { revalidated: true }
+      >;
+    }
+  : TProcedure extends AnyMutationProcedure
+  ? {
+      mutate: Resolver<TRouter, TProcedure>;
+    }
+  : TProcedure extends AnySubscriptionProcedure
+  ? {
+      subscribe: Resolver<TRouter, TProcedure>;
+    }
+  : never;
 
-export type NextAppDirDecoratedProcedureRecord<
-  TProcedures extends ProcedureRouterRecord,
-> = {
-  [TKey in keyof TProcedures]: TProcedures[TKey] extends AnyRouter
-    ? NextAppDirDecoratedProcedureRecord<TProcedures[TKey]['_def']['record']>
-    : TProcedures[TKey] extends AnyProcedure
-    ? DecorateProcedureServer<TProcedures[TKey]>
+export type NextAppDirDecoratedProcedureRecord<TRouter extends AnyRouter> = {
+  [TKey in keyof TRouter['_def']['record']]: TRouter['_def']['record'][TKey] extends AnyRouter
+    ? NextAppDirDecoratedProcedureRecord<
+        TRouter['_def']['record'][TKey]['_def']['record']
+      >
+    : TRouter['_def']['record'][TKey] extends AnyProcedure
+    ? DecorateProcedureServer<TRouter, TRouter['_def']['record'][TKey]>
     : never;
 };

--- a/packages/next/src/createTRPCNext.tsx
+++ b/packages/next/src/createTRPCNext.tsx
@@ -35,7 +35,7 @@ export type CreateTRPCNext<
   TFlags,
 > = ProtectedIntersection<
   CreateTRPCNextBase<TRouter, TSSRContext>,
-  DecoratedProcedureRecord<TRouter['_def']['record'], TFlags>
+  DecoratedProcedureRecord<TRouter, TFlags>
 >;
 
 export function createTRPCNext<

--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -7,7 +7,6 @@ import {
   AnyRouter,
   AnySubscriptionProcedure,
   inferProcedureInput,
-  ProcedureRouterRecord,
   ProtectedIntersection,
 } from '@trpc/server';
 import {
@@ -48,11 +47,15 @@ import { CreateTRPCReactOptions } from './shared/types';
  * @internal
  */
 export interface ProcedureUseQuery<
+  TRouter extends AnyRouter,
   TProcedure extends AnyProcedure,
   TPath extends string,
 > {
   <
-    TQueryFnData extends inferTransformedProcedureOutput<TProcedure> = inferTransformedProcedureOutput<TProcedure>,
+    TQueryFnData extends inferTransformedProcedureOutput<
+      TRouter,
+      TProcedure
+    > = inferTransformedProcedureOutput<TRouter, TProcedure>,
     TData = TQueryFnData,
   >(
     input: inferProcedureInput<TProcedure>,
@@ -61,13 +64,16 @@ export interface ProcedureUseQuery<
       inferProcedureInput<TProcedure>,
       TQueryFnData,
       TData,
-      TRPCClientErrorLike<TProcedure>,
-      inferTransformedProcedureOutput<TProcedure>
+      TRPCClientErrorLike<TRouter>,
+      inferTransformedProcedureOutput<TRouter, TProcedure>
     >,
-  ): DefinedUseTRPCQueryResult<TData, TRPCClientErrorLike<TProcedure>>;
+  ): DefinedUseTRPCQueryResult<TData, TRPCClientErrorLike<TRouter>>;
 
   <
-    TQueryFnData extends inferTransformedProcedureOutput<TProcedure> = inferTransformedProcedureOutput<TProcedure>,
+    TQueryFnData extends inferTransformedProcedureOutput<
+      TRouter,
+      TProcedure
+    > = inferTransformedProcedureOutput<TRouter, TProcedure>,
     TData = TQueryFnData,
   >(
     input: inferProcedureInput<TProcedure>,
@@ -76,16 +82,17 @@ export interface ProcedureUseQuery<
       inferProcedureInput<TProcedure>,
       TQueryFnData,
       TData,
-      TRPCClientErrorLike<TProcedure>,
-      inferTransformedProcedureOutput<TProcedure>
+      TRPCClientErrorLike<TRouter>,
+      inferTransformedProcedureOutput<TRouter, TProcedure>
     >,
-  ): UseTRPCQueryResult<TData, TRPCClientErrorLike<TProcedure>>;
+  ): UseTRPCQueryResult<TData, TRPCClientErrorLike<TRouter>>;
 }
 
 /**
  * @internal
  */
 export type DecorateProcedure<
+  TRouter extends AnyRouter,
   TProcedure extends AnyProcedure,
   _TFlags,
   TPath extends string,
@@ -100,12 +107,12 @@ export type DecorateProcedure<
             opts?: UseTRPCInfiniteQueryOptions<
               TPath,
               inferProcedureInput<TProcedure>,
-              inferTransformedProcedureOutput<TProcedure>,
-              TRPCClientErrorLike<TProcedure>
+              inferTransformedProcedureOutput<TRouter, TProcedure>,
+              TRPCClientErrorLike<TRouter>
             >,
           ) => UseTRPCInfiniteQueryResult<
-            inferTransformedProcedureOutput<TProcedure>,
-            TRPCClientErrorLike<TProcedure>
+            inferTransformedProcedureOutput<TRouter, TProcedure>,
+            TRPCClientErrorLike<TRouter>
           >;
           /**
            * @see https://trpc.io/docs/client/react/suspense
@@ -116,16 +123,16 @@ export type DecorateProcedure<
               UseTRPCInfiniteQueryOptions<
                 TPath,
                 inferProcedureInput<TProcedure>,
-                inferTransformedProcedureOutput<TProcedure>,
-                TRPCClientErrorLike<TProcedure>
+                inferTransformedProcedureOutput<TRouter, TProcedure>,
+                TRPCClientErrorLike<TRouter>
               >,
               'enabled' | 'suspense'
             >,
           ) => [
-            InfiniteData<inferTransformedProcedureOutput<TProcedure>>,
+            InfiniteData<inferTransformedProcedureOutput<TRouter, TProcedure>>,
             UseTRPCInfiniteQuerySuccessResult<
-              inferTransformedProcedureOutput<TProcedure>,
-              TRPCClientErrorLike<TProcedure>
+              inferTransformedProcedureOutput<TRouter, TProcedure>,
+              TRPCClientErrorLike<TRouter>
             >,
           ];
         }
@@ -133,12 +140,15 @@ export type DecorateProcedure<
       /**
        * @see https://trpc.io/docs/client/react/useQuery
        */
-      useQuery: ProcedureUseQuery<TProcedure, TPath>;
+      useQuery: ProcedureUseQuery<TRouter, TProcedure, TPath>;
       /**
        * @see https://trpc.io/docs/client/react/suspense#usesuspensequery
        */
       useSuspenseQuery: <
-        TQueryFnData extends inferTransformedProcedureOutput<TProcedure> = inferTransformedProcedureOutput<TProcedure>,
+        TQueryFnData extends inferTransformedProcedureOutput<
+          TRouter,
+          TProcedure
+        > = inferTransformedProcedureOutput<TRouter, TProcedure>,
         TData = TQueryFnData,
       >(
         input: inferProcedureInput<TProcedure>,
@@ -148,13 +158,13 @@ export type DecorateProcedure<
             inferProcedureInput<TProcedure>,
             TQueryFnData,
             TData,
-            TRPCClientErrorLike<TProcedure>
+            TRPCClientErrorLike<TRouter>
           >,
           'enabled' | 'suspense'
         >,
       ) => [
         TData,
-        UseTRPCQuerySuccessResult<TData, TRPCClientErrorLike<TProcedure>>,
+        UseTRPCQuerySuccessResult<TData, TRPCClientErrorLike<TRouter>>,
       ];
     }
   : TProcedure extends AnyMutationProcedure
@@ -165,13 +175,13 @@ export type DecorateProcedure<
       useMutation: <TContext = unknown>(
         opts?: UseTRPCMutationOptions<
           inferProcedureInput<TProcedure>,
-          TRPCClientErrorLike<TProcedure>,
-          inferTransformedProcedureOutput<TProcedure>,
+          TRPCClientErrorLike<TRouter>,
+          inferTransformedProcedureOutput<TRouter, TProcedure>,
           TContext
         >,
       ) => UseTRPCMutationResult<
-        inferTransformedProcedureOutput<TProcedure>,
-        TRPCClientErrorLike<TProcedure>,
+        inferTransformedProcedureOutput<TRouter, TProcedure>,
+        TRPCClientErrorLike<TRouter>,
         inferProcedureInput<TProcedure>,
         TContext
       >;
@@ -184,8 +194,8 @@ export type DecorateProcedure<
       useSubscription: (
         input: inferProcedureInput<TProcedure>,
         opts?: UseTRPCSubscriptionOptions<
-          inferTransformedSubscriptionOutput<TProcedure>,
-          TRPCClientErrorLike<TProcedure>
+          inferTransformedSubscriptionOutput<TRouter, TProcedure>,
+          TRPCClientErrorLike<TRouter>
         >,
       ) => void;
     }
@@ -195,18 +205,23 @@ export type DecorateProcedure<
  * @internal
  */
 export type DecoratedProcedureRecord<
-  TProcedures extends ProcedureRouterRecord,
+  TRouter extends AnyRouter,
   TFlags,
   TPath extends string = '',
 > = {
-  [TKey in keyof TProcedures]: TProcedures[TKey] extends AnyRouter
+  [TKey in keyof TRouter['_def']['record']]: TRouter['_def']['record'][TKey] extends AnyRouter
     ? DecoratedProcedureRecord<
-        TProcedures[TKey]['_def']['record'],
+        TRouter['_def']['record'][TKey],
         TFlags,
         `${TPath}${TKey & string}.`
       >
-    : TProcedures[TKey] extends AnyProcedure
-    ? DecorateProcedure<TProcedures[TKey], TFlags, `${TPath}${TKey & string}`>
+    : TRouter['_def']['record'][TKey] extends AnyProcedure
+    ? DecorateProcedure<
+        TRouter,
+        TRouter['_def']['record'][TKey],
+        TFlags,
+        `${TPath}${TKey & string}`
+      >
     : never;
 };
 
@@ -230,7 +245,7 @@ export type CreateTRPCReact<
   TFlags,
 > = ProtectedIntersection<
   CreateTRPCReactBase<TRouter, TSSRContext>,
-  DecoratedProcedureRecord<TRouter['_def']['record'], TFlags>
+  DecoratedProcedureRecord<TRouter, TFlags>
 >;
 
 /**

--- a/packages/react-query/src/internals/getQueryKey.ts
+++ b/packages/react-query/src/internals/getQueryKey.ts
@@ -74,18 +74,32 @@ type GetParams<
   TFlags,
 > = TProcedureOrRouter extends AnyQueryProcedure
   ? [
-      procedureOrRouter: DecorateProcedure<TProcedureOrRouter, TFlags, TPath>,
+      procedureOrRouter: DecorateProcedure<
+        AnyRouter,
+        TProcedureOrRouter,
+        TFlags,
+        TPath
+      >,
       ..._params: GetQueryParams<TProcedureOrRouter>,
     ]
   : TProcedureOrRouter extends AnyMutationProcedure
-  ? [procedureOrRouter: DecorateProcedure<TProcedureOrRouter, TFlags, TPath>]
-  : [
+  ? [
+      procedureOrRouter: DecorateProcedure<
+        AnyRouter,
+        TProcedureOrRouter,
+        TFlags,
+        TPath
+      >,
+    ]
+  : TProcedureOrRouter extends AnyRouter
+  ? [
       procedureOrRouter: DecoratedProcedureRecord<
-        TProcedureOrRouter['_def']['record'],
+        TProcedureOrRouter,
         TFlags,
         any
       >,
-    ];
+    ]
+  : never;
 
 type GetQueryKeyParams<
   TProcedureOrRouter extends

--- a/packages/react-query/src/server/ssgProxy.ts
+++ b/packages/react-query/src/server/ssgProxy.ts
@@ -16,7 +16,6 @@ import {
   AnyRouter,
   callProcedure,
   ClientDataTransformerOptions,
-  Filter,
   inferHandlerInput,
   inferRouterContext,
   ProtectedIntersection,
@@ -77,10 +76,11 @@ type DecorateProcedure<TProcedure extends AnyProcedure> = {
  * @internal
  */
 type DecoratedProcedureSSGRecord<TRouter extends AnyRouter> = {
-  [TKey in keyof Filter<
-    TRouter['_def']['record'],
-    AnyQueryProcedure | AnyRouter
-  >]: TRouter['_def']['record'][TKey] extends AnyRouter
+  [TKey in keyof TRouter['_def']['record'] as TRouter[TKey] extends
+    | AnyQueryProcedure
+    | AnyRouter
+    ? TKey
+    : never]: TRouter['_def']['record'][TKey] extends AnyRouter
     ? DecoratedProcedureSSGRecord<TRouter['_def']['record'][TKey]>
     : // utils only apply to queries
       DecorateProcedure<TRouter['_def']['record'][TKey]>;

--- a/packages/react-query/src/server/ssgProxy.ts
+++ b/packages/react-query/src/server/ssgProxy.ts
@@ -46,20 +46,25 @@ type CreateServerSideHelpersOptions<TRouter extends AnyRouter> =
   CreateTRPCReactQueryClientConfig &
     (CreateSSGHelpersExternal<TRouter> | CreateSSGHelpersInternal<TRouter>);
 
-type DecorateProcedure<TProcedure extends AnyProcedure> = {
+type DecorateProcedure<
+  TRouter extends AnyRouter,
+  TProcedure extends AnyProcedure,
+> = {
   /**
    * @link https://tanstack.com/query/v4/docs/react/guides/prefetching
    */
   fetch(
     ...args: inferHandlerInput<TProcedure>
-  ): Promise<inferTransformedProcedureOutput<TProcedure>>;
+  ): Promise<inferTransformedProcedureOutput<TRouter, TProcedure>>;
 
   /**
    * @link https://tanstack.com/query/v4/docs/react/guides/prefetching
    */
   fetchInfinite(
     ...args: inferHandlerInput<TProcedure>
-  ): Promise<InfiniteData<inferTransformedProcedureOutput<TProcedure>>>;
+  ): Promise<
+    InfiniteData<inferTransformedProcedureOutput<TRouter, TProcedure>>
+  >;
 
   /**
    * @link https://tanstack.com/query/v4/docs/react/guides/prefetching
@@ -83,10 +88,10 @@ type DecoratedProcedureSSGRecord<TRouter extends AnyRouter> = {
     : never]: TRouter['_def']['record'][TKey] extends AnyRouter
     ? DecoratedProcedureSSGRecord<TRouter['_def']['record'][TKey]>
     : // utils only apply to queries
-      DecorateProcedure<TRouter['_def']['record'][TKey]>;
+      DecorateProcedure<TRouter, TRouter['_def']['record'][TKey]>;
 };
 
-type AnyDecoratedProcedure = DecorateProcedure<any>;
+type AnyDecoratedProcedure = DecorateProcedure<any, any>;
 
 /**
  * Create functions you can use for server-side rendering / static generation

--- a/packages/react-query/src/shared/polymorphism/mutationLike.ts
+++ b/packages/react-query/src/shared/polymorphism/mutationLike.ts
@@ -1,4 +1,4 @@
-import { AnyProcedure, inferProcedureInput } from '@trpc/server';
+import { AnyProcedure, AnyRouter, inferProcedureInput } from '@trpc/server';
 import { inferTransformedProcedureOutput } from '@trpc/server/shared';
 import {
   InferMutationOptions,
@@ -8,24 +8,31 @@ import {
 /**
  * Use to describe a mutation route which matches a given mutation procedure's interface
  */
-export type MutationLike<TProcedure extends AnyProcedure = AnyProcedure> = {
+export type MutationLike<
+  TRouter extends AnyRouter,
+  TProcedure extends AnyProcedure = AnyProcedure,
+> = {
   useMutation: (
-    opts?: InferMutationOptions<TProcedure>,
-  ) => InferMutationResult<TProcedure>;
+    opts?: InferMutationOptions<TRouter, TProcedure>,
+  ) => InferMutationResult<TRouter, TProcedure>;
 };
 
 /**
  * Use to unwrap a MutationLike's input
  */
-export type InferMutationLikeInput<TMutationLike extends MutationLike> =
-  TMutationLike extends MutationLike<infer TProcedure>
-    ? inferProcedureInput<TProcedure>
-    : never;
+export type InferMutationLikeInput<
+  TRouter extends AnyRouter,
+  TMutationLike extends MutationLike<TRouter>,
+> = TMutationLike extends MutationLike<any, infer TProcedure>
+  ? inferProcedureInput<TProcedure>
+  : never;
 
 /**
  * Use to unwrap a MutationLike's data output
  */
-export type InferMutationLikeData<TMutationLike extends MutationLike> =
-  TMutationLike extends MutationLike<infer TProcedure>
-    ? inferTransformedProcedureOutput<TProcedure>
-    : never;
+export type InferMutationLikeData<
+  TRouter extends AnyRouter,
+  TMutationLike extends MutationLike<TRouter>,
+> = TMutationLike extends MutationLike<any, infer TProcedure>
+  ? inferTransformedProcedureOutput<TRouter, TProcedure>
+  : never;

--- a/packages/react-query/src/shared/polymorphism/queryLike.ts
+++ b/packages/react-query/src/shared/polymorphism/queryLike.ts
@@ -1,4 +1,4 @@
-import { AnyProcedure, inferProcedureInput } from '@trpc/server';
+import { AnyProcedure, AnyRouter, inferProcedureInput } from '@trpc/server';
 import { inferTransformedProcedureOutput } from '@trpc/server/shared';
 import {
   InferQueryOptions,
@@ -8,25 +8,32 @@ import {
 /**
  * Use to request a query route which matches a given query procedure's interface
  */
-export type QueryLike<TProcedure extends AnyProcedure = AnyProcedure> = {
+export type QueryLike<
+  TRouter extends AnyRouter,
+  TProcedure extends AnyProcedure = AnyProcedure,
+> = {
   useQuery: (
     variables: inferProcedureInput<TProcedure>,
-    opts?: InferQueryOptions<TProcedure, any, any>,
-  ) => InferQueryResult<TProcedure>;
+    opts?: InferQueryOptions<TRouter, TProcedure, any, any>,
+  ) => InferQueryResult<TRouter, TProcedure>;
 };
 
 /**
  * Use to unwrap a QueryLike's input
  */
-export type InferQueryLikeInput<TQueryLike extends QueryLike> =
-  TQueryLike extends QueryLike<infer TProcedure>
-    ? inferProcedureInput<TProcedure>
-    : never;
+export type InferQueryLikeInput<
+  TRouter extends AnyRouter,
+  TQueryLike extends QueryLike<TRouter>,
+> = TQueryLike extends QueryLike<any, infer TProcedure>
+  ? inferProcedureInput<TProcedure>
+  : never;
 
 /**
  * Use to unwrap a QueryLike's data output
  */
-export type InferQueryLikeData<TQueryLike extends QueryLike> =
-  TQueryLike extends QueryLike<infer TProcedure>
-    ? inferTransformedProcedureOutput<TProcedure>
-    : never;
+export type InferQueryLikeData<
+  TRouter extends AnyRouter,
+  TQueryLike extends QueryLike<TRouter>,
+> = TQueryLike extends QueryLike<any, infer TProcedure>
+  ? inferTransformedProcedureOutput<TRouter, TProcedure>
+  : never;

--- a/packages/react-query/src/shared/proxy/useQueriesProxy.ts
+++ b/packages/react-query/src/shared/proxy/useQueriesProxy.ts
@@ -4,7 +4,6 @@ import {
   AnyProcedure,
   AnyQueryProcedure,
   AnyRouter,
-  Filter,
   inferProcedureInput,
 } from '@trpc/server';
 import {
@@ -40,10 +39,11 @@ export type UseQueriesProcedureRecord<
   TRouter extends AnyRouter,
   TPath extends string = '',
 > = {
-  [TKey in keyof Filter<
-    TRouter['_def']['record'],
-    AnyQueryProcedure | AnyRouter
-  >]: TRouter['_def']['record'][TKey] extends AnyRouter
+  [TKey in keyof TRouter['_def']['record'] as TRouter[TKey] extends
+    | AnyQueryProcedure
+    | AnyRouter
+    ? TKey
+    : never]: TRouter['_def']['record'][TKey] extends AnyRouter
     ? UseQueriesProcedureRecord<
         TRouter['_def']['record'][TKey],
         `${TPath}${TKey & string}.`

--- a/packages/react-query/src/shared/proxy/useQueriesProxy.ts
+++ b/packages/react-query/src/shared/proxy/useQueriesProxy.ts
@@ -13,23 +13,25 @@ import {
 import { getQueryKeyInternal } from '../../internals/getQueryKey';
 import { TrpcQueryOptionsForUseQueries } from '../../internals/useQueries';
 
-type GetQueryOptions<TProcedure extends AnyProcedure, TPath extends string> = <
-  TData = inferTransformedProcedureOutput<TProcedure>,
->(
+type GetQueryOptions<
+  TRouter extends AnyRouter,
+  TProcedure extends AnyProcedure,
+  TPath extends string,
+> = <TData = inferTransformedProcedureOutput<TRouter, TProcedure>>(
   input: inferProcedureInput<TProcedure>,
   opts?: TrpcQueryOptionsForUseQueries<
     TPath,
     inferProcedureInput<TProcedure>,
-    inferTransformedProcedureOutput<TProcedure>,
+    inferTransformedProcedureOutput<TRouter, TProcedure>,
     TData,
-    TRPCClientError<TProcedure>
+    TRPCClientError<TRouter>
   >,
 ) => TrpcQueryOptionsForUseQueries<
   TPath,
   inferProcedureInput<TProcedure>,
-  inferTransformedProcedureOutput<TProcedure>,
+  inferTransformedProcedureOutput<TRouter, TProcedure>,
   TData,
-  TRPCClientError<TProcedure>
+  TRPCClientError<TRouter>
 >;
 
 /**
@@ -49,6 +51,7 @@ export type UseQueriesProcedureRecord<
         `${TPath}${TKey & string}.`
       >
     : GetQueryOptions<
+        TRouter,
         TRouter['_def']['record'][TKey],
         `${TPath}${TKey & string}`
       >;

--- a/packages/react-query/src/shared/proxy/utilsProxy.ts
+++ b/packages/react-query/src/shared/proxy/utilsProxy.ts
@@ -15,7 +15,6 @@ import {
   AnyQueryProcedure,
   AnyRouter,
   DeepPartial,
-  Filter,
   inferProcedureInput,
   ProtectedIntersection,
 } from '@trpc/server';
@@ -210,10 +209,11 @@ type DecorateRouter = {
  */
 export type DecoratedProcedureUtilsRecord<TRouter extends AnyRouter> =
   DecorateRouter & {
-    [TKey in keyof Filter<
-      TRouter['_def']['record'],
-      AnyQueryProcedure | AnyRouter
-    >]: TRouter['_def']['record'][TKey] extends AnyRouter
+    [TKey in keyof TRouter['_def']['record'] as TRouter[TKey] extends
+      | AnyQueryProcedure
+      | AnyRouter
+      ? TKey
+      : never]: TRouter['_def']['record'][TKey] extends AnyRouter
       ? DecoratedProcedureUtilsRecord<TRouter['_def']['record'][TKey]> &
           DecorateRouter
       : // utils only apply to queries

--- a/packages/react-query/src/shared/proxy/utilsProxy.ts
+++ b/packages/react-query/src/shared/proxy/utilsProxy.ts
@@ -36,7 +36,10 @@ import {
   QueryType,
 } from '../../internals/getQueryKey';
 
-type DecorateProcedure<TProcedure extends AnyQueryProcedure> = {
+type DecorateProcedure<
+  TRouter extends AnyRouter,
+  TProcedure extends AnyQueryProcedure,
+> = {
   /**
    * @link https://tanstack.com/query/v4/docs/reference/QueryClient#queryclientfetchquery
    */
@@ -44,10 +47,10 @@ type DecorateProcedure<TProcedure extends AnyQueryProcedure> = {
     input: inferProcedureInput<TProcedure>,
     opts?: TRPCFetchQueryOptions<
       inferProcedureInput<TProcedure>,
-      TRPCClientError<TProcedure>,
-      inferTransformedProcedureOutput<TProcedure>
+      TRPCClientError<TRouter>,
+      inferTransformedProcedureOutput<TRouter, TProcedure>
     >,
-  ): Promise<inferTransformedProcedureOutput<TProcedure>>;
+  ): Promise<inferTransformedProcedureOutput<TRouter, TProcedure>>;
 
   /**
    * @link https://tanstack.com/query/v4/docs/reference/QueryClient#queryclientfetchinfinitequery
@@ -56,10 +59,12 @@ type DecorateProcedure<TProcedure extends AnyQueryProcedure> = {
     input: inferProcedureInput<TProcedure>,
     opts?: TRPCFetchInfiniteQueryOptions<
       inferProcedureInput<TProcedure>,
-      TRPCClientError<TProcedure>,
-      inferTransformedProcedureOutput<TProcedure>
+      TRPCClientError<TRouter>,
+      inferTransformedProcedureOutput<TRouter, TProcedure>
     >,
-  ): Promise<InfiniteData<inferTransformedProcedureOutput<TProcedure>>>;
+  ): Promise<
+    InfiniteData<inferTransformedProcedureOutput<TRouter, TProcedure>>
+  >;
 
   /**
    * @link https://tanstack.com/query/v4/docs/reference/QueryClient#queryclientprefetchquery
@@ -68,8 +73,8 @@ type DecorateProcedure<TProcedure extends AnyQueryProcedure> = {
     input: inferProcedureInput<TProcedure>,
     opts?: TRPCFetchQueryOptions<
       inferProcedureInput<TProcedure>,
-      TRPCClientError<TProcedure>,
-      inferTransformedProcedureOutput<TProcedure>
+      TRPCClientError<TRouter>,
+      inferTransformedProcedureOutput<TRouter, TProcedure>
     >,
   ): Promise<void>;
 
@@ -80,8 +85,8 @@ type DecorateProcedure<TProcedure extends AnyQueryProcedure> = {
     input: inferProcedureInput<TProcedure>,
     opts?: TRPCFetchInfiniteQueryOptions<
       inferProcedureInput<TProcedure>,
-      TRPCClientError<TProcedure>,
-      inferTransformedProcedureOutput<TProcedure>
+      TRPCClientError<TRouter>,
+      inferTransformedProcedureOutput<TRouter, TProcedure>
     >,
   ): Promise<void>;
 
@@ -92,10 +97,10 @@ type DecorateProcedure<TProcedure extends AnyQueryProcedure> = {
     input: inferProcedureInput<TProcedure>,
     opts?: TRPCFetchQueryOptions<
       inferProcedureInput<TProcedure>,
-      TRPCClientError<TProcedure>,
-      inferTransformedProcedureOutput<TProcedure>
+      TRPCClientError<TRouter>,
+      inferTransformedProcedureOutput<TRouter, TProcedure>
     >,
-  ): Promise<inferTransformedProcedureOutput<TProcedure>>;
+  ): Promise<inferTransformedProcedureOutput<TRouter, TProcedure>>;
 
   /**
    * @link https://tanstack.com/query/v4/docs/reference/QueryClient#queryclientinvalidatequeries
@@ -106,7 +111,7 @@ type DecorateProcedure<TProcedure extends AnyQueryProcedure> = {
       predicate?: (
         query: Query<
           inferProcedureInput<TProcedure>,
-          TRPCClientError<TProcedure>,
+          TRPCClientError<TRouter>,
           inferProcedureInput<TProcedure>,
           QueryKeyKnown<
             inferProcedureInput<TProcedure>,
@@ -154,8 +159,8 @@ type DecorateProcedure<TProcedure extends AnyQueryProcedure> = {
      */
     input: inferProcedureInput<TProcedure>,
     updater: Updater<
-      inferTransformedProcedureOutput<TProcedure> | undefined,
-      inferTransformedProcedureOutput<TProcedure> | undefined
+      inferTransformedProcedureOutput<TRouter, TProcedure> | undefined,
+      inferTransformedProcedureOutput<TRouter, TProcedure> | undefined
     >,
     options?: SetDataOptions,
   ): void;
@@ -166,8 +171,10 @@ type DecorateProcedure<TProcedure extends AnyQueryProcedure> = {
   setInfiniteData(
     input: inferProcedureInput<TProcedure>,
     updater: Updater<
-      InfiniteData<inferTransformedProcedureOutput<TProcedure>> | undefined,
-      InfiniteData<inferTransformedProcedureOutput<TProcedure>> | undefined
+      | InfiniteData<inferTransformedProcedureOutput<TRouter, TProcedure>>
+      | undefined,
+      | InfiniteData<inferTransformedProcedureOutput<TRouter, TProcedure>>
+      | undefined
     >,
     options?: SetDataOptions,
   ): void;
@@ -177,14 +184,16 @@ type DecorateProcedure<TProcedure extends AnyQueryProcedure> = {
    */
   getData(
     input?: inferProcedureInput<TProcedure>,
-  ): inferTransformedProcedureOutput<TProcedure> | undefined;
+  ): inferTransformedProcedureOutput<TRouter, TProcedure> | undefined;
 
   /**
    * @link https://tanstack.com/query/v4/docs/reference/QueryClient#queryclientgetquerydata
    */
   getInfiniteData(
     input?: inferProcedureInput<TProcedure>,
-  ): InfiniteData<inferTransformedProcedureOutput<TProcedure>> | undefined;
+  ):
+    | InfiniteData<inferTransformedProcedureOutput<TRouter, TProcedure>>
+    | undefined;
 };
 
 /**
@@ -217,10 +226,10 @@ export type DecoratedProcedureUtilsRecord<TRouter extends AnyRouter> =
       ? DecoratedProcedureUtilsRecord<TRouter['_def']['record'][TKey]> &
           DecorateRouter
       : // utils only apply to queries
-        DecorateProcedure<TRouter['_def']['record'][TKey]>;
+        DecorateProcedure<TRouter, TRouter['_def']['record'][TKey]>;
   }; // Add functions that should be available at utils root
 
-type AnyDecoratedProcedure = DecorateProcedure<any>;
+type AnyDecoratedProcedure = DecorateProcedure<any, any>;
 
 export type CreateReactUtilsProxy<
   TRouter extends AnyRouter,

--- a/packages/react-query/src/utils/inferReactQueryProcedure.ts
+++ b/packages/react-query/src/utils/inferReactQueryProcedure.ts
@@ -18,16 +18,17 @@ import {
  * @internal
  */
 export type InferQueryOptions<
+  TRouter extends AnyRouter,
   TProcedure extends AnyProcedure,
   TPath extends string,
-  TData = inferTransformedProcedureOutput<TProcedure>,
+  TData = inferTransformedProcedureOutput<TRouter, TProcedure>,
 > = Omit<
   UseTRPCQueryOptions<
     TPath,
     inferProcedureInput<TProcedure>,
-    inferTransformedProcedureOutput<TProcedure>,
-    inferTransformedProcedureOutput<TProcedure>,
-    TRPCClientErrorLike<TProcedure>,
+    inferTransformedProcedureOutput<TRouter, TProcedure>,
+    inferTransformedProcedureOutput<TRouter, TProcedure>,
+    TRPCClientErrorLike<TRouter>,
     TData
   >,
   'select'
@@ -36,31 +37,36 @@ export type InferQueryOptions<
 /**
  * @internal
  */
-export type InferMutationOptions<TProcedure extends AnyProcedure> =
-  UseTRPCMutationOptions<
-    inferProcedureInput<TProcedure>,
-    TRPCClientErrorLike<TProcedure>,
-    inferTransformedProcedureOutput<TProcedure>
-  >;
+export type InferMutationOptions<
+  TRouter extends AnyRouter,
+  TProcedure extends AnyProcedure,
+> = UseTRPCMutationOptions<
+  inferProcedureInput<TProcedure>,
+  TRPCClientErrorLike<TRouter>,
+  inferTransformedProcedureOutput<TRouter, TProcedure>
+>;
 
 /**
  * @internal
  */
-export type InferQueryResult<TProcedure extends AnyProcedure> =
-  UseTRPCQueryResult<
-    inferTransformedProcedureOutput<TProcedure>,
-    TRPCClientErrorLike<TProcedure>
-  >;
+export type InferQueryResult<
+  TRouter extends AnyRouter,
+  TProcedure extends AnyProcedure,
+> = UseTRPCQueryResult<
+  inferTransformedProcedureOutput<TRouter, TProcedure>,
+  TRPCClientErrorLike<TRouter>
+>;
 
 /**
  * @internal
  */
 export type InferMutationResult<
+  TRouter extends AnyRouter,
   TProcedure extends AnyProcedure,
   TContext = unknown,
 > = UseTRPCMutationResult<
-  inferTransformedProcedureOutput<TProcedure>,
-  TRPCClientErrorLike<TProcedure>,
+  inferTransformedProcedureOutput<TRouter, TProcedure>,
+  TRPCClientErrorLike<TRouter>,
   inferProcedureInput<TProcedure>,
   TContext
 >;
@@ -76,9 +82,13 @@ export type inferReactQueryProcedureOptions<
           `${TPath}${TKey & string}.`
         >
       : TRouterOrProcedure extends AnyMutationProcedure
-      ? InferMutationOptions<TRouterOrProcedure>
+      ? InferMutationOptions<TRouter, TRouterOrProcedure>
       : TRouterOrProcedure extends AnyQueryProcedure
-      ? InferQueryOptions<TRouterOrProcedure, `${TPath}${TKey & string}`>
+      ? InferQueryOptions<
+          TRouter,
+          TRouterOrProcedure,
+          `${TPath}${TKey & string}`
+        >
       : never
     : never;
 };

--- a/packages/server/src/core/index.ts
+++ b/packages/server/src/core/index.ts
@@ -12,7 +12,6 @@ export type {
   AnyQueryProcedure,
   AnyMutationProcedure,
   AnySubscriptionProcedure,
-  AnyProcedureParams,
   ProcedureParams,
   ProcedureArgs,
   ProcedureOptions,

--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -11,11 +11,11 @@ import { inferParser, Parser } from '../parser';
 import {
   AnyMutationProcedure,
   AnyProcedure,
-  AnyProcedureParams,
   AnyQueryProcedure,
   AnySubscriptionProcedure,
   Procedure,
   ProcedureParams,
+  RootParams,
 } from '../procedure';
 import { ProcedureType } from '../types';
 import { AnyRootConfig } from './config';
@@ -31,8 +31,8 @@ import {
 } from './utils';
 
 type CreateProcedureReturnInput<
-  TPrev extends ProcedureParams<AnyProcedureParams>,
-  TNext extends ProcedureParams<AnyProcedureParams>,
+  TPrev extends RootParams,
+  TNext extends ProcedureParams,
 > = ProcedureBuilder<{
   _config: TPrev['_config'];
   _meta: TPrev['_meta'];
@@ -48,7 +48,7 @@ type CreateProcedureReturnInput<
  */
 export interface BuildProcedure<
   TType extends ProcedureType,
-  TParams extends ProcedureParams<AnyProcedureParams>,
+  TParams extends ProcedureParams,
   TOutput,
 > extends Procedure<
     TType,
@@ -69,9 +69,7 @@ type OverwriteIfDefined<TType, TWith> = UnsetMarker extends TType
 
 type ErrorMessage<TMessage extends string> = TMessage;
 
-export type ProcedureBuilderDef<
-  TParams extends ProcedureParams<AnyProcedureParams>,
-> = {
+export type ProcedureBuilderDef<TParams extends ProcedureParams> = {
   inputs: Parser[];
   output?: Parser;
   meta?: TParams['_meta'];
@@ -84,9 +82,7 @@ export type ProcedureBuilderDef<
 
 export type AnyProcedureBuilderDef = ProcedureBuilderDef<any>;
 
-export interface ProcedureBuilder<
-  TParams extends ProcedureParams<AnyProcedureParams>,
-> {
+export interface ProcedureBuilder<TParams extends RootParams> {
   /**
    * Add an input parser to the procedure.
    */
@@ -139,7 +135,7 @@ export interface ProcedureBuilder<
   /**
    * Add a middleware to the procedure.
    */
-  use<$Params extends ProcedureParams<AnyProcedureParams>>(
+  use<$Params extends ProcedureParams>(
     fn:
       | MiddlewareBuilder<TParams, $Params>
       | MiddlewareFunction<TParams, $Params>,

--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -171,6 +171,9 @@ export interface ProcedureBuilder<TParams extends RootParams> {
    */
   _def: ProcedureBuilderDef<TParams>;
 }
+export type inferProcedureBuilderParams<
+  TProcedureBuilder extends ProcedureBuilder<any>,
+> = TProcedureBuilder extends ProcedureBuilder<infer TParams> ? TParams : never;
 
 type AnyProcedureBuilder = ProcedureBuilder<any>;
 

--- a/packages/server/src/core/internals/utils.ts
+++ b/packages/server/src/core/internals/utils.ts
@@ -1,5 +1,5 @@
 import { Simplify } from '../../types';
-import { AnyProcedureParams, ProcedureParams } from '../procedure';
+import { RootParams } from '../procedure';
 
 /**
  * @internal
@@ -52,9 +52,7 @@ export type UnsetMarker = typeof unsetMarker;
 /**
  * @internal
  */
-export interface ResolveOptions<
-  TParams extends ProcedureParams<AnyProcedureParams>,
-> {
+export interface ResolveOptions<TParams extends RootParams> {
   ctx: Simplify<
     Overwrite<TParams['_config']['$types']['ctx'], TParams['_ctx_out']>
   >;

--- a/packages/server/src/core/procedure.ts
+++ b/packages/server/src/core/procedure.ts
@@ -63,7 +63,10 @@ export interface Procedure<
   TParams extends ProcedureParams,
 > {
   _type: TType;
-  _def: ProcedureBuilderDef<TParams> & TParams;
+  _def: ProcedureBuilderDef<TParams> & {
+    _input_in: TParams['_input_in'];
+    _output_out: TParams['_output_out'];
+  };
   _procedure: true;
   /**
    * @internal

--- a/packages/server/src/core/procedure.ts
+++ b/packages/server/src/core/procedure.ts
@@ -47,7 +47,7 @@ export interface RootParams extends ProcedureParams {
 /**
  * @internal
  */
-export type ProcedureArgs<TParams extends ProcedureParams> =
+export type ProcedureArgs<TParams extends BuiltProcedureParams> =
   TParams['_input_in'] extends UnsetMarker
     ? [input?: undefined | void, opts?: ProcedureOptions]
     : undefined extends TParams['_input_in']

--- a/packages/server/src/core/procedure.ts
+++ b/packages/server/src/core/procedure.ts
@@ -22,25 +22,32 @@ export interface ProcedureOptions {
 /**
  * @internal
  */
-export type AnyProcedureParams = {
-  _config: AnyRootConfig;
+export interface BuiltProcedureParams {
+  _input_in: unknown;
+  _output_out: unknown;
+}
+
+/**
+ * @internal
+ */
+export interface ProcedureParams extends BuiltProcedureParams {
   _meta: unknown;
   _ctx_out: unknown;
-  _input_in: unknown;
   _input_out: unknown;
   _output_in: unknown;
-  _output_out: unknown;
-};
+}
 
 /**
  * @internal
  */
-export type ProcedureParams<TParams extends AnyProcedureParams> = TParams;
+export interface RootParams extends ProcedureParams {
+  _config: AnyRootConfig;
+}
 
 /**
  * @internal
  */
-export type ProcedureArgs<TParams extends ProcedureParams<AnyProcedureParams>> =
+export type ProcedureArgs<TParams extends ProcedureParams> =
   TParams['_input_in'] extends UnsetMarker
     ? [input?: undefined | void, opts?: ProcedureOptions]
     : undefined extends TParams['_input_in']
@@ -53,7 +60,7 @@ export type ProcedureArgs<TParams extends ProcedureParams<AnyProcedureParams>> =
  */
 export interface Procedure<
   TType extends ProcedureType,
-  TParams extends ProcedureParams<AnyProcedureParams>,
+  TParams extends ProcedureParams,
 > {
   _type: TType;
   _def: ProcedureBuilderDef<TParams> & TParams;

--- a/packages/server/src/core/router.ts
+++ b/packages/server/src/core/router.ts
@@ -216,7 +216,10 @@ export function callProcedure(
 ) {
   const { type, path } = opts;
 
-  if (!(path in opts.procedures) || !opts.procedures[path]?._def[type]) {
+  if (
+    !(path in opts.procedures) ||
+    !(opts.procedures[path] as AnyProcedure)._def[type]
+  ) {
     throw new TRPCError({
       code: 'NOT_FOUND',
       message: `No "${type}"-procedure on path "${path}"`,

--- a/packages/server/src/core/types.ts
+++ b/packages/server/src/core/types.ts
@@ -36,9 +36,6 @@ export type inferProcedureParams<TProcedure> = TProcedure extends AnyProcedure
 export type inferProcedureOutput<TProcedure> =
   inferProcedureParams<TProcedure>['_output_out'];
 
-export type inferProcedureClientError<TProcedure extends AnyProcedure> =
-  inferProcedureParams<TProcedure>['_config']['errorShape'];
-
 type GetInferenceHelpers<
   TType extends 'input' | 'output',
   TRouter extends AnyRouter,
@@ -49,7 +46,7 @@ type GetInferenceHelpers<
       : TRouterOrProcedure extends AnyProcedure
       ? TType extends 'input'
         ? inferProcedureInput<TRouterOrProcedure>
-        : inferTransformedProcedureOutput<TRouterOrProcedure>
+        : inferTransformedProcedureOutput<TRouter, TRouterOrProcedure>
       : never
     : never;
 };

--- a/packages/server/src/shared/jsonify.ts
+++ b/packages/server/src/shared/jsonify.ts
@@ -1,4 +1,4 @@
-import { AnyProcedure } from '../core';
+import { AnyProcedure, AnyRouter } from '../core';
 import { inferObservableValue } from '../observable';
 import { DefaultDataTransformer } from '../transformer';
 import type { Serialize } from './internal/serialize';
@@ -6,13 +6,16 @@ import type { Serialize } from './internal/serialize';
 /**
  * @internal
  */
-export type inferTransformedProcedureOutput<TProcedure extends AnyProcedure> =
-  TProcedure['_def']['_config']['transformer'] extends DefaultDataTransformer
-    ? Serialize<TProcedure['_def']['_output_out']>
-    : TProcedure['_def']['_output_out'];
+export type inferTransformedProcedureOutput<
+  TRouter extends AnyRouter,
+  TProcedure extends AnyProcedure,
+> = TRouter['_def']['_config']['transformer'] extends DefaultDataTransformer
+  ? Serialize<TProcedure['_def']['_output_out']>
+  : TProcedure['_def']['_output_out'];
 
 export type inferTransformedSubscriptionOutput<
+  TRouter extends AnyRouter,
   TProcedure extends AnyProcedure,
-> = TProcedure['_def']['_config']['transformer'] extends DefaultDataTransformer
+> = TRouter['_def']['_config']['transformer'] extends DefaultDataTransformer
   ? Serialize<inferObservableValue<TProcedure['_def']['_output_out']>>
   : inferObservableValue<TProcedure['_def']['_output_out']>;

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -91,14 +91,6 @@ export type FilterKeys<TObj extends object, TFilter> = {
 }[keyof TObj];
 
 /**
- * @internal
- */
-export type Filter<TObj extends object, TFilter> = Pick<
-  TObj,
-  FilterKeys<TObj, TFilter>
->;
-
-/**
  * Unwrap return type if the type is a function (sync or async), else use the type as is
  * @internal
  */

--- a/packages/tests/server/input.test.ts
+++ b/packages/tests/server/input.test.ts
@@ -5,6 +5,7 @@ import {
   inferProcedureParams,
   initTRPC,
 } from '@trpc/server';
+import { inferProcedureBuilderParams } from '@trpc/server/core/internals/procedureBuilder';
 import { UnsetMarker } from '@trpc/server/core/internals/utils';
 import { konn } from 'konn';
 import { z, ZodError } from 'zod';
@@ -302,11 +303,16 @@ test('no input', async () => {
     return input;
   });
 
+  type ProcTypeBeforeResolver = inferProcedureBuilderParams<typeof t.procedure>;
   type ProcType = inferProcedureParams<typeof proc>;
 
   expectTypeOf<ProcType['_input_in']>().toEqualTypeOf<UnsetMarker>();
-  expectTypeOf<ProcType['_input_out']>().toEqualTypeOf<UnsetMarker>();
-  expectTypeOf<ProcType['_output_in']>().toBeUndefined();
+  expectTypeOf<
+    ProcTypeBeforeResolver['_input_out']
+  >().toEqualTypeOf<UnsetMarker>();
+  expectTypeOf<
+    ProcTypeBeforeResolver['_output_in']
+  >().toEqualTypeOf<UnsetMarker>();
   expectTypeOf<ProcType['_output_out']>().toBeUndefined();
 
   const router = t.router({
@@ -323,17 +329,19 @@ test('no input', async () => {
 test('zod default() string', async () => {
   const t = initTRPC.create();
 
-  const proc = t.procedure
-    .input(z.string().default('bar'))
-    .query(({ input }) => {
-      expectTypeOf(input).toBeString();
-      return input;
-    });
+  const procWithInput = t.procedure.input(z.string().default('bar'));
+  const proc = procWithInput.query(({ input }) => {
+    expectTypeOf(input).toBeString();
+    return input;
+  });
 
+  type ProcTypeBeforeResolver = inferProcedureBuilderParams<
+    typeof procWithInput
+  >;
   type ProcType = inferProcedureParams<typeof proc>;
 
   expectTypeOf<ProcType['_input_in']>().toEqualTypeOf<string | undefined>();
-  expectTypeOf<ProcType['_input_out']>().toEqualTypeOf<string>();
+  expectTypeOf<ProcTypeBeforeResolver['_input_out']>().toEqualTypeOf<string>();
 
   const router = t.router({
     proc,
@@ -350,21 +358,25 @@ test('zod default() string', async () => {
 test('zod default() required object', async () => {
   const t = initTRPC.create();
 
-  const proc = t.procedure
-    .input(
-      z.object({
-        foo: z.string().optional().default('foo'),
-      }),
-    )
-    .query(({ input }) => {
-      expectTypeOf(input).toBeObject();
-      return input;
-    });
+  const procWithInput = t.procedure.input(
+    z.object({
+      foo: z.string().optional().default('foo'),
+    }),
+  );
+  const proc = procWithInput.query(({ input }) => {
+    expectTypeOf(input).toBeObject();
+    return input;
+  });
 
+  type ProcTypeBeforeResolver = inferProcedureBuilderParams<
+    typeof procWithInput
+  >;
   type ProcType = inferProcedureParams<typeof proc>;
 
   expectTypeOf<ProcType['_input_in']>().toEqualTypeOf<{ foo?: string }>();
-  expectTypeOf<ProcType['_input_out']>().toEqualTypeOf<{ foo: string }>();
+  expectTypeOf<ProcTypeBeforeResolver['_input_out']>().toEqualTypeOf<{
+    foo: string;
+  }>();
 
   const router = t.router({
     proc,
@@ -383,27 +395,29 @@ test('zod default() required object', async () => {
 test('zod default() mixed default object', async () => {
   const t = initTRPC.create();
 
-  const proc = t.procedure
-    .input(
-      z
-        .object({
-          foo: z.string(),
-          bar: z.string().optional().default('barFoo'),
-        })
-        .optional()
-        .default({ foo: 'fooBar' }),
-    )
-    .query(({ input }) => {
-      expectTypeOf(input).toBeObject();
-      return input;
-    });
+  const procWithInput = t.procedure.input(
+    z
+      .object({
+        foo: z.string(),
+        bar: z.string().optional().default('barFoo'),
+      })
+      .optional()
+      .default({ foo: 'fooBar' }),
+  );
+  const proc = procWithInput.query(({ input }) => {
+    expectTypeOf(input).toBeObject();
+    return input;
+  });
 
+  type ProcTypeBeforeResolver = inferProcedureBuilderParams<
+    typeof procWithInput
+  >;
   type ProcType = inferProcedureParams<typeof proc>;
 
   expectTypeOf<ProcType['_input_in']>().toEqualTypeOf<
     { foo: string; bar?: string } | undefined
   >();
-  expectTypeOf<ProcType['_input_out']>().toEqualTypeOf<{
+  expectTypeOf<ProcTypeBeforeResolver['_input_out']>().toEqualTypeOf<{
     foo: string;
     bar: string;
   }>();
@@ -436,27 +450,29 @@ test('zod default() mixed default object', async () => {
 test('zod default() defaults within object', async () => {
   const t = initTRPC.create();
 
-  const proc = t.procedure
-    .input(
-      z
-        .object({
-          foo: z.string().optional().default('defaultFoo'),
-          bar: z.string().optional().default('defaultBar'),
-        })
-        .optional()
-        .default({}),
-    )
-    .query(({ input }) => {
-      expectTypeOf(input).toBeObject();
-      return input;
-    });
+  const procWithInput = t.procedure.input(
+    z
+      .object({
+        foo: z.string().optional().default('defaultFoo'),
+        bar: z.string().optional().default('defaultBar'),
+      })
+      .optional()
+      .default({}),
+  );
+  const proc = procWithInput.query(({ input }) => {
+    expectTypeOf(input).toBeObject();
+    return input;
+  });
 
+  type ProcTypeBeforeResolver = inferProcedureBuilderParams<
+    typeof procWithInput
+  >;
   type ProcType = inferProcedureParams<typeof proc>;
 
   expectTypeOf<ProcType['_input_in']>().toEqualTypeOf<
     { foo?: string; bar?: string } | undefined
   >();
-  expectTypeOf<ProcType['_input_out']>().toEqualTypeOf<{
+  expectTypeOf<ProcTypeBeforeResolver['_input_out']>().toEqualTypeOf<{
     foo: string;
     bar: string;
   }>();

--- a/packages/tests/server/react/errors.test.tsx
+++ b/packages/tests/server/react/errors.test.tsx
@@ -184,42 +184,28 @@ describe('no custom formatter', () => {
   });
 });
 
-test('types', async () => {
-  const t = initTRPC.create();
-  const appRouter = t.router({
-    post: t.router({
-      byId: t.procedure
-        .input(
-          z.object({
-            // Minimum post id 1
-            id: z.number().min(1),
-          }),
-        )
-        .query(() => {
-          return '__result' as const;
-        }),
-    }),
-  });
+// test('types', async () => {
+//   const t = initTRPC.create();
+//   const appRouter = t.router({
+//     post: t.router({
+//       byId: t.procedure
+//         .input(
+//           z.object({
+//             // Minimum post id 1
+//             id: z.number().min(1),
+//           }),
+//         )
+//         .query(() => {
+//           return '__result' as const;
+//         }),
+//     }),
+//   });
 
-  type TRouterError = TRPCClientErrorLike<typeof appRouter>;
-  type TProcedureError = TRPCClientErrorLike<
-    (typeof appRouter)['post']['byId']
-  >;
+//   type TRouterError = TRPCClientErrorLike<typeof appRouter>;
 
-  type TRouterError__data = TRouterError['data'];
-  //      ^?
-  type TProcedureError__data = TProcedureError['data'];
-  //     ^?
+//   type TRouterError__data = TRouterError['data'];
+//   //      ^?
 
-  expectTypeOf<TRouterError__data>().toMatchTypeOf<TProcedureError__data>();
-
-  type TRouterError__shape = TRouterError['shape'];
-  //      ^?
-  type TProcedureError__shape = TProcedureError['shape'];
-  //     ^?
-
-  expectTypeOf<TRouterError__shape>().toMatchTypeOf<TProcedureError__shape>();
-
-  expectTypeOf<TRouterError>().toEqualTypeOf<TProcedureError>();
-  expectTypeOf<TRouterError>().toMatchTypeOf<TProcedureError>();
-});
+//   type TRouterError__shape = TRouterError['shape'];
+//   //      ^?
+// });

--- a/packages/tests/server/react/polymorphism.test.tsx
+++ b/packages/tests/server/react/polymorphism.test.tsx
@@ -481,7 +481,7 @@ function ExportStatus<TStatus extends Factory.ExportRouteLike['status']>({
     <p>
       Last Export: `{exportStatus.data?.name}` (
       {exportStatus.data.downloadUri ? 'Ready!' : 'Working'})
-      {renderAdditionalFields?.(exportStatus.data as any)}
+      {renderAdditionalFields?.(exportStatus.data)}
     </p>
   );
 }

--- a/packages/tests/server/smoke.test.ts
+++ b/packages/tests/server/smoke.test.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import { routerToServerAndClientNew, waitError } from './___testHelpers';
 import { waitFor } from '@testing-library/react';
 import { TRPCClientError, wsLink } from '@trpc/client/src';
-import { inferProcedureParams, initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server/src';
 import { observable, Unsubscribable } from '@trpc/server/src/observable';
 import { z } from 'zod';
 
@@ -60,14 +60,13 @@ test('very happy path', async () => {
   });
 
   {
-    type TContext = typeof greeting._def._config.$types.ctx;
+    type TContext = typeof router._def._config.$types.ctx;
     expectTypeOf<TContext>().toMatchTypeOf<{
       foo?: 'bar';
     }>();
   }
   {
-    type TParams = inferProcedureParams<(typeof router)['greeting']>;
-    type TConfig = TParams['_config'];
+    type TConfig = (typeof router)['_def']['_config'];
     type TContext = TConfig['$types']['ctx'];
     type TError = TConfig['$types']['errorShape'];
     expectTypeOf<NonNullable<TContext['foo']>>().toMatchTypeOf<'bar'>();

--- a/www/docs/main/quickstart.mdx
+++ b/www/docs/main/quickstart.mdx
@@ -82,7 +82,7 @@ tRPC combines concepts from [REST](https://www.sitepoint.com/rest-api/) and [Gra
 tRPC is split between several packages, so you can install only what you need. Make sure to install the packages you want in the proper sections of your codebase. For this quickstart guide we'll keep it simple and use the vanilla client only. For framework guides, checkout [usage with React](/docs/client/react/setup) and [usage with Next.js](/docs/client/nextjs/setup).
 
 :::info Requirements
-- tRPC requires TypeScript >= 4.7.0
+- tRPC requires TypeScript >= 5.1.6
 - We strongly recommend you using `"strict": true` in your `tsconfig.json` as we don't officially support non-strict mode.
 :::
 


### PR DESCRIPTION
## 🎯 Changes

Closes #4709

What changes are made in this PR? Is it a feature or a bug fix?
Simplify the procedure type after you build it so we only keep track of the properties you need (`_input_in` and `output_out`)