### PR TITLE
fix: localstorage do not have setAttribute method

### DIFF
--- a/www/docusaurus.preferredTheme.js
+++ b/www/docusaurus.preferredTheme.js
@@ -24,7 +24,7 @@ if (ExecutionEnvironment.canUseDOM) {
   const colorSchemeChangeListener = (e) => {
     const newTheme = e.matches ? darkTheme : lightTheme;
     htmlElement?.setAttribute('data-theme', newTheme);
-    localStorage.setAttribute('theme', newTheme);
+    localStorage.setItem('theme', newTheme);
   };
   mediaMatch.addEventListener('change', colorSchemeChangeListener);
 }


### PR DESCRIPTION
Closes #Have_no_issue_created

## 🎯 Changes

Localstorage do not have setAttribute method. Change it to .setItem as intended.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
