### PR TITLE
fix: codecov v4 doesn't exist?

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Test
         run: pnpm turbo --filter tests test-ci
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v3
         with:
           # token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
           directory: ./packages


### PR DESCRIPTION
all PRs are failing cause v4 cannot be found. did renovate fuck up?

looks like it's in beta: https://github.com/codecov/codecov-action/releases