### PR TITLE
feat(server): allow a mix of text and files with fileUploadHandler

### DIFF
--- a/packages/server/src/adapters/node-http/content-type/form-data/memoryUploadHandler.ts
+++ b/packages/server/src/adapters/node-http/content-type/form-data/memoryUploadHandler.ts
@@ -50,10 +50,6 @@ export function createMemoryUploadHandler({
       chunks.push(chunk);
     }
 
-    if (typeof filename === 'string') {
-      return new File(chunks, filename, { type: contentType });
-    }
-
-    return await new Blob(chunks, { type: contentType }).text();
+    return new File(chunks, filename, { type: contentType });
   };
 }

--- a/packages/server/src/adapters/node-http/content-type/form-data/uploadHandler.ts
+++ b/packages/server/src/adapters/node-http/content-type/form-data/uploadHandler.ts
@@ -11,8 +11,8 @@ export type UploadHandlerPart = {
 };
 
 export type UploadHandler = (
-  part: UploadHandlerPart,
-) => Promise<File | NodeOnDiskFile | string | null | undefined>;
+  part: Required<UploadHandlerPart>,
+) => Promise<File | NodeOnDiskFile | null | undefined>;
 
 export function composeUploadHandlers(
   ...handlers: UploadHandler[]
@@ -32,6 +32,12 @@ export function composeUploadHandlers(
 export class MaxPartSizeExceededError extends Error {
   constructor(public field: string, public maxBytes: number) {
     super(`Field "${field}" exceeded upload size of ${maxBytes} bytes.`);
+  }
+}
+
+export class MaxBodySizeExceededError extends Error {
+  constructor(public maxBytes: number) {
+    super(`Body exceeded upload size of ${maxBytes} bytes.`);
   }
 }
 
@@ -78,10 +84,6 @@ export function createMemoryUploadHandler({
       chunks.push(chunk);
     }
 
-    if (typeof filename === 'string') {
-      return new File(chunks, filename, { type: contentType });
-    }
-
-    return await new Blob(chunks, { type: contentType }).text();
+    return new File(chunks, filename, { type: contentType });
   };
 }

--- a/packages/tests/server/react/formData.test.tsx
+++ b/packages/tests/server/react/formData.test.tsx
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import { routerToServerAndClientNew } from '../___testHelpers';
 import { createQueryClient } from '../__queryClient';
 import { QueryClientProvider } from '@tanstack/react-query';
@@ -11,8 +12,10 @@ import { createTRPCReact } from '@trpc/react-query';
 import { CreateTRPCReactBase } from '@trpc/react-query/createTRPCReact';
 import { initTRPC } from '@trpc/server';
 import {
+  experimental_createFileUploadHandler,
   experimental_createMemoryUploadHandler,
   experimental_isMultipartFormDataRequest,
+  experimental_NodeOnDiskFile,
   experimental_parseMultipartFormData,
   nodeHTTPFormDataContentTypeHandler,
 } from '@trpc/server/adapters/node-http/content-type/form-data';
@@ -84,6 +87,43 @@ const ctx = konn()
               type: input.file.type,
               file: await input.file.text(),
             },
+          };
+        }),
+      uploadFilesOnDiskAndIncludeTextPropertiesToo: t.procedure
+        .use(async (opts) => {
+          const maxBodySize = 100; // 100 bytes
+          const formData = await experimental_parseMultipartFormData(
+            opts.ctx.req,
+            experimental_createFileUploadHandler(),
+            maxBodySize,
+          );
+
+          return opts.next({
+            rawInput: formData,
+          });
+        })
+        .input(
+          zfd.formData({
+            files: zfd.repeatableOfType(
+              z.instanceof(experimental_NodeOnDiskFile),
+            ),
+            text: z.string(),
+            json: zfd.json(z.object({ foo: z.string() })),
+          }),
+        )
+        .mutation(async ({ input }) => {
+          const files = await Promise.all(
+            input.files.map(async (file) => ({
+              name: file.name,
+              type: file.type,
+              file: await file.text(),
+            })),
+          );
+
+          return {
+            files,
+            text: input.text,
+            json: input.json,
           };
         }),
     });
