### PR TITLE
server: add support for next valibot version

### DIFF
--- a/packages/server/src/core/internals/getParseFn.ts
+++ b/packages/server/src/core/internals/getParseFn.ts
@@ -21,14 +21,6 @@ export function getParseFn<TType>(procedureParser: Parser): ParseFn<TType> {
     return parser.parse.bind(parser);
   }
 
-  if (typeof parser._parse === 'function') {
-    // ParserValibotEsque (>= v0.13.X)
-    return async (value) => {
-      const { parseAsync } = await import('valibot');
-      return parseAsync(parser, value);
-    };
-  }
-
   if (typeof parser.validateSync === 'function') {
     // ParserYupEsque
     return parser.validateSync.bind(parser);
@@ -44,6 +36,14 @@ export function getParseFn<TType>(procedureParser: Parser): ParseFn<TType> {
     return (value) => {
       parser.assert(value);
       return value as TType;
+    };
+  }
+
+  if (typeof parser._parse === 'function') {
+    // ParserValibotEsque (>= v0.13.X)
+    return async (value) => {
+      const { parseAsync } = await import('valibot');
+      return parseAsync(parser, value);
     };
   }
 

--- a/packages/server/src/core/internals/getParseFn.ts
+++ b/packages/server/src/core/internals/getParseFn.ts
@@ -1,3 +1,4 @@
+import { parseAsync } from 'valibot';
 import { Parser } from '../parser';
 
 export type ParseFn<TType> = (value: unknown) => Promise<TType> | TType;
@@ -17,8 +18,13 @@ export function getParseFn<TType>(procedureParser: Parser): ParseFn<TType> {
 
   if (typeof parser.parse === 'function') {
     // ParserZodEsque
-    // ParserValibotEsque
+    // ParserValibotEsque (<= v0.12.X)
     return parser.parse.bind(parser);
+  }
+
+  if (typeof parser._parse === 'function') {
+    // ParserValibotEsque (>= v0.13.X)
+    return (value) => parseAsync(parser, value);
   }
 
   if (typeof parser.validateSync === 'function') {

--- a/packages/server/src/core/internals/getParseFn.ts
+++ b/packages/server/src/core/internals/getParseFn.ts
@@ -1,4 +1,3 @@
-import { parseAsync } from 'valibot';
 import { Parser } from '../parser';
 
 export type ParseFn<TType> = (value: unknown) => Promise<TType> | TType;
@@ -24,7 +23,10 @@ export function getParseFn<TType>(procedureParser: Parser): ParseFn<TType> {
 
   if (typeof parser._parse === 'function') {
     // ParserValibotEsque (>= v0.13.X)
-    return (value) => parseAsync(parser, value);
+    return async (value) => {
+      const { parseAsync } = await import('valibot');
+      return parseAsync(parser, value);
+    };
   }
 
   if (typeof parser.validateSync === 'function') {


### PR DESCRIPTION
Closes #4737

## 🎯 Changes

In the next version of Valibot, the internal API will change. Therefore I have extended the implementation.

I had to add an import statement. Since `valibot` is currently only a dev dependency, I am not sure if this is problematic.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
