### PR TITLE
fix(`@trpc/server`): rearrange the order of context generation in `resolveHTTPResponse` method

### DIFF
--- a/.changeset/twelve-rocks-look.md
+++ b/.changeset/twelve-rocks-look.md
@@ -1,0 +1,5 @@
+---
+'@trpc/server': patch
+---
+
+Fixed a bug where the context could be empty in `errorFormatter` and `onError` functions when the requested endpoint url contained invalid JSON data.

--- a/.changeset/twelve-rocks-look.md
+++ b/.changeset/twelve-rocks-look.md
@@ -1,5 +1,0 @@
----
-'@trpc/server': patch
----
-
-Fixed a bug where the context could be empty in `errorFormatter` and `onError` functions when the requested endpoint url contained invalid JSON data.

--- a/packages/server/src/http/resolveHTTPResponse.ts
+++ b/packages/server/src/http/resolveHTTPResponse.ts
@@ -289,6 +289,13 @@ export async function resolveHTTPResponse<
   try {
     // we create context first so that (unless `createContext()` throws)
     // error handler may access context information
+    //
+    // this way even if the client sends malformed input that might cause an exception:
+    //  - `opts.error` has value,
+    //  - batching is not enabled,
+    //  - `type` is unknown,
+    //  - `getInputs` throws because of malformed JSON,
+    // context value is still available to the error handler
     ctx = await opts.createContext();
 
     if (opts.error) {

--- a/packages/server/src/http/resolveHTTPResponse.ts
+++ b/packages/server/src/http/resolveHTTPResponse.ts
@@ -287,6 +287,10 @@ export async function resolveHTTPResponse<
     req.headers['trpc-batch-mode'] === 'stream';
 
   try {
+    // we create context first so that unless `createContext()` throws,
+    // error handler may access context information
+    ctx = await opts.createContext();
+
     if (opts.error) {
       throw opts.error;
     }
@@ -306,8 +310,6 @@ export async function resolveHTTPResponse<
         code: 'METHOD_NOT_SUPPORTED',
       });
     }
-
-    ctx = await opts.createContext();
 
     const inputs = await contentTypeHandler.getInputs({
       isBatchCall,

--- a/packages/server/src/http/resolveHTTPResponse.ts
+++ b/packages/server/src/http/resolveHTTPResponse.ts
@@ -287,7 +287,7 @@ export async function resolveHTTPResponse<
     req.headers['trpc-batch-mode'] === 'stream';
 
   try {
-    // we create context first so that unless `createContext()` throws,
+    // we create context first so that (unless `createContext()` throws)
     // error handler may access context information
     ctx = await opts.createContext();
 

--- a/packages/server/src/http/resolveHTTPResponse.ts
+++ b/packages/server/src/http/resolveHTTPResponse.ts
@@ -307,6 +307,8 @@ export async function resolveHTTPResponse<
       });
     }
 
+    ctx = await opts.createContext();
+
     const inputs = await contentTypeHandler.getInputs({
       isBatchCall,
       req,
@@ -317,7 +319,6 @@ export async function resolveHTTPResponse<
     paths = isBatchCall
       ? decodeURIComponent(opts.path).split(',')
       : [opts.path];
-    ctx = await opts.createContext();
     const promises = paths.map((path, index) =>
       inputToProcedureCall({ opts, ctx, type, input: inputs[index], path }),
     );


### PR DESCRIPTION
This PR fixes an issue where context would be empty in `onError` and `errorFormatter` functions when calling the TRPC server with invalid JSON data.

We encountered this error while testing by calling an endpoint like `http://localhost:3001/trpc/brands.getDefault?input=QUERY`. Because "QUERY" is not a valid JSON, the default `getJsonContentTypeInputs` (i.e. `getInputs`) function would throw. Since context currently only gets generated *after* the input is parsed, it wouldn't be created correctly.

> We use context to communicate through the application the configuration parameters. One of the configurations is the production/development stage which we use to determine whether error should be transformed. Because of the bug, the transformer wouldn't work as expected and essentially leaked information about our file system in the stack trace.

```ts
const t = initTRPC.context<Context>().create({
  transformer: superjson,
  errorFormatter: ({ shape, ctx }) => {
    if (ctx?.config.isProduction) {
      return {
        message: 'Internal server error',
        code: -32603 as any,
        data: {},
      }
    }

    return shape
  },
})
```

I believe this is not intentional and this PR fixes the bug by changing the order of context generation and input parsing. This way `caughtErrorToData` gets the correct context value even if `getInputs` throws on invalid JSON.
