### PR TITLE
fix(`react-query`): `useQueries` does not pass context data

### DIFF
--- a/packages/react-query/src/shared/proxy/useQueriesProxy.ts
+++ b/packages/react-query/src/shared/proxy/useQueriesProxy.ts
@@ -13,6 +13,7 @@ import {
 } from '@trpc/server/shared';
 import { getQueryKeyInternal } from '../../internals/getQueryKey';
 import { TrpcQueryOptionsForUseQueries } from '../../internals/useQueries';
+import { TRPCReactRequestOptions } from '../hooks/types';
 
 type GetQueryOptions<TProcedure extends AnyProcedure, TPath extends string> = <
   TData = inferTransformedProcedureOutput<TProcedure>,
@@ -63,16 +64,24 @@ export function createUseQueriesProxy<TRouter extends AnyRouter>(
 ) {
   return createRecursiveProxy((opts) => {
     const path = opts.path.join('.');
-    const [input, ...rest] = opts.args;
+    const [input, _opts] = opts.args as [
+      unknown,
+      (
+        | undefined
+        | {
+            trpc?: TRPCReactRequestOptions;
+          }
+      ),
+    ];
 
     const queryKey = getQueryKeyInternal(path, input);
 
     const options: QueryOptions = {
       queryKey,
       queryFn: () => {
-        return client.query(path, input);
+        return client.query(path, input, _opts?.trpc);
       },
-      ...(rest[0] as any),
+      ...(_opts as any),
     };
 
     return options;

--- a/packages/tests/server/react/useQueries.test.tsx
+++ b/packages/tests/server/react/useQueries.test.tsx
@@ -148,3 +148,58 @@ test('single query with options', async () => {
     expect(utils.container).toHaveTextContent(`__result2`);
   });
 });
+
+// regression https://github.com/trpc/trpc/issues/4802
+test('regression #4802: passes context to links', async () => {
+  const { proxy, App } = ctx;
+
+  function MyComponent() {
+    const results = proxy.useQueries((t) => [
+      t.post.byId(
+        { id: '1' },
+        {
+          trpc: {
+            context: {
+              id: '1',
+            },
+          },
+        },
+      ),
+      t.post.byId(
+        { id: '2' },
+        {
+          trpc: {
+            context: {
+              id: '2',
+            },
+          },
+        },
+      ),
+    ]);
+    if (results.some((v) => !v.data)) {
+      return <>...</>;
+    }
+
+    return <pre>{JSON.stringify(results, null, 4)}</pre>;
+  }
+
+  const utils = render(
+    <App>
+      <MyComponent />
+    </App>,
+  );
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent(`__result1`);
+    expect(utils.container).toHaveTextContent(`__result2`);
+  });
+
+  expect(ctx.spyLink).toHaveBeenCalledTimes(2);
+  const ops = ctx.spyLink.mock.calls.map((it) => it[0]);
+
+  expect(ops[0]!.context).toEqual({
+    id: '1',
+  });
+  expect(ops[1]!.context).toEqual({
+    id: '2',
+  });
+});


### PR DESCRIPTION
Closes #4802

## 🎯 Changes

- [x] add failing test
- [x] fix failing test