### PR TITLE
fix(server): middleware input requirements shouldn't widen procedure inputs

### DIFF
--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -36,9 +36,7 @@ type CreateProcedureReturnInput<
   _config: TPrev['_config'];
   _meta: TPrev['_meta'];
   _ctx_out: Overwrite<TPrev['_ctx_out'], TNext['_ctx_out']>;
-  _input_in: UnsetMarker extends TNext['_input_in']
-    ? TPrev['_input_in']
-    : Overwrite<TPrev['_input_in'], TNext['_input_in']>;
+  _input_in: TPrev['_input_in'];
   _input_out: UnsetMarker extends TNext['_input_out']
     ? TPrev['_input_out']
     : Overwrite<TPrev['_input_out'], TNext['_input_out']>;

--- a/packages/server/src/core/internals/utils.ts
+++ b/packages/server/src/core/internals/utils.ts
@@ -21,7 +21,8 @@ export type Overwrite<TType, TWith> = TWith extends any
         ? { [key: string]: TWith[string] }
         : number extends keyof TWith
         ? { [key: number]: TWith[number] }
-        : object)
+        : // eslint-disable-next-line @typescript-eslint/ban-types
+          {})
     : TWith
   : never;
 

--- a/packages/server/src/core/middleware.ts
+++ b/packages/server/src/core/middleware.ts
@@ -7,6 +7,7 @@ import {
   DefaultValue as FallbackValue,
   MiddlewareMarker,
   Overwrite,
+  UnsetMarker,
 } from './internals/utils';
 import { ProcedureParams } from './procedure';
 import { ProcedureType } from './types';
@@ -118,7 +119,7 @@ type deriveParamsFromConfig<
   _config: TConfig;
   // eslint-disable-next-line @typescript-eslint/ban-types
   _ctx_out: {};
-  _input_out: TInputIn;
+  _input_out: UnsetMarker;
   _input_in: TInputIn;
   _output_in: unknown;
   _output_out: unknown;
@@ -137,7 +138,7 @@ export type MiddlewareFunction<
     >;
     type: ProcedureType;
     path: string;
-    input: TParams['_input_out'];
+    input: TParams['_input_in'];
     rawInput: unknown;
     meta: TParams['_meta'] | undefined;
     next: {

--- a/packages/tests/server/regression/issue-5056-input-parser-standalone-mw-inference.test.ts
+++ b/packages/tests/server/regression/issue-5056-input-parser-standalone-mw-inference.test.ts
@@ -1,7 +1,7 @@
 import { experimental_standaloneMiddleware, initTRPC } from '@trpc/server';
 import * as z from 'zod';
 
-describe('context inference w/ middlewares', () => {
+describe('input/context proper narrowing in procedure chain', () => {
   test("a narrower input type earlier in the chain should not widen because of a later middleware's wider input requirements", () => {
     const t = initTRPC.create();
 

--- a/packages/tests/server/regression/issue-5056-input-parser-standalone-mw-inference.test.ts
+++ b/packages/tests/server/regression/issue-5056-input-parser-standalone-mw-inference.test.ts
@@ -1,0 +1,51 @@
+import { experimental_standaloneMiddleware, initTRPC } from '@trpc/server';
+import * as z from 'zod';
+
+describe('context inference w/ middlewares', () => {
+  test("a narrower input type earlier in the chain should not widen because of a later middleware's wider input requirements", () => {
+    const t = initTRPC.create();
+
+    const organizationAuth = experimental_standaloneMiddleware<{
+      input: { organizationId?: string };
+    }>().create(async ({ next, ctx }) => {
+      return await next({ ctx });
+    });
+
+    t.router({
+      createProject: t.procedure
+        // input enforces that organizationId is required
+        .input(z.object({ organizationId: z.string().uuid() }))
+        // middleware allows organizationId to be optional
+        .use(organizationAuth)
+        .mutation(({ input }) => {
+          // input is still required
+          expectTypeOf(input).toEqualTypeOf<{ organizationId: string }>();
+        }),
+      updateProject: t.procedure
+        // input allows organizationId to be optional
+        .input(z.object({ organizationId: z.string().uuid().optional() }))
+        // middleware allows organizationId to be optional
+        .use(organizationAuth)
+        .mutation(({ input }) => {
+          // input remains optional
+          expectTypeOf(input).toEqualTypeOf<{ organizationId?: string }>();
+        }),
+    });
+  });
+
+  test("a narrower ctx type earlier in the chain should not widen because of a later middleware's wider ctx requirements", () => {
+    const t = initTRPC.context<{ organizationId: string }>().create();
+
+    const organizationCtx = experimental_standaloneMiddleware<{
+      ctx: { organizationId?: string };
+    }>().create(async ({ next }) => {
+      return next();
+    });
+
+    t.router({
+      createProject: t.procedure.use(organizationCtx).mutation(({ ctx }) => {
+        expectTypeOf(ctx).toEqualTypeOf<{ organizationId: string }>();
+      }),
+    });
+  });
+});


### PR DESCRIPTION
…rocedure inputs

Closes #5056

## 🎯 Changes

E.g.

```
.input(z.object({ foo: string })
.use(middlewareThatRequiresOptionalFoo)
.query(({ input }) => ...)
```

input.foo should still be string, not an optional string.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
