### PR TITLE
Feat(server): narrow the type of 'meta' when runtime meta value injected

### DIFF
--- a/packages/server/src/core/initTRPC.ts
+++ b/packages/server/src/core/initTRPC.ts
@@ -21,7 +21,7 @@ import {
 } from './internals/config';
 import { mergeRouters } from './internals/mergeRouters';
 import { createBuilder } from './internals/procedureBuilder';
-import { PickFirstDefined, ValidateShape } from './internals/utils';
+import { Overwrite, PickFirstDefined, ValidateShape } from './internals/utils';
 import { createMiddlewareFactory } from './middleware';
 import { createRouterFactory } from './router';
 
@@ -103,7 +103,9 @@ function createTRPCInner<TParams extends PartialRootConfigTypes>() {
 
     type $Config = RootConfig<{
       ctx: $Context;
-      meta: $Meta;
+      meta: TOptions['defaultMeta'] extends infer T extends object
+        ? Overwrite<Partial<$Meta>, T>
+        : Partial<$Meta>;
       errorShape: $ErrorShape;
       transformer: $Transformer;
     }>;

--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -130,7 +130,11 @@ export interface ProcedureBuilder<TParams extends ProcedureParams> {
   /**
    * Add a meta data to the procedure.
    */
-  meta(meta: TParams['_meta']): ProcedureBuilder<TParams>;
+  meta<TMeta extends Partial<TParams['_meta']>>(
+    meta: TMeta,
+  ): ProcedureBuilder<
+    Overwrite<TParams, { _meta: Overwrite<TParams['_meta'], TMeta> }>
+  >;
   /**
    * Add a middleware to the procedure.
    */

--- a/packages/server/src/core/middleware.ts
+++ b/packages/server/src/core/middleware.ts
@@ -136,7 +136,11 @@ export type MiddlewareFunction<
     path: string;
     input: TParams['_input_out'];
     rawInput: unknown;
-    meta: TParams['_meta'] | undefined;
+    // Always infer opts.meta as potentially undefined in middlewares if it hasn't been injected by a previous middleware or by defaultMeta
+    // Allowing meta to be undefined is for backwards compatibility reasons
+    meta: Record<PropertyKey, never> extends TParams['_meta']
+      ? TParams['_meta'] | undefined
+      : TParams['_meta'];
     next: {
       (): Promise<MiddlewareResult<TParams>>;
       <$Context>(opts: { ctx: $Context }): Promise<

--- a/packages/server/src/core/types.ts
+++ b/packages/server/src/core/types.ts
@@ -15,8 +15,9 @@ export type inferRouterContext<TRouter extends AnyRouter> =
   inferRouterDef<TRouter>['_config']['$types']['ctx'];
 export type inferRouterError<TRouter extends AnyRouter> =
   inferRouterDef<TRouter>['_config']['$types']['errorShape'];
-export type inferRouterMeta<TRouter extends AnyRouter> =
-  inferRouterDef<TRouter>['_config']['$types']['meta'];
+export type inferRouterMeta<TRouter extends AnyRouter> = Required<
+  inferRouterDef<TRouter>['_config']['$types']['meta']
+>;
 
 export const procedureTypes = ['query', 'mutation', 'subscription'] as const;
 /**

--- a/packages/tests/server/initTRPC.test.ts
+++ b/packages/tests/server/initTRPC.test.ts
@@ -76,7 +76,7 @@ test('config types', () => {
 
     // ^?
     expectTypeOf<typeof t._config.$types.ctx>().toEqualTypeOf<Context>();
-    expectTypeOf<typeof t._config.$types.meta>().toEqualTypeOf<Meta>();
+    expectTypeOf<typeof t._config.$types.meta>().toEqualTypeOf<Partial<Meta>>();
   }
 
   {

--- a/packages/tests/server/meta.test.ts
+++ b/packages/tests/server/meta.test.ts
@@ -2,14 +2,14 @@ import { routerToServerAndClientNew } from './___testHelpers';
 import { initTRPC } from '@trpc/server/src';
 import { konn } from 'konn';
 
-test('meta is undefined in a middleware', () => {
+test('meta is "Partial<Meta> | undefined" in a middleware where defaultMeta or procedure.meta() has not injected metadata', () => {
   type Meta = {
     permissions: string[];
   };
   const t = initTRPC.meta<Meta>().create();
 
   t.middleware((opts) => {
-    expectTypeOf(opts.meta).toEqualTypeOf<Meta | undefined>();
+    expectTypeOf(opts.meta).toEqualTypeOf<Partial<Meta> | undefined>();
 
     return opts.next();
   });
@@ -23,7 +23,7 @@ describe('meta', () => {
 
   const ctx = konn()
     .beforeEach(() => {
-      const middlewareCalls = vi.fn((_opts: Meta | undefined) => {
+      const middlewareCalls = vi.fn((_opts: Partial<Meta> | undefined) => {
         // noop
       });
       const baseProc = t.procedure.use(({ next, meta }) => {


### PR DESCRIPTION
## 🎯 Changes

Feat(server): narrow the type of 'meta' when runtime meta value injected

Currently tRPC middlewares always assume that the type of `opts.meta`
is `Meta | undefined` even when a procedure injects metadata using
`.meta()` or `defaultMeta` is provided to `initTRPC().create()`.

This commit modifies the behavior so that whenever either `procedure.meta()`
or `defaultMeta` is provided, the type of Meta is narrowed in downstream
handlers.

The `RootConfig` created in `initTRPC` is now changed
from `Meta` to `Partial<Meta>`, since this facilitates removing the type:

`_meta: TConfig['_meta'] | undefined`

from the definition of `MiddlewareFunction` (this is needed so that middlewares
aren't always stuck assuming `opts.meta` is a union of `Meta` and `undefined`.

Note: this would have the potential to break users' typechecks if they are doing sth
like:

`if (opts.meta && !opts.meta.foo) { throw new Error("bang!"); }`

because with the changed types, `opts.meta` is Partial<Meta>. To combat this
I changed the definition of `MiddlewareFunction` to `Meta | undefined` ONLY when `meta`
has not been injected by a procedure or by `defaultMeta`, which should preserve
backwards compatibility, as without runtime injection, the runtime value of Meta
will be `undefined`.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
