### PR TITLE
feat(client): accept URL object param

### DIFF
--- a/packages/client/src/links/internals/httpUtils.ts
+++ b/packages/client/src/links/internals/httpUtils.ts
@@ -38,7 +38,7 @@ export function resolveHTTPLinkOptions(
   opts: HTTPLinkBaseOptions,
 ): ResolvedHTTPLinkOptions {
   return {
-    url: opts.url.toString(),
+    url: opts.url.toString().replace(/\/$/, ''), // Remove any trailing slashes
     fetch: opts.fetch,
     AbortController: getAbortController(opts.AbortController),
   };

--- a/packages/client/src/links/internals/httpUtils.ts
+++ b/packages/client/src/links/internals/httpUtils.ts
@@ -17,7 +17,7 @@ import { HTTPHeaders, PromiseAndCancel, TRPCClientRuntime } from '../types';
  * @internal
  */
 export interface HTTPLinkBaseOptions {
-  url: string;
+  url: string | URL;
   /**
    * Add ponyfill for fetch
    */
@@ -38,7 +38,7 @@ export function resolveHTTPLinkOptions(
   opts: HTTPLinkBaseOptions,
 ): ResolvedHTTPLinkOptions {
   return {
-    url: opts.url,
+    url: opts.url.toString(),
     fetch: opts.fetch,
     AbortController: getAbortController(opts.AbortController),
   };


### PR DESCRIPTION
This makes `HTTPLink` and `HTTPBatchLink` accept `URL` object for the `url` param