### PR TITLE
feat(client): add `lazy` option on `WSClient`

### DIFF
--- a/packages/client/src/internals/retryDelay.ts
+++ b/packages/client/src/internals/retryDelay.ts
@@ -1,3 +1,0 @@
-/* istanbul ignore next -- @preserve */
-export const retryDelay = (attemptIndex: number) =>
-  attemptIndex === 0 ? 0 : Math.min(1000 * 2 ** attemptIndex, 30000);

--- a/packages/client/src/links/wsLink.ts
+++ b/packages/client/src/links/wsLink.ts
@@ -106,11 +106,6 @@ export function createWSClient(opts: WebSocketClientOptions) {
     undefined;
   let activeConnection: null | Connection = lazy ? null : createConnection();
 
-  /**
-   * Global connection has been killed
-   */
-  let killed = false;
-
   type Connection = {
     id: number;
   } & (
@@ -158,7 +153,7 @@ export function createWSClient(opts: WebSocketClientOptions) {
     });
   }
   function tryReconnect() {
-    if (!!connectTimer || killed) {
+    if (!!connectTimer) {
       return;
     }
 
@@ -389,7 +384,7 @@ export function createWSClient(opts: WebSocketClientOptions) {
   }
   return {
     close: () => {
-      killed = true;
+      connectAttempt = 0;
 
       for (const req of Object.values(pendingRequests)) {
         if (req.type === 'subscription') {
@@ -405,8 +400,8 @@ export function createWSClient(opts: WebSocketClientOptions) {
       }
       activeConnection && closeIfNoPending(activeConnection);
       clearTimeout(connectTimer);
-
       connectTimer = undefined;
+      activeConnection = null;
     },
     request,
     get connection() {

--- a/packages/client/src/links/wsLink.ts
+++ b/packages/client/src/links/wsLink.ts
@@ -27,7 +27,7 @@ type WSCallbackObserver<TRouter extends AnyRouter, TOutput> = Observer<
 type LazyMode = {
   enabled: true;
   /**
-   * Disconnect after this many milliseconds of inactivity
+   * Disconnect after this many milliseconds of inactivity (no message sent or received and no pending requests)
    * @default 100
    */
   disconnectAfterMs?: number;

--- a/packages/client/src/links/wsLink.ts
+++ b/packages/client/src/links/wsLink.ts
@@ -47,7 +47,7 @@ export type WebSocketClientOptions = {
   WebSocket?: typeof WebSocket;
   /**
    * The number of milliseconds before a reconnect is attempted.
-   * @default exponentialBackoff
+   * @default {@link exponentialBackoff}
    */
   retryDelayMs?: typeof exponentialBackoff;
   /**

--- a/packages/client/src/links/wsLink.ts
+++ b/packages/client/src/links/wsLink.ts
@@ -134,7 +134,7 @@ export function createWSClient(opts: WebSocketClientOptions) {
   function dispatch() {
     // using a timeout to batch messages
     setTimeout(() => {
-      if (!activeConnection && lazy) {
+      if (!activeConnection) {
         activeConnection = createConnection();
         return;
       }

--- a/packages/client/src/links/wsLink.ts
+++ b/packages/client/src/links/wsLink.ts
@@ -37,14 +37,26 @@ const exponentialBackoff = (attemptIndex: number) =>
   attemptIndex === 0 ? 0 : Math.min(1000 * 2 ** attemptIndex, 30000);
 
 export type WebSocketClientOptions = {
+  /**
+   * The URL to connect to (can be a function that returns a URL)
+   */
   url: string | (() => MaybePromise<string>);
+  /**
+   * Ponyfill which WebSocket implementation to use
+   */
   WebSocket?: typeof WebSocket;
   /**
    * The number of milliseconds before a reconnect is attempted.
    * @default exponentialBackoff
    */
   retryDelayMs?: typeof exponentialBackoff;
+  /**
+   * Triggered when a WebSocket connection is established
+   */
   onOpen?: () => void;
+  /**
+   * Triggered when a WebSocket connection is closed
+   */
   onClose?: (cause?: { code?: number }) => void;
   /**
    * Lazy mode will disconnect automatically after a period of inactivity

--- a/packages/client/src/links/wsLink.ts
+++ b/packages/client/src/links/wsLink.ts
@@ -132,12 +132,12 @@ export function createWSClient(opts: WebSocketClientOptions) {
    * tries to send the list of messages
    */
   function dispatch() {
+    if (!activeConnection) {
+      activeConnection = createConnection();
+      return;
+    }
     // using a timeout to batch messages
     setTimeout(() => {
-      if (!activeConnection) {
-        activeConnection = createConnection();
-        return;
-      }
       if (activeConnection?.state !== 'open') {
         return;
       }
@@ -409,7 +409,7 @@ export function createWSClient(opts: WebSocketClientOptions) {
       connectTimer = undefined;
     },
     request,
-    getConnection() {
+    get connection() {
       return activeConnection;
     },
   };

--- a/packages/tests/server/websockets.test.ts
+++ b/packages/tests/server/websockets.test.ts
@@ -410,11 +410,13 @@ test(
     await waitFor(() => {
       expect(onSlowMutationCalled).toHaveBeenCalledTimes(1);
     });
+    const conn = wsClient.connection!;
     wsClient.close();
     expect(await promise).toMatchInlineSnapshot(`"slow query resolved"`);
+
     await close();
     await waitFor(() => {
-      expect(wsClient.connection!.ws!.readyState).toBe(WebSocket.CLOSED);
+      expect(conn.ws!.readyState).toBe(WebSocket.CLOSED);
     });
     await close();
   },
@@ -432,13 +434,14 @@ test(
       expect(onNewClient).toHaveBeenCalledTimes(1);
     });
     const promise = client.slow.mutate();
+    const conn = wsClient.connection;
     wsClient.close();
     await expect(promise).rejects.toMatchInlineSnapshot(
       '[TRPCClientError: Closed before connection was established]',
     );
     await close();
     await waitFor(() => {
-      expect(wsClient.connection!.ws!.readyState).toBe(WebSocket.CLOSED);
+      expect(conn!.ws!.readyState).toBe(WebSocket.CLOSED);
     });
     await close();
   },


### PR DESCRIPTION
Closes #5028 
Closes #5055

## 🎯 Changes

Adds `lazy` option on `WSClient`


### Notes

`wsLink.ts` is spaghetti 🍝 