### PR TITLE
fix(devenv): increase docusaurus node process memory limit

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -6,7 +6,7 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "dev:og-image": "cd og-image && pnpm dev --port 3001",
-    "dev:docusaurus": "docusaurus start",
+    "dev:docusaurus": "NODE_OPTIONS=--max_old_space_size=16384 docusaurus start",
     "dev": "run-p dev:* --print-label",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",


### PR DESCRIPTION
Closes #

## 🎯 Changes

In dev when updating docs, starting dev docusaurus takes a long time and often crashes to OOM. Bumping the node process max heap size to 16 gigs prevents this and also seems to make starting the dev docs server a lot faster. Obviously not ideal but does the job.

oh lawd he comin

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
