### PR TITLE
fix(form-data): export `MaxPartSizeExceededError` for error handling

### DIFF
--- a/packages/server/src/adapters/node-http/content-type/form-data/index.ts
+++ b/packages/server/src/adapters/node-http/content-type/form-data/index.ts
@@ -100,6 +100,9 @@ export const nodeHTTPFormDataContentTypeHandler =
 export { parseMultipartFormData as experimental_parseMultipartFormData };
 export { createMemoryUploadHandler as experimental_createMemoryUploadHandler } from './memoryUploadHandler';
 export { createFileUploadHandler as experimental_createFileUploadHandler } from './fileUploadHandler';
-export { composeUploadHandlers as experimental_composeUploadHandlers } from './uploadHandler';
+export {
+  composeUploadHandlers as experimental_composeUploadHandlers,
+  MaxPartSizeExceededError,
+} from './uploadHandler';
 export { type UploadHandler } from './uploadHandler';
 export { isMultipartFormDataRequest as experimental_isMultipartFormDataRequest };


### PR DESCRIPTION
Closes #4867

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

- exports the error class so that it can be used for error handling