### PR TITLE
docs: add k6-trpc extension

### DIFF
--- a/www/docs/community/awesome-trpc.mdx
+++ b/www/docs/community/awesome-trpc.mdx
@@ -61,6 +61,7 @@ A collection of resources on tRPC.
 | ZenStack - Full-stack toolkit adds access control to Prisma and generates trpc routers from schema  | https://github.com/zenstackhq/zenstack                                |
 | tRPC-SWR - tRPC adapter for Vercel's SWR client                                                     | https://trpc-swr.vercel.app/                                          |
 | trpc-rtk-query - Automatically generate RTK Query api endpoints from your tRPC setup                | https://github.com/otahontas/trpc-rtk-query                           |
+| k6-trpc - k6 compatible tRPC client                                                                 | https://github.com/dextertanyj/k6-trpc                                |
 
 ## 🍀 Starting points, example projects, etc
 


### PR DESCRIPTION
Adds `k6-trpc` adapter to community page.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
