### PR TITLE
fix: Module '"http"' has no default export

### DIFF
--- a/examples/next-prisma-websockets-starter/src/server/prodServer.ts
+++ b/examples/next-prisma-websockets-starter/src/server/prodServer.ts
@@ -1,7 +1,7 @@
 import { createContext } from './context';
 import { appRouter } from './routers/_app';
 import { applyWSSHandler } from '@trpc/server/adapters/ws';
-import http from 'http';
+import * as http from 'http';
 import next from 'next';
 import { parse } from 'url';
 import ws from 'ws';

--- a/packages/server/src/adapters/standalone.ts
+++ b/packages/server/src/adapters/standalone.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import http from 'http';
+import * as http from 'http';
 import { AnyRouter } from '../core';
 import {
   NodeHTTPCreateContextFnOptions,

--- a/packages/tests/server/adapters/express.test.tsx
+++ b/packages/tests/server/adapters/express.test.tsx
@@ -1,4 +1,4 @@
-import http from 'http';
+import * as http from 'http';
 import { Context, router } from './__router';
 import {
   createTRPCProxyClient,

--- a/packages/tests/server/errors.test.ts
+++ b/packages/tests/server/errors.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-import http from 'http';
+import * as http from 'http';
 import { routerToServerAndClientNew, waitError } from './___testHelpers';
 import {
   createTRPCProxyClient,

--- a/packages/tests/server/interop/adapters/express.test.tsx
+++ b/packages/tests/server/interop/adapters/express.test.tsx
@@ -1,4 +1,4 @@
-import http from 'http';
+import * as http from 'http';
 import { Context, router } from './__router';
 import { createTRPCClient, httpBatchLink } from '@trpc/client/src';
 import * as trpc from '@trpc/server/src';

--- a/packages/tests/server/regression/issue-3085-bad-responses.test.ts
+++ b/packages/tests/server/regression/issue-3085-bad-responses.test.ts
@@ -1,5 +1,5 @@
 import '../___packages';
-import http from 'http';
+import * as http from 'http';
 import { waitError } from '../___testHelpers';
 import { createTRPCProxyClient, httpLink, TRPCClientError } from '@trpc/client';
 import { observable } from '@trpc/server/observable';

--- a/packages/tests/server/regression/issue-3359-http-status-413-payload-too-large.test.ts
+++ b/packages/tests/server/regression/issue-3359-http-status-413-payload-too-large.test.ts
@@ -1,4 +1,4 @@
-import http from 'http';
+import * as http from 'http';
 import { waitError } from '../___testHelpers';
 import {
   createTRPCProxyClient,


### PR DESCRIPTION
Closes #

## 🎯 Changes

Fixing [the error `Module '"http"' has no default export`](https://stackoverflow.com/a/66820523/4170935).

![image](https://github.com/trpc/trpc/assets/8110568/e2142a41-c044-4836-9c3b-1d1f995e21c4)

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
