### PR TITLE
chore(deps): update react to v18

### DIFF
--- a/.wip/changes.md
+++ b/.wip/changes.md
@@ -47,3 +47,7 @@ We exported a bunch of utility functions that we used in tRPC within `@trpc/serv
 If you're making an adapter for tRPC, we're happy to move these to another export and ensure they don't break between minor versions.
 
 Refactor: `inferAsyncReturnType<x>` -> `Awaited<ReturnType<x>>`
+
+## React is now >=18.2.0
+
+Check their migration guide: https://react.dev/blog/2022/03/08/react-18-upgrade-guide

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -71,8 +71,8 @@
     "@trpc/react-query": "10.44.1",
     "@trpc/server": "10.44.1",
     "next": "*",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0"
+    "react": ">=18.2.0",
+    "react-dom": ">=18.2.0"
   },
   "dependencies": {
     "react-ssr-prepass": "^1.5.0"

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -60,8 +60,8 @@
     "@tanstack/react-query": "^5.0.0",
     "@trpc/client": "10.44.1",
     "@trpc/server": "10.44.1",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0"
+    "react": ">=18.2.0",
+    "react-dom": ">=18.2.0"
   },
   "devDependencies": {
     "@tanstack/react-query": "^5.0.0",


### PR DESCRIPTION
Closes #

## 🎯 Changes

React has released v18.2.0 for about 2 years now.
This upgrade is also [blocking](https://github.com/trpc/trpc/pull/3343) replacing obsolete `react-ssr-prepass` library with a native React streaming function.

It seems like nothing did break, but I'm not sure if there were actually tests made against react v16 - as devDependencies in respective packages were listing v18.2.0 for some time now.

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
