### PR TITLE
fix(docs): typo in client/nextjs/introduction

### DIFF
--- a/www/docs/client/nextjs/introduction.mdx
+++ b/www/docs/client/nextjs/introduction.mdx
@@ -13,7 +13,7 @@ Our Next.js integration is built on top of our [React Query Integration](../) wi
 
 When using the Next.js integration, you'll get the following features:
 
-- **Server-sider rendering** - You can tell tRPC to render your pages on the server, and then hydrate them on the client. This way, you'll avoid an initial loading state, although time to first byte will be blocked by the server. Read more about [Server-side rendering](/docs/client/nextjs/ssr).
+- **Server-side rendering** - You can tell tRPC to render your pages on the server, and then hydrate them on the client. This way, you'll avoid an initial loading state, although time to first byte will be blocked by the server. Read more about [Server-side rendering](/docs/client/nextjs/ssr).
 - **Static site generation** - Prefetch queries on the server and generate static HTML files that are ready to be served. Read more about [Static site generation](/docs/client/nextjs/ssg).
 - **Automatic Provider Wrapping** - `@trpc/next` provides a higher-order component (HOC) that wraps your app with the necessary providers so you don't have to do it yourself.
 


### PR DESCRIPTION
Closes #null

## 🎯 Changes

Fixed typo in client/nextjs/introduction

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
