### PR TITLE
fix(`server`): don't destroy underlying tcp socket when maxBodySize exceeded

### DIFF
--- a/packages/server/src/adapters/node-http/content-type/json/getPostBody.ts
+++ b/packages/server/src/adapters/node-http/content-type/json/getPostBody.ts
@@ -28,7 +28,6 @@ export async function getPostBody(opts: {
           ok: false,
           error: new TRPCError({ code: 'PAYLOAD_TOO_LARGE' }),
         });
-        req.socket.destroy();
       }
     });
     req.on('end', () => {

--- a/packages/tests/server/adapters/__router.ts
+++ b/packages/tests/server/adapters/__router.ts
@@ -27,4 +27,7 @@ export const router = t.router({
       message: 'Unexpected error',
     });
   }),
+  exampleMutation: t.procedure
+    .input(z.object({ payload: z.string() }))
+    .mutation(() => 'ok'),
 });

--- a/packages/tests/server/adapters/express.test.tsx
+++ b/packages/tests/server/adapters/express.test.tsx
@@ -35,6 +35,7 @@ async function startServer() {
     '/trpc',
     trpcExpress.createExpressMiddleware({
       router,
+      maxBodySize: 10, // 10 bytes,
       createContext,
     }),
   );
@@ -104,5 +105,14 @@ test('error query', async () => {
     await t.client.exampleError.query();
   } catch (e) {
     expect(e).toStrictEqual(new TRPCClientError('Unexpected error'));
+  }
+});
+
+test('payload too large', async () => {
+  try {
+    await t.client.exampleMutation.mutate({ payload: 'a'.repeat(100) });
+    expect(true).toBe(false); // should not be reached
+  } catch (e) {
+    expect(e).toStrictEqual(new TRPCClientError('PAYLOAD_TOO_LARGE'));
   }
 });


### PR DESCRIPTION
Closes #4886

## 🎯 Changes

Issue #4886 describes the bug. I could see no reason to hang up the underlying TCP socket in this case so I just made a PR.

Wrote a failing test first to verify the bug, then changed the implementation.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
