### PR TITLE
Update docs and tests for Valibot >= v0.13.0

### DIFF
--- a/packages/server/src/core/internals/getParseFn.ts
+++ b/packages/server/src/core/internals/getParseFn.ts
@@ -17,7 +17,7 @@ export function getParseFn<TType>(procedureParser: Parser): ParseFn<TType> {
 
   if (typeof parser.parse === 'function') {
     // ParserZodEsque
-    // ParserValibotEsque
+    // ParserValibotEsque (<= v0.12.X)
     return parser.parse.bind(parser);
   }
 

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@cloudflare/workers-types": "^4.0.0",
+    "@decs/typeschema": "^0.10.2",
     "@effect/schema": "^0.36.0",
     "@fastify/busboy": "^1.2.1",
     "@fastify/websocket": "^7.1.2",
@@ -57,7 +58,7 @@
     "superstruct": "^1.0.0",
     "tsx": "^3.12.7",
     "typescript": "^5.1.3",
-    "valibot": "^0.12.0",
+    "valibot": "^0.15.0",
     "vite": "^4.1.2",
     "vitest": "^0.32.0",
     "vitest-environment-miniflare": "^2.12.0",

--- a/packages/tests/server/outputParser.test.ts
+++ b/packages/tests/server/outputParser.test.ts
@@ -1,4 +1,5 @@
 import { routerToServerAndClientNew } from './___testHelpers';
+import { wrap } from '@decs/typeschema';
 import { initTRPC } from '@trpc/server/src';
 import myzod from 'myzod';
 import * as t from 'superstruct';
@@ -107,12 +108,8 @@ test('valibot', async () => {
   const trpc = initTRPC.create();
   const router = trpc.router({
     q: trpc.procedure
-      .input(v.union([v.string(), v.number()]))
-      .output(
-        v.object({
-          input: v.string(),
-        }),
-      )
+      .input(wrap(v.union([v.string(), v.number()])))
+      .output(wrap(v.object({ input: v.string() })))
       .query(({ input }) => {
         return { input: input as string };
       }),
@@ -138,13 +135,12 @@ test('valibot async', async () => {
   const trpc = initTRPC.create();
   const router = trpc.router({
     q: trpc.procedure
-      .input(v.unionAsync([v.stringAsync(), v.numberAsync()]))
+      .input(wrap(v.unionAsync([v.stringAsync(), v.numberAsync()])))
       .output(
-        v.objectAsync(
-          {
-            input: v.stringAsync(),
-          },
-          [v.customAsync<{ input: string }>(async (value) => !!value)],
+        wrap(
+          v.objectAsync({ input: v.stringAsync() }, [
+            v.customAsync(async (value) => !!value),
+          ]),
         ),
       )
       .query(({ input }) => {
@@ -173,11 +169,13 @@ test('valibot transform', async () => {
   const trpc = initTRPC.create();
   const router = trpc.router({
     q: trpc.procedure
-      .input(v.union([v.string(), v.number()]))
+      .input(wrap(v.union([v.string(), v.number()])))
       .output(
-        v.object({
-          input: v.transform(v.string(), (s) => s.length),
-        }),
+        wrap(
+          v.object({
+            input: v.transform(v.string(), (s) => s.length),
+          }),
+        ),
       )
       .query(({ input }) => {
         return { input: input as string };

--- a/packages/tests/server/validators.test.ts
+++ b/packages/tests/server/validators.test.ts
@@ -1,4 +1,5 @@
 import { routerToServerAndClientNew } from './___testHelpers';
+import { wrap } from '@decs/typeschema';
 import * as S from '@effect/schema/Schema';
 import { initTRPC } from '@trpc/server/src';
 import * as arktype from 'arktype';
@@ -139,7 +140,7 @@ test('valibot', async () => {
   const t = initTRPC.create();
 
   const router = t.router({
-    num: t.procedure.input(v.number()).query(({ input }) => {
+    num: t.procedure.input(wrap(v.number())).query(({ input }) => {
       expectTypeOf(input).toBeNumber();
       return {
         input,
@@ -159,9 +160,9 @@ test('valibot', async () => {
 
 test('valibot async', async () => {
   const t = initTRPC.create();
-  const input = v.stringAsync([
-    v.customAsync(async (value) => value === 'foo'),
-  ]);
+  const input = wrap(
+    v.stringAsync([v.customAsync(async (value) => value === 'foo')]),
+  );
 
   const router = t.router({
     q: t.procedure.input(input).query(({ input }) => {
@@ -188,9 +189,11 @@ test('valibot async', async () => {
 
 test('valibot transform mixed input/output', async () => {
   const t = initTRPC.create();
-  const input = v.object({
-    length: v.transform(v.string(), (s) => s.length),
-  });
+  const input = wrap(
+    v.object({
+      length: v.transform(v.string(), (s) => s.length),
+    }),
+  );
 
   const router = t.router({
     num: t.procedure.input(input).query(({ input }) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 overrides:
   '@tanstack/react-query': 4.18.0
   '@tanstack/react-query-devtools': 4.18.0
@@ -1678,6 +1682,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.0.0
         version: 4.20230215.0
+      '@decs/typeschema':
+        specifier: ^0.10.2
+        version: 0.10.2(@effect/data@0.18.5)(@effect/io@0.40.1)(@effect/schema@0.36.0)(arktype@1.0.14-alpha)(runtypes@6.6.0)(superstruct@1.0.3)(valibot@0.15.0)(vite@4.1.2)(yup@1.0.0)(zod@3.20.2)
       '@effect/schema':
         specifier: ^0.36.0
         version: 0.36.0(@effect/data@0.18.5)(@effect/io@0.40.1)
@@ -1796,8 +1803,8 @@ importers:
         specifier: ^5.1.3
         version: 5.1.3
       valibot:
-        specifier: ^0.12.0
-        version: 0.12.0
+        specifier: ^0.15.0
+        version: 0.15.0
       vite:
         specifier: ^4.1.2
         version: 4.1.2(@types/node@18.16.16)
@@ -1904,6 +1911,9 @@ importers:
       '@babel/preset-env':
         specifier: ^7.18.6
         version: 7.20.2(@babel/core@7.20.2)
+      '@decs/typeschema':
+        specifier: ^0.10.2
+        version: 0.10.2(@effect/data@0.18.5)(@effect/io@0.40.1)(@effect/schema@0.36.0)(ajv@6.12.6)(arktype@1.0.14-alpha)(runtypes@6.6.0)(superstruct@1.0.3)(valibot@0.15.0)(yup@1.0.0)(zod@3.20.2)
       '@effect/schema':
         specifier: ^0.36.0
         version: 0.36.0(@effect/data@0.18.5)(@effect/io@0.40.1)
@@ -1983,8 +1993,8 @@ importers:
         specifier: ^5.1.3
         version: 5.1.3
       valibot:
-        specifier: ^0.12.0
-        version: 0.12.0
+        specifier: ^0.15.0
+        version: 0.15.0
       yup:
         specifier: ^1.0.0
         version: 1.0.0
@@ -5513,6 +5523,142 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /@decs/typeschema@0.10.2(@effect/data@0.18.5)(@effect/io@0.40.1)(@effect/schema@0.36.0)(ajv@6.12.6)(arktype@1.0.14-alpha)(runtypes@6.6.0)(superstruct@1.0.3)(valibot@0.15.0)(yup@1.0.0)(zod@3.20.2):
+    resolution: {integrity: sha512-5Mtpwg8I11hwB+ndlFtDbmQKZTjoCsqMV8eVn+21nm28jlIn8uwRRqGmNIhT4TE9/JxKtGWSgTTiilmhe3S0Pw==}
+    peerDependencies:
+      '@deepkit/type': ^1.0.1-alpha.97
+      '@effect/data': ^0.17.6
+      '@effect/io': ^0.38.2
+      '@effect/schema': ^0.33.2
+      '@sinclair/typebox': ^0.31.0
+      ajv: ^8.12.0
+      arktype: ^1.0.19-alpha
+      fp-ts: ^2.16.0
+      io-ts: ^2.2.20
+      joi: ^17.9.2
+      ow: ^0.28.2
+      runtypes: ^6.7.0
+      superstruct: ^1.0.3
+      valibot: ^0.13.1
+      vite: ^4.4.9
+      yup: ^1.2.0
+      zod: ^3.21.4
+    peerDependenciesMeta:
+      '@deepkit/type':
+        optional: true
+      '@effect/data':
+        optional: true
+      '@effect/io':
+        optional: true
+      '@effect/schema':
+        optional: true
+      '@sinclair/typebox':
+        optional: true
+      ajv:
+        optional: true
+      arktype:
+        optional: true
+      fp-ts:
+        optional: true
+      io-ts:
+        optional: true
+      joi:
+        optional: true
+      ow:
+        optional: true
+      runtypes:
+        optional: true
+      superstruct:
+        optional: true
+      valibot:
+        optional: true
+      vite:
+        optional: true
+      yup:
+        optional: true
+      zod:
+        optional: true
+    dependencies:
+      '@effect/data': 0.18.5
+      '@effect/io': 0.40.1(@effect/data@0.18.5)
+      '@effect/schema': 0.36.0(@effect/data@0.18.5)(@effect/io@0.40.1)
+      ajv: 6.12.6
+      arktype: 1.0.14-alpha
+      runtypes: 6.6.0
+      superstruct: 1.0.3
+      valibot: 0.15.0
+      yup: 1.0.0
+      zod: 3.20.2
+    dev: true
+
+  /@decs/typeschema@0.10.2(@effect/data@0.18.5)(@effect/io@0.40.1)(@effect/schema@0.36.0)(arktype@1.0.14-alpha)(runtypes@6.6.0)(superstruct@1.0.3)(valibot@0.15.0)(vite@4.1.2)(yup@1.0.0)(zod@3.20.2):
+    resolution: {integrity: sha512-5Mtpwg8I11hwB+ndlFtDbmQKZTjoCsqMV8eVn+21nm28jlIn8uwRRqGmNIhT4TE9/JxKtGWSgTTiilmhe3S0Pw==}
+    peerDependencies:
+      '@deepkit/type': ^1.0.1-alpha.97
+      '@effect/data': ^0.17.6
+      '@effect/io': ^0.38.2
+      '@effect/schema': ^0.33.2
+      '@sinclair/typebox': ^0.31.0
+      ajv: ^8.12.0
+      arktype: ^1.0.19-alpha
+      fp-ts: ^2.16.0
+      io-ts: ^2.2.20
+      joi: ^17.9.2
+      ow: ^0.28.2
+      runtypes: ^6.7.0
+      superstruct: ^1.0.3
+      valibot: ^0.13.1
+      vite: ^4.4.9
+      yup: ^1.2.0
+      zod: ^3.21.4
+    peerDependenciesMeta:
+      '@deepkit/type':
+        optional: true
+      '@effect/data':
+        optional: true
+      '@effect/io':
+        optional: true
+      '@effect/schema':
+        optional: true
+      '@sinclair/typebox':
+        optional: true
+      ajv:
+        optional: true
+      arktype:
+        optional: true
+      fp-ts:
+        optional: true
+      io-ts:
+        optional: true
+      joi:
+        optional: true
+      ow:
+        optional: true
+      runtypes:
+        optional: true
+      superstruct:
+        optional: true
+      valibot:
+        optional: true
+      vite:
+        optional: true
+      yup:
+        optional: true
+      zod:
+        optional: true
+    dependencies:
+      '@effect/data': 0.18.5
+      '@effect/io': 0.40.1(@effect/data@0.18.5)
+      '@effect/schema': 0.36.0(@effect/data@0.18.5)(@effect/io@0.40.1)
+      arktype: 1.0.14-alpha
+      runtypes: 6.6.0
+      superstruct: 1.0.3
+      valibot: 0.15.0
+      vite: 4.1.2(@types/node@18.16.16)
+      yup: 1.0.0
+      zod: 3.20.2
+    dev: false
 
   /@docsearch/css@3.3.0:
     resolution: {integrity: sha512-rODCdDtGyudLj+Va8b6w6Y85KE85bXRsps/R4Yjwt5vueXKXZQKYw0aA9knxLBT6a/bI/GMrAcmCR75KYOM6hg==}
@@ -13530,7 +13676,7 @@ packages:
       eslint: 8.40.0
       eslint-import-resolver-node: 0.3.6
       eslint-import-resolver-typescript: 3.5.2(eslint-plugin-import@2.26.0)(eslint@8.40.0)
-      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.59.2)(eslint-import-resolver-typescript@3.5.2)(eslint@8.40.0)
+      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@6.2.1)(eslint@8.40.0)
       eslint-plugin-jsx-a11y: 6.6.1(eslint@8.40.0)
       eslint-plugin-react: 7.32.2(eslint@8.40.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.40.0)
@@ -13567,7 +13713,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       enhanced-resolve: 5.12.0
       eslint: 8.40.0
-      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.59.2)(eslint-import-resolver-typescript@3.5.2)(eslint@8.40.0)
+      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@6.2.1)(eslint@8.40.0)
       get-tsconfig: 4.6.2
       globby: 13.1.3
       is-core-module: 2.12.0
@@ -13577,7 +13723,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.59.2)(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@3.5.2)(eslint@8.40.0):
+  /eslint-module-utils@2.7.4(@typescript-eslint/parser@6.2.1)(eslint-import-resolver-node@0.3.6)(eslint@8.40.0):
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -13598,16 +13744,15 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.59.2(eslint@8.40.0)(typescript@5.1.3)
+      '@typescript-eslint/parser': 6.2.1(eslint@8.40.0)(typescript@5.1.3)
       debug: 3.2.7
       eslint: 8.40.0
       eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 3.5.2(eslint-plugin-import@2.26.0)(eslint@8.40.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.59.2)(eslint-import-resolver-typescript@3.5.2)(eslint@8.40.0):
+  /eslint-plugin-import@2.26.0(@typescript-eslint/parser@6.2.1)(eslint@8.40.0):
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -13617,14 +13762,14 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.59.2(eslint@8.40.0)(typescript@5.1.3)
+      '@typescript-eslint/parser': 6.2.1(eslint@8.40.0)(typescript@5.1.3)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 8.40.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.59.2)(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@3.5.2)(eslint@8.40.0)
+      eslint-module-utils: 2.7.4(@typescript-eslint/parser@6.2.1)(eslint-import-resolver-node@0.3.6)(eslint@8.40.0)
       has: 1.0.3
       is-core-module: 2.12.0
       is-glob: 4.0.3
@@ -22979,6 +23124,10 @@ packages:
 
   /valibot@0.12.0:
     resolution: {integrity: sha512-EGx/uDUpRa9wB9NkD7fsktc02rvXWlJzDTC/ihbE+NybhzAsMhns2OOdNv2R4BtdGnDvaCEGi/DbgR5RvgCS8A==}
+    dev: true
+
+  /valibot@0.15.0:
+    resolution: {integrity: sha512-OOE8+EeR/TO/uks08FGYe/6DJVIgkD4Ap3dkd8M4ws/bCaQUg3XDk1PGDFiAUJqyQilW/QZ5buBEA3R1gIgQ0g==}
 
   /validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -24024,7 +24173,3 @@ packages:
     requiresBuild: true
     dependencies:
       '@prisma/engines': 4.14.1
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/www/docs/main/quickstart.mdx
+++ b/www/docs/main/quickstart.mdx
@@ -313,7 +313,7 @@ const appRouter = router({
 
   </TabItem>
   <TabItem value="valibot" label="Valibot">
-    The input parser can be any <code>BaseSchema</code> or <code>BaseSchemaAsync</code>, e.g. <code>string()</code> or <code>object({})</code>.
+    With Valibot, you simply need to <code>wrap</code> your schema with TypeSchema.
 
 <br />
 <br />
@@ -327,12 +327,13 @@ const appRouter = router({
 import { db } from './db';
 import { publicProcedure, router } from './trpc';
 // ---cut---
+import { wrap } from '@decs/typeschema';
 import { string } from 'valibot';
 
 const appRouter = router({
   // ...
   userById: publicProcedure
-    .input(string())
+    .input(wrap(string()))
     .query(async (opts) => {
       const { input } = opts;
       //      ^?

--- a/www/docs/server/validators.md
+++ b/www/docs/server/validators.md
@@ -390,6 +390,7 @@ export type AppRouter = typeof appRouter;
 ### With [Valibot](https://github.com/fabian-hiller/valibot)
 
 ```ts twoslash
+import { wrap } from '@decs/typeschema';
 import { initTRPC } from '@trpc/server';
 import { object, string } from 'valibot';
 
@@ -399,16 +400,8 @@ const publicProcedure = t.procedure;
 
 export const appRouter = t.router({
   hello: publicProcedure
-    .input(
-      object({
-        name: string(),
-      }),
-    )
-    .output(
-      object({
-        greeting: string(),
-      }),
-    )
+    .input(wrap(object({ name: string() })))
+    .output(wrap(object({ greeting: string() })))
     .query(({ input }) => {
       //      ^?
       return {

--- a/www/package.json
+++ b/www/package.json
@@ -61,6 +61,7 @@
   "devDependencies": {
     "@babel/core": "^7.18.6",
     "@babel/preset-env": "^7.18.6",
+    "@decs/typeschema": "^0.10.2",
     "@effect/schema": "^0.36.0",
     "@octokit/graphql": "^7.0.0",
     "@octokit/graphql-schema": "^14.0.0",
@@ -87,7 +88,7 @@
     "typedoc": "^0.24.7",
     "typedoc-plugin-markdown": "^4.0.0-next.13",
     "typescript": "^5.1.3",
-    "valibot": "^0.12.0",
+    "valibot": "^0.15.0",
     "yup": "^1.0.0"
   }
 }


### PR DESCRIPTION
Closes #4737

## 🎯 Changes

- Upgrade Valibot to v0.15.0
- Add `@decs/typeschema` package
- Update Valibot docs using `wrap`
- Update Valibot tests using `wrap`

> Currently there is still a problem with `wrap` so this is only a draft.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
