### PR TITLE
fix(client): mark ws connection as connecting

### DIFF
--- a/packages/client/src/links/wsLink.ts
+++ b/packages/client/src/links/wsLink.ts
@@ -155,11 +155,12 @@ export function createWSClient(opts: WebSocketClientOptions) {
       outgoing = [];
     });
   }
-  function tryReconnect() {
+  function tryReconnect(conn: Connection) {
     if (!!connectTimer) {
       return;
     }
 
+    conn.state = 'connecting';
     const timeout = retryDelayFn(connectAttempt++);
     reconnectInMs(timeout);
   }
@@ -228,7 +229,7 @@ export function createWSClient(opts: WebSocketClientOptions) {
     const onError = () => {
       self.state = 'closed';
       if (self === activeConnection) {
-        tryReconnect();
+        tryReconnect(self);
       }
     };
     run(async () => {
@@ -313,7 +314,7 @@ export function createWSClient(opts: WebSocketClientOptions) {
 
         if (activeConnection === self) {
           // connection might have been replaced already
-          tryReconnect();
+          tryReconnect(self);
         }
 
         for (const [key, req] of Object.entries(pendingRequests)) {


### PR DESCRIPTION
Closes #5118 

## 🎯 Changes

Mark the connection as `"connecting"` when we're attempting to reconnect. 

The root of the issue is https://github.com/trpc/trpc/blob/next/packages/client/src/links/wsLink.ts#L312
Subscriptions aren't automatically restored because the connection is marked as closed.

Adding tests soon

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [X] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [X] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
