### PR TITLE
chore: enable noPropertyAccessFromIndexSignature compiler option

### DIFF
--- a/packages/client/src/TRPCClientError.ts
+++ b/packages/client/src/TRPCClientError.ts
@@ -26,9 +26,9 @@ function isTRPCClientError(cause: unknown): cause is TRPCClientError<any> {
 function isTRPCErrorResponse(obj: unknown): obj is TRPCErrorResponse<any> {
   return (
     isObject(obj) &&
-    isObject(obj.error) &&
-    typeof obj.error.code === 'number' &&
-    typeof obj.error.message === 'string'
+    isObject(obj['error']) &&
+    typeof obj['error']['code'] === 'number' &&
+    typeof obj['error']['message'] === 'string'
   );
 }
 

--- a/packages/client/src/links/loggerLink.ts
+++ b/packages/client/src/links/loggerLink.ts
@@ -135,7 +135,7 @@ function constructPartsAndArgs(
 
   const [light, dark] = palettes.css[type];
   const css = `
-    background-color: #${direction === 'up' ? light : dark}; 
+    background-color: #${direction === 'up' ? light : dark};
     color: ${direction === 'up' ? 'black' : 'white'};
     padding: 2px;
   `;

--- a/packages/client/src/shared/transformResult.ts
+++ b/packages/client/src/shared/transformResult.ts
@@ -68,7 +68,7 @@ export function transformResult<TRouter extends AnyRouter, TOutput>(
   if (
     !result.ok &&
     (!isObject(result.error.error) ||
-      typeof result.error.error.code !== 'number')
+      typeof result.error.error['code'] !== 'number')
   ) {
     throw new TransformResultError();
   }

--- a/packages/next/src/app-dir/links/nextCache.ts
+++ b/packages/next/src/app-dir/links/nextCache.ts
@@ -25,8 +25,9 @@ export function experimental_nextCacheLink<TRouter extends AnyRouter>(
         const cacheTag = generateCacheTag(path, input);
         // Let per-request revalidate override global revalidate
         const requestRevalidate =
-          typeof context.revalidate === 'number' || context.revalidate === false
-            ? context.revalidate
+          typeof context['revalidate'] === 'number' ||
+          context['revalidate'] === false
+            ? context['revalidate']
             : undefined;
         const revalidate = requestRevalidate ?? opts.revalidate ?? false;
 

--- a/packages/next/src/app-dir/links/nextHttp.ts
+++ b/packages/next/src/app-dir/links/nextHttp.ts
@@ -27,8 +27,9 @@ export function experimental_nextHttpLink<
 
       // Let per-request revalidate override global revalidate
       const requestRevalidate =
-        typeof context.revalidate === 'number' || context.revalidate === false
-          ? context.revalidate
+        typeof context['revalidate'] === 'number' ||
+        context['revalidate'] === false
+          ? context['revalidate']
           : undefined;
       const revalidate = requestRevalidate ?? opts.revalidate ?? false;
 

--- a/packages/next/src/withTRPC.tsx
+++ b/packages/next/src/withTRPC.tsx
@@ -243,7 +243,7 @@ export function withTRPC<
         };
 
         // dehydrate query client's state and add it to the props
-        pageProps.trpcState =
+        pageProps['trpcState'] =
           trpcClient.runtime.combinedTransformer.output.serialize(
             dehydratedCacheWithErrors,
           );

--- a/packages/server/src/adapters/next.ts
+++ b/packages/server/src/adapters/next.ts
@@ -22,11 +22,11 @@ export function createNextApiHandler<TRouter extends AnyRouter>(
 ): NextApiHandler {
   return async (req, res) => {
     function getPath(): string | null {
-      if (typeof req.query.trpc === 'string') {
-        return req.query.trpc;
+      if (typeof req.query['trpc'] === 'string') {
+        return req.query['trpc'];
       }
-      if (Array.isArray(req.query.trpc)) {
-        return req.query.trpc.join('/');
+      if (Array.isArray(req.query['trpc'])) {
+        return req.query['trpc'].join('/');
       }
       return null;
     }

--- a/packages/server/src/core/initTRPC.ts
+++ b/packages/server/src/core/initTRPC.ts
@@ -116,7 +116,9 @@ function createTRPCInner<TParams extends PartialRootConfigTypes>() {
     const config: $Config = {
       transformer,
       isDev:
-        runtime?.isDev ?? globalThis.process?.env?.NODE_ENV !== 'production',
+        runtime?.isDev ??
+        // eslint-disable-next-line @typescript-eslint/dot-notation
+        globalThis.process?.env?.['NODE_ENV'] !== 'production',
       allowOutsideOfServer: runtime?.allowOutsideOfServer ?? false,
       errorFormatter,
       isServer: runtime?.isServer ?? isServerDefault,

--- a/packages/server/src/core/internals/config.ts
+++ b/packages/server/src/core/internals/config.ts
@@ -18,9 +18,10 @@ export interface RootConfigTypes {
 export const isServerDefault: boolean =
   typeof window === 'undefined' ||
   'Deno' in window ||
-  globalThis.process?.env?.NODE_ENV === 'test' ||
-  !!globalThis.process?.env?.JEST_WORKER_ID ||
-  !!globalThis.process?.env?.VITEST_WORKER_ID;
+  // eslint-disable-next-line @typescript-eslint/dot-notation
+  globalThis.process?.env?.['NODE_ENV'] === 'test' ||
+  !!globalThis.process?.env?.['JEST_WORKER_ID'] ||
+  !!globalThis.process?.env?.['VITEST_WORKER_ID'];
 
 /**
  * The runtime config that are used and actually represents real values underneath

--- a/packages/server/src/error/utils.ts
+++ b/packages/server/src/error/utils.ts
@@ -16,8 +16,8 @@ export function getMessageFromUnknownError(
   if (typeof err === 'string') {
     return err;
   }
-  if (isObject(err) && typeof err.message === 'string') {
-    return err.message;
+  if (isObject(err) && typeof err['message'] === 'string') {
+    return err['message'];
   }
   return fallback;
 }

--- a/packages/server/src/http/getHTTPStatusCode.ts
+++ b/packages/server/src/http/getHTTPStatusCode.ts
@@ -37,8 +37,8 @@ export function getHTTPStatusCode(json: TRPCResponse | TRPCResponse[]) {
     arr.map((res) => {
       if ('error' in res) {
         const data = res.error.data;
-        if (typeof data.httpStatus === 'number') {
-          return data.httpStatus;
+        if (typeof data['httpStatus'] === 'number') {
+          return data['httpStatus'];
         }
         const code = TRPC_ERROR_CODES_BY_NUMBER[res.error.code];
         return getStatusCodeFromKey(code);

--- a/packages/tests/server/adapters/fastify.test.ts
+++ b/packages/tests/server/adapters/fastify.test.ts
@@ -27,7 +27,7 @@ const config = {
 };
 
 function createContext({ req, res, info }: CreateFastifyContextOptions) {
-  const user = { name: req.headers.username ?? 'anonymous' };
+  const user = { name: req.headers['username'] ?? 'anonymous' };
   return { req, res, user, info };
 }
 

--- a/packages/tests/server/adapters/fetch.test.ts
+++ b/packages/tests/server/adapters/fetch.test.ts
@@ -91,7 +91,7 @@ async function startServer(endpoint = '') {
   });
 
   const globalScope = await mf.getGlobalScope();
-  globalScope.addEventListener('fetch', (event: FetchEvent) => {
+  globalScope['addEventListener']('fetch', (event: FetchEvent) => {
     const response = fetchRequestHandler({
       endpoint,
       req: event.request,

--- a/packages/tests/server/errors.test.ts
+++ b/packages/tests/server/errors.test.ts
@@ -446,9 +446,9 @@ describe('links have meta data about http failures', async () => {
     );
 
     expect(meta).not.toBeUndefined();
-    expect(meta?.responseJSON).not.toBeFalsy();
-    expect(meta?.responseJSON).not.toBeFalsy();
-    expect(meta?.responseJSON).toMatchInlineSnapshot(`
+    expect(meta?.['responseJSON']).not.toBeFalsy();
+    expect(meta?.['responseJSON']).not.toBeFalsy();
+    expect(meta?.['responseJSON']).toMatchInlineSnapshot(`
       Object {
         "__error": Object {
           "foo": "bar",
@@ -488,9 +488,9 @@ describe('links have meta data about http failures', async () => {
     );
 
     expect(meta).not.toBeUndefined();
-    expect(meta?.responseJSON).not.toBeFalsy();
-    expect(meta?.responseJSON).not.toBeFalsy();
-    expect(meta?.responseJSON).toMatchInlineSnapshot(`
+    expect(meta?.['responseJSON']).not.toBeFalsy();
+    expect(meta?.['responseJSON']).not.toBeFalsy();
+    expect(meta?.['responseJSON']).toMatchInlineSnapshot(`
       Object {
         "__error": Object {
           "foo": "bar",
@@ -520,14 +520,14 @@ describe('links have meta data about http failures', async () => {
           error(err) {
             if (
               err.meta &&
-              isObject(err.meta.responseJSON) &&
-              '__error' in err.meta.responseJSON // <----- you need to modify this
+              isObject(err.meta['responseJSON']) &&
+              '__error' in err.meta['responseJSON'] // <----- you need to modify this
             ) {
               // custom error handling
               observer.error(
                 new MyCustomError(
                   `custom error: ${JSON.stringify(
-                    err.meta.responseJSON.__error,
+                    err.meta['responseJSON']['__error'],
                   )}`,
                 ),
               );

--- a/packages/tests/server/index.test.ts
+++ b/packages/tests/server/index.test.ts
@@ -283,7 +283,7 @@ describe('integration tests', () => {
       }
       // auth, should work
       {
-        headers.authorization = 'kattsecret';
+        headers['authorization'] = 'kattsecret';
         const res = await client.whoami.query();
         expectTypeOf(res).toMatchTypeOf<{ id: number; name: string }>();
         expect(res).toEqual({

--- a/packages/tests/server/links.test.ts
+++ b/packages/tests/server/links.test.ts
@@ -66,8 +66,8 @@ test('chainer', async () => {
   });
 
   const result = await observableToPromise(chain).promise;
-  expect(result?.context?.response).toBeTruthy();
-  result.context!.response = '[redacted]' as any;
+  expect(result?.context?.['response']).toBeTruthy();
+  result.context!['response'] = '[redacted]' as any;
   expect(result).toMatchInlineSnapshot(`
     Object {
       "context": Object {
@@ -171,8 +171,8 @@ describe('batching', () => {
       observableToPromise(chain2).promise,
     ]);
     for (const res of results) {
-      expect(res?.context?.response).toBeTruthy();
-      res.context!.response = '[redacted]';
+      expect(res?.context?.['response']).toBeTruthy();
+      res.context!['response'] = '[redacted]';
     }
     expect(results).toMatchInlineSnapshot(`
       Array [
@@ -289,8 +289,8 @@ describe('batching', () => {
       observableToPromise(chain2).promise,
     ]);
     for (const res of results) {
-      expect(res?.context?.response).toBeTruthy();
-      res.context!.response = '[redacted]';
+      expect(res?.context?.['response']).toBeTruthy();
+      res.context!['response'] = '[redacted]';
     }
     expect(results).toMatchInlineSnapshot(`
       Array [
@@ -518,7 +518,7 @@ describe('loggerLink', () => {
     );
     expect(logger.log.mock.calls[0]![1]!).toMatchInlineSnapshot(`
       "
-          background-color: #72e3ff; 
+          background-color: #72e3ff;
           color: black;
           padding: 2px;
         "
@@ -749,8 +749,8 @@ test('init with URL object', async () => {
   });
 
   const result = await observableToPromise(chain).promise;
-  expect(result?.context?.response).toBeTruthy();
-  result.context!.response = '[redacted]' as any;
+  expect(result?.context?.['response']).toBeTruthy();
+  result.context!['response'] = '[redacted]' as any;
   expect(result).toMatchInlineSnapshot(`
     Object {
       "context": Object {

--- a/packages/tests/server/react/overrides.test.tsx
+++ b/packages/tests/server/react/overrides.test.tsx
@@ -32,7 +32,7 @@ describe('mutation override', () => {
         overrides: {
           useMutation: {
             async onSuccess(opts) {
-              if (!opts.meta.skipInvalidate) {
+              if (!opts.meta['skipInvalidate']) {
                 await opts.originalFn();
                 await opts.queryClient.invalidateQueries();
               }

--- a/packages/tests/server/react/trpc-options.test.tsx
+++ b/packages/tests/server/react/trpc-options.test.tsx
@@ -61,7 +61,7 @@ test('useQuery()', async () => {
   });
   expect(ctx.spyLink).toHaveBeenCalledTimes(1);
   const firstCall = ctx.spyLink.mock.calls[0]![0]!;
-  expect(firstCall.context.foo).toBe('bar');
+  expect(firstCall.context['foo']).toBe('bar');
   expect(firstCall).toMatchInlineSnapshot(`
     Object {
       "context": Object {
@@ -110,7 +110,7 @@ test('useMutation()', async () => {
   });
   expect(ctx.spyLink).toHaveBeenCalledTimes(1);
   const firstCall = ctx.spyLink.mock.calls[0]![0]!;
-  expect(firstCall.context.foo).toBe('bar');
+  expect(firstCall.context['foo']).toBe('bar');
   expect(firstCall).toMatchInlineSnapshot(`
     Object {
       "context": Object {

--- a/packages/tests/vitest.config.ts
+++ b/packages/tests/vitest.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
       include: ['*/src/**/*.{ts,tsx,js,jsx}'],
       exclude: ['**/deprecated/**'],
     },
-    useAtomics: !!process.env.CI,
+    useAtomics: !!process.env['CI'],
   },
   resolve: {
     alias: {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -15,7 +15,8 @@
     "moduleResolution": "node",
     "jsx": "react",
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noPropertyAccessFromIndexSignature": true
   },
   "exclude": ["test", "**/*.test.ts", "**/*.test.tsx"]
 }


### PR DESCRIPTION
Closes #5175

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

Enables the `noPropertyAccessFromIndexSignature` compiler option. Minor updates to files / lines impacted by enabling this option.

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [X] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
