### PR TITLE
fix(`server`): `PAYLOAD_TOO_LARGE` not returned to client

### DIFF
--- a/packages/server/src/adapters/node-http/content-type/json/getPostBody.ts
+++ b/packages/server/src/adapters/node-http/content-type/json/getPostBody.ts
@@ -28,7 +28,6 @@ export async function getPostBody(opts: {
           ok: false,
           error: new TRPCError({ code: 'PAYLOAD_TOO_LARGE' }),
         });
-        req.socket.destroy();
       }
     });
     req.on('end', () => {

--- a/packages/tests/server/adapters/__router.ts
+++ b/packages/tests/server/adapters/__router.ts
@@ -27,4 +27,5 @@ export const router = t.router({
       message: 'Unexpected error',
     });
   }),
+  mut: t.procedure.input(z.string()).mutation((opts) => opts.input),
 });


### PR DESCRIPTION
Closes #4886