### PR TITLE
fix(server): constrain the IsRecord utility type to objects

### DIFF
--- a/packages/server/src/shared/internal/serialize.ts
+++ b/packages/server/src/shared/internal/serialize.ts
@@ -18,7 +18,9 @@ type IsAny<T> = 0 extends T & 1 ? true : false;
 // support it as both a Primitive and a NonJsonPrimitive
 type JsonReturnable = JsonPrimitive | undefined;
 
-type IsRecord<T> = keyof WithoutIndexSignature<T> extends never ? true : false;
+type IsRecord<T extends object> = keyof WithoutIndexSignature<T> extends never
+  ? true
+  : false;
 
 /* prettier-ignore */
 export type Serialize<T> =
@@ -31,8 +33,9 @@ export type Serialize<T> =
   T extends [] ? [] :
   T extends [unknown, ...unknown[]] ? SerializeTuple<T> :
   T extends readonly (infer U)[] ? (U extends NonJsonPrimitive ? null : Serialize<U>)[] :
-  IsRecord<T> extends true ? Record<keyof T, Serialize<T[keyof T]>> :
-  T extends object ? Simplify<SerializeObject<UndefinedToOptional<T>>> :
+  T extends object ?
+    IsRecord<T> extends true ? Record<keyof T, Serialize<T[keyof T]>> :
+    Simplify<SerializeObject<UndefinedToOptional<T>>> :
   never;
 
 /** JSON serialize [tuples](https://www.typescriptlang.org/docs/handbook/2/objects.html#tuple-types) */


### PR DESCRIPTION
Followup to #5077 ; prevents false positives from IsRecord

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
