### PR TITLE
Drop TPath from type system, fix polymorphism types

### DIFF
--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -94,7 +94,7 @@ export type MaybeDecoratedInfiniteQuery<
   TConfig extends AnyRootConfig,
 > = inferProcedureInput<TProcedure> extends {
   cursor?: any;
-} | void
+} // | void TODO: why was this void here? It seems to have broken after moving out? If no .input is set surely infinitequery makes no sense?
   ? {
       /**
        * @see https://trpc.io/docs/client/react/suspense#useinfinitesuspensequery

--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -132,7 +132,7 @@ export type MaybeDecoratedInfiniteQuery<
 /**
  * @internal
  */
-export type DecoratedQuery<
+export type DecoratedQueryMethods<
   TConfig extends AnyRootConfig,
   TProcedure extends AnyProcedure,
 > = {
@@ -158,6 +158,15 @@ export type DecoratedQuery<
     >,
   ) => UseTRPCSuspenseQueryResult<TData, TRPCClientErrorLike<TConfig>>;
 } & MaybeDecoratedInfiniteQuery<TProcedure, TConfig>;
+
+/**
+ * @internal
+ */
+export type DecoratedQuery<
+  TConfig extends AnyRootConfig,
+  TProcedure extends AnyProcedure,
+> = MaybeDecoratedInfiniteQuery<TProcedure, TConfig> &
+  DecoratedQueryMethods<TConfig, TProcedure>;
 
 /**
  * @internal

--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -162,7 +162,7 @@ export type DecoratedQueryMethods<
       TRPCClientErrorLike<TConfig>
     >,
   ) => UseTRPCSuspenseQueryResult<TData, TRPCClientErrorLike<TConfig>>;
-} & MaybeDecoratedInfiniteQuery<TProcedure, TConfig>;
+};
 
 /**
  * @internal

--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -89,86 +89,102 @@ export interface ProcedureUseQuery<
 /**
  * @internal
  */
+export type DecoratedQuery<
+  TConfig extends AnyRootConfig,
+  TProcedure extends AnyProcedure,
+> = (inferProcedureInput<TProcedure> extends { cursor?: any } | void
+  ? {
+      /**
+       * @see https://trpc.io/docs/client/react/suspense#useinfinitesuspensequery
+       */
+      useInfiniteQuery: (
+        input: Omit<inferProcedureInput<TProcedure>, 'cursor'>,
+        opts: UseTRPCInfiniteQueryOptions<
+          inferProcedureInput<TProcedure>,
+          inferTransformedProcedureOutput<TConfig, TProcedure>,
+          TRPCClientErrorLike<TConfig>
+        >,
+      ) => UseTRPCInfiniteQueryResult<
+        inferTransformedProcedureOutput<TConfig, TProcedure>,
+        TRPCClientErrorLike<TConfig>,
+        inferProcedureInput<TProcedure>
+      >;
+      /**
+       * @see https://trpc.io/docs/client/react/suspense
+       */
+      useSuspenseInfiniteQuery: (
+        input: Omit<inferProcedureInput<TProcedure>, 'cursor'>,
+        opts: UseTRPCSuspenseInfiniteQueryOptions<
+          inferProcedureInput<TProcedure>,
+          inferTransformedProcedureOutput<TConfig, TProcedure>,
+          TRPCClientErrorLike<TConfig>
+        >,
+      ) => UseTRPCSuspenseInfiniteQueryResult<
+        inferTransformedProcedureOutput<TConfig, TProcedure>,
+        TRPCClientErrorLike<TConfig>,
+        inferProcedureInput<TProcedure>
+      >;
+    }
+  : object) & {
+  /**
+   * @see https://trpc.io/docs/client/react/useQuery
+   */
+  useQuery: ProcedureUseQuery<TConfig, TProcedure>;
+  /**
+   * @see https://trpc.io/docs/client/react/suspense#usesuspensequery
+   */
+  useSuspenseQuery: <
+    TQueryFnData extends inferTransformedProcedureOutput<
+      TConfig,
+      TProcedure
+    > = inferTransformedProcedureOutput<TConfig, TProcedure>,
+    TData = TQueryFnData,
+  >(
+    input: inferProcedureInput<TProcedure>,
+    opts?: UseTRPCSuspenseQueryOptions<
+      TQueryFnData,
+      TData,
+      TRPCClientErrorLike<TConfig>
+    >,
+  ) => UseTRPCSuspenseQueryResult<TData, TRPCClientErrorLike<TConfig>>;
+};
+
+/**
+ * @internal
+ */
+export interface DecoratedMutation<
+  TConfig extends AnyRootConfig,
+  TProcedure extends AnyProcedure,
+> {
+  /**
+   * @see https://trpc.io/docs/client/react/useMutation
+   */
+  useMutation: <TContext = unknown>(
+    opts?: UseTRPCMutationOptions<
+      inferProcedureInput<TProcedure>,
+      TRPCClientErrorLike<TConfig>,
+      inferTransformedProcedureOutput<TConfig, TProcedure>,
+      TContext
+    >,
+  ) => UseTRPCMutationResult<
+    inferTransformedProcedureOutput<TConfig, TProcedure>,
+    TRPCClientErrorLike<TConfig>,
+    inferProcedureInput<TProcedure>,
+    TContext
+  >;
+}
+
+/**
+ * @internal
+ */
 export type DecorateProcedure<
   TConfig extends AnyRootConfig,
   TProcedure extends AnyProcedure,
   _TFlags,
 > = TProcedure extends AnyQueryProcedure
-  ? (inferProcedureInput<TProcedure> extends { cursor?: any } | void
-      ? {
-          /**
-           * @see https://trpc.io/docs/client/react/suspense#useinfinitesuspensequery
-           */
-          useInfiniteQuery: (
-            input: Omit<inferProcedureInput<TProcedure>, 'cursor'>,
-            opts: UseTRPCInfiniteQueryOptions<
-              inferProcedureInput<TProcedure>,
-              inferTransformedProcedureOutput<TConfig, TProcedure>,
-              TRPCClientErrorLike<TConfig>
-            >,
-          ) => UseTRPCInfiniteQueryResult<
-            inferTransformedProcedureOutput<TConfig, TProcedure>,
-            TRPCClientErrorLike<TConfig>,
-            inferProcedureInput<TProcedure>
-          >;
-          /**
-           * @see https://trpc.io/docs/client/react/suspense
-           */
-          useSuspenseInfiniteQuery: (
-            input: Omit<inferProcedureInput<TProcedure>, 'cursor'>,
-            opts: UseTRPCSuspenseInfiniteQueryOptions<
-              inferProcedureInput<TProcedure>,
-              inferTransformedProcedureOutput<TConfig, TProcedure>,
-              TRPCClientErrorLike<TConfig>
-            >,
-          ) => UseTRPCSuspenseInfiniteQueryResult<
-            inferTransformedProcedureOutput<TConfig, TProcedure>,
-            TRPCClientErrorLike<TConfig>,
-            inferProcedureInput<TProcedure>
-          >;
-        }
-      : object) & {
-      /**
-       * @see https://trpc.io/docs/client/react/useQuery
-       */
-      useQuery: ProcedureUseQuery<TConfig, TProcedure>;
-      /**
-       * @see https://trpc.io/docs/client/react/suspense#usesuspensequery
-       */
-      useSuspenseQuery: <
-        TQueryFnData extends inferTransformedProcedureOutput<
-          TConfig,
-          TProcedure
-        > = inferTransformedProcedureOutput<TConfig, TProcedure>,
-        TData = TQueryFnData,
-      >(
-        input: inferProcedureInput<TProcedure>,
-        opts?: UseTRPCSuspenseQueryOptions<
-          TQueryFnData,
-          TData,
-          TRPCClientErrorLike<TConfig>
-        >,
-      ) => UseTRPCSuspenseQueryResult<TData, TRPCClientErrorLike<TConfig>>;
-    }
+  ? DecoratedQuery<TConfig, TProcedure>
   : TProcedure extends AnyMutationProcedure
