### PR TITLE
feat(`server`): add standalone middleware (experimental)

### DIFF
--- a/packages/server/src/core/index.ts
+++ b/packages/server/src/core/index.ts
@@ -17,7 +17,11 @@ export type {
   ProcedureOptions,
 } from './procedure';
 export type { inferParser } from './parser';
-export { createInputMiddleware, createOutputMiddleware } from './middleware';
+export {
+  createInputMiddleware,
+  createOutputMiddleware,
+  standaloneMiddleware,
+} from './middleware';
 export type { MiddlewareFunction, MiddlewareBuilder } from './middleware';
 export { initTRPC } from './initTRPC';
 export * from './types';

--- a/packages/server/src/core/index.ts
+++ b/packages/server/src/core/index.ts
@@ -20,7 +20,7 @@ export type { inferParser } from './parser';
 export {
   createInputMiddleware,
   createOutputMiddleware,
-  standaloneMiddleware,
+  experimental_standaloneMiddleware,
 } from './middleware';
 export type { MiddlewareFunction, MiddlewareBuilder } from './middleware';
 export { initTRPC } from './initTRPC';

--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -138,7 +138,9 @@ export interface ProcedureBuilder<TParams extends ProcedureParams> {
     fn:
       | MiddlewareBuilder<TParams, $Params>
       | MiddlewareFunction<TParams, $Params>,
-  ): CreateProcedureReturnInput<TParams, $Params>;
+  ): TParams['_ctx_out'] extends $Params['_config']['$types']['ctx']
+    ? CreateProcedureReturnInput<TParams, $Params>
+    : `The context type is not compatible with the middleware`;
   /**
    * Extend the procedure with another procedure.
    * @warning The TypeScript inference fails when chaining concatenated procedures.
@@ -249,7 +251,6 @@ export function createBuilder<TConfig extends AnyRootConfig>(
       return createNewBuilder(_def, builder._def) as any;
     },
     use(middlewareBuilderOrFn) {
-      // Distinguish between a middleware builder and a middleware function
       const middlewares =
         '_middlewares' in middlewareBuilderOrFn
           ? middlewareBuilderOrFn._middlewares
@@ -257,7 +258,7 @@ export function createBuilder<TConfig extends AnyRootConfig>(
 
       return createNewBuilder(_def, {
         middlewares: middlewares as ProcedureBuilderMiddleware[],
-      }) as AnyProcedureBuilder;
+      }) as any; // FIXME: I can't type this properly
     },
     query(resolver) {
       return createResolver(

--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -138,9 +138,7 @@ export interface ProcedureBuilder<TParams extends ProcedureParams> {
     fn:
       | MiddlewareBuilder<TParams, $Params>
       | MiddlewareFunction<TParams, $Params>,
-  ): TParams['_ctx_out'] extends $Params['_config']['$types']['ctx']
-    ? CreateProcedureReturnInput<TParams, $Params>
-    : `The context type is not compatible with the middleware`;
+  ): CreateProcedureReturnInput<TParams, $Params>;
   /**
    * Extend the procedure with another procedure.
    * @warning The TypeScript inference fails when chaining concatenated procedures.
@@ -258,7 +256,7 @@ export function createBuilder<TConfig extends AnyRootConfig>(
 
       return createNewBuilder(_def, {
         middlewares: middlewares as ProcedureBuilderMiddleware[],
-      }) as any; // FIXME: I can't type this properly
+      }) as AnyProcedureBuilder;
     },
     query(resolver) {
       return createResolver(

--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -249,6 +249,7 @@ export function createBuilder<TConfig extends AnyRootConfig>(
       return createNewBuilder(_def, builder._def) as any;
     },
     use(middlewareBuilderOrFn) {
+      // Distinguish between a middleware builder and a middleware function
       const middlewares =
         '_middlewares' in middlewareBuilderOrFn
           ? middlewareBuilderOrFn._middlewares

--- a/packages/server/src/core/middleware.ts
+++ b/packages/server/src/core/middleware.ts
@@ -11,6 +11,8 @@ import {
 import { ProcedureParams } from './procedure';
 import { ProcedureType } from './types';
 
+
+
 /**
  * @internal
  */
