### PR TITLE
fix(server): fix regression introduced by #5017

### DIFF
--- a/packages/server/src/core/internals/utils.ts
+++ b/packages/server/src/core/internals/utils.ts
@@ -1,5 +1,9 @@
-import { Simplify, WithoutIndexSignature } from '../../types';
+import { OmitIndexSignature, PickIndexSignature, Simplify } from '../../types';
 import { ProcedureParams } from '../procedure';
+
+type SimpleOverwrite<TType, TWith> = {
+  [$Key in keyof TType as $Key extends keyof TWith ? never : $Key]: TType[$Key];
+} & TWith;
 
 /**
  * @internal
@@ -9,19 +13,10 @@ import { ProcedureParams } from '../procedure';
  */
 export type Overwrite<TType, TWith> = TWith extends any
   ? TType extends object
-    ? {
-        [K in  // Exclude index signature from keys
-          | keyof WithoutIndexSignature<TType>
-          | keyof WithoutIndexSignature<TWith>]: K extends keyof TWith
-          ? TWith[K]
-          : K extends keyof TType
-          ? TType[K]
-          : never;
-      } & (string extends keyof TWith // Handle cases with an index signature
-        ? { [key: string]: TWith[string] }
-        : number extends keyof TWith
-        ? { [key: number]: TWith[number] }
-        : object)
+    ? Simplify<
+        SimpleOverwrite<OmitIndexSignature<TType>, OmitIndexSignature<TWith>> &
+          SimpleOverwrite<PickIndexSignature<TWith>, PickIndexSignature<TType>>
+      >
     : TWith
   : never;
 

--- a/packages/server/src/core/internals/utils.ts
+++ b/packages/server/src/core/internals/utils.ts
@@ -1,9 +1,5 @@
-import { OmitIndexSignature, PickIndexSignature, Simplify } from '../../types';
+import { Simplify, WithoutIndexSignature } from '../../types';
 import { ProcedureParams } from '../procedure';
-
-type SimpleOverwrite<TType, TWith> = {
-  [$Key in keyof TType as $Key extends keyof TWith ? never : $Key]: TType[$Key];
-} & TWith;
 
 /**
  * @internal
@@ -13,10 +9,19 @@ type SimpleOverwrite<TType, TWith> = {
  */
 export type Overwrite<TType, TWith> = TWith extends any
   ? TType extends object
-    ? Simplify<
-        SimpleOverwrite<OmitIndexSignature<TType>, OmitIndexSignature<TWith>> &
-          SimpleOverwrite<PickIndexSignature<TWith>, PickIndexSignature<TType>>
-      >
+    ? {
+        [K in  // Exclude index signature from keys
+          | keyof WithoutIndexSignature<TType>
+          | keyof WithoutIndexSignature<TWith>]: K extends keyof TWith
+          ? TWith[K]
+          : K extends keyof TType
+          ? TType[K]
+          : never;
+      } & (string extends keyof TWith // Handle cases with an index signature
+        ? { [key: string]: TWith[string] }
+        : number extends keyof TWith
+        ? { [key: number]: TWith[number] }
+        : object)
     : TWith
   : never;
 

--- a/packages/server/src/core/internals/utils.ts
+++ b/packages/server/src/core/internals/utils.ts
@@ -4,14 +4,12 @@ import { ProcedureParams } from '../procedure';
 /**
  * @internal
  * Overwrite properties in `TType` with properties in `TWith`
- * Only overwrites properties when both types are objects
- * Otherwise it will overwrite the entire TType with TWith,
- * unless TWith is never.
+ * Only overwrites properties when the type to be overwritten
+ * is an object. Otherwise it will just use the type from `TWith`.
  */