@@ -180,4 +220,87 @@ test('polymorphic - accept both JSON and FormData', async () => {
     text: 'foo',
   });
   expect(formDataRes).toEqual(jsonRes);
+});
+
+test('upload a combination of files and non-file text fields', async () => {
+  const form = new FormData();
+  form.append(
+    'files',
+    new File(['hi bob'], 'bob.txt', {
+      type: 'text/plain',
+    }),
+  );
+  form.append(
+    'files',
+    new File(['hi alice'], 'alice.txt', {
+      type: 'text/plain',
+    }),
+  );
+  form.set('text', 'foo');
+  form.set('json', JSON.stringify({ foo: 'bar' }));
+
+  const fileContents =
+    await ctx.proxy.uploadFilesOnDiskAndIncludeTextPropertiesToo.mutate(form);
+
+  expect(fileContents).toEqual({
+    files: [
+      {
+        file: 'hi bob',
+        name: expect.stringMatching(/\.txt$/),
+        type: 'text/plain',
+      },
+      {
+        file: 'hi alice',
+        name: expect.stringMatching(/\.txt$/),
+        type: 'text/plain',
+      },
+    ],
+    text: 'foo',
+    json: {
+      foo: 'bar',
+    },
+  });
+});
+
+test('Throws when aggregate size of uploaded files and non-file text fields exceeds maxBodySize - files too large', async () => {
+  const form = new FormData();
+  form.append(
+    'files',
+    new File(['a'.repeat(50)], 'bob.txt', {
+      type: 'text/plain',
+    }),
+  );
+  form.append(
+    'files',
+    new File(['a'.repeat(51)], 'alice.txt', {
+      type: 'text/plain',
+    }),
+  );
+  form.set('text', 'foo');
+  form.set('json', JSON.stringify({ foo: 'bar' }));
+
+  await expect(
+    ctx.proxy.uploadFilesOnDiskAndIncludeTextPropertiesToo.mutate(form),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(
+    `"Body exceeded upload size of 100 bytes."`,
+  );
+});
+
+test('Throws when aggregate size of uploaded files and non-file text fields exceeds maxBodySize - text fields too large', async () => {
+  const form = new FormData();
+  form.append(
+    'files',
+    new File(['hi bob'], 'bob.txt', {
+      type: 'text/plain',
+    }),
+  );
+
+  form.set('text', 'a'.repeat(101));
+  form.set('json', JSON.stringify({ foo: 'bar' }));
+
+  await expect(
+    ctx.proxy.uploadFilesOnDiskAndIncludeTextPropertiesToo.mutate(form),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(
+    `"Body exceeded upload size of 100 bytes."`,
+  );
 });


### PR DESCRIPTION
## 🎯 Changes

…dler

Sending a FormData object with a mix of files and text fields was not possible when using `experimental_createFileUploadHandler`, because the handling of all fields was baked into the `UploadHandler` business logic, and logic for handling non-file fields was only implemented for the memory upload handler. Ergo, the file upload handler just ignored all fields that were not files.

This PR does a few things:

1. Moves the logic for handling non-file fields to `parseMultipartFormData`, and only file fields are passed to the upload handler. Now non-file fields are handled identically regardless of upload handler type.
2. Like with other body parsers, adds `maxBodySize` parameter to the function `parseMultipartFormData` that defaults to Infinity. Throws when combined size of all fields and files exceeds the maximum and unlinks any files that were already uploaded.
3. Exposes `NodeOnDiskFile` as `experimental_NodeOnDiskFile` because `zfd.file()` schema from `zod-form-data` throws when `NodeOnDiskFile` is returned.
4. Exposes `MaxBodySizeExceededError`

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