-  ? {
-      /**
-       * @see https://trpc.io/docs/client/react/useMutation
-       */
-      useMutation: <TContext = unknown>(
-        opts?: UseTRPCMutationOptions<
-          inferProcedureInput<TProcedure>,
-          TRPCClientErrorLike<TConfig>,
-          inferTransformedProcedureOutput<TConfig, TProcedure>,
-          TContext
-        >,
-      ) => UseTRPCMutationResult<
-        inferTransformedProcedureOutput<TConfig, TProcedure>,
-        TRPCClientErrorLike<TConfig>,
-        inferProcedureInput<TProcedure>,
-        TContext
-      >;
-    }
+  ? DecoratedMutation<TConfig, TProcedure>
   : TProcedure extends AnySubscriptionProcedure
   ? {
       /**

--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -87,14 +87,19 @@ export interface ProcedureUseQuery<
 }
 
 /**
+ * @remark `void` is here due to https://github.com/trpc/trpc/pull/4374
+ */
+type CursorInput = {
+  cursor?: any;
+} | void;
+
+/**
  * @internal
  */
 export type MaybeDecoratedInfiniteQuery<
   TProcedure extends AnyProcedure,
   TConfig extends AnyRootConfig,
-> = inferProcedureInput<TProcedure> extends {
-  cursor?: any;
-} | void
+> = inferProcedureInput<TProcedure> extends CursorInput
   ? {
       /**
        * @see https://trpc.io/docs/client/react/suspense#useinfinitesuspensequery

--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -94,7 +94,7 @@ export type MaybeDecoratedInfiniteQuery<
   TConfig extends AnyRootConfig,
 > = inferProcedureInput<TProcedure> extends {
   cursor?: any;
-} // | void TODO: why was this void here? It seems to have broken after moving out? If no .input is set surely infinitequery makes no sense?
+} | void
   ? {
       /**
        * @see https://trpc.io/docs/client/react/suspense#useinfinitesuspensequery
@@ -132,7 +132,7 @@ export type MaybeDecoratedInfiniteQuery<
 /**
  * @internal
  */
-export type DecoratedQueryMethods<
+export type DecoratedQuery<
   TConfig extends AnyRootConfig,
   TProcedure extends AnyProcedure,
 > = {
@@ -157,16 +157,7 @@ export type DecoratedQueryMethods<
       TRPCClientErrorLike<TConfig>
     >,
   ) => UseTRPCSuspenseQueryResult<TData, TRPCClientErrorLike<TConfig>>;
-};
-
-/**
- * @internal
- */
-export type DecoratedQuery<
-  TConfig extends AnyRootConfig,
-  TProcedure extends AnyProcedure,
-> = MaybeDecoratedInfiniteQuery<TProcedure, TConfig> &
-  DecoratedQueryMethods<TConfig, TProcedure>;
+} & MaybeDecoratedInfiniteQuery<TProcedure, TConfig>;
 
 /**
  * @internal

--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -89,10 +89,12 @@ export interface ProcedureUseQuery<
 /**
  * @internal
  */
-export type DecoratedQuery<
-  TConfig extends AnyRootConfig,
+export type MaybeDecoratedInfiniteQuery<
   TProcedure extends AnyProcedure,
