### PR TITLE
feat(server + client): add method override option

### DIFF
--- a/packages/client/src/links/httpFormDataLink.ts
+++ b/packages/client/src/links/httpFormDataLink.ts
@@ -1,5 +1,5 @@
 import { httpLinkFactory } from './httpLink';
-import { GetBody, httpRequest, Requester } from './internals/httpUtils';
+import { GetBody, httpRequest, isPOST, Requester } from './internals/httpUtils';
 
 const getBody: GetBody = (opts) => {
   if (!('input' in opts)) {
@@ -12,7 +12,7 @@ const getBody: GetBody = (opts) => {
 };
 
 const formDataRequester: Requester = (opts) => {
-  if (opts.type !== 'mutation') {
+  if (!isPOST(opts)) {
     // TODO(?) handle formdata queries
     throw new Error('We only handle mutations with formdata');
   }

--- a/packages/client/src/links/internals/httpUtils.ts
+++ b/packages/client/src/links/internals/httpUtils.ts
@@ -26,6 +26,10 @@ export interface HTTPLinkBaseOptions {
    * Add ponyfill for AbortController
    */
   AbortController?: AbortControllerEsque | null;
+  /**
+   * HTTP method to use - defaults to `GET` for queries and `POST` for mutations
+   */
+  unstable_methodOverride?: 'GET' | 'POST';
 }
 
 export interface ResolvedHTTPLinkOptions {

--- a/packages/server/src/adapters/aws-lambda/index.ts
+++ b/packages/server/src/adapters/aws-lambda/index.ts
@@ -101,7 +101,8 @@ export function awsLambdaRequestHandler<
     const response = await resolveHTTPResponse({
       router: opts.router,
       batching: opts.batching,
-      responseMeta: opts?.responseMeta,
+      responseMeta: opts.responseMeta,
+      unstable_methodOverride: opts.unstable_methodOverride,
       createContext,
       req,
       path,

--- a/packages/server/src/adapters/aws-lambda/utils.ts
+++ b/packages/server/src/adapters/aws-lambda/utils.ts
@@ -38,6 +38,9 @@ export type AWSLambdaOptions<
       batching?: {
         enabled: boolean;
       };
+      unstable_methodOverride?: {
+        enabled: boolean;
+      };
       onError?: OnErrorFunction<TRouter, TEvent>;
       responseMeta?: ResponseMetaFn<TRouter>;
     } & (

--- a/packages/server/src/adapters/fastify/fastifyRequestHandler.ts
+++ b/packages/server/src/adapters/fastify/fastifyRequestHandler.ts
@@ -97,6 +97,7 @@ export async function fastifyRequestHandler<
     path: opts.path,
     router: opts.router,
     batching: opts.batching,
+    unstable_methodOverride: opts.unstable_methodOverride,
     responseMeta: opts.responseMeta,
     onError(o) {
       opts?.onError?.({ ...o, req: opts.req });

--- a/packages/server/src/adapters/fetch/fetchRequestHandler.ts
+++ b/packages/server/src/adapters/fetch/fetchRequestHandler.ts
@@ -102,6 +102,7 @@ export async function fetchRequestHandler<TRouter extends AnyRouter>(
     path,
     router: opts.router,
     batching: opts.batching,
+    unstable_methodOverride: opts.unstable_methodOverride,
     responseMeta: opts.responseMeta,
     onError(o) {
       opts?.onError?.({ ...o, req: opts.req });

--- a/packages/server/src/adapters/node-http/nodeHTTPRequestHandler.ts
+++ b/packages/server/src/adapters/node-http/nodeHTTPRequestHandler.ts
@@ -109,6 +109,7 @@ export async function nodeHTTPRequestHandler<
 
     await resolveHTTPResponse({
       batching: opts.batching,
+      unstable_methodOverride: opts.unstable_methodOverride,
       responseMeta: opts.responseMeta,
       path: opts.path,
       createContext,

--- a/packages/server/src/internals/types.ts
+++ b/packages/server/src/internals/types.ts
@@ -8,7 +8,16 @@ import { TRPCError } from '../error/TRPCError';
  */
 export interface BaseHandlerOptions<TRouter extends AnyRouter, TRequest> {
   onError?: OnErrorFunction<TRouter, TRequest>;
+  /**
+   * Allow batching
+   */
   batching?: {
+    enabled: boolean;
+  };
+  /**
+   * Allow method override via query param
+   */
+  unstable_methodOverride?: {
     enabled: boolean;
   };
   router: TRouter;

--- a/packages/tests/server/methodOverride.test.ts
+++ b/packages/tests/server/methodOverride.test.ts
@@ -174,32 +174,6 @@ test('everything as POST', async () => {
   expect(req).toMatchInlineSnapshot();
 });
 
-test('use method override when not allowed', async () => {
-  const t = await setup({
-    methodOverride: {
-      enabled: false,
-    },
-    linkOptions: {
-      unstable_methodOverride: 'POST',
-    },
-  });
-
-  const err = await waitError(() =>
-    t.client.q.query({
-      who: 'test1',
-    }),
-  );
-
-  expect(err).toMatchInlineSnapshot();
-
-  expect(t.requests).toHaveLength(1);
-  const req = t.requests[0]!;
-
-  expect(req.method).toBe('POST');
-  expect(req.url).toContain('_method=GET');
-  expect(req).toMatchInlineSnapshot();
-});
-
 test('everything as POST & batched', async () => {
   const t = await setup({
     methodOverride: {
@@ -225,6 +199,32 @@ test('everything as POST & batched', async () => {
       // }),
     ]),
   ).toEqual(['hello test1', 'hello test2']);
+
+  expect(t.requests).toHaveLength(1);
+  const req = t.requests[0]!;
+
+  expect(req.method).toBe('POST');
+  expect(req.url).toContain('_method=GET');
+  expect(req).toMatchInlineSnapshot();
+});
+
+test('use method override when not allowed', async () => {
+  const t = await setup({
+    methodOverride: {
+      enabled: false,
+    },
+    linkOptions: {
+      unstable_methodOverride: 'POST',
+    },
+  });
+
+  const err = await waitError(() =>
+    t.client.q.query({
+      who: 'test1',
+    }),
+  );
+
+  expect(err).toMatchInlineSnapshot();
 
   expect(t.requests).toHaveLength(1);
   const req = t.requests[0]!;

--- a/packages/tests/server/methodOverride.test.ts
+++ b/packages/tests/server/methodOverride.test.ts
@@ -1,0 +1,183 @@
+import './___packages';
+import http from 'http';
+import {
+  createTRPCProxyClient,
+  httpBatchLink,
+  httpLink,
+  TRPCClientError,
+} from '@trpc/client/src';
+import { HTTPLinkBaseOptions } from '@trpc/client/src/links/internals/httpUtils';
+import { initTRPC, TRPCError } from '@trpc/server';
+import { BaseHandlerOptions } from '@trpc/server/internals/types';
+import { getPostBody } from '@trpc/server/src/adapters/node-http/content-type/json/getPostBody';
+import {
+  createHTTPHandler,
+  CreateHTTPHandlerOptions,
+  createHTTPServer,
+} from '@trpc/server/src/adapters/standalone';
+import fetch from 'node-fetch';
+import { beforeEach } from 'node:test';
+import { afterEach, test, vi } from 'vitest';
+import { z } from 'zod';
+
+const t = initTRPC.create();
+const router = t.router({
+  q: t.procedure
+    .input(
+      z.object({
+        who: z.string().nullish(),
+      }),
+    )
+    .query((opts) => `hello ${opts.input?.who ?? 'world'}`),
+  m: t.procedure
+    .input(
+      z.object({
+        who: z.string().nullish(),
+      }),
+    )
+    .mutation((opts) => `hello ${opts.input?.who ?? 'world'}`),
+});
+
+async function startServer(opts: {
+  methodOverride: BaseHandlerOptions<any, any>['unstable_methodOverride'];
+  linkOptions?: Partial<HTTPLinkBaseOptions>;
+}) {
+  const handler = createHTTPHandler({
+    router: router,
+  });
+  const requests: {
+    method: string;
+    url: string;
+    body: unknown;
+  }[] = [];
+  const onRequest = vi.fn<
+    [
+      {
+        method: NonNullable<http.IncomingMessage['method']>;
+        url: string;
+      },
+    ]
+  >();
+  const server = http.createServer(async (req, res) => {
+    assert(req.url);
+    assert(req.method);
+    const bodyResult = await getPostBody({ req });
+
+    const body =
+      bodyResult.ok && bodyResult.data !== undefined
+        ? JSON.parse(bodyResult.data as string)
+        : null;
+
+    requests.push({
+      method: req.method,
+      url: req.url,
+      body,
+    });
+
+    (req as any).body = body;
+
+    handler(req, res);
+  });
+
+  server.listen(0);
+
+  const port = (server.address() as any).port as number;
+
+  const client = createTRPCProxyClient<typeof router>({
+    links: [
+      httpLink({
+        url: `http://localhost:${port}`,
+        fetch: fetch as any,
+        ...opts.linkOptions,
+      }),
+    ],
+  });
+
+  return {
+    port,
+    router,
+    client,
+    requests,
+    close: () => {
+      return new Promise<void>((resolve) => {
+        server.close(() => {
+          resolve();
+        });
+      });
+    },
+  };
+}
+let app: Awaited<ReturnType<typeof startServer>>;
+async function setup(...args: Parameters<typeof startServer>) {
+  app = await startServer(...args);
+  return app;
+}
+
+afterEach(async () => {
+  if (app) {
+    app.close();
+  }
+});
+
+test('standard', async () => {
+  const t = await setup({
+    methodOverride: {
+      enabled: false,
+    },
+  });
+
+  expect(
+    await t.client.q.query({
+      who: 'test1',
+    }),
+  ).toBe('hello test1');
+  expect(
+    await t.client.m.mutate({
+      who: 'test2',
+    }),
+  ).toBe('hello test2');
+
+  expect(t.requests.map((req) => req.method)).toEqual(['GET', 'POST']);
+  expect(t.requests).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "body": null,
+        "method": "GET",
+        "url": "/q?input=%7B%22who%22%3A%22test1%22%7D",
+      },
+      Object {
+        "body": Object {
+          "who": "test2",
+        },
+        "method": "POST",
+        "url": "/m",
+      },
+    ]
+  `);
+});
+
+test('everything as POST', async () => {
+  const t = await setup({
+    methodOverride: {
+      enabled: true,
+    },
+    linkOptions: {
+      unstable_methodOverride: 'POST',
+    },
+  });
+
+  expect(
+    await t.client.q.query({
+      who: 'test1',
+    }),
+  ).toBe('hello test1');
+  expect(
+    await t.client.m.mutate({
+      who: 'test2',
+    }),
+  ).toBe('hello test2');
+
+  expect(t.requests.map((req) => req.method)).toEqual(['POST', 'POST']);
+
+  expect(t.requests).toMatchInlineSnapshot();
+});

--- a/www/docs/client/links/httpLink.md
+++ b/www/docs/client/links/httpLink.md
@@ -48,6 +48,12 @@ export interface HTTPLinkOptions {
   headers?:
     | HTTPHeaders
     | ((opts: { op: Operation }) => HTTPHeaders | Promise<HTTPHeaders>);
+  /**
+   * Send all requests as GET/POST requests regardless of the procedure type
+   * The server must separately allow overriding the method. See:
+   * @link https://trpc.io/docs/rpc
+   */
+  unstable_methodOverride?: 'GET' | 'POST';
 }
 ```
 

--- a/www/docs/further/rpc.md
+++ b/www/docs/further/rpc.md
@@ -13,6 +13,32 @@ slug: /rpc
 | `POST`       | `.mutation()`     | Input as POST body.                                                                                            |
 | <em>n/a</em> | `.subscription()` | <em>Subscriptions are not supported in HTTP transport</em>                                                     |
 
+### Overriding the default HTTP method
+
+To override the HTTP method used for queries/mutations, you can use the `unstable_methodOverride` option:
+
+```tsx title = 'server/httpHandler.ts'
+// Your server must separately allow the client to override the HTTP method
+const handler = createHTTPHandler({
+  router: router,
+  unstable_methodOverride: {
+    enabled: true,
+  },
+});
+```
+
+```tsx title = 'client/trpc.ts'
+// The client can then specify which HTTP method to use for all queries/mutations
+const client = createTRPCProxyClient<typeof router>({
+  links: [
+    httpLink({
+      url: `http://localhost:3000`,
+      unstable_methodOverride: 'POST', // all queries and mutations will be sent to the tRPC Server as POST requests. Supported: GET, POST
+    }),
+  ],
+});
+```
+
 ## Accessing nested procedures
 
 Nested procedures are separated by dots, so for a request to `byId` below would end up being a request to `/api/trpc/post.byId`.


### PR DESCRIPTION
Closes #3910

## 🎯 Changes

Add method override.

## 🚧  Checklist

 - [x] Add some failing tests
 - [x] Add some more tests
 - [x] Add working implementation
   - [x] Client
   - [x] Server
 - [x] Update docs
 - [ ] clarify necessity of _procedureType query parameter (see PR comments)
 - [ ] check formDataRequester (see PR comment)