### PR TITLE
fix: allow `inferRouterOutputs` in different repos

### DIFF
--- a/examples/.test/internal-types-export/src/client.ts
+++ b/examples/.test/internal-types-export/src/client.ts
@@ -1,5 +1,6 @@
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
 import type { AppRouter } from './server.js';
+import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 
 export const client = createTRPCProxyClient<AppRouter>({
   links: [
@@ -8,3 +9,6 @@ export const client = createTRPCProxyClient<AppRouter>({
     })
   ]
 });
+
+export type RouterInputs = inferRouterInputs<AppRouter>;
+export type RouterOutputs = inferRouterOutputs<AppRouter>;


### PR DESCRIPTION
Closes #4748

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
