### PR TITLE
docs: keep RQ at v4 on nextjs setup until trpc v11 is released

### DIFF
--- a/www/docs/client/nextjs/setup.mdx
+++ b/www/docs/client/nextjs/setup.mdx
@@ -43,7 +43,7 @@ We recommend a file structure like this one, although it is not enforced by tRPC
   <TabItem value="npm" label="npm" default>
 
 ```sh
-npm install @trpc/server @trpc/client @trpc/react-query @trpc/next @tanstack/react-query zod
+npm install @trpc/server @trpc/client @trpc/react-query @trpc/next @tanstack/react-query@^4.0.0 zod
 ```
 
   </TabItem>
@@ -51,7 +51,7 @@ npm install @trpc/server @trpc/client @trpc/react-query @trpc/next @tanstack/rea
 <TabItem value="yarn" label="yarn">
 
 ```sh
-yarn add @trpc/server @trpc/client @trpc/react-query @trpc/next @tanstack/react-query zod
+yarn add @trpc/server @trpc/client @trpc/react-query @trpc/next @tanstack/react-query@^4.0.0 zod
 ```
 
 </TabItem>
@@ -59,7 +59,7 @@ yarn add @trpc/server @trpc/client @trpc/react-query @trpc/next @tanstack/react-
 <TabItem value="pnpm" label="pnpm">
 
 ```sh
-pnpm add @trpc/server @trpc/client @trpc/react-query @trpc/next @tanstack/react-query zod
+pnpm add @trpc/server @trpc/client @trpc/react-query @trpc/next @tanstack/react-query@^4.0.0 zod
 ```
 
 </TabItem>
@@ -67,7 +67,7 @@ pnpm add @trpc/server @trpc/client @trpc/react-query @trpc/next @tanstack/react-
 <TabItem value="bun" label="bun">
 
 ```sh
-bun add @trpc/server @trpc/client @trpc/react-query @trpc/next @tanstack/react-query zod
+bun add @trpc/server @trpc/client @trpc/react-query @trpc/next @tanstack/react-query@^4.0.0 zod
 ```
 
 </TabItem>


### PR DESCRIPTION
Closes #5022 

## 🎯 Changes

update the installation instructions to be ^4.0.0-range of the RQ deps until v11 is out

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
