### PR TITLE
fix(next): omit "fetch" from options

### DIFF
--- a/packages/next/src/app-dir/links/nextHttp.ts
+++ b/packages/next/src/app-dir/links/nextHttp.ts
@@ -1,4 +1,5 @@
 import {
+  getFetch,
   httpBatchLink,
   HTTPBatchLinkOptions,
   httpLink,
@@ -33,12 +34,12 @@ export function experimental_nextHttpLink<
       const revalidate = requestRevalidate ?? opts.revalidate ?? false;
 
       const linkFactory = opts.batch ? httpBatchLink : httpLink;
-      const fetchFn = opts.fetch ?? fetch;
+
       const link = linkFactory({
         headers: opts.headers as any,
         url: opts.url,
         fetch: (url, fetchOpts) => {
-          return fetchFn(url, {
+          return getFetch(opts.fetch)(url, {
             ...fetchOpts,
             // cache: 'no-cache',
             next: {

--- a/packages/next/src/app-dir/links/nextHttp.ts
+++ b/packages/next/src/app-dir/links/nextHttp.ts
@@ -9,7 +9,7 @@ import { AnyRouter } from '@trpc/server';
 import { generateCacheTag } from '../shared';
 
 type NextFetchLinkOptions<TBatch extends boolean> = (TBatch extends true
-  ? Omit<HTTPBatchLinkOptions, 'fetch'>
+  ? HTTPBatchLinkOptions
   : HTTPLinkOptions) & {
   batch?: TBatch;
   revalidate?: number | false;
@@ -19,7 +19,7 @@ type NextFetchLinkOptions<TBatch extends boolean> = (TBatch extends true
 export function experimental_nextHttpLink<
   TRouter extends AnyRouter,
   TBatch extends boolean,
->(opts: NextFetchLinkOptions<TBatch>): TRPCLink<TRouter> {
+>(opts: Omit<NextFetchLinkOptions<TBatch>, 'fetch'>): TRPCLink<TRouter> {
   return (runtime) => {
     return (ctx) => {
       const { path, input, context } = ctx.op;

--- a/packages/next/src/app-dir/links/nextHttp.ts
+++ b/packages/next/src/app-dir/links/nextHttp.ts
@@ -33,11 +33,12 @@ export function experimental_nextHttpLink<
       const revalidate = requestRevalidate ?? opts.revalidate ?? false;
 
       const linkFactory = opts.batch ? httpBatchLink : httpLink;
+      const fetchFn = opts.fetch ?? fetch;
       const link = linkFactory({
         headers: opts.headers as any,
         url: opts.url,
         fetch: (url, fetchOpts) => {
-          return fetch(url, {
+          return fetchFn(url, {
             ...fetchOpts,
             // cache: 'no-cache',
             next: {

--- a/packages/next/src/app-dir/links/nextHttp.ts
+++ b/packages/next/src/app-dir/links/nextHttp.ts
@@ -1,5 +1,4 @@
 import {
-  getFetch,
   httpBatchLink,
   HTTPBatchLinkOptions,
   httpLink,
@@ -10,7 +9,7 @@ import { AnyRouter } from '@trpc/server';
 import { generateCacheTag } from '../shared';
 
 type NextFetchLinkOptions<TBatch extends boolean> = (TBatch extends true
-  ? HTTPBatchLinkOptions
+  ? Omit<HTTPBatchLinkOptions, 'fetch'>
   : HTTPLinkOptions) & {
   batch?: TBatch;
   revalidate?: number | false;
@@ -39,7 +38,7 @@ export function experimental_nextHttpLink<
         headers: opts.headers as any,
         url: opts.url,
         fetch: (url, fetchOpts) => {
-          return getFetch(opts.fetch)(url, {
+          return fetch(url, {
             ...fetchOpts,
             // cache: 'no-cache',
             next: {

--- a/packages/next/src/app-dir/links/nextHttp.ts
+++ b/packages/next/src/app-dir/links/nextHttp.ts
@@ -33,7 +33,6 @@ export function experimental_nextHttpLink<
       const revalidate = requestRevalidate ?? opts.revalidate ?? false;
 
       const linkFactory = opts.batch ? httpBatchLink : httpLink;
-
       const link = linkFactory({
         headers: opts.headers as any,
         url: opts.url,


### PR DESCRIPTION
## 🎯 Changes

Use `fetch` from options when it's defined.
In the current implementation, `opts.fetch` it typed but never gets used.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
