### PR TITLE
chore: fixed typo in links docs

### DIFF
--- a/www/docs/client/links/httpBatchLink.md
+++ b/www/docs/client/links/httpBatchLink.md
@@ -46,11 +46,11 @@ export interface HTTPBatchLinkOptions extends HTTPLinkOptions {
 export interface HTTPLinkOptions {
   url: string;
   /**
-   * Add ponyfill for fetch
+   * Add polyfill for fetch
    */
   fetch?: typeof fetch;
   /**
-   * Add ponyfill for AbortController
+   * Add polyfill for AbortController
    */
   AbortController?: typeof AbortController | null;
   /**


### PR DESCRIPTION
## 🎯 Changes

Fixed a typo in the [httpBatchLink.md](www/docs/client/links/httpBatchLink.md) file.

```diff
- ponyfill
+ polyfill
```

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
