### PR TITLE
chore: add test for #4645

### DIFF
--- a/packages/tests/server/regression/issue-4645-inferProcedureOutput.test.ts
+++ b/packages/tests/server/regression/issue-4645-inferProcedureOutput.test.ts
@@ -1,10 +1,11 @@
 import { inferProcedureOutput, initTRPC } from '@trpc/server';
 import { inferTransformedProcedureOutput } from '@trpc/server/shared';
+import SuperJSON from 'superjson';
 import { z } from 'zod';
 
 test('infer json-esque', async () => {
   const t = initTRPC.create();
-  const helloProcedure = t.procedure.input(z.string()).query((opts) => {
+  const helloProcedure = t.procedure.input(z.string()).query(() => {
     return {
       hello: Math.random() > 0.5 ? 'hello' : undefined,
     };
@@ -20,5 +21,27 @@ test('infer json-esque', async () => {
     // Example: JSON.stringify({ hello: undefined }) === '{}'
     type Inferred = inferTransformedProcedureOutput<typeof helloProcedure>;
     expectTypeOf<Inferred>().toEqualTypeOf<{ hello?: string }>();
+  }
+});
+
+test('infer with superjson', async () => {
+  const t = initTRPC.create({
+    transformer: SuperJSON,
+  });
+  const helloProcedure = t.procedure.input(z.string()).query((opts) => {
+    return {
+      hello: Math.random() > 0.5 ? 'hello' : undefined,
+    };
+  });
+
+  {
+    type Inferred = inferProcedureOutput<typeof helloProcedure>;
+    expectTypeOf<Inferred>().toEqualTypeOf<{ hello: string | undefined }>();
+  }
+  {
+    // This type is what the client will receive
+    // Here, we use a transformer which will handle preservation of undefined
+    type Inferred = inferTransformedProcedureOutput<typeof helloProcedure>;
+    expectTypeOf<Inferred>().toEqualTypeOf<{ hello: string | undefined }>();
   }
 });

--- a/packages/tests/server/regression/issue-4645-inferProcedureOutput.test.ts
+++ b/packages/tests/server/regression/issue-4645-inferProcedureOutput.test.ts
@@ -32,7 +32,7 @@ test('infer with superjson', async () => {
   const t = initTRPC.create({
     transformer: SuperJSON,
   });
-  const helloProcedure = t.procedure.input(z.string()).query((opts) => {
+  const helloProcedure = t.procedure.input(z.string()).query(() => {
     return {
       hello: Math.random() > 0.5 ? 'hello' : undefined,
     };
@@ -52,7 +52,7 @@ test('infer with superjson', async () => {
 
 test('inference helpers', async () => {
   const t = initTRPC.create();
-  const helloProcedure = t.procedure.input(z.string()).query((opts) => {
+  const helloProcedure = t.procedure.input(z.string()).query(() => {
     return {
       hello: Math.random() > 0.5 ? 'hello' : undefined,
     };

--- a/packages/tests/server/regression/issue-4645-inferProcedureOutput.test.ts
+++ b/packages/tests/server/regression/issue-4645-inferProcedureOutput.test.ts
@@ -1,4 +1,8 @@
-import { inferProcedureOutput, initTRPC } from '@trpc/server';
+import {
+  inferProcedureOutput,
+  inferRouterOutputs,
+  initTRPC,
+} from '@trpc/server';
 import { inferTransformedProcedureOutput } from '@trpc/server/shared';
 import SuperJSON from 'superjson';
 import { z } from 'zod';
@@ -44,4 +48,18 @@ test('infer with superjson', async () => {
     type Inferred = inferTransformedProcedureOutput<typeof helloProcedure>;
     expectTypeOf<Inferred>().toEqualTypeOf<{ hello: string | undefined }>();
   }
+});
+
+test('inference helpers', async () => {
+  const t = initTRPC.create();
+  const helloProcedure = t.procedure.input(z.string()).query((opts) => {
+    return {
+      hello: Math.random() > 0.5 ? 'hello' : undefined,
+    };
+  });
+  const router = t.router({
+    hello: helloProcedure,
+  });
+  type Outputs = inferRouterOutputs<typeof router>;
+  expectTypeOf<Outputs['hello']>().toEqualTypeOf<{ hello?: string }>();
 });

--- a/packages/tests/server/regression/issue-4645-inferProcedureOutput.test.ts
+++ b/packages/tests/server/regression/issue-4645-inferProcedureOutput.test.ts
@@ -1,0 +1,24 @@
+import { inferProcedureOutput, initTRPC } from '@trpc/server';
+import { inferTransformedProcedureOutput } from '@trpc/server/shared';
+import { z } from 'zod';
+
+test('infer json-esque', async () => {
+  const t = initTRPC.create();
+  const helloProcedure = t.procedure.input(z.string()).query((opts) => {
+    return {
+      hello: Math.random() > 0.5 ? 'hello' : undefined,
+    };
+  });
+
+  {
+    type Inferred = inferProcedureOutput<typeof helloProcedure>;
+    expectTypeOf<Inferred>().toEqualTypeOf<{ hello: string | undefined }>();
+  }
+  {
+    // This type is what the client will receive
+    // Because it will be sent as JSON, the undefined will be stripped by `JSON.stringify`
+    // Example: JSON.stringify({ hello: undefined }) === '{}'
+    type Inferred = inferTransformedProcedureOutput<typeof helloProcedure>;
+    expectTypeOf<Inferred>().toEqualTypeOf<{ hello?: string }>();
+  }
+});

--- a/packages/tests/tsconfig.json
+++ b/packages/tests/tsconfig.json
@@ -5,6 +5,7 @@
     "skipLibCheck": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "target": "ES2020",
-    "types": ["node", "vitest/globals"]
+    "types": ["node", "vitest/globals"],
+    "noUnusedLocals": false
   }
 }


### PR DESCRIPTION
Closes #4645

## 🎯 Changes

Add test for #4645 - we have the correct behavior. See inline

cc @ddydng: you might be looking for `inferTransformerProcedureOutputs` or `inferRouterOutputs` - see https://trpc.io/docs/client/vanilla/infer-types