### PR TITLE
[Docs] infer-types.md: fix typo in name of router factory function

### DIFF
--- a/www/docs/client/react/infer-types.md
+++ b/www/docs/client/react/infer-types.md
@@ -143,7 +143,7 @@ export function createMyRouter() {
 }
 
 // Infer the type of your router, and then generate the abstract types for use in the client
-type MyRouterType = ReturnType<typeof createRouter>
+type MyRouterType = ReturnType<typeof createMyRouter>
 export MyRouterLike = RouterLike<MyRouterType>
 export MyRouterUtilsLike = UtilsLike<MyRouterType>
 ```


### PR DESCRIPTION
Fix type inference example to reference the createMyRouter function defined earlier in the file (rather than the nonexistent createRouter).

Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
