### PR TITLE
fix(server + client): incorrect inferred input type when using standalone middleware

### DIFF
--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -36,7 +36,9 @@ type CreateProcedureReturnInput<
   _config: TPrev['_config'];
   _meta: TPrev['_meta'];
   _ctx_out: Overwrite<TPrev['_ctx_out'], TNext['_ctx_out']>;
-  _input_in: FallbackValue<TNext['_input_in'], TPrev['_input_in']>;
+  _input_in: UnsetMarker extends TNext['_input_in']
+    ? TPrev['_input_in']
+    : Overwrite<TPrev['_input_in'], TNext['_input_in']>;
   _input_out: UnsetMarker extends TNext['_input_out']
     ? TPrev['_input_out']
     : Overwrite<TPrev['_input_out'], TNext['_input_out']>;

--- a/packages/server/src/core/middleware.ts
+++ b/packages/server/src/core/middleware.ts
@@ -11,7 +11,6 @@ import {
 import { ProcedureParams } from './procedure';
 import { ProcedureType } from './types';
 
-
 /**
  * @internal
  */

--- a/packages/server/src/core/middleware.ts
+++ b/packages/server/src/core/middleware.ts
@@ -7,10 +7,10 @@ import {
   DefaultValue as FallbackValue,
   MiddlewareMarker,
   Overwrite,
-  UnsetMarker,
 } from './internals/utils';
 import { ProcedureParams } from './procedure';
 import { ProcedureType } from './types';
+
 
 /**
  * @internal
@@ -65,9 +65,7 @@ export interface MiddlewareBuilder<
       _meta: TRoot['_meta'];
       _ctx_out: Overwrite<TRoot['_ctx_out'], TNewParams['_ctx_out']>;
       _input_in: FallbackValue<TRoot['_input_in'], TNewParams['_input_in']>;
-      _input_out: UnsetMarker extends TNewParams['_input_out']
-        ? TRoot['_input_out']
-        : Overwrite<TRoot['_input_out'], TNewParams['_input_out']>;
+      _input_out: FallbackValue<TRoot['_input_out'], TNewParams['_input_out']>;
       _output_in: FallbackValue<TRoot['_output_in'], TNewParams['_output_in']>;
       _output_out: FallbackValue<
         TRoot['_output_out'],
@@ -105,9 +103,7 @@ type CreateMiddlewareReturnInput<
     _meta: TPrev['_meta'];
     _ctx_out: Overwrite<TPrev['_ctx_out'], TNext['_ctx_out']>;
     _input_in: FallbackValue<TNext['_input_in'], TPrev['_input_in']>;
-    _input_out: UnsetMarker extends TNext['_input_out']
-      ? TPrev['_input_out']
-      : Overwrite<TPrev['_input_out'], TNext['_input_out']>;
+    _input_out: FallbackValue<TNext['_input_out'], TPrev['_input_out']>;
     _output_in: FallbackValue<TNext['_output_in'], TPrev['_output_in']>;
     _output_out: FallbackValue<TNext['_output_out'], TPrev['_output_out']>;
   }

--- a/packages/tests/server/regression/issue-4947-merged-middleware-inputs.test.ts
+++ b/packages/tests/server/regression/issue-4947-merged-middleware-inputs.test.ts
@@ -1,7 +1,6 @@
 import { experimental_standaloneMiddleware, initTRPC } from '@trpc/server';
 import * as z from 'zod';
 
-
 test('Fix #4947: standalone middlewares -- inputs are merged properly when using multiple standalone middlewares', async () => {
   const t = initTRPC.create();
   const schemaA = z.object({ valueA: z.string() });

--- a/packages/tests/server/regression/issue-4947-merged-middleware-inputs.test.ts
+++ b/packages/tests/server/regression/issue-4947-merged-middleware-inputs.test.ts
@@ -1,7 +1,8 @@
 import { experimental_standaloneMiddleware, initTRPC } from '@trpc/server';
 import * as z from 'zod';
 
-test('Fix #4947: standalone middlewares -- inputs are merged properly when using multiple standalone middlewares', () => {
+
+test('Fix #4947: standalone middlewares -- inputs are merged properly when using multiple standalone middlewares', async () => {
   const t = initTRPC.create();
   const schemaA = z.object({ valueA: z.string() });
   const schemaB = z.object({ valueB: z.string() });
@@ -51,4 +52,20 @@ test('Fix #4947: standalone middlewares -- inputs are merged properly when using
     valueB: string;
     extraProp: string;
   }>();
+
+  const router = t.router({
+    proc,
+  });
+
+  const caller = router.createCaller({});
+
+  const result = await caller.proc({
+    valueA: 'a',
+    valueB: 'b',
+    extraProp: 'extra',
+  });
+
+  expect(result).toEqual(
+    'valueA: a, valueB: b, extraProp: extra, valueAUppercase: A, valueBUppercase: B',
+  );
 });

--- a/packages/tests/server/regression/issue-4947-merged-middleware-inputs.test.ts
+++ b/packages/tests/server/regression/issue-4947-merged-middleware-inputs.test.ts
@@ -1,4 +1,9 @@
-import { experimental_standaloneMiddleware, initTRPC } from '@trpc/server';
+import { createTRPCProxyClient } from '@trpc/react-query';
+import {
+  experimental_standaloneMiddleware,
+  inferRouterInputs,
+  initTRPC,
+} from '@trpc/server';
 import * as z from 'zod';
 
 test('Fix #4947: standalone middlewares -- inputs are merged properly when using multiple standalone middlewares', async () => {
@@ -40,25 +45,20 @@ test('Fix #4947: standalone middlewares -- inputs are merged properly when using
         `valueA: ${valueA}, valueB: ${valueB}, extraProp: ${extraProp}, valueAUppercase: ${valueAUppercase}, valueBUppercase: ${valueBUppercase}`,
     );
 
-  expectTypeOf(proc._def._input_in).toEqualTypeOf<{
-    valueA: string;
-    valueB: string;
-    extraProp: string;
-  }>();
-
-  expectTypeOf(proc._def._input_out).toEqualTypeOf<{
-    valueA: string;
-    valueB: string;
-    extraProp: string;
-  }>();
-
   const router = t.router({
     proc,
   });
 
-  const caller = router.createCaller({});
+  type Inputs = inferRouterInputs<typeof router>;
+  expectTypeOf(null as unknown as Inputs['proc']).toEqualTypeOf<{
+    valueA: string;
+    valueB: string;
+    extraProp: string;
+  }>();
 
-  const result = await caller.proc({
+  const serverSideCaller = router.createCaller({});
+
+  const result = await serverSideCaller.proc({
     valueA: 'a',
     valueB: 'b',
     extraProp: 'extra',
@@ -67,4 +67,16 @@ test('Fix #4947: standalone middlewares -- inputs are merged properly when using
   expect(result).toEqual(
     'valueA: a, valueB: b, extraProp: extra, valueAUppercase: A, valueBUppercase: B',
   );
+
+  const client = createTRPCProxyClient<typeof router>({
+    links: [],
+  });
+
+  type QueryKey = Parameters<typeof client.proc.query>[0];
+
+  expectTypeOf<{
+    valueA: 'a';
+    valueB: 'b';
+    extraProp: 'extra';
+  }>().toMatchTypeOf<QueryKey>();
 });

--- a/packages/tests/server/regression/issue-4947-merged-middleware-inputs.test.ts
+++ b/packages/tests/server/regression/issue-4947-merged-middleware-inputs.test.ts
@@ -28,7 +28,7 @@ test('Fix #4947: standalone middlewares -- inputs are merged properly when using
     extraProp: z.string(),
   });
 
-  t.procedure
+  const proc = t.procedure
     .input(combinedInputThatSatisfiesBothMiddlewares)
     .use(valueAUppercaserMiddleware)
     .use(valueBUppercaserMiddleware)
@@ -39,4 +39,16 @@ test('Fix #4947: standalone middlewares -- inputs are merged properly when using
       }) =>
         `valueA: ${valueA}, valueB: ${valueB}, extraProp: ${extraProp}, valueAUppercase: ${valueAUppercase}, valueBUppercase: ${valueBUppercase}`,
     );
+
+  expectTypeOf(proc._def._input_in).toEqualTypeOf<{
+    valueA: string;
+    valueB: string;
+    extraProp: string;
+  }>();
+
+  expectTypeOf(proc._def._input_out).toEqualTypeOf<{
+    valueA: string;
+    valueB: string;
+    extraProp: string;
+  }>();
 });


### PR DESCRIPTION
…wares

Closes #4972

## 🎯 Changes

The previous fix fixed _input_out which resolved the incorrect types on the server side when defining the procedure, but still had incorrect _input_in types, which clients use.

Similar fix as before: do a merge of the _input_in types similarly as with _input_out.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
