### PR TITLE
fix(server): Response meta headers type

### DIFF
--- a/packages/server/src/http/types.ts
+++ b/packages/server/src/http/types.ts
@@ -24,5 +24,5 @@ export interface HTTPBaseHandlerOptions<TRouter extends AnyRouter, TRequest>
 
 export interface ResponseMeta {
   status?: number;
-  headers?: Record<string, string>;
+  headers?: HTTPHeaders;
 }


### PR DESCRIPTION
## 🎯 Changes

- Changes type of `ResponseMeta['headers']` from `Record<string, string>` to `HTTPHeaders`
- This allows for multiple headers setting. My use case: setting cookies with it.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made. (Not nescessary)
- [x] I have added or updated the tests related to the changes made.
