### PR TITLE
docs: keep RQ at v4 until trpc v11 is released

### DIFF
--- a/www/docs/client/react/setup.mdx
+++ b/www/docs/client/react/setup.mdx
@@ -17,7 +17,7 @@ The following dependencies should be installed
   <TabItem value="npm" label="npm" default>
 
 ```bash
-npm install @trpc/client @trpc/server @trpc/react-query @tanstack/react-query
+npm install @trpc/client @trpc/server @trpc/react-query @tanstack/react-query@^4.0.0
 ```
 
   </TabItem>
@@ -25,7 +25,7 @@ npm install @trpc/client @trpc/server @trpc/react-query @tanstack/react-query
   <TabItem value="yarn" label="yarn">
 
 ```bash
-yarn add @trpc/client @trpc/server @trpc/react-query @tanstack/react-query
+yarn add @trpc/client @trpc/server @trpc/react-query @tanstack/react-query@^4.0.0
 ```
 
   </TabItem>
@@ -33,7 +33,7 @@ yarn add @trpc/client @trpc/server @trpc/react-query @tanstack/react-query
   <TabItem value="pnpm" label="pnpm">
 
 ```bash
-pnpm add @trpc/client @trpc/server @trpc/react-query @tanstack/react-query
+pnpm add @trpc/client @trpc/server @trpc/react-query @tanstack/react-query@^4.0.0
 ```
 
   </TabItem>
@@ -41,7 +41,7 @@ pnpm add @trpc/client @trpc/server @trpc/react-query @tanstack/react-query
   <TabItem value="bun" label="bun">
 
 ```bash
-bun add @trpc/client @trpc/server @trpc/react-query @tanstack/react-query
+bun add @trpc/client @trpc/server @trpc/react-query @tanstack/react-query@^4.0.0
 ```
 
   </TabItem>


### PR DESCRIPTION
https://github.com/trpc/trpc/issues/5006

Closes [#5006](https://github.com/trpc/trpc/issues/5006)

## 🎯 Changes

update the installation instructions to be ^4.0.0-range of the RQ deps until v11 is out

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
