### PR TITLE
fix(server): merge _input_out when using standalone middlewares

### DIFF
--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -37,7 +37,9 @@ type CreateProcedureReturnInput<
   _meta: TPrev['_meta'];
   _ctx_out: Overwrite<TPrev['_ctx_out'], TNext['_ctx_out']>;
   _input_in: FallbackValue<TNext['_input_in'], TPrev['_input_in']>;
-  _input_out: FallbackValue<TNext['_input_out'], TPrev['_input_out']>;
+  _input_out: UnsetMarker extends TNext['_input_out']
+    ? TPrev['_input_out']
+    : Overwrite<TPrev['_input_out'], TNext['_input_out']>;
   _output_in: FallbackValue<TNext['_output_in'], TPrev['_output_in']>;
   _output_out: FallbackValue<TNext['_output_out'], TPrev['_output_out']>;
 }>;

--- a/packages/server/src/core/middleware.ts
+++ b/packages/server/src/core/middleware.ts
@@ -7,6 +7,7 @@ import {
   DefaultValue as FallbackValue,
   MiddlewareMarker,
   Overwrite,
+  UnsetMarker,
 } from './internals/utils';
 import { ProcedureParams } from './procedure';
 import { ProcedureType } from './types';
@@ -64,7 +65,9 @@ export interface MiddlewareBuilder<
       _meta: TRoot['_meta'];
       _ctx_out: Overwrite<TRoot['_ctx_out'], TNewParams['_ctx_out']>;
       _input_in: FallbackValue<TRoot['_input_in'], TNewParams['_input_in']>;
-      _input_out: FallbackValue<TRoot['_input_out'], TNewParams['_input_out']>;
+      _input_out: UnsetMarker extends TNewParams['_input_out']
+        ? TRoot['_input_out']
+        : Overwrite<TRoot['_input_out'], TNewParams['_input_out']>;
       _output_in: FallbackValue<TRoot['_output_in'], TNewParams['_output_in']>;
       _output_out: FallbackValue<
         TRoot['_output_out'],
@@ -102,7 +105,9 @@ type CreateMiddlewareReturnInput<
     _meta: TPrev['_meta'];
     _ctx_out: Overwrite<TPrev['_ctx_out'], TNext['_ctx_out']>;
     _input_in: FallbackValue<TNext['_input_in'], TPrev['_input_in']>;
-    _input_out: FallbackValue<TNext['_input_out'], TPrev['_input_out']>;
+    _input_out: UnsetMarker extends TNext['_input_out']
+      ? TPrev['_input_out']
+      : Overwrite<TPrev['_input_out'], TNext['_input_out']>;
     _output_in: FallbackValue<TNext['_output_in'], TPrev['_output_in']>;
     _output_out: FallbackValue<TNext['_output_out'], TPrev['_output_out']>;
   }

--- a/packages/tests/server/middlewares.test.ts
+++ b/packages/tests/server/middlewares.test.ts
@@ -319,42 +319,6 @@ test('standalone middlewares that define the ctx/input they require and can be u
   tHumanWithMeta.procedure.use(shamefullyLogIfProcedureIsNotCoolMiddleware);
 });
 
