### PR TITLE
wip draft RFC composable standalone inputs and middlewares

### DIFF
--- a/packages/server/src/core/index.ts
+++ b/packages/server/src/core/index.ts
@@ -21,7 +21,9 @@ export {
   createInputMiddleware,
   createOutputMiddleware,
   experimental_standaloneMiddleware,
+  experimental_standaloneInputMiddleware,
+  composeMiddlewares,
 } from './middleware';
-export type { MiddlewareFunction, MiddlewareBuilder } from './middleware';
+export type { MiddlewareFunction } from './middleware';
 export { initTRPC } from './initTRPC';
 export * from './types';

--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -3,7 +3,6 @@ import { MaybePromise, Simplify } from '../../types';
 import {
   createInputMiddleware,
   createOutputMiddleware,
-  MiddlewareBuilder,
   MiddlewareFunction,
   MiddlewareResult,
 } from '../middleware';
@@ -122,9 +121,7 @@ export interface ProcedureBuilder<TParams extends AnyProcedureBuilderParams> {
    * Add a middleware to the procedure.
    */
   use<$Params extends AnyProcedureBuilderParams>(
-    fn:
-      | MiddlewareBuilder<TParams, $Params>
-      | MiddlewareFunction<TParams, $Params>,
+    fn: MiddlewareFunction<TParams, $Params>,
   ): CreateProcedureReturnInput<TParams, $Params>;
   /**
    * Query procedure
@@ -229,12 +226,8 @@ export function createBuilder<TConfig extends AnyRootConfig>(
         meta: meta as Record<string, unknown>,
       }) as AnyProcedureBuilder;
     },
-    use(middlewareBuilderOrFn) {
-      // Distinguish between a middleware builder and a middleware function
-      const middlewares =
-        '_middlewares' in middlewareBuilderOrFn
-          ? middlewareBuilderOrFn._middlewares
-          : [middlewareBuilderOrFn];
+    use(middlewareFn) {
+      const middlewares = [middlewareFn];
 
       return createNewBuilder(_def, {
         middlewares: middlewares as ProcedureBuilderMiddleware[],

--- a/packages/server/src/unstableInternalsExport.ts
+++ b/packages/server/src/unstableInternalsExport.ts
@@ -6,5 +6,5 @@
 export { mergeRouters } from './core/internals/mergeRouters';
 export * from './core/internals/procedureBuilder';
 export * from './core/internals/utils';
-export type { MiddlewareFunction, MiddlewareBuilder } from './core/middleware';
+export type { MiddlewareFunction } from './core/middleware';
 export * from './core/procedure';

--- a/packages/tests/tsconfig.json
+++ b/packages/tests/tsconfig.json
@@ -6,6 +6,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "target": "ES2020",
     "types": ["node", "vitest/globals"],
-    "noUnusedLocals": false
+    "noUnusedLocals": false,
+    "noErrorTruncation": true
   }
 }


### PR DESCRIPTION
wip draft for breaking change for v11 maybe

ideas:

- `composeMiddlewares(mw1, input1, input2, mw2, mw3...)` instead of `mw1.unstable_pipe(mw2)`
- gets rid of `MiddlewareBuilder`, `CreateMiddlewareReturnInput` etc types. `composeMiddlewares()` just returns a `MiddlewareFunction`
- ability to compose input parsers and regular middlewares into one unit

<img width="597" alt="image" src="https://github.com/trpc/trpc/assets/22619982/7c68e7a2-cb5d-4ba8-ab6b-cbf9d82136f4">

<img width="848" alt="image" src="https://github.com/trpc/trpc/assets/22619982/48881344-6713-4567-a2be-75d161bc3be3">

<img width="854" alt="image" src="https://github.com/trpc/trpc/assets/22619982/609ca15c-351c-4261-80e6-a2e575fc2055">

---

just a thing i experimented with today. for what it's worth i'm probably going to use this branch as a sort of sandbox to try out different things that can break the existing API

couple of random notes i'll just throw down:

- `AnyRootConfig` etc. need to be killed with fire. any types with `any` wreck inference because e.g. `any extends 'foo' ? true : false` returns `boolean` (i.e. it matches _both at the same time_)
- Does `MiddlewareFunction` even require two type arguments?