### PR TITLE
chore(examples): using TypeScript `satisfies` keyword instead of `Prisma.validator`

### DIFF
--- a/examples/next-prisma-starter/src/server/routers/post.ts
+++ b/examples/next-prisma-starter/src/server/routers/post.ts
@@ -13,13 +13,13 @@ import { prisma } from '~/server/prisma';
  * It's important to always explicitly say which fields you want to return in order to not leak extra information
  * @see https://github.com/prisma/prisma/issues/9353
  */
-const defaultPostSelect = Prisma.validator<Prisma.PostSelect>()({
+const defaultPostSelect = {
   id: true,
   title: true,
   text: true,
   createdAt: true,
   updatedAt: true,
-});
+} satisfies Prisma.PostSelect;
 
 export const postRouter = router({
   list: publicProcedure


### PR DESCRIPTION
## 🎯 Changes

Since TypeScript introduced the `satisfies` keyword, it's now recommended to use it instead of `Prisma.validator`

From the Prisma Docs:

> If you have a use case for Prisma.validator, be sure to check out this [blog post](https://www.prisma.io/blog/satisfies-operator-ur8ys8ccq7zb) about improving your Prisma workflows with the new TypeScript satisfies keyword. It's likely that you can solve your use case natively using satisfies instead of using Prisma.validator.

https://www.prisma.io/docs/concepts/components/prisma-client/advanced-type-safety/prisma-validator

Before using `Prisma.validator`:
```typescript
const defaultPostSelect = Prisma.validator<Prisma.PostSelect>()({
  id: true,
  title: true,
  text: true,
  createdAt: true,
  updatedAt: true,
});
```


After using `satisfies` keyword
```typescript
const defaultPostSelect = {
  id: true,
  title: true,
  text: true,
  createdAt: true,
  updatedAt: true,
} satisfies Prisma.PostSelect;
```

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