-test('Fix #4947: standalone middlewares -- inputs are merged properly when using multiple standalone middlewares', () => {
-  const t = initTRPC.create();
-  const schemaA = z.object({ valueA: z.string() });
-  const schemaB = z.object({ valueB: z.string() });
-
-  const valueAUppercaserMiddleware = experimental_standaloneMiddleware<{
-    input: z.infer<typeof schemaA>;
-  }>().create((opts) => {
-    return opts.next({
-      ctx: { valueAUppercase: opts.input.valueA.toUpperCase() },
-    });
-  });
-
-  const valueBUppercaserMiddleware = experimental_standaloneMiddleware<{
-    input: z.infer<typeof schemaB>;
-  }>().create((opts) => {
-    return opts.next({
-      ctx: { valueBUppercase: opts.input.valueB.toUpperCase() },
-    });
-  });
-
-  const combinedInputThatSatisfiesBothMiddlewares = schemaA.merge(schemaB);
-
-  t.procedure
-    .input(combinedInputThatSatisfiesBothMiddlewares)
-    .use(valueAUppercaserMiddleware)
-    .use(valueBUppercaserMiddleware)
-    .query(
-      ({
-        input: { valueA, valueB },
-        ctx: { valueAUppercase, valueBUppercase },
-      }) =>
-        `valueA: ${valueA}, valueB: ${valueB}, valueAUppercase: ${valueAUppercase}, valueBUppercase: ${valueBUppercase}`,
-    );
-});
-
 test('pipe middlewares - inlined', async () => {
   const t = initTRPC
     .context<{

--- a/packages/tests/server/middlewares.test.ts
+++ b/packages/tests/server/middlewares.test.ts
@@ -319,6 +319,42 @@ test('standalone middlewares that define the ctx/input they require and can be u
   tHumanWithMeta.procedure.use(shamefullyLogIfProcedureIsNotCoolMiddleware);
 });
 
+test('Fix #4947: standalone middlewares -- inputs are merged properly when using multiple standalone middlewares', () => {
+  const t = initTRPC.create();
+  const schemaA = z.object({ valueA: z.string() });
+  const schemaB = z.object({ valueB: z.string() });
+
+  const valueAUppercaserMiddleware = experimental_standaloneMiddleware<{
+    input: z.infer<typeof schemaA>;
+  }>().create((opts) => {
+    return opts.next({
+      ctx: { valueAUppercase: opts.input.valueA.toUpperCase() },
+    });
+  });
+
+  const valueBUppercaserMiddleware = experimental_standaloneMiddleware<{
+    input: z.infer<typeof schemaB>;
+  }>().create((opts) => {
+    return opts.next({
+      ctx: { valueBUppercase: opts.input.valueB.toUpperCase() },
+    });
+  });
+
+  const combinedInputThatSatisfiesBothMiddlewares = schemaA.merge(schemaB);
+
+  t.procedure
+    .input(combinedInputThatSatisfiesBothMiddlewares)
+    .use(valueAUppercaserMiddleware)
+    .use(valueBUppercaserMiddleware)
+    .query(
+      ({
+        input: { valueA, valueB },
+        ctx: { valueAUppercase, valueBUppercase },
+      }) =>
+        `valueA: ${valueA}, valueB: ${valueB}, valueAUppercase: ${valueAUppercase}, valueBUppercase: ${valueBUppercase}`,
+    );
+});
+
 test('pipe middlewares - inlined', async () => {
   const t = initTRPC
     .context<{

--- a/packages/tests/server/regression/issue-4947-merged-middleware-inputs.test.ts
+++ b/packages/tests/server/regression/issue-4947-merged-middleware-inputs.test.ts
@@ -22,7 +22,11 @@ test('Fix #4947: standalone middlewares -- inputs are merged properly when using
     });
   });
 
-  const combinedInputThatSatisfiesBothMiddlewares = schemaA.merge(schemaB);
+  const combinedInputThatSatisfiesBothMiddlewares = z.object({
+    valueA: z.string(),
+    valueB: z.string(),
+    extraProp: z.string(),
+  });
 
   t.procedure
     .input(combinedInputThatSatisfiesBothMiddlewares)
@@ -30,9 +34,9 @@ test('Fix #4947: standalone middlewares -- inputs are merged properly when using
     .use(valueBUppercaserMiddleware)
     .query(
       ({
-        input: { valueA, valueB },
+        input: { valueA, valueB, extraProp },
         ctx: { valueAUppercase, valueBUppercase },
       }) =>
-        `valueA: ${valueA}, valueB: ${valueB}, valueAUppercase: ${valueAUppercase}, valueBUppercase: ${valueBUppercase}`,
+        `valueA: ${valueA}, valueB: ${valueB}, extraProp: ${extraProp}, valueAUppercase: ${valueAUppercase}, valueBUppercase: ${valueBUppercase}`,
     );
 });

--- a/packages/tests/server/regression/issue-4947-merged-middleware-inputs.test.ts
+++ b/packages/tests/server/regression/issue-4947-merged-middleware-inputs.test.ts
@@ -1,0 +1,38 @@
+import { experimental_standaloneMiddleware, initTRPC } from '@trpc/server';
+import * as z from 'zod';
+
+test('Fix #4947: standalone middlewares -- inputs are merged properly when using multiple standalone middlewares', () => {
+  const t = initTRPC.create();
+  const schemaA = z.object({ valueA: z.string() });
+  const schemaB = z.object({ valueB: z.string() });
+
+  const valueAUppercaserMiddleware = experimental_standaloneMiddleware<{
+    input: z.infer<typeof schemaA>;
+  }>().create((opts) => {
+    return opts.next({
+      ctx: { valueAUppercase: opts.input.valueA.toUpperCase() },
+    });
+  });
+
+  const valueBUppercaserMiddleware = experimental_standaloneMiddleware<{
+    input: z.infer<typeof schemaB>;
+  }>().create((opts) => {
+    return opts.next({
+      ctx: { valueBUppercase: opts.input.valueB.toUpperCase() },
+    });
+  });
+
+  const combinedInputThatSatisfiesBothMiddlewares = schemaA.merge(schemaB);
+
+  t.procedure
+    .input(combinedInputThatSatisfiesBothMiddlewares)
+    .use(valueAUppercaserMiddleware)
+    .use(valueBUppercaserMiddleware)
+    .query(
+      ({
+        input: { valueA, valueB },
+        ctx: { valueAUppercase, valueBUppercase },
+      }) =>
+        `valueA: ${valueA}, valueB: ${valueB}, valueAUppercase: ${valueAUppercase}, valueBUppercase: ${valueBUppercase}`,
+    );
+});


### PR DESCRIPTION
Closes #4947

## 🎯 Changes

There was a problem in the current implementation of `experimental_standaloneMiddleware`
where the `input` type was not merged properly in the middleware chain.

Example:

```
  const t = initTRPC.create();
  const schemaA = z.object({ valueA: z.string() });
  const schemaB = z.object({ valueB: z.string() });

  const mw1 = experimental_standaloneMiddleware<{
    input: z.infer<typeof schemaA>;
  }>().create((opts) => {
    return opts.next();
  });

  const mw2 = experimental_standaloneMiddleware<{
    input: z.infer<typeof schemaB>;
  }>().create((opts) => {
    return opts.next();
  });

  const combinedInputThatSatisfiesBothMiddlewares = z.object({
    valueA: z.string(),
    valueB: z.string(),
  })

  t.procedure
    .input(combinedInputThatSatisfiesBothMiddlewares)
    .use(mw1)
    .use(mw2) // <-- error: input only has { valueA: string }
    .query(
      ({
        input: { valueA, valueB }, // <-- error: input only has { valueB: string }
      }) =>
        `valueA: ${valueA}, valueB: ${valueB}`,
    );
```

Funnily enough, since tRPC merges multiple .input() schemas under the hood, it was
possible to never encounter this problem if you e.g. defined another .input() parser
after a standalone middleware, e.g.:

```
t.input(onlyA).use(requiresAMiddleware).input(otherStuff).query(opts => /* opts.input has merged onlyA and otherStuff! */
```

This commits fixes the problem by merging `_input_out` whenever necessary.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