-export type Overwrite<TType, TWith> = TType extends object
-  ? TWith extends object
-    ? // Both TType and TWith are objects: overwrite key-by-key
-      {
+export type Overwrite<TType, TWith> = TWith extends any
+  ? TType extends object
+    ? {
         [K in  // Exclude index signature from keys
           | keyof WithoutIndexSignature<TType>
           | keyof WithoutIndexSignature<TWith>]: K extends keyof TWith
@@ -24,15 +22,7 @@ export type Overwrite<TType, TWith> = TType extends object
         : number extends keyof TWith
         ? { [key: number]: TWith[number] }
         : object)
-    : TWith extends any
-    ? // TWith is not an object but some non-never type, so fully overwrite TType
-      TWith
-    : never
-  : TType extends any
-  ? TWith extends any
-    ? // Same as above: just overwrite TType with TWith
-      TWith
-    : TType
+    : TWith
   : never;
 
 /**

--- a/packages/server/src/shared/internal/serialize.ts
+++ b/packages/server/src/shared/internal/serialize.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { Simplify, WithoutIndexSignature } from '../../types';
+import { OmitIndexSignature, Simplify } from '../../types';
 
 /**
  * @link https://github.com/remix-run/remix/blob/2248669ed59fd716e267ea41df5d665d4781f4a9/packages/remix-server-runtime/serialize.ts
@@ -72,10 +72,7 @@ type FilterDefinedKeys<TObj extends object> = Exclude<
  */
 type UndefinedToOptional<T extends object> =
   // Property is not a union with `undefined`, keep as-is
-  Pick<
-    WithoutIndexSignature<T>,
-    FilterDefinedKeys<WithoutIndexSignature<T>>
-  > & {
+  Pick<OmitIndexSignature<T>, FilterDefinedKeys<OmitIndexSignature<T>>> & {
     // Property _is_ a union with `defined`. Set as optional (via `?`) and remove `undefined` from the union
     [k in keyof Omit<T, FilterDefinedKeys<T>>]?: Exclude<T[k], undefined>;
   };

--- a/packages/server/src/shared/internal/serialize.ts
+++ b/packages/server/src/shared/internal/serialize.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { OmitIndexSignature, Simplify } from '../../types';
+import { Simplify, WithoutIndexSignature } from '../../types';
 
 /**
  * @link https://github.com/remix-run/remix/blob/2248669ed59fd716e267ea41df5d665d4781f4a9/packages/remix-server-runtime/serialize.ts
@@ -72,7 +72,10 @@ type FilterDefinedKeys<TObj extends object> = Exclude<
  */
 type UndefinedToOptional<T extends object> =
   // Property is not a union with `undefined`, keep as-is
-  Pick<OmitIndexSignature<T>, FilterDefinedKeys<OmitIndexSignature<T>>> & {
+  Pick<
+    WithoutIndexSignature<T>,
+    FilterDefinedKeys<WithoutIndexSignature<T>>
+  > & {
     // Property _is_ a union with `defined`. Set as optional (via `?`) and remove `undefined` from the union
     [k in keyof Omit<T, FilterDefinedKeys<T>>]?: Exclude<T[k], undefined>;
   };

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -60,6 +60,7 @@ export type ThenArg<TType> = TType extends PromiseLike<infer U>
 export type Simplify<TType> = TType extends any[] | Date
   ? TType
   : { [K in keyof TType]: TType[K] };
+
 /**
  * @public
  */
@@ -123,10 +124,16 @@ export type DeepPartial<TObject> = TObject extends object
  * type information about the keys and only the index signature will remain.
  * @internal
  */
-export type WithoutIndexSignature<TObj> = {
-  [K in keyof TObj as string extends K
+export type OmitIndexSignature<TObj> = {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  [$Key in keyof TObj as {} extends Record<$Key, unknown>
     ? never
-    : number extends K
-    ? never
-    : K]: TObj[K];
+    : $Key]: TObj[$Key];
+};
+
+export type PickIndexSignature<TObj> = {
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  [$Key in keyof TObj as {} extends Record<$Key, unknown>
+    ? $Key
+    : never]: TObj[$Key];
 };

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -123,7 +123,7 @@ export type DeepPartial<TObject> = TObject extends object
  * type information about the keys and only the index signature will remain.
  * @internal
  */
-export type WithoutIndexSignature<TObj extends object> = {
+export type WithoutIndexSignature<TObj> = {
   [K in keyof TObj as string extends K
     ? never
     : number extends K

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -60,7 +60,6 @@ export type ThenArg<TType> = TType extends PromiseLike<infer U>
 export type Simplify<TType> = TType extends any[] | Date
   ? TType
   : { [K in keyof TType]: TType[K] };
-
 /**
  * @public
  */
@@ -124,16 +123,10 @@ export type DeepPartial<TObject> = TObject extends object
  * type information about the keys and only the index signature will remain.
  * @internal
  */
-export type OmitIndexSignature<TObj> = {
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  [$Key in keyof TObj as {} extends Record<$Key, unknown>
+export type WithoutIndexSignature<TObj> = {
+  [K in keyof TObj as string extends K
     ? never
-    : $Key]: TObj[$Key];
-};
-
-export type PickIndexSignature<TObj> = {
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  [$Key in keyof TObj as {} extends Record<$Key, unknown>
-    ? $Key
-    : never]: TObj[$Key];
+    : number extends K
+    ? never
+    : K]: TObj[K];
 };

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -14,7 +14,8 @@
     "test-watch:vitest": "vitest",
     "test-watch:tsc": "tsc --noEmit --pretty --watch",
     "test-ci": "concurrently \"CI=true vitest --coverage\" npm:test-run:tsc",
-    "test-ui": "vitest --ui"
+    "test-ui": "vitest --ui",
+    "ts-watch": "tsc --watch"
   },
   "dependencies": {
     "@cloudflare/workers-types": "^4.0.0",

--- a/packages/tests/server/regression/issue-5034-input-with-index-signature.test.ts
+++ b/packages/tests/server/regression/issue-5034-input-with-index-signature.test.ts
@@ -89,7 +89,7 @@ describe('inferRouterInputs/inferRouterOutputs', () => {
     type Output = AppRouterOutputs['middlewareWithSymbolKey'];
 
     expectTypeOf<Output>().toEqualTypeOf<{
-      readonly foo: 'bar';
+      foo: 'bar';
       // symbol is stripped as part of SerializeObject
     }>();
   });

--- a/packages/tests/server/regression/issue-5034-input-with-index-signature.test.ts
+++ b/packages/tests/server/regression/issue-5034-input-with-index-signature.test.ts
@@ -8,6 +8,7 @@ export function hardcodedExample() {
 }
 
 const t = initTRPC.create();
+const symbol = Symbol('symbol');
 const appRouter = t.router({
   inputWithIndexSignature: t.procedure
     .input(hardcodedExample())
@@ -18,6 +19,19 @@ const appRouter = t.router({
     .query(({ input }) => input),
   normalInput: t.procedure
     .input(z.object({ name: z.string() }))
+    .query(({ input }) => {
+      return input;
+    }),
+
+  middlewareWithSymbolKey: t.procedure
+    .input(z.object({ name: z.string() }))
+    .use((opts) =>
+      opts.next({
+        ctx: {
+          [symbol]: true,
+        },
+      }),
+    )
     .query(({ input }) => {
       return input;
     }),
@@ -59,5 +73,15 @@ describe('inferRouterInputs/inferRouterOutputs', () => {
     type Output = AppRouterOutputs['normalInput'];
     expectTypeOf<Input>().toEqualTypeOf<{ name: string }>();
     expectTypeOf<Output>().toEqualTypeOf<{ name: string }>();
+  });
+
+  test('middleware with symbol key', async () => {
+    type Input = AppRouterInputs['middlewareWithSymbolKey'];
+    type Output = AppRouterOutputs['middlewareWithSymbolKey'];
+    expectTypeOf<Input>().toEqualTypeOf<{ name: string }>();
+    expectTypeOf<Output>().toEqualTypeOf<{
+      name: string;
+      [symbol]: true;
+    }>();
   });
 });

--- a/packages/tests/server/regression/issue-5037-context-inference.test.ts
+++ b/packages/tests/server/regression/issue-5037-context-inference.test.ts
@@ -1,6 +1,7 @@
 import { inferRouterOutputs, initTRPC } from '@trpc/server';
 import { z } from 'zod';
 
+
 /**
  * See @sentry/node trpc middleware:
  * https://github.com/getsentry/sentry-javascript/blob/6d424571e3cd5e99991b711f4e23d773e321e294/packages/node/src/handlers.ts#L328
@@ -37,8 +38,8 @@ type Context = {
   some: 'prop';
 };
 
-describe('inferRouterInputs', () => {
-  test('string', async () => {
+describe('context inference w/ middlewares', () => {
+  test('a base procedure using a generically constructed middleware should be extensible using another middleware', async () => {
     const t = initTRPC.context<Context>().create();
 
     const baseMiddleware = t.middleware(sentryTrpcMiddleware({ foo: 'bar' }));

--- a/packages/tests/server/regression/issue-5037-context-inference.test.ts
+++ b/packages/tests/server/regression/issue-5037-context-inference.test.ts
@@ -1,7 +1,6 @@
 import { inferRouterOutputs, initTRPC } from '@trpc/server';
 import { z } from 'zod';
 
-
 /**
  * See @sentry/node trpc middleware:
  * https://github.com/getsentry/sentry-javascript/blob/6d424571e3cd5e99991b711f4e23d773e321e294/packages/node/src/handlers.ts#L328

--- a/packages/tests/server/regression/issue-5037-context-inference.test.ts
+++ b/packages/tests/server/regression/issue-5037-context-inference.test.ts
@@ -1,0 +1,69 @@
+import { inferRouterOutputs, initTRPC } from '@trpc/server';
+import { z } from 'zod';
+
+/**
+ * See @sentry/node trpc middleware:
+ * https://github.com/getsentry/sentry-javascript/blob/6d424571e3cd5e99991b711f4e23d773e321e294/packages/node/src/handlers.ts#L328
+ */
+interface TrpcMiddlewareArguments<T> {
+  path: string;
+  type: string;
+  next: () => T;
+  rawInput: unknown;
+}
+
+/**
+ * See @sentry/node trpc middleware:
+ * https://github.com/getsentry/sentry-javascript/blob/6d424571e3cd5e99991b711f4e23d773e321e294/packages/node/src/handlers.ts#L328
+ */
+function sentryTrpcMiddleware(_options: any) {
+  return function <T>({
+    path,
+    type,
+    next,
+    rawInput,
+  }: TrpcMiddlewareArguments<T>): T {
+    path;
+    type;
+    next;
+    rawInput;
+
+    // This function is effectively what @sentry/node does to provide its trpc middleware.
+    return null as any as T;
+  };
+}
+
+type Context = {
+  some: 'prop';
+};
+
+describe('inferRouterInputs', () => {
+  test('string', async () => {
+    const t = initTRPC.context<Context>().create();
+
+    const baseMiddleware = t.middleware(sentryTrpcMiddleware({ foo: 'bar' }));
+
+    const someMiddleware = t.middleware(async (opts) => {
+      return opts.next({
+        ctx: {
+          object: {
+            a: 'b',
+          },
+        },
+      });
+    });
+
+    const baseProcedure = t.procedure.use(baseMiddleware);
+    const bazQuxProcedure = baseProcedure.use(someMiddleware);
+
+    const appRouter = t.router({
+      foo: bazQuxProcedure.input(z.string()).query(({ ctx }) => ctx),
+    });
+    type Output = inferRouterOutputs<typeof appRouter>['foo'];
+
+    expectTypeOf<Output>().toEqualTypeOf<{
+      object: { a: string };
+      some: 'prop';
+    }>();
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -14,7 +14,8 @@
     "noUncheckedIndexedAccess": true,
     "moduleResolution": "node",
     "jsx": "react",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "exclude": ["test", "**/*.test.ts", "**/*.test.tsx"]
 }


### PR DESCRIPTION
Closes #5037

## 🎯 Changes

There were two bug reports about 10.43.3, the cause of which can be traced back to PR #5017 (which fixed another inference bug... seeing a pattern here)

I _think_ in both bug reports the cause has something to do with using generics to construct either tRPC instances or tRPC middlewares using a type parameter that is not constrained to `object`, which causes TS to infer incompatible types for middleware builders after `Overwrite` was changed to only do the key-wise merge on types that extend `object`.

This PR basically reverts the changes in #5017 and replaces it with a check to see whether `TWith` (the type that overwrites the target type) extends a JS primitive, and if so, wholly replaces it. This achieves the intended end result of #5017 while (hopefully) fixing the issues introduced in 10.43.3 and reported in #5037.

This PR includes a test with which I was able to reproduce a compile error similar to the one(s) reported in #5037, and which was fixed with the added changes.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
