### PR TITLE
fix(client+server): fix output serialization of records (again)

### DIFF
--- a/packages/server/src/shared/internal/serialize.ts
+++ b/packages/server/src/shared/internal/serialize.ts
@@ -18,7 +18,7 @@ type IsAny<T> = 0 extends T & 1 ? true : false;
 // support it as both a Primitive and a NonJsonPrimitive
 type JsonReturnable = JsonPrimitive | undefined;
 
-// prettier-ignore
+/* prettier-ignore */
 export type Serialize<T> =
   IsAny<T> extends true ? any :
   unknown extends T ? unknown :
@@ -29,6 +29,7 @@ export type Serialize<T> =
   T extends [] ? [] :
   T extends [unknown, ...unknown[]] ? SerializeTuple<T> :
   T extends readonly (infer U)[] ? (U extends NonJsonPrimitive ? null : Serialize<U>)[] :
+  Record<never, never> extends T ? Record<keyof T, Serialize<T[keyof T]>> :
   T extends object ? Simplify<SerializeObject<UndefinedToOptional<T>>> :
   never;
 

--- a/packages/tests/server/regression/issue-4985-serialize-type.test.ts
+++ b/packages/tests/server/regression/issue-4985-serialize-type.test.ts
@@ -1,4 +1,8 @@
-import { inferRouterOutputs, initTRPC } from '@trpc/server/src';
+import {
+  inferRouterInputs,
+  inferRouterOutputs,
+  initTRPC,
+} from '@trpc/server/src';
 import * as z from 'zod';
 
 describe('Serialization of Record types', () => {
@@ -20,16 +24,31 @@ describe('Serialization of Record types', () => {
         str: 'string',
       };
     }),
+    // output serialization behaves differently if the output is inferred vs. given with .output()
+    inputWithRecord: t.procedure
+      .input(z.record(z.string()))
+      .query(({ input }) => input),
+    inputWithComplexRecord: t.procedure
+      .input(
+        z.record(
+          z.object({
+            name: z.string(),
+            age: z.number(),
+            symbol: z.symbol(),
+          }),
+        ),
+      )
+      .query(({ input }) => input),
   });
 
   test('Record<string, any> gets inferred on the client as { [x: string]: any }', async () => {
     type Output = inferRouterOutputs<typeof appRouter>['recordStringAny'];
-    expectTypeOf<Output>().toEqualTypeOf<{ [x: string]: any }>();
+    expectTypeOf<Output>().toEqualTypeOf<Record<string, any>>();
   });
 
   test('Record<string, unknown> gets inferred on the client as { [x: string]: unknown }', async () => {
     type Output = inferRouterOutputs<typeof appRouter>['recordStringUnknown'];
-    expectTypeOf<Output>().toEqualTypeOf<{ [x: string]: unknown }>();
+    expectTypeOf<Output>().toEqualTypeOf<Record<string, unknown>>();
   });
 
   test('Symbol keys get erased on the client', async () => {
@@ -37,5 +56,25 @@ describe('Serialization of Record types', () => {
     expectTypeOf<Output>().toEqualTypeOf<{
       str: string;
     }>();
+  });
+
+  test('input type with a record, returned as inferred output', async () => {
+    type Input = inferRouterInputs<typeof appRouter>['inputWithRecord'];
+    type Output = inferRouterOutputs<typeof appRouter>['inputWithRecord'];
+    expectTypeOf<Input>().toEqualTypeOf<Record<string, string>>();
+    expectTypeOf<Output>().toEqualTypeOf<Record<string, string>>();
+  });
+
+  test('input type with a complex record, returned as inferred output', async () => {
+    type Input = inferRouterInputs<typeof appRouter>['inputWithComplexRecord'];
+    type Output = inferRouterOutputs<
+      typeof appRouter
+    >['inputWithComplexRecord'];
+    expectTypeOf<Input>().toEqualTypeOf<
+      Record<string, { name: string; age: number; symbol: symbol }>
+    >();
+    expectTypeOf<Output>().toEqualTypeOf<
+      Record<string, { name: string; age: number }>
+    >();
   });
 });


### PR DESCRIPTION
Closes #

## 🎯 Changes

apparently our earlier regression tests did not catch a regression to record serialization, because the tests were constructed using .output() instead of inferring the return type of the query/mutation.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