@@ -200,13 +202,14 @@ export function createMiddlewareFactory<
 export const standaloneMiddleware = <
   TCtx extends {
     ctx?: object;
+    meta?: object;
     input?: unknown;
   },
 >() => ({
   create: createMiddlewareFactory<
     RootConfig<{
-      ctx: TCtx extends { ctx: infer T } ? T : object;
-      meta: object;
+      ctx: TCtx extends { ctx: infer T extends object } ? T : object;
+      meta: TCtx extends { meta: infer T extends object } ? T : object;
       errorShape: object;
       transformer: object;
     }>,

--- a/packages/server/src/core/middleware.ts
+++ b/packages/server/src/core/middleware.ts
@@ -1,6 +1,6 @@
 import { TRPCError } from '../error/TRPCError';
 import { Simplify } from '../types';
-import { AnyRootConfig } from './internals/config';
+import { AnyRootConfig, RootConfig } from './internals/config';
 import { ParseFn } from './internals/getParseFn';
 import { ProcedureBuilderMiddleware } from './internals/procedureBuilder';
 import {
@@ -187,6 +187,17 @@ export function createMiddlewareFactory<TConfig extends AnyRootConfig>() {
 
   return createMiddleware;
 }
+
+export const standaloneMiddleware = <TCtx extends object>() => ({
+  create: createMiddlewareFactory<
+    RootConfig<{
+      ctx: TCtx;
+      meta: object;
+      errorShape: object;
+      transformer: object;
+    }>
+  >(),
+});
 
 function isPlainObject(obj: unknown) {
   return obj && typeof obj === 'object' && !Array.isArray(obj);

--- a/packages/server/src/core/middleware.ts
+++ b/packages/server/src/core/middleware.ts
@@ -11,8 +11,6 @@ import {
 import { ProcedureParams } from './procedure';
 import { ProcedureType } from './types';
 
-
-
 /**
  * @internal
  */

--- a/packages/server/src/core/middleware.ts
+++ b/packages/server/src/core/middleware.ts
@@ -197,7 +197,7 @@ export function createMiddlewareFactory<
   return createMiddleware;
 }
 
-export const standaloneMiddleware = <
+export const experimental_standaloneMiddleware = <
   TCtx extends {
     ctx?: object;
     meta?: object;

--- a/packages/server/src/core/middleware.ts
+++ b/packages/server/src/core/middleware.ts
@@ -200,7 +200,7 @@ export function createMiddlewareFactory<
 export const standaloneMiddleware = <
   TCtx extends {
     ctx?: object;
-    input?: object;
+    input?: unknown;
   },
 >() => ({
   create: createMiddlewareFactory<

--- a/packages/tests/server/middlewares.test.ts
+++ b/packages/tests/server/middlewares.test.ts
@@ -1,7 +1,6 @@
 import { initTRPC, standaloneMiddleware, TRPCError } from '@trpc/server/src';
 import * as z from 'zod';
 
-
 test('decorate independently', () => {
   type User = {
     id: string;

--- a/packages/tests/server/middlewares.test.ts
+++ b/packages/tests/server/middlewares.test.ts
@@ -129,32 +129,20 @@ test('standalone middlewares that define the ctx/input they require and can be u
   });
 
   // This is not OK because determineIfUserNameIsLongMiddleware requires { nameLength: number } which is not in either context:
-  const expectErrorHumanContextDoesNotHaveNameLength = tHuman.procedure.use(
+  tHuman.procedure.use(
     // @ts-expect-error: no user in context
     determineIfUserNameIsLongMiddleware,
   );
-  const expectErrorAlienContextDoesNotHaveNameLength = tAlien.procedure.use(
+  tAlien.procedure.use(
     // @ts-expect-error: no user in context
     determineIfUserNameIsLongMiddleware,
   );
-
-  expectTypeOf(
-    expectErrorHumanContextDoesNotHaveNameLength,
-  ).toEqualTypeOf<'The context type is not compatible with the middleware'>();
-
-  expectTypeOf(
-    expectErrorAlienContextDoesNotHaveNameLength,
-  ).toEqualTypeOf<'The context type is not compatible with the middleware'>();
 
   // This is not OK because determineIfUserNameIsLongMiddleware requires { nameLength: number } which is not in HumanContext & { foo: string }
-  const expectErrorFooMiddlewareDoesNotAddNameLength = tHuman.procedure
+  tHuman.procedure
     .use(addFooToCtxMiddleware)
     // @ts-expect-error: no nameLength in context
     .use(determineIfUserNameIsLongMiddleware);
-
-  expectTypeOf(
-    expectErrorFooMiddlewareDoesNotAddNameLength,
-  ).toEqualTypeOf<'The context type is not compatible with the middleware'>();
 
   // This is OK because the context provides { user: Human } or { user: Alien } which is what addUserNameLengthToCtx requires
   tHuman.procedure
@@ -188,7 +176,7 @@ test('standalone middlewares that define the ctx/input they require and can be u
       }>();
     });
 
-  const _invalidPipedVersion1 = addFooToCtxMiddleware
+  addFooToCtxMiddleware
     // This is not OK because the requirements of the later middlewares are not met
     // @ts-expect-error: No user in context at this point
     .unstable_pipe(addUserNameLengthToCtxMiddleware)


### PR DESCRIPTION
## 🎯 Changes

Proposal/feat: `standaloneMiddleware`

```
  const projectAccessMiddleware = standaloneMiddleware<{
    ctx: { allowedProjects: string[] }; // defaults to 'object' if not defined
    input: { projectId: string }; // defaults to 'unknown' if not defined
  }>().create((opts) => {
    if (!opts.ctx.allowedProjects.includes(opts.input.projectId)) {
      throw new TRPCError({
        code: 'FORBIDDEN',
        message: 'Not allowed',
      });
    }

    return opts.next();
  });
```
    
Enables creation of middlewares that are not bound to any particular
tRPC instance; instead they can define a type of `Context`/`Input` that they
expect, and as long as the preceding middleware chain provides `Context` and `Input`
types that are assignable to the middleware's required context type,
the middleware can be used in the chain. The required context defaults to `object` and the required input defaults to `unknown`.
    
This commit provides a few tests that demonstrate the usage of
standalone middlewares in two different tRPC instances.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
