### PR TITLE
fix(client+server): avoid losing type information w/ index signatures

### DIFF
--- a/packages/server/src/core/internals/utils.ts
+++ b/packages/server/src/core/internals/utils.ts
@@ -1,4 +1,4 @@
-import { Simplify } from '../../types';
+import { Simplify, WithoutIndexSignature } from '../../types';
 import { ProcedureParams } from '../procedure';
 
 /**
@@ -12,12 +12,18 @@ export type Overwrite<TType, TWith> = TType extends object
   ? TWith extends object
     ? // Both TType and TWith are objects: overwrite key-by-key
       {
-        [K in keyof TType | keyof TWith]: K extends keyof TWith
+        [K in  // Exclude index signature from keys
+          | keyof WithoutIndexSignature<TType>
+          | keyof WithoutIndexSignature<TWith>]: K extends keyof TWith
           ? TWith[K]
           : K extends keyof TType
           ? TType[K]
           : never;
-      }
+      } & (string extends keyof TWith // Handle cases with an index signature
+        ? { [key: string]: TWith[string] }
+        : number extends keyof TWith
+        ? { [key: number]: TWith[number] }
+        : object)
     : TWith extends any
     ? // TWith is not an object but some non-never type, so fully overwrite TType
       TWith

--- a/packages/server/src/shared/internal/serialize.ts
+++ b/packages/server/src/shared/internal/serialize.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { Simplify } from '../../types';
+import { Simplify, WithoutIndexSignature } from '../../types';
 
 /**
  * @link https://github.com/remix-run/remix/blob/2248669ed59fd716e267ea41df5d665d4781f4a9/packages/remix-server-runtime/serialize.ts
@@ -72,7 +72,10 @@ type FilterDefinedKeys<TObj extends object> = Exclude<
  */
 type UndefinedToOptional<T extends object> =
   // Property is not a union with `undefined`, keep as-is
-  Pick<T, FilterDefinedKeys<T>> & {
+  Pick<
+    WithoutIndexSignature<T>,
+    FilterDefinedKeys<WithoutIndexSignature<T>>
+  > & {
     // Property _is_ a union with `defined`. Set as optional (via `?`) and remove `undefined` from the union
     [k in keyof Omit<T, FilterDefinedKeys<T>>]?: Exclude<T[k], undefined>;
   };

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -115,3 +115,18 @@ export type DeepPartial<TObject> = TObject extends object
       [P in keyof TObject]?: DeepPartial<TObject[P]>;
     }
   : TObject;
+
+/**
+ * See https://github.com/microsoft/TypeScript/issues/41966#issuecomment-758187996
+ * Fixes issues with iterating over keys of objects with index signatures.
+ * Without this, iterations over keys of objects with index signatures will lose
+ * type information about the keys and only the index signature will remain.
+ * @internal
+ */
+export type WithoutIndexSignature<TObj extends object> = {
+  [K in keyof TObj as string extends K
+    ? never
+    : number extends K
+    ? never
+    : K]: TObj[K];
+};

--- a/packages/tests/server/regression/issue-5034-input-with-index-signature.test.ts
+++ b/packages/tests/server/regression/issue-5034-input-with-index-signature.test.ts
@@ -1,0 +1,63 @@
+import { inferRouterInputs, inferRouterOutputs, initTRPC } from '@trpc/server';
+import * as z from 'zod';
+
+export function hardcodedExample() {
+  return async (data?: unknown) => {
+    return data as { [x: string]: unknown; name: string };
+  };
+}
+
+const t = initTRPC.create();
+const appRouter = t.router({
+  inputWithIndexSignature: t.procedure
+    .input(hardcodedExample())
+    .query(({ input }) => input),
+  inputWithIndexSignatureAndMiddleware: t.procedure
+    .input(hardcodedExample())
+    .use((opts) => opts.next())
+    .query(({ input }) => input),
+  normalInput: t.procedure
+    .input(z.object({ name: z.string() }))
+    .query(({ input }) => {
+      return input;
+    }),
+});
+type AppRouter = typeof appRouter;
+
+describe('inferRouterInputs/inferRouterOutputs', () => {
+  type AppRouterInputs = inferRouterInputs<AppRouter>;
+  type AppRouterOutputs = inferRouterOutputs<AppRouter>;
+
+  test('input type with a known key and an index signature', async () => {
+    type Input = AppRouterInputs['inputWithIndexSignature'];
+    type Output = AppRouterOutputs['inputWithIndexSignature'];
+    expectTypeOf<Input>().toEqualTypeOf<{
+      [x: string]: unknown;
+      name: string;
+    }>();
+    expectTypeOf<Output>().toEqualTypeOf<{
+      [x: string]: unknown;
+      name: string;
+    }>();
+  });
+
+  test('input type with a known key and an index signature and middleware', async () => {
+    type Input = AppRouterInputs['inputWithIndexSignatureAndMiddleware'];
+    type Output = AppRouterOutputs['inputWithIndexSignatureAndMiddleware'];
+    expectTypeOf<Input>().toEqualTypeOf<{
+      [x: string]: unknown;
+      name: string;
+    }>();
+    expectTypeOf<Output>().toEqualTypeOf<{
+      [x: string]: unknown;
+      name: string;
+    }>();
+  });
+
+  test('normal input as sanity check', async () => {
+    type Input = AppRouterInputs['normalInput'];
+    type Output = AppRouterOutputs['normalInput'];
+    expectTypeOf<Input>().toEqualTypeOf<{ name: string }>();
+    expectTypeOf<Output>().toEqualTypeOf<{ name: string }>();
+  });
+});


### PR DESCRIPTION
Closes #5034

## 🎯 Changes

When dealing with objects that have an index signature and known properties, such as:

```
{
  [x: string]: unknown;
  foo: string
}
```

If you use `Omit`, `Pick` or `keyof` in any capacity, the resulting iteration loses type information because the key collapses to just `string | number` due to how union types work:

```
  type Foo = keyof { [x: string]: unknown, foo: string } // string | number. 
  
  // string | 'foo' collapses to just ---> string
  // number is included because objects can be accessed with number keys as well
```

This is intended behavior in TypeScript, see e.g. [this TS issue](https://github.com/microsoft/TypeScript/issues/45367) and linked related issues of the same issue.

This means to support use cases with such types, we need to carefully construct our key iterating functions to handle these edge cases, IF we want to support them at all. This PR changes the behavior of a few utility functions to use a new `WithoutIndexSignature` type-level function that handles this case. 

The PR also adds a new regression test for the linked issue.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
