### PR TITLE
fix(client): allow constructing client error with no error property

### DIFF
--- a/packages/client/src/TRPCClientError.ts
+++ b/packages/client/src/TRPCClientError.ts
@@ -79,7 +79,7 @@ export class TRPCClientError<TRouterOrProcedure extends ErrorInferrable>
   ): TRPCClientError<TRouterOrProcedure> {
     if (!(cause instanceof Error)) {
       return new TRPCClientError<TRouterOrProcedure>(
-        cause.error.message ?? '',
+        cause.error?.message ?? '',
         {
           ...opts,
           cause: undefined,


### PR DESCRIPTION
Closes #4794

## 🎯 Changes

Resolves the issue linked above by allow `cause` objects to not include an `error` object, and instead defaults to an empty string (like existing behaviour when `message` is nullish)

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