-> = (inferProcedureInput<TProcedure> extends { cursor?: any } | void
+  TConfig extends AnyRootConfig,
+> = inferProcedureInput<TProcedure> extends {
+  cursor?: any;
+} | void
   ? {
       /**
        * @see https://trpc.io/docs/client/react/suspense#useinfinitesuspensequery
@@ -125,7 +127,15 @@ export type DecoratedQuery<
         inferProcedureInput<TProcedure>
       >;
     }
-  : object) & {
+  : object;
+
+/**
+ * @internal
+ */
+export type DecoratedQueryMethods<
+  TConfig extends AnyRootConfig,
+  TProcedure extends AnyProcedure,
+> = {
   /**
    * @see https://trpc.io/docs/client/react/useQuery
    */
@@ -148,6 +158,15 @@ export type DecoratedQuery<
     >,
   ) => UseTRPCSuspenseQueryResult<TData, TRPCClientErrorLike<TConfig>>;
 };
+
+/**
+ * @internal
+ */
+export type DecoratedQuery<
+  TConfig extends AnyRootConfig,
+  TProcedure extends AnyProcedure,
+> = MaybeDecoratedInfiniteQuery<TProcedure, TConfig> &
+  DecoratedQueryMethods<TConfig, TProcedure>;
 
 /**
  * @internal

--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -52,7 +52,6 @@ import { CreateTRPCReactOptions } from './shared/types';
 export interface ProcedureUseQuery<
   TConfig extends AnyRootConfig,
   TProcedure extends AnyProcedure,
-  TPath extends string,
 > {
   <
     TQueryFnData extends inferTransformedProcedureOutput<
@@ -63,8 +62,6 @@ export interface ProcedureUseQuery<
   >(
     input: inferProcedureInput<TProcedure>,
     opts: DefinedUseTRPCQueryOptions<
-      TPath,
-      inferProcedureInput<TProcedure>,
       TQueryFnData,
       TData,
       TRPCClientErrorLike<TConfig>,
@@ -81,8 +78,6 @@ export interface ProcedureUseQuery<
   >(
     input: inferProcedureInput<TProcedure>,
     opts?: UseTRPCQueryOptions<
-      TPath,
-      inferProcedureInput<TProcedure>,
       TQueryFnData,
       TData,
       TRPCClientErrorLike<TConfig>,
@@ -98,7 +93,6 @@ export type DecorateProcedure<
   TConfig extends AnyRootConfig,
   TProcedure extends AnyProcedure,
   _TFlags,
-  TPath extends string,
 > = TProcedure extends AnyQueryProcedure
   ? (inferProcedureInput<TProcedure> extends { cursor?: any } | void
       ? {
@@ -108,7 +102,6 @@ export type DecorateProcedure<
           useInfiniteQuery: (
             input: Omit<inferProcedureInput<TProcedure>, 'cursor'>,
             opts: UseTRPCInfiniteQueryOptions<
-              TPath,
               inferProcedureInput<TProcedure>,
               inferTransformedProcedureOutput<TConfig, TProcedure>,
               TRPCClientErrorLike<TConfig>
@@ -124,7 +117,6 @@ export type DecorateProcedure<
           useSuspenseInfiniteQuery: (
             input: Omit<inferProcedureInput<TProcedure>, 'cursor'>,
             opts: UseTRPCSuspenseInfiniteQueryOptions<
-              TPath,
               inferProcedureInput<TProcedure>,
               inferTransformedProcedureOutput<TConfig, TProcedure>,
               TRPCClientErrorLike<TConfig>
@@ -139,7 +131,7 @@ export type DecorateProcedure<
       /**
        * @see https://trpc.io/docs/client/react/useQuery
        */
-      useQuery: ProcedureUseQuery<TConfig, TProcedure, TPath>;
+      useQuery: ProcedureUseQuery<TConfig, TProcedure>;
       /**
        * @see https://trpc.io/docs/client/react/suspense#usesuspensequery
        */
@@ -152,8 +144,6 @@ export type DecorateProcedure<
       >(
         input: inferProcedureInput<TProcedure>,
         opts?: UseTRPCSuspenseQueryOptions<
-          TPath,
-          inferProcedureInput<TProcedure>,
           TQueryFnData,
           TData,
           TRPCClientErrorLike<TConfig>
@@ -201,22 +191,15 @@ export type DecoratedProcedureRecord<
   TConfig extends AnyRootConfig,
   TProcedures extends ProcedureRouterRecord,
   TFlags,
-  TPath extends string = '',
 > = {
   [TKey in keyof TProcedures]: TProcedures[TKey] extends AnyRouter
     ? DecoratedProcedureRecord<
         TConfig,
         TProcedures[TKey]['_def']['record'],
-        TFlags,
-        `${TPath}${TKey & string}.`
+        TFlags
       >
     : TProcedures[TKey] extends AnyProcedure
-    ? DecorateProcedure<
-        TConfig,
-        TProcedures[TKey],
-        TFlags,
-        `${TPath}${TKey & string}`
-      >
+    ? DecorateProcedure<TConfig, TProcedures[TKey], TFlags>
     : never;
 };
 

--- a/packages/react-query/src/internals/getQueryKey.ts
+++ b/packages/react-query/src/internals/getQueryKey.ts
@@ -72,34 +72,20 @@ type GetParams<
     | AnyMutationProcedure
     | AnyQueryProcedure
     | AnyRouter,
-  TPath extends string,
   TFlags,
 > = TProcedureOrRouter extends AnyQueryProcedure
   ? [
-      procedureOrRouter: DecorateProcedure<
-        TConfig,
-        TProcedureOrRouter,
-        TFlags,
-        TPath
-      >,
+      procedureOrRouter: DecorateProcedure<TConfig, TProcedureOrRouter, TFlags>,
       ..._params: GetQueryParams<TProcedureOrRouter>,
     ]
   : TProcedureOrRouter extends AnyMutationProcedure
-  ? [
-      procedureOrRouter: DecorateProcedure<
-        TConfig,
-        TProcedureOrRouter,
-        TFlags,
-        TPath
-      >,
-    ]
+  ? [procedureOrRouter: DecorateProcedure<TConfig, TProcedureOrRouter, TFlags>]
   : TProcedureOrRouter extends AnyRouter
   ? [
       procedureOrRouter: DecoratedProcedureRecord<
         TConfig,
         TProcedureOrRouter['_def']['record'],
-        TFlags,
-        any
+        TFlags
       >,
     ]
   : never;
@@ -110,9 +96,8 @@ type GetQueryKeyParams<
     | AnyMutationProcedure
     | AnyQueryProcedure
     | AnyRouter,
-  TPath extends string,
   TFlags,
-> = GetParams<TConfig, TProcedureOrRouter, TPath, TFlags>;
+> = GetParams<TConfig, TProcedureOrRouter, TFlags>;
 
 /**
  * Method to extract the query key for a procedure
@@ -127,9 +112,8 @@ export function getQueryKey<
     | AnyMutationProcedure
     | AnyQueryProcedure
     | AnyRouter,
-  TPath extends string,
   TFlags,
->(..._params: GetQueryKeyParams<TConfig, TProcedureOrRouter, TPath, TFlags>) {
+>(..._params: GetQueryKeyParams<TConfig, TProcedureOrRouter, TFlags>) {
   const [procedureOrRouter, input, type] = _params;
   // @ts-expect-error - we don't expose _def on the type layer
   const path = procedureOrRouter._def().path as string[];

--- a/packages/react-query/src/internals/useQueries.ts
+++ b/packages/react-query/src/internals/useQueries.ts
@@ -22,16 +22,8 @@ export type UseQueryOptionsForUseQueries<
 /**
  * @internal
  */
-export type TrpcQueryOptionsForUseQueries<
-  TPath,
-  TInput,
-  TOutput,
-  TData,
-  TError,
-> = DistributiveOmit<
-  UseTRPCQueryOptions<TPath, TInput, TOutput, TData, TError>,
-  'queryKey'
->;
+export type TrpcQueryOptionsForUseQueries<TOutput, TData, TError> =
+  DistributiveOmit<UseTRPCQueryOptions<TOutput, TData, TError>, 'queryKey'>;
 
 /**
  * @internal

--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -249,7 +249,7 @@ export function createRootHooks<
   function useQuery(
     path: string[],
     input: unknown,
-    opts?: UseTRPCQueryOptions<unknown, unknown, unknown, unknown, TError>,
+    opts?: UseTRPCQueryOptions<unknown, unknown, TError>,
   ): UseTRPCQueryResult<unknown, TError> {
     const context = useContext();
     if (!context) {

--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -311,13 +311,7 @@ export function createRootHooks<
   function useSuspenseQuery(
     path: string[],
     input: unknown,
-    opts?: UseTRPCSuspenseQueryOptions<
-      unknown,
-      unknown,
-      unknown,
-      unknown,
-      TError
-    >,
+    opts?: UseTRPCSuspenseQueryOptions<unknown, unknown, TError>,
   ): UseTRPCSuspenseQueryResult<unknown, TError> {
     const hookResult = useQuery(path, input, {
       ...opts,
@@ -417,7 +411,7 @@ export function createRootHooks<
   function useInfiniteQuery(
     path: string[],
     input: unknown,
-    opts: UseTRPCInfiniteQueryOptions<unknown, unknown, unknown, TError>,
+    opts: UseTRPCInfiniteQueryOptions<unknown, unknown, TError>,
   ): UseTRPCInfiniteQueryResult<unknown, TError, unknown> {
     const {
       client,
@@ -486,12 +480,7 @@ export function createRootHooks<
   function useSuspenseInfiniteQuery(
     path: string[],
     input: unknown,
-    opts: UseTRPCSuspenseInfiniteQueryOptions<
-      unknown,
-      unknown,
-      unknown,
-      TError
-    >,
+    opts: UseTRPCSuspenseInfiniteQueryOptions<unknown, unknown, TError>,
   ): UseTRPCSuspenseInfiniteQueryResult<unknown, TError, unknown> {
     const hookResult = useInfiniteQuery(path, input, {
       ...opts,
@@ -513,7 +502,7 @@ export function createRootHooks<
 
     if (typeof window === 'undefined' && ssrState === 'prepass') {
       for (const query of queries) {
-        const queryOption = query as TRPCQueryOptions<any, any, any, any>;
+        const queryOption = query as TRPCQueryOptions<any, any>;
         if (
           queryOption.trpc?.ssr !== false &&
           !queryClient.getQueryCache().find({ queryKey: queryOption.queryKey })
@@ -527,7 +516,7 @@ export function createRootHooks<
       {
         queries: queries.map((query) => ({
           ...query,
-          queryKey: (query as TRPCQueryOptions<any, any, any, any>).queryKey,
+          queryKey: (query as TRPCQueryOptions<any, any>).queryKey,
         })),
       },
       queryClient,

--- a/packages/react-query/src/shared/hooks/types.ts
+++ b/packages/react-query/src/shared/hooks/types.ts
@@ -54,56 +54,38 @@ export interface TRPCUseQueryBaseOptions {
 }
 
 export interface UseTRPCQueryOptions<
-  TPath,
-  TInput,
   TOutput,
   TData,
   TError,
   TQueryOptsData = TOutput,
 > extends DistributiveOmit<
-      UseBaseQueryOptions<
-        TOutput,
-        TError,
-        TData,
-        TQueryOptsData,
-        [TPath, TInput]
-      >,
+      UseBaseQueryOptions<TOutput, TError, TData, TQueryOptsData, any>,
       'queryKey'
     >,
     TRPCUseQueryBaseOptions {}
 
-export interface UseTRPCSuspenseQueryOptions<
-  TPath,
-  TInput,
-  TOutput,
-  TData,
-  TError,
-> extends DistributiveOmit<
-      UseSuspenseQueryOptions<TOutput, TError, TData, [TPath, TInput]>,
+export interface UseTRPCSuspenseQueryOptions<TOutput, TData, TError>
+  extends DistributiveOmit<
+      UseSuspenseQueryOptions<TOutput, TError, TData, any>,
       'queryKey'
     >,
     TRPCUseQueryBaseOptions {}
 
 /** @internal **/
 export interface DefinedUseTRPCQueryOptions<
-  TPath,
-  TInput,
   TOutput,
   TData,
   TError,
   TQueryOptsData = TOutput,
 > extends DistributiveOmit<
-    UseTRPCQueryOptions<TPath, TInput, TOutput, TData, TError, TQueryOptsData>,
+    UseTRPCQueryOptions<TOutput, TData, TError, TQueryOptsData>,
     'queryKey'
   > {
   initialData: InitialDataFunction<TQueryOptsData> | TQueryOptsData;
 }
 
-export interface TRPCQueryOptions<TPath, TInput, TData, TError>
-  extends DistributiveOmit<
-      QueryOptions<TData, TError, TData, [TPath, TInput]>,
-      'queryKey'
-    >,
+export interface TRPCQueryOptions<TData, TError>
+  extends DistributiveOmit<QueryOptions<TData, TError, TData, any>, 'queryKey'>,
     TRPCUseQueryBaseOptions {
   queryKey: TRPCQueryKey;
 }
@@ -112,14 +94,14 @@ export type ExtractCursorType<TInput> = TInput extends { cursor?: any }
   ? TInput['cursor']
   : unknown;
 
-export interface UseTRPCInfiniteQueryOptions<TPath, TInput, TOutput, TError>
+export interface UseTRPCInfiniteQueryOptions<TInput, TOutput, TError>
   extends DistributiveOmit<
       UseInfiniteQueryOptions<
         TOutput,
         TError,
         TOutput,
         TOutput,
-        [TPath, Omit<TInput, 'cursor'>],
+        any,
         ExtractCursorType<TInput>
       >,
       'queryKey' | 'defaultPageParam'
@@ -128,18 +110,14 @@ export interface UseTRPCInfiniteQueryOptions<TPath, TInput, TOutput, TError>
   initialCursor?: ExtractCursorType<TInput>;
 }
 
-export interface UseTRPCSuspenseInfiniteQueryOptions<
-  TPath,
-  TInput,
-  TOutput,
-  TError,
-> extends DistributiveOmit<
+export interface UseTRPCSuspenseInfiniteQueryOptions<TInput, TOutput, TError>
+  extends DistributiveOmit<
       UseSuspenseInfiniteQueryOptions<
         TOutput,
         TError,
         TOutput,
         TOutput,
-        [TPath, Omit<TInput, 'cursor'>],
+        any,
         ExtractCursorType<TInput>
       >,
       'queryKey' | 'defaultPageParam'

--- a/packages/react-query/src/shared/polymorphism/mutationLike.ts
+++ b/packages/react-query/src/shared/polymorphism/mutationLike.ts
@@ -1,6 +1,9 @@
+import {
+  InferMutationOptions,
+  InferMutationResult,
+} from '@trpc/react-query/utils/inferReactQueryProcedure';
 import { AnyProcedure, AnyRootConfig, inferProcedureInput } from '@trpc/server';
 import { inferTransformedProcedureOutput } from '@trpc/server/shared';
-import { DecoratedMutation } from '../../createTRPCReact';
 
 /**
  * Use to describe a mutation route which matches a given mutation procedure's interface
@@ -8,7 +11,11 @@ import { DecoratedMutation } from '../../createTRPCReact';
 export type MutationLike<
   TConfig extends AnyRootConfig = AnyRootConfig,
   TProcedure extends AnyProcedure = AnyProcedure,
-> = DecoratedMutation<TConfig, TProcedure>;
+> = {
+  useMutation: (
+    opts?: InferMutationOptions<TConfig, TProcedure>,
+  ) => InferMutationResult<TConfig, TProcedure>;
+};
 
 /**
  * Use to unwrap a MutationLike's input

--- a/packages/react-query/src/shared/polymorphism/mutationLike.ts
+++ b/packages/react-query/src/shared/polymorphism/mutationLike.ts
@@ -1,6 +1,6 @@
-import { DecoratedMutation } from '@trpc/react-query/createTRPCReact';
 import { AnyProcedure, AnyRootConfig, inferProcedureInput } from '@trpc/server';
 import { inferTransformedProcedureOutput } from '@trpc/server/shared';
+import { DecoratedMutation } from '../../createTRPCReact';
 
 /**
  * Use to describe a mutation route which matches a given mutation procedure's interface

--- a/packages/react-query/src/shared/polymorphism/mutationLike.ts
+++ b/packages/react-query/src/shared/polymorphism/mutationLike.ts
@@ -1,9 +1,6 @@
+import { DecoratedMutation } from '@trpc/react-query/createTRPCReact';
 import { AnyProcedure, AnyRootConfig, inferProcedureInput } from '@trpc/server';
 import { inferTransformedProcedureOutput } from '@trpc/server/shared';
-import {
-  InferMutationOptions,
-  InferMutationResult,
-} from '../../utils/inferReactQueryProcedure';
 
 /**
  * Use to describe a mutation route which matches a given mutation procedure's interface
@@ -11,11 +8,7 @@ import {
 export type MutationLike<
   TConfig extends AnyRootConfig = AnyRootConfig,
   TProcedure extends AnyProcedure = AnyProcedure,
-> = {
-  useMutation: (
-    opts?: InferMutationOptions<TConfig, TProcedure>,
-  ) => InferMutationResult<TConfig, TProcedure>;
-};
+> = DecoratedMutation<TConfig, TProcedure>;
 
 /**
  * Use to unwrap a MutationLike's input

--- a/packages/react-query/src/shared/polymorphism/queryLike.ts
+++ b/packages/react-query/src/shared/polymorphism/queryLike.ts
@@ -1,6 +1,9 @@
+import {
+  InferQueryOptions,
+  InferQueryResult,
+} from '@trpc/react-query/utils/inferReactQueryProcedure';
 import { AnyProcedure, AnyRootConfig, inferProcedureInput } from '@trpc/server';
 import { inferTransformedProcedureOutput } from '@trpc/server/shared';
-import { DecoratedQuery, DecoratedQueryMethods } from '../../createTRPCReact';
 
 /**
  * Use to request a query route which matches a given query procedure's interface
@@ -8,14 +11,19 @@ import { DecoratedQuery, DecoratedQueryMethods } from '../../createTRPCReact';
 export type QueryLike<
   TConfig extends AnyRootConfig = AnyRootConfig,
   TProcedure extends AnyProcedure = AnyProcedure,
-> = DecoratedQuery<TConfig, TProcedure>;
+> = {
+  useQuery: (
+    variables: inferProcedureInput<TProcedure>,
+    opts?: InferQueryOptions<TConfig, TProcedure, any>,
+  ) => InferQueryResult<TConfig, TProcedure>;
+};
 
 /**
  * Use to unwrap a QueryLike's input
  */
 export type InferQueryLikeInput<
-  TQueryLike extends DecoratedQueryMethods<AnyRootConfig, AnyProcedure>,
-> = TQueryLike extends DecoratedQueryMethods<any, infer TProcedure>
+  TQueryLike extends QueryLike<AnyRootConfig, AnyProcedure>,
+> = TQueryLike extends QueryLike<any, infer TProcedure>
   ? inferProcedureInput<TProcedure>
   : never;
 
@@ -23,7 +31,7 @@ export type InferQueryLikeInput<
  * Use to unwrap a QueryLike's data output
  */
 export type InferQueryLikeData<
-  TQueryLike extends DecoratedQueryMethods<AnyRootConfig, AnyProcedure>,
-> = TQueryLike extends DecoratedQueryMethods<infer TConfig, infer TProcedure>
+  TQueryLike extends QueryLike<AnyRootConfig, AnyProcedure>,
+> = TQueryLike extends QueryLike<infer TConfig, infer TProcedure>
   ? inferTransformedProcedureOutput<TConfig, TProcedure>
   : never;

--- a/packages/react-query/src/shared/polymorphism/queryLike.ts
+++ b/packages/react-query/src/shared/polymorphism/queryLike.ts
@@ -1,6 +1,6 @@
 import { AnyProcedure, AnyRootConfig, inferProcedureInput } from '@trpc/server';
 import { inferTransformedProcedureOutput } from '@trpc/server/shared';
-import { DecoratedQuery, DecoratedQueryMethods } from '../..//createTRPCReact';
+import { DecoratedQuery, DecoratedQueryMethods } from '../../createTRPCReact';
 
 /**
  * Use to request a query route which matches a given query procedure's interface

--- a/packages/react-query/src/shared/polymorphism/queryLike.ts
+++ b/packages/react-query/src/shared/polymorphism/queryLike.ts
@@ -14,7 +14,7 @@ export type QueryLike<
  * Use to unwrap a QueryLike's input
  */
 export type InferQueryLikeInput<
-  TQueryLike extends DecoratedQueryMethods<AnyRootConfig, any>,
+  TQueryLike extends DecoratedQueryMethods<AnyRootConfig, AnyProcedure>,
 > = TQueryLike extends DecoratedQueryMethods<any, infer TProcedure>
   ? inferProcedureInput<TProcedure>
   : never;
@@ -23,7 +23,7 @@ export type InferQueryLikeInput<
  * Use to unwrap a QueryLike's data output
  */
 export type InferQueryLikeData<
-  TQueryLike extends DecoratedQueryMethods<AnyRootConfig, any>,
+  TQueryLike extends DecoratedQueryMethods<AnyRootConfig, AnyProcedure>,
 > = TQueryLike extends DecoratedQueryMethods<infer TConfig, infer TProcedure>
   ? inferTransformedProcedureOutput<TConfig, TProcedure>
   : never;

--- a/packages/react-query/src/shared/polymorphism/queryLike.ts
+++ b/packages/react-query/src/shared/polymorphism/queryLike.ts
@@ -1,9 +1,6 @@
-import {
-  DecoratedQuery,
-  DecoratedQueryMethods,
-} from '@trpc/react-query/createTRPCReact';
 import { AnyProcedure, AnyRootConfig, inferProcedureInput } from '@trpc/server';
 import { inferTransformedProcedureOutput } from '@trpc/server/shared';
+import { DecoratedQuery, DecoratedQueryMethods } from '../..//createTRPCReact';
 
 /**
  * Use to request a query route which matches a given query procedure's interface

--- a/packages/react-query/src/shared/polymorphism/queryLike.ts
+++ b/packages/react-query/src/shared/polymorphism/queryLike.ts
@@ -14,7 +14,7 @@ export type QueryLike<
 > = {
   useQuery: (
     variables: inferProcedureInput<TProcedure>,
-    opts?: InferQueryOptions<TConfig, TProcedure, any, any>,
+    opts?: InferQueryOptions<TConfig, TProcedure, any>,
   ) => InferQueryResult<TConfig, TProcedure>;
 };
 

--- a/packages/react-query/src/shared/polymorphism/queryLike.ts
+++ b/packages/react-query/src/shared/polymorphism/queryLike.ts
@@ -1,4 +1,7 @@
-import { DecoratedQuery } from '@trpc/react-query/createTRPCReact';
+import {
+  DecoratedQuery,
+  DecoratedQueryMethods,
+} from '@trpc/react-query/createTRPCReact';
 import { AnyProcedure, AnyRootConfig, inferProcedureInput } from '@trpc/server';
 import { inferTransformedProcedureOutput } from '@trpc/server/shared';
 
@@ -13,15 +16,17 @@ export type QueryLike<
 /**
  * Use to unwrap a QueryLike's input
  */
-export type InferQueryLikeInput<TQueryLike extends QueryLike> =
-  TQueryLike extends QueryLike<any, infer TProcedure>
-    ? inferProcedureInput<TProcedure>
-    : never;
+export type InferQueryLikeInput<
+  TQueryLike extends DecoratedQueryMethods<AnyRootConfig, any>,
+> = TQueryLike extends DecoratedQueryMethods<any, infer TProcedure>
+  ? inferProcedureInput<TProcedure>
+  : never;
 
 /**
  * Use to unwrap a QueryLike's data output
  */
-export type InferQueryLikeData<TQueryLike extends QueryLike> =
-  TQueryLike extends QueryLike<infer TConfig, infer TProcedure>
-    ? inferTransformedProcedureOutput<TConfig, TProcedure>
-    : never;
+export type InferQueryLikeData<
+  TQueryLike extends DecoratedQueryMethods<AnyRootConfig, any>,
+> = TQueryLike extends DecoratedQueryMethods<infer TConfig, infer TProcedure>
+  ? inferTransformedProcedureOutput<TConfig, TProcedure>
+  : never;

--- a/packages/react-query/src/shared/polymorphism/queryLike.ts
+++ b/packages/react-query/src/shared/polymorphism/queryLike.ts
@@ -1,9 +1,6 @@
+import { DecoratedQuery } from '@trpc/react-query/createTRPCReact';
 import { AnyProcedure, AnyRootConfig, inferProcedureInput } from '@trpc/server';
 import { inferTransformedProcedureOutput } from '@trpc/server/shared';
-import {
-  InferQueryOptions,
-  InferQueryResult,
-} from '../../utils/inferReactQueryProcedure';
 
 /**
  * Use to request a query route which matches a given query procedure's interface
@@ -11,12 +8,7 @@ import {
 export type QueryLike<
   TConfig extends AnyRootConfig = AnyRootConfig,
   TProcedure extends AnyProcedure = AnyProcedure,
-> = {
-  useQuery: (
-    variables: inferProcedureInput<TProcedure>,
-    opts?: InferQueryOptions<TConfig, TProcedure, any>,
-  ) => InferQueryResult<TConfig, TProcedure>;
-};
+> = DecoratedQuery<TConfig, TProcedure>;
 
 /**
  * Use to unwrap a QueryLike's input

--- a/packages/react-query/src/shared/polymorphism/routerLike.ts
+++ b/packages/react-query/src/shared/polymorphism/routerLike.ts
@@ -1,26 +1,11 @@
-import {
-  AnyMutationProcedure,
-  AnyQueryProcedure,
-  AnyRouter,
-  Router,
-} from '@trpc/server';
-import { MutationLike } from './mutationLike';
-import { QueryLike } from './queryLike';
+import { CreateTRPCReact } from '@trpc/react-query/createTRPCReact';
+import { AnyRouter } from '@trpc/server';
 
 /**
  * Use to describe a route path which matches a given route's interface
  */
-export type RouterLike<
-  TRouter extends AnyRouter,
-  TRecord extends TRouter['_def']['record'] = TRouter['_def']['record'],
-> = TRouter extends Router<infer TDef>
-  ? {
-      [key in keyof TRecord]: TRecord[key] extends AnyRouter
-        ? RouterLike<TRecord[key]>
-        : TRecord[key] extends AnyQueryProcedure
-        ? QueryLike<TDef['_config'], TRecord[key]>
-        : TRecord[key] extends AnyMutationProcedure
-        ? MutationLike<TDef['_config'], TRecord[key]>
-        : never;
-    }
-  : never;
+export type RouterLike<TRouter extends AnyRouter> = CreateTRPCReact<
+  TRouter,
+  any,
+  any
+>;

--- a/packages/react-query/src/shared/polymorphism/routerLike.ts
+++ b/packages/react-query/src/shared/polymorphism/routerLike.ts
@@ -1,19 +1,29 @@
-import { AnyRouter } from '@trpc/server';
-import { DecoratedProcedureRecord } from '../../createTRPCReact';
+import {
+  AnyMutationProcedure,
+  AnyProcedure,
+  AnyQueryProcedure,
+  AnyRootConfig,
+  AnyRouter,
+} from '@trpc/server';
+import { MutationLike } from './mutationLike';
+import { QueryLike } from './queryLike';
 
 /**
  * Use to describe a route path which matches a given route's interface
  */
-export type RouterLike<TRouter extends AnyRouter> = DecoratedProcedureRecord<
+export type RouterLike<TRouter extends AnyRouter> = RouterLikeInner<
   TRouter['_def']['_config'],
-  TRouter['_def']['procedures'],
-  any
+  TRouter['_def']['procedures']
 >;
-
-// export type RouterLike<TRouter extends AnyRouter> = TRouter extends Router<
-//   infer TRouterDef
-// >
-//   ? TRouterDef extends RouterDef<infer TConfig, infer TProcedures>
-//     ? DecoratedProcedureRecord<TConfig, TProcedures, any>
-//     : never
-//   : never;
+export type RouterLikeInner<
+  TConfig extends AnyRootConfig,
+  TProcedures extends AnyProcedure,
+> = {
+  [TKey in keyof TProcedures]: TProcedures[TKey] extends AnyRouter
+    ? RouterLikeInner<TConfig, TProcedures[TKey]['_def']['record']>
+    : TProcedures[TKey] extends AnyQueryProcedure
+    ? QueryLike<TConfig, TProcedures[TKey]>
+    : TProcedures[TKey] extends AnyMutationProcedure
+    ? MutationLike<TConfig, TProcedures[TKey]>
+    : never;
+};

--- a/packages/react-query/src/shared/polymorphism/routerLike.ts
+++ b/packages/react-query/src/shared/polymorphism/routerLike.ts
@@ -1,5 +1,5 @@
-import { DecoratedProcedureRecord } from '@trpc/react-query/createTRPCReact';
 import { AnyRouter } from '@trpc/server';
+import { DecoratedProcedureRecord } from '../../createTRPCReact';
 
 /**
  * Use to describe a route path which matches a given route's interface

--- a/packages/react-query/src/shared/polymorphism/routerLike.ts
+++ b/packages/react-query/src/shared/polymorphism/routerLike.ts
@@ -1,11 +1,19 @@
-import { CreateTRPCReact } from '@trpc/react-query/createTRPCReact';
+import { DecoratedProcedureRecord } from '@trpc/react-query/createTRPCReact';
 import { AnyRouter } from '@trpc/server';
 
 /**
  * Use to describe a route path which matches a given route's interface
  */
-export type RouterLike<TRouter extends AnyRouter> = CreateTRPCReact<
-  TRouter,
-  any,
+export type RouterLike<TRouter extends AnyRouter> = DecoratedProcedureRecord<
+  TRouter['_def']['_config'],
+  TRouter['_def']['procedures'],
   any
 >;
+
+// export type RouterLike<TRouter extends AnyRouter> = TRouter extends Router<
+//   infer TRouterDef
+// >
+//   ? TRouterDef extends RouterDef<infer TConfig, infer TProcedures>
+//     ? DecoratedProcedureRecord<TConfig, TProcedures, any>
+//     : never
+//   : never;

--- a/packages/react-query/src/shared/proxy/useQueriesProxy.ts
+++ b/packages/react-query/src/shared/proxy/useQueriesProxy.ts
@@ -18,19 +18,14 @@ import { TrpcQueryOptionsForUseQueries } from '../../internals/useQueries';
 type GetQueryOptions<
   TConfig extends AnyRootConfig,
   TProcedure extends AnyProcedure,
-  TPath extends string,
 > = <TData = inferTransformedProcedureOutput<TConfig, TProcedure>>(
   input: inferProcedureInput<TProcedure>,
   opts?: TrpcQueryOptionsForUseQueries<
-    TPath,
-    inferProcedureInput<TProcedure>,
     inferTransformedProcedureOutput<TConfig, TProcedure>,
     TData,
     TRPCClientError<TConfig>
   >,
 ) => TrpcQueryOptionsForUseQueries<
-  TPath,
-  inferProcedureInput<TProcedure>,
   inferTransformedProcedureOutput<TConfig, TProcedure>,
   TData,
   TRPCClientError<TConfig>
@@ -39,22 +34,15 @@ type GetQueryOptions<
 /**
  * @internal
  */
-export type UseQueriesProcedureRecord<
-  TRouter extends AnyRouter,
-  TPath extends string = '',
-> = {
+export type UseQueriesProcedureRecord<TRouter extends AnyRouter> = {
   [TKey in keyof Filter<
     TRouter['_def']['record'],
     AnyQueryProcedure | AnyRouter
   >]: TRouter['_def']['record'][TKey] extends AnyRouter
-    ? UseQueriesProcedureRecord<
-        TRouter['_def']['record'][TKey],
-        `${TPath}${TKey & string}.`
-      >
+    ? UseQueriesProcedureRecord<TRouter['_def']['record'][TKey]>
     : GetQueryOptions<
         TRouter['_def']['_config'],
-        TRouter['_def']['record'][TKey],
-        `${TPath}${TKey & string}`
+        TRouter['_def']['record'][TKey]
       >;
 };
 

--- a/packages/react-query/src/utils/inferReactQueryProcedure.ts
+++ b/packages/react-query/src/utils/inferReactQueryProcedure.ts
@@ -21,12 +21,9 @@ import {
 export type InferQueryOptions<
   TConfig extends AnyRootConfig,
   TProcedure extends AnyProcedure,
-  TPath extends string,
   TData = inferTransformedProcedureOutput<TConfig, TProcedure>,
 > = Omit<
   UseTRPCQueryOptions<
-    TPath,
-    inferProcedureInput<TProcedure>,
     inferTransformedProcedureOutput<TConfig, TProcedure>,
     inferTransformedProcedureOutput<TConfig, TProcedure>,
     TRPCClientErrorLike<TConfig>,
@@ -72,24 +69,14 @@ export type InferMutationResult<
   TContext
 >;
 
-export type inferReactQueryProcedureOptions<
-  TRouter extends AnyRouter,
-  TPath extends string = '',
-> = {
+export type inferReactQueryProcedureOptions<TRouter extends AnyRouter> = {
   [TKey in keyof TRouter['_def']['record']]: TRouter['_def']['record'][TKey] extends infer TRouterOrProcedure
     ? TRouterOrProcedure extends AnyRouter
-      ? inferReactQueryProcedureOptions<
-          TRouterOrProcedure,
-          `${TPath}${TKey & string}.`
-        >
+      ? inferReactQueryProcedureOptions<TRouterOrProcedure>
       : TRouterOrProcedure extends AnyMutationProcedure
       ? InferMutationOptions<TRouter['_def']['_config'], TRouterOrProcedure>
       : TRouterOrProcedure extends AnyQueryProcedure
-      ? InferQueryOptions<
-          TRouter['_def']['_config'],
-          TRouterOrProcedure,
-          `${TPath}${TKey & string}`
-        >
+      ? InferQueryOptions<TRouter['_def']['_config'], TRouterOrProcedure>
       : never
     : never;
 };

--- a/packages/server/src/core/procedure.ts
+++ b/packages/server/src/core/procedure.ts
@@ -61,6 +61,11 @@ export interface Procedure<
     _output_out: TDef['output'];
     procedure: true;
     type: TType;
+    /**
+     * @internal
+     * Meta is not inferrable on individual procedures, only on the router
+     */
+    meta: unknown;
   };
   /**
    * @internal

--- a/packages/server/src/core/types.ts
+++ b/packages/server/src/core/types.ts
@@ -30,7 +30,7 @@ export type inferHandlerInput<TProcedure extends AnyProcedure> = ProcedureArgs<
 >;
 
 export type inferProcedureInput<TProcedure extends AnyProcedure> =
-  inferHandlerInput<TProcedure>[0];
+  inferProcedureParams<TProcedure>['_input_in'];
 
 export type inferProcedureParams<TProcedure> = TProcedure extends AnyProcedure
   ? TProcedure['_def']

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -9,9 +9,8 @@
     "test": "concurrently -P -c \"green,blue\" \"npm:test-run:vitest -- {@}\" npm:test-run:tsc",
     "test-run:vitest": "vitest --run",
     "test-run:tsc": "tsc --noEmit --pretty",
-    "test-watch": "concurrently -P -c \"green,blue\" \"npm:test-watch:vitest -- {@}\" npm:test-watch:tsc",
-    "test-watch:vitest": "vitest",
-    "test-watch:tsc": "tsc --noEmit --pretty --watch",
+    "test-watch": "vitest",
+    "ts-watch": "tsc --noEmit --pretty --watch",
     "test-ci": "concurrently \"CI=true vitest --coverage\" npm:test-run:tsc",
     "test-ui": "vitest --ui"
   },

--- a/packages/tests/server/input.test.ts
+++ b/packages/tests/server/input.test.ts
@@ -304,9 +304,7 @@ test('no input', async () => {
 
   type ProcType = inferProcedureParams<typeof proc>;
 
-  expectTypeOf<ProcType['_input_in']>().toEqualTypeOf<UnsetMarker>();
-  expectTypeOf<ProcType['_input_out']>().toEqualTypeOf<UnsetMarker>();
-  expectTypeOf<ProcType['_output_in']>().toBeUndefined();
+  expectTypeOf<ProcType['_input_in']>().toEqualTypeOf<void>();
   expectTypeOf<ProcType['_output_out']>().toBeUndefined();
 
   const router = t.router({
@@ -333,7 +331,6 @@ test('zod default() string', async () => {
   type ProcType = inferProcedureParams<typeof proc>;
 
   expectTypeOf<ProcType['_input_in']>().toEqualTypeOf<string | undefined>();
-  expectTypeOf<ProcType['_input_out']>().toEqualTypeOf<string>();
 
   const router = t.router({
     proc,
@@ -364,7 +361,6 @@ test('zod default() required object', async () => {
   type ProcType = inferProcedureParams<typeof proc>;
 
   expectTypeOf<ProcType['_input_in']>().toEqualTypeOf<{ foo?: string }>();
-  expectTypeOf<ProcType['_input_out']>().toEqualTypeOf<{ foo: string }>();
 
   const router = t.router({
     proc,
@@ -403,10 +399,6 @@ test('zod default() mixed default object', async () => {
   expectTypeOf<ProcType['_input_in']>().toEqualTypeOf<
     { foo: string; bar?: string } | undefined
   >();
-  expectTypeOf<ProcType['_input_out']>().toEqualTypeOf<{
-    foo: string;
-    bar: string;
-  }>();
 
   const router = t.router({
     proc,
@@ -456,10 +448,6 @@ test('zod default() defaults within object', async () => {
   expectTypeOf<ProcType['_input_in']>().toEqualTypeOf<
     { foo?: string; bar?: string } | undefined
   >();
-  expectTypeOf<ProcType['_input_out']>().toEqualTypeOf<{
-    foo: string;
-    bar: string;
-  }>();
 
   const router = t.router({
     proc,

--- a/packages/tests/server/react/errors.test.tsx
+++ b/packages/tests/server/react/errors.test.tsx
@@ -1,7 +1,8 @@
 import { getServerAndReactClient } from './__reactHelpers';
 import { render, waitFor } from '@testing-library/react';
 import { TRPCClientError, TRPCClientErrorLike } from '@trpc/client/src';
-import { initTRPC } from '@trpc/server/src';
+import { initTRPC, Maybe } from '@trpc/server';
+import { DefaultErrorData } from '@trpc/server/error/formatter';
 import { konn } from 'konn';
 import React from 'react';
 import { z, ZodError } from 'zod';
@@ -202,24 +203,9 @@ test('types', async () => {
   });
 
   type TRouterError = TRPCClientErrorLike<typeof appRouter>;
-  type TProcedureError = TRPCClientErrorLike<
-    (typeof appRouter)['post']['byId']
-  >;
 
   type TRouterError__data = TRouterError['data'];
   //      ^?
-  type TProcedureError__data = TProcedureError['data'];
-  //     ^?
 
-  expectTypeOf<TRouterError__data>().toMatchTypeOf<TProcedureError__data>();
-
-  type TRouterError__shape = TRouterError['shape'];
-  //      ^?
-  type TProcedureError__shape = TProcedureError['shape'];
-  //     ^?
-
-  expectTypeOf<TRouterError__shape>().toMatchTypeOf<TProcedureError__shape>();
-
-  expectTypeOf<TRouterError>().toEqualTypeOf<TProcedureError>();
-  expectTypeOf<TRouterError>().toMatchTypeOf<TProcedureError>();
+  expectTypeOf<TRouterError__data>().toMatchTypeOf<Maybe<DefaultErrorData>>();
 });

--- a/packages/tests/server/react/formData.test.tsx
+++ b/packages/tests/server/react/formData.test.tsx
@@ -8,7 +8,7 @@ import {
   splitLink,
 } from '@trpc/client';
 import { createTRPCReact } from '@trpc/react-query';
-import { CreateTRPCReactBase } from '@trpc/react-query/createTRPCReact';
+import { CreateTRPCReactBase } from '@trpc/react-query/src/createTRPCReact';
 import { initTRPC } from '@trpc/server';
 import {
   experimental_createMemoryUploadHandler,

--- a/packages/tests/server/react/invalidateQueries.test.tsx
+++ b/packages/tests/server/react/invalidateQueries.test.tsx
@@ -340,7 +340,7 @@ test('predicate type should be narrowed', () => {
           [
             string[],
             {
-              input?: { limit?: number | undefined } | void;
+              input?: { limit?: number | undefined } | undefined;
               type: 'infinite';
             }?,
           ]

--- a/packages/tests/server/react/polymorphism.common.tsx
+++ b/packages/tests/server/react/polymorphism.common.tsx
@@ -1,0 +1,3 @@
+import { initTRPC } from '@trpc/server';
+
+export const t = initTRPC.create();

--- a/packages/tests/server/react/polymorphism.common.tsx
+++ b/packages/tests/server/react/polymorphism.common.tsx
@@ -1,3 +1,5 @@
 import { initTRPC } from '@trpc/server';
 
 export const t = initTRPC.create();
+
+export type Config = (typeof t)['_config'];

--- a/packages/tests/server/react/polymorphism.factory.tsx
+++ b/packages/tests/server/react/polymorphism.factory.tsx
@@ -7,6 +7,7 @@ import { AnyRootConfig, TRPCError } from '@trpc/server';
 import { createBuilder } from '@trpc/server/core/internals/procedureBuilder';
 import { createRouterFactory } from '@trpc/server/core/router';
 import z from 'zod';
+import { t } from './polymorphism.common';
 
 //
 // DTOs
@@ -46,15 +47,9 @@ export type DataProvider = FileExportStatusType[];
 let COUNTER = 1;
 
 export function createExportRoute<
-  TConfig extends AnyRootConfig,
-  TRouterFactory extends RouterFactory<TConfig>,
-  TBaseProcedure extends BaseProcedure<TConfig>,
->(
-  createRouter: TRouterFactory,
-  baseProcedure: TBaseProcedure,
-  dataProvider: DataProvider,
-) {
-  return createRouter({
+  TBaseProcedure extends BaseProcedure<(typeof t)['_config']>,
+>(baseProcedure: TBaseProcedure, dataProvider: DataProvider) {
+  return t.router({
     start: baseProcedure
       .input(FileExportRequest)
       .output(FileExportStatus)

--- a/packages/tests/server/react/polymorphism.factory.tsx
+++ b/packages/tests/server/react/polymorphism.factory.tsx
@@ -7,7 +7,7 @@ import { AnyRootConfig, TRPCError } from '@trpc/server';
 import { createBuilder } from '@trpc/server/core/internals/procedureBuilder';
 import { createRouterFactory } from '@trpc/server/core/router';
 import z from 'zod';
-import { t } from './polymorphism.common';
+import { Config, t } from './polymorphism.common';
 
 //
 // DTOs
@@ -30,9 +30,6 @@ export type FileExportStatusType = z.infer<typeof FileExportStatus>;
 // Dependencies
 //
 
-type RouterFactory<TConfig extends AnyRootConfig> = ReturnType<
-  typeof createRouterFactory<TConfig>
->;
 type BaseProcedure<TConfig extends AnyRootConfig> = ReturnType<
   typeof createBuilder<TConfig>
 >;
@@ -46,9 +43,10 @@ export type DataProvider = FileExportStatusType[];
 
 let COUNTER = 1;
 
-export function createExportRoute<
-  TBaseProcedure extends BaseProcedure<(typeof t)['_config']>,
->(baseProcedure: TBaseProcedure, dataProvider: DataProvider) {
+export function createExportRoute<TBaseProcedure extends BaseProcedure<Config>>(
+  baseProcedure: TBaseProcedure,
+  dataProvider: DataProvider,
+) {
   return t.router({
     start: baseProcedure
       .input(FileExportRequest)

--- a/packages/tests/server/react/polymorphism.subtyped-factory.tsx
+++ b/packages/tests/server/react/polymorphism.subtyped-factory.tsx
@@ -7,6 +7,7 @@ import { AnyRootConfig, TRPCError } from '@trpc/server';
 import { createBuilder } from '@trpc/server/core/internals/procedureBuilder';
 import { createRouterFactory } from '@trpc/server/core/router';
 import z from 'zod';
+import { t } from './polymorphism.common';
 import { FileExportRequest, FileExportStatus } from './polymorphism.factory';
 
 //
@@ -45,15 +46,9 @@ export type SubTypedDataProvider = SubTypedFileExportStatusType[];
 let COUNTER = 1;
 
 export function createSubTypedExportRoute<
-  TConfig extends AnyRootConfig,
-  TRouterFactory extends RouterFactory<TConfig>,
-  TBaseProcedure extends BaseProcedure<TConfig>,
->(
-  createRouter: TRouterFactory,
-  baseProcedure: TBaseProcedure,
-  dataProvider: SubTypedDataProvider,
-) {
-  return createRouter({
+  TBaseProcedure extends BaseProcedure<(typeof t)['_config']>,
+>(baseProcedure: TBaseProcedure, dataProvider: SubTypedDataProvider) {
+  return t.router({
     start: baseProcedure
       .input(SubTypedFileExportRequest)
       .output(SubTypedFileExportStatus)

--- a/packages/tests/server/react/polymorphism.test.tsx
+++ b/packages/tests/server/react/polymorphism.test.tsx
@@ -18,6 +18,7 @@ import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 import React, { ReactNode, useState } from 'react';
 import { z } from 'zod';
+import { t } from './polymorphism.common';
 /**
  * We define a router factory which can be used many times.
  *
@@ -34,8 +35,6 @@ import * as SubTypedFactory from './polymorphism.subtyped-factory';
  * The tRPC backend is defined here
  */
 function createTRPCApi() {
-  const t = initTRPC.create();
-
   /**
    * Backend data sources.
    *
@@ -53,19 +52,11 @@ function createTRPCApi() {
   const appRouter = t.router({
     github: t.router({
       issues: t.router({
-        export: Factory.createExportRoute(
-          t.router,
-          t.procedure,
-          IssueExportsProvider,
-        ),
+        export: Factory.createExportRoute(t.procedure, IssueExportsProvider),
       }),
       discussions: t.router({
         export: t.mergeRouters(
-          Factory.createExportRoute(
-            t.router,
-            t.procedure,
-            DiscussionExportsProvider,
-          ),
+          Factory.createExportRoute(t.procedure, DiscussionExportsProvider),
 
           // We want to be sure that routers with abstract types,
           //  which then get merged into a larger router, can be used polymorphically
@@ -80,7 +71,6 @@ function createTRPCApi() {
       }),
       pullRequests: t.router({
         export: SubTypedFactory.createSubTypedExportRoute(
-          t.router,
           t.procedure,
           PullRequestExportsProvider,
         ),

--- a/packages/tests/server/react/polymorphism.test.tsx
+++ b/packages/tests/server/react/polymorphism.test.tsx
@@ -283,6 +283,7 @@ describe('polymorphism', () => {
             {/* ... or you can adapt them to support sub-types */}
             <ExportStatus
               status={trpc.github.pullRequests.export.status}
+              //                                       ^?
               currentExport={currentExport}
               renderAdditionalFields={(data) => {
                 return `Description: "${data?.description}"`;
@@ -449,6 +450,7 @@ function RefreshExportsListButton({
 }
 
 type ExportStatusProps<TStatus extends Factory.ExportRouteLike['status']> = {
+  //                                                             ^?
   status: TStatus;
   renderAdditionalFields?: (data: InferQueryLikeData<TStatus>) => ReactNode;
   currentExport: number | null;

--- a/packages/tests/server/react/polymorphism.test.tsx
+++ b/packages/tests/server/react/polymorphism.test.tsx
@@ -460,9 +460,7 @@ function RefreshExportsListButton({
 
 type ExportStatusProps<TStatus extends Factory.ExportRouteLike['status']> = {
   status: TStatus;
-  renderAdditionalFields?: (
-    data: InferQueryLikeData<any, TStatus>,
-  ) => ReactNode;
+  renderAdditionalFields?: (data: InferQueryLikeData<TStatus>) => ReactNode;
   currentExport: number | null;
 };
 function ExportStatus<TStatus extends Factory.ExportRouteLike['status']>({

--- a/packages/tests/server/regression/issue-4645-inferProcedureOutput.test.ts
+++ b/packages/tests/server/regression/issue-4645-inferProcedureOutput.test.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 
 test('infer json-esque', async () => {
   const t = initTRPC.create();
+  type Config = (typeof t)['_config'];
   const helloProcedure = t.procedure.input(z.string()).query(() => {
     return {
       hello: Math.random() > 0.5 ? 'hello' : undefined,
@@ -23,7 +24,10 @@ test('infer json-esque', async () => {
     // This type is what the client will receive
     // Because it will be sent as JSON, the undefined will be stripped by `JSON.stringify`
     // Example: JSON.stringify({ hello: undefined }) === '{}'
-    type Inferred = inferTransformedProcedureOutput<typeof helloProcedure>;
+    type Inferred = inferTransformedProcedureOutput<
+      Config,
+      typeof helloProcedure
+    >;
     expectTypeOf<Inferred>().toEqualTypeOf<{ hello?: string }>();
   }
 });
@@ -32,6 +36,7 @@ test('infer with superjson', async () => {
   const t = initTRPC.create({
     transformer: SuperJSON,
   });
+  type Config = (typeof t)['_config'];
   const helloProcedure = t.procedure.input(z.string()).query(() => {
     return {
       hello: Math.random() > 0.5 ? 'hello' : undefined,
@@ -45,7 +50,10 @@ test('infer with superjson', async () => {
   {
     // This type is what the client will receive
     // Here, we use a transformer which will handle preservation of undefined
-    type Inferred = inferTransformedProcedureOutput<typeof helloProcedure>;
+    type Inferred = inferTransformedProcedureOutput<
+      Config,
+      typeof helloProcedure
+    >;
     expectTypeOf<Inferred>().toEqualTypeOf<{ hello: string | undefined }>();
   }
 });

--- a/packages/tests/server/routerMeta.test.ts
+++ b/packages/tests/server/routerMeta.test.ts
@@ -28,15 +28,12 @@ test('route meta types', async () => {
   expect(router._def.procedures.query).toMatchInlineSnapshot(`[Function]`);
 
   const queryMeta = router._def.procedures.query._def.meta;
-  expectTypeOf(queryMeta).toMatchTypeOf<TMeta | undefined>();
   expect(queryMeta).toEqual(testMeta);
 
   const mutationMeta = router._def.procedures.mutation._def.meta;
-  expectTypeOf(mutationMeta).toMatchTypeOf<TMeta | undefined>();
   expect(mutationMeta).toEqual(testMeta);
 
   const subscriptionMeta = router._def.procedures.subscription._def.meta;
-  expectTypeOf(subscriptionMeta).toMatchTypeOf<TMeta | undefined>();
   expect(subscriptionMeta).toEqual(testMeta);
 });
 


### PR DESCRIPTION
If we can remove TPath from the types, then the polymorphism work mostly becomes redundant, since this was the key thing which makes query types structurally incompatible. It's not clear if we actually need TPath encoded into the types 

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
