### PR TITLE
feat(react-query): Add `trpc.useSuspenseQueries()`

### DIFF
--- a/packages/next/src/createTRPCNext.tsx
+++ b/packages/next/src/createTRPCNext.tsx
@@ -7,6 +7,7 @@ import {
   createRootHooks,
   DecoratedProcedureRecord,
   TRPCUseQueries,
+  TRPCUseSuspenseQueries,
 } from '@trpc/react-query/shared';
 import { AnyRouter } from '@trpc/server';
 import { createFlatProxy } from '@trpc/server/shared';
@@ -34,6 +35,7 @@ export interface CreateTRPCNextBase<
   useUtils(): CreateReactUtils<TRouter, TSSRContext>;
   withTRPC: ReturnType<typeof withTRPC<TRouter, TSSRContext>>;
   useQueries: TRPCUseQueries<TRouter>;
+  useSuspenseQueries: TRPCUseSuspenseQueries<TRouter>;
 }
 
 /**
@@ -77,6 +79,10 @@ export function createTRPCNext<
 
     if (key === 'useQueries') {
       return hooks.useQueries;
+    }
+
+    if (key === 'useSuspenseQueries') {
+      return hooks.useSuspenseQueries;
     }
 
     if (key === 'withTRPC') {

--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -16,7 +16,7 @@ import {
 } from '@trpc/server/shared';
 import { ProtectedIntersection } from '@trpc/server/unstableInternalsExport';
 import { useMemo } from 'react';
-import { TRPCUseQueries } from './internals/useQueries';
+import { TRPCUseQueries, TRPCUseSuspenseQueries } from './internals/useQueries';
 import {
   createReactDecoration,
   createReactQueryUtils,
@@ -260,6 +260,7 @@ export type CreateTRPCReactBase<TRouter extends AnyRouter, TSSRContext> = {
   Provider: TRPCProvider<TRouter, TSSRContext>;
   createClient: CreateClient<TRouter>;
   useQueries: TRPCUseQueries<TRouter>;
+  useSuspenseQueries: TRPCUseSuspenseQueries<TRouter>;
   useDehydratedState: UseDehydratedState<TRouter>;
 };
 

--- a/packages/react-query/src/internals/useQueries.ts
+++ b/packages/react-query/src/internals/useQueries.ts
@@ -2,7 +2,6 @@ import {
   QueryKey,
   UseQueryOptions,
   UseSuspenseQueryOptions,
-  UseSuspenseQueryResult,
 } from '@tanstack/react-query';
 import { AnyRouter } from '@trpc/server';
 import { DistributiveOmit } from '@trpc/server/unstableInternalsExport';
@@ -12,6 +11,7 @@ import {
   UseTRPCQueryOptions,
   UseTRPCQueryResult,
   UseTRPCSuspenseQueryOptions,
+  UseTRPCSuspenseQueryResult,
 } from '../shared';
 
 /**
@@ -81,19 +81,34 @@ export declare type SuspenseQueriesResults<
     any,
     any
   >[],
-> = {
-  [TKey in keyof TQueriesOptions]: TQueriesOptions[TKey] extends UseQueryOptionsForUseSuspenseQueries<
-    infer TQueryFnData,
-    infer TError,
-    infer TData,
-    any
-  >
-    ? UseSuspenseQueryResult<
-        unknown extends TData ? TQueryFnData : TData,
-        TError
-      >
-    : never;
-};
+> = [
+  {
+    [TKey in keyof TQueriesOptions]: TQueriesOptions[TKey] extends UseQueryOptionsForUseSuspenseQueries<
+      infer TQueryFnData,
+      infer TError,
+      infer TData,
+      any
+    >
+      ? UseTRPCSuspenseQueryResult<
+          unknown extends TData ? TQueryFnData : TData,
+          TError
+        >[0]
+      : never;
+  },
+  {
+    [TKey in keyof TQueriesOptions]: TQueriesOptions[TKey] extends UseQueryOptionsForUseSuspenseQueries<
+      infer TQueryFnData,
+      infer TError,
+      infer TData,
+      any
+    >
+      ? UseTRPCSuspenseQueryResult<
+          unknown extends TData ? TQueryFnData : TData,
+          TError
+        >[1]
+      : never;
+  },
+];
 
 type GetOptions<TQueryOptions> =
   TQueryOptions extends UseQueryOptionsForUseQueries<any, any, any, any>

--- a/packages/react-query/src/internals/useQueries.ts
+++ b/packages/react-query/src/internals/useQueries.ts
@@ -2,6 +2,7 @@ import {
   QueryKey,
   UseQueryOptions,
   UseSuspenseQueryOptions,
+  UseSuspenseQueryResult,
 } from '@tanstack/react-query';
 import { AnyRouter } from '@trpc/server';
 import { DistributiveOmit } from '@trpc/server/unstableInternalsExport';
@@ -11,7 +12,6 @@ import {
   UseTRPCQueryOptions,
   UseTRPCQueryResult,
   UseTRPCSuspenseQueryOptions,
-  UseTRPCSuspenseQueryResult,
 } from '../shared';
 
 /**
@@ -85,14 +85,13 @@ export declare type SuspenseQueriesResults<
   {
     [TKey in keyof TQueriesOptions]: TQueriesOptions[TKey] extends UseQueryOptionsForUseSuspenseQueries<
       infer TQueryFnData,
-      infer TError,
+      any,
       infer TData,
       any
     >
-      ? UseTRPCSuspenseQueryResult<
-          unknown extends TData ? TQueryFnData : TData,
-          TError
-        >[0]
+      ? unknown extends TData
+        ? TQueryFnData
+        : TData
       : never;
   },
   {
@@ -102,10 +101,10 @@ export declare type SuspenseQueriesResults<
       infer TData,
       any
     >
-      ? UseTRPCSuspenseQueryResult<
+      ? UseSuspenseQueryResult<
           unknown extends TData ? TQueryFnData : TData,
           TError
-        >[1]
+        >
       : never;
   },
 ];

--- a/packages/react-query/src/internals/useQueries.ts
+++ b/packages/react-query/src/internals/useQueries.ts
@@ -1,10 +1,17 @@
-import { QueryKey, UseQueryOptions } from '@tanstack/react-query';
+import {
+  QueryKey,
+  UseQueryOptions,
+  UseSuspenseQueryOptions,
+  UseSuspenseQueryResult,
+} from '@tanstack/react-query';
 import { AnyRouter } from '@trpc/server';
 import { DistributiveOmit } from '@trpc/server/unstableInternalsExport';
 import {
   UseQueriesProcedureRecord,
+  UseSuspenseQueriesProcedureRecord,
   UseTRPCQueryOptions,
   UseTRPCQueryResult,
+  UseTRPCSuspenseQueryOptions,
 } from '../shared';
 
 /**
@@ -23,8 +30,30 @@ export type UseQueryOptionsForUseQueries<
 /**
  * @internal
  */
+export type UseQueryOptionsForUseSuspenseQueries<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+> = DistributiveOmit<
+  UseSuspenseQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+  'queryKey'
+>;
+
+/**
+ * @internal
+ */
 export type TrpcQueryOptionsForUseQueries<TOutput, TData, TError> =
   DistributiveOmit<UseTRPCQueryOptions<TOutput, TData, TError>, 'queryKey'>;
+
+/**
+ * @internal
+ */
+export type TrpcQueryOptionsForUseSuspenseQueries<TOutput, TData, TError> =
+  DistributiveOmit<
+    UseTRPCSuspenseQueryOptions<TOutput, TData, TError>,
+    'queryKey'
+  >;
 
 /**
  * @internal
@@ -39,6 +68,30 @@ export declare type QueriesResults<
     any
   >
     ? UseTRPCQueryResult<unknown extends TData ? TQueryFnData : TData, TError>
+    : never;
+};
+
+/**
+ * @internal
+ */
+export declare type SuspenseQueriesResults<
+  TQueriesOptions extends UseQueryOptionsForUseSuspenseQueries<
+    any,
+    any,
+    any,
+    any
+  >[],
+> = {
+  [TKey in keyof TQueriesOptions]: TQueriesOptions[TKey] extends UseQueryOptionsForUseSuspenseQueries<
+    infer TQueryFnData,
+    infer TError,
+    infer TData,
+    any
+  >
+    ? UseSuspenseQueryResult<
+        unknown extends TData ? TQueryFnData : TData,
+        TError
+      >
     : never;
 };
 
@@ -70,6 +123,39 @@ export type QueriesOptions<
   ? UseQueryOptionsForUseQueries<TQueryFnData, TError, TData, TQueryKey>[]
   : UseQueryOptionsForUseQueries[];
 
+type GetSuspenseOptions<TQueryOptions> =
+  TQueryOptions extends UseQueryOptionsForUseSuspenseQueries<any, any, any, any>
+    ? TQueryOptions
+    : never;
+
+/**
+ * @internal
+ */
+export type SuspenseQueriesOptions<
+  TQueriesOptions extends any[],
+  TResult extends any[] = [],
+> = TQueriesOptions extends []
+  ? []
+  : TQueriesOptions extends [infer Head]
+  ? [...TResult, GetSuspenseOptions<Head>]
+  : TQueriesOptions extends [infer Head, ...infer Tail]
+  ? QueriesOptions<Tail, [...TResult, GetSuspenseOptions<Head>]>
+  : unknown[] extends TQueriesOptions
+  ? TQueriesOptions
+  : TQueriesOptions extends UseQueryOptionsForUseSuspenseQueries<
+      infer TQueryFnData,
+      infer TError,
+      infer TData,
+      infer TQueryKey
+    >[]
+  ? UseQueryOptionsForUseSuspenseQueries<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryKey
+    >[]
+  : UseQueryOptionsForUseSuspenseQueries[];
+
 /**
  * @internal
  */
@@ -80,3 +166,19 @@ export type TRPCUseQueries<TRouter extends AnyRouter> = <
     t: UseQueriesProcedureRecord<TRouter>,
   ) => readonly [...QueriesOptions<TQueryOptions>],
 ) => QueriesResults<TQueryOptions>;
+
+/**
+ * @internal
+ */
+export type TRPCUseSuspenseQueries<TRouter extends AnyRouter> = <
+  TQueryOptions extends UseQueryOptionsForUseSuspenseQueries<
+    any,
+    any,
+    any,
+    any
+  >[],
+>(
+  queriesCallback: (
+    t: UseSuspenseQueriesProcedureRecord<TRouter>,
+  ) => readonly [...SuspenseQueriesOptions<TQueryOptions>],
+) => SuspenseQueriesResults<TQueryOptions>;

--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -4,6 +4,7 @@ import {
   useQueries as __useQueries,
   useQuery as __useQuery,
   useSuspenseInfiniteQuery as __useSuspenseInfiniteQuery,
+  useSuspenseQueries as __useSuspenseQueries,
   useSuspenseQuery as __useSuspenseQuery,
   DehydratedState,
   hashKey,
@@ -20,7 +21,10 @@ import {
 import { getClientArgs } from '../../internals/getClientArgs';
 import { getQueryKeyInternal, TRPCQueryKey } from '../../internals/getQueryKey';
 import { useHookResult } from '../../internals/useHookResult';
-import { TRPCUseQueries } from '../../internals/useQueries';
+import {
+  TRPCUseQueries,
+  TRPCUseSuspenseQueries,
+} from '../../internals/useQueries';
 import { createUtilityFunctions } from '../../utils/createUtilityFunctions';
 import { createUseQueries } from '../proxy/useQueriesProxy';
 import { CreateTRPCReactOptions, UseMutationOverride } from '../types';
@@ -463,6 +467,26 @@ export function createRootHooks<
     );
   };
 
+  const useSuspenseQueries: TRPCUseSuspenseQueries<TRouter> = (
+    queriesCallback,
+  ) => {
+    const { queryClient, client } = useContext();
+
+    const proxy = createUseQueries(client);
+
+    const queries = queriesCallback(proxy);
+
+    return __useSuspenseQueries(
+      {
+        queries: queries.map((query) => ({
+          ...query,
+          queryKey: (query as TRPCQueryOptions<any, any>).queryKey,
+        })),
+      },
+      queryClient,
+    );
+  };
+
   const useDehydratedState: UseDehydratedState<TRouter> = (
     client,
     trpcState,
@@ -485,6 +509,7 @@ export function createRootHooks<
     useQuery,
     useSuspenseQuery,
     useQueries,
+    useSuspenseQueries,
     useMutation,
     useSubscription,
     useDehydratedState,

--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -476,7 +476,7 @@ export function createRootHooks<
 
     const queries = queriesCallback(proxy);
 
-    return __useSuspenseQueries(
+    const hook = __useSuspenseQueries(
       {
         queries: queries.map((query) => ({
           ...query,
@@ -485,6 +485,8 @@ export function createRootHooks<
       },
       queryClient,
     );
+
+    return [hook.map((h) => h.data), hook] as any;
   };
 
   const useDehydratedState: UseDehydratedState<TRouter> = (

--- a/packages/react-query/src/shared/index.ts
+++ b/packages/react-query/src/shared/index.ts
@@ -5,7 +5,10 @@ export type {
   DecoratedProcedureRecord,
   DecorateProcedure,
 } from '../createTRPCReact';
-export type { TRPCUseQueries } from '../internals/useQueries';
+export type {
+  TRPCUseQueries,
+  TRPCUseSuspenseQueries,
+} from '../internals/useQueries';
 export * from './hooks/createRootHooks';
 export * from './queryClient';
 export * from './types';

--- a/packages/react-query/src/shared/proxy/useQueriesProxy.ts
+++ b/packages/react-query/src/shared/proxy/useQueriesProxy.ts
@@ -13,7 +13,10 @@ import {
 } from '@trpc/server/shared';
 import { Filter } from '@trpc/server/unstableInternalsExport';
 import { getQueryKeyInternal } from '../../internals/getQueryKey';
-import { TrpcQueryOptionsForUseQueries } from '../../internals/useQueries';
+import {
+  TrpcQueryOptionsForUseQueries,
+  TrpcQueryOptionsForUseSuspenseQueries,
+} from '../../internals/useQueries';
 import { TRPCUseQueryBaseOptions } from '../hooks/types';
 
 type GetQueryOptions<
@@ -42,6 +45,37 @@ export type UseQueriesProcedureRecord<TRouter extends AnyRouter> = {
   >]: TRouter['_def']['record'][TKey] extends AnyRouter
     ? UseQueriesProcedureRecord<TRouter['_def']['record'][TKey]>
     : GetQueryOptions<
+        TRouter['_def']['_config'],
+        TRouter['_def']['record'][TKey]
+      >;
+};
+
+type GetSuspenseQueryOptions<
+  TConfig extends AnyRootConfig,
+  TProcedure extends AnyProcedure,
+> = <TData = inferTransformedProcedureOutput<TConfig, TProcedure>>(
+  input: inferProcedureInput<TProcedure>,
+  opts?: TrpcQueryOptionsForUseSuspenseQueries<
+    inferTransformedProcedureOutput<TConfig, TProcedure>,
+    TData,
+    TRPCClientError<TConfig>
+  >,
+) => TrpcQueryOptionsForUseSuspenseQueries<
+  inferTransformedProcedureOutput<TConfig, TProcedure>,
+  TData,
+  TRPCClientError<TConfig>
+>;
+
+/**
+ * @internal
+ */
+export type UseSuspenseQueriesProcedureRecord<TRouter extends AnyRouter> = {
+  [TKey in keyof Filter<
+    TRouter['_def']['record'],
+    AnyQueryProcedure | AnyRouter
+  >]: TRouter['_def']['record'][TKey] extends AnyRouter
+    ? UseSuspenseQueriesProcedureRecord<TRouter['_def']['record'][TKey]>
+    : GetSuspenseQueryOptions<
         TRouter['_def']['_config'],
         TRouter['_def']['record'][TKey]
       >;

--- a/packages/tests/server/react/useSuspenseQueries.test.tsx
+++ b/packages/tests/server/react/useSuspenseQueries.test.tsx
@@ -118,6 +118,41 @@ test('mapping queries', async () => {
   });
 });
 
+test('disallowed options', async () => {
+  const { client, App } = ctx;
+
+  function MyComponent() {
+    const [posts] = client.useSuspenseQueries((t) => [
+      t.post.byId(
+        { id: '1' },
+        {
+          // @ts-expect-error -- can't set suspense to false
+          suspense: false,
+        },
+      ),
+      t.post.byId(
+        { id: '2' },
+        {
+          // @ts-expect-error -- can't set placeholderData
+          placeholderData: '123',
+        },
+      ),
+    ]);
+
+    return <pre>{JSON.stringify(posts ?? 'n/a', null, 4)}</pre>;
+  }
+
+  const utils = render(
+    <App>
+      <MyComponent />
+    </App>,
+  );
+
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent(`__result`);
+  });
+});
+
 // regression https://github.com/trpc/trpc/issues/4802
 test('regression #4802: passes context to links', async () => {
   const { client, App } = ctx;

--- a/packages/tests/server/react/useSuspenseQueries.test.tsx
+++ b/packages/tests/server/react/useSuspenseQueries.test.tsx
@@ -42,7 +42,7 @@ const ctx = konn()
 test('single query', async () => {
   const { client, App } = ctx;
   function MyComponent() {
-    const results = client.useSuspenseQueries((t) => [
+    const [posts] = client.useSuspenseQueries((t) => [
       t.post.byId({ id: '1' }),
       t.post.byId(
         { id: '1' },
@@ -54,12 +54,10 @@ test('single query', async () => {
       ),
     ]);
 
-    expectTypeOf(results[0].data).toEqualTypeOf<`__result${string}`>();
-    expectTypeOf(
-      results[1].data,
-    ).toEqualTypeOf<`__RESULT${Uppercase<string>}`>();
+    expectTypeOf(posts[0]).toEqualTypeOf<`__result${string}`>();
+    expectTypeOf(posts[1]).toEqualTypeOf<`__RESULT${Uppercase<string>}`>();
 
-    return <pre>{JSON.stringify(results[0].data ?? 'n/a', null, 4)}</pre>;
+    return <pre>{JSON.stringify(posts[0] ?? 'n/a', null, 4)}</pre>;
   }
 
   const utils = render(
@@ -75,14 +73,12 @@ test('single query', async () => {
 test('different queries', async () => {
   const { client, App } = ctx;
   function MyComponent() {
-    const results = client.useSuspenseQueries((t) => [t.foo(), t.bar()]);
+    const [posts] = client.useSuspenseQueries((t) => [t.foo(), t.bar()]);
 
-    expectTypeOf(results[0].data).toEqualTypeOf<'foo'>();
-    expectTypeOf(results[1].data).toEqualTypeOf<'bar'>();
+    expectTypeOf(posts[0]).toEqualTypeOf<'foo'>();
+    expectTypeOf(posts[1]).toEqualTypeOf<'bar'>();
 
-    return (
-      <pre>{JSON.stringify(results.map((v) => v.data) ?? 'n/a', null, 4)}</pre>
-    );
+    return <pre>{JSON.stringify(posts ?? 'n/a', null, 4)}</pre>;
   }
 
   const utils = render(
@@ -101,17 +97,13 @@ test('mapping queries', async () => {
 
   const { client, App } = ctx;
   function MyComponent() {
-    const results = client.useSuspenseQueries((t) =>
+    const [posts] = client.useSuspenseQueries((t) =>
       ids.map((id) => t.post.byId({ id })),
     );
 
-    if (results[0]) {
-      expectTypeOf(results[0].data).toEqualTypeOf<`__result${string}`>();
-    }
+    expectTypeOf(posts).toEqualTypeOf<`__result${string}`[]>();
 
-    return (
-      <pre>{JSON.stringify(results.map((v) => v.data) ?? 'n/a', null, 4)}</pre>
-    );
+    return <pre>{JSON.stringify(posts ?? 'n/a', null, 4)}</pre>;
   }
 
   const utils = render(
@@ -131,7 +123,7 @@ test('regression #4802: passes context to links', async () => {
   const { client, App } = ctx;
 
   function MyComponent() {
-    const results = client.useSuspenseQueries((t) => [
+    const [posts] = client.useSuspenseQueries((t) => [
       t.post.byId(
         { id: '1' },
         {
@@ -153,11 +145,11 @@ test('regression #4802: passes context to links', async () => {
         },
       ),
     ]);
-    if (results.some((v) => !v.data)) {
+    if (posts.some((v) => !v)) {
       return <>...</>;
     }
 
-    return <pre>{JSON.stringify(results, null, 4)}</pre>;
+    return <pre>{JSON.stringify(posts, null, 4)}</pre>;
   }
 
   const utils = render(

--- a/packages/tests/server/react/useSuspenseQueries.test.tsx
+++ b/packages/tests/server/react/useSuspenseQueries.test.tsx
@@ -1,0 +1,182 @@
+import { getServerAndReactClient } from './__reactHelpers';
+import { render, waitFor } from '@testing-library/react';
+import { initTRPC } from '@trpc/server/src';
+import { konn } from 'konn';
+import React from 'react';
+import { z } from 'zod';
+
+const ctx = konn()
+  .beforeEach(() => {
+    const t = initTRPC.create({
+      errorFormatter({ shape }) {
+        return {
+          ...shape,
+          data: {
+            ...shape.data,
+            foo: 'bar' as const,
+          },
+        };
+      },
+    });
+    const appRouter = t.router({
+      post: t.router({
+        byId: t.procedure
+          .input(
+            z.object({
+              id: z.string(),
+            }),
+          )
+          .query(({ input }) => `__result${input.id}` as const),
+      }),
+      foo: t.procedure.query(() => 'foo' as const),
+      bar: t.procedure.query(() => 'bar' as const),
+    });
+
+    return getServerAndReactClient(appRouter);
+  })
+  .afterEach(async (ctx) => {
+    await ctx?.close?.();
+  })
+  .done();
+
+test('single query', async () => {
+  const { client, App } = ctx;
+  function MyComponent() {
+    const results = client.useSuspenseQueries((t) => [
+      t.post.byId({ id: '1' }),
+      t.post.byId(
+        { id: '1' },
+        {
+          select(data) {
+            return data as Uppercase<typeof data>;
+          },
+        },
+      ),
+    ]);
+
+    expectTypeOf(results[0].data).toEqualTypeOf<`__result${string}`>();
+    expectTypeOf(
+      results[1].data,
+    ).toEqualTypeOf<`__RESULT${Uppercase<string>}`>();
+
+    return <pre>{JSON.stringify(results[0].data ?? 'n/a', null, 4)}</pre>;
+  }
+
+  const utils = render(
+    <App>
+      <MyComponent />
+    </App>,
+  );
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent(`__result1`);
+  });
+});
+
+test('different queries', async () => {
+  const { client, App } = ctx;
+  function MyComponent() {
+    const results = client.useSuspenseQueries((t) => [t.foo(), t.bar()]);
+
+    expectTypeOf(results[0].data).toEqualTypeOf<'foo'>();
+    expectTypeOf(results[1].data).toEqualTypeOf<'bar'>();
+
+    return (
+      <pre>{JSON.stringify(results.map((v) => v.data) ?? 'n/a', null, 4)}</pre>
+    );
+  }
+
+  const utils = render(
+    <App>
+      <MyComponent />
+    </App>,
+  );
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent(`foo`);
+    expect(utils.container).toHaveTextContent(`bar`);
+  });
+});
+
+test('mapping queries', async () => {
+  const ids = ['1', '2', '3'];
+
+  const { client, App } = ctx;
+  function MyComponent() {
+    const results = client.useSuspenseQueries((t) =>
+      ids.map((id) => t.post.byId({ id })),
+    );
+
+    if (results[0]) {
+      expectTypeOf(results[0].data).toEqualTypeOf<`__result${string}`>();
+    }
+
+    return (
+      <pre>{JSON.stringify(results.map((v) => v.data) ?? 'n/a', null, 4)}</pre>
+    );
+  }
+
+  const utils = render(
+    <App>
+      <MyComponent />
+    </App>,
+  );
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent(`__result1`);
+    expect(utils.container).toHaveTextContent(`__result2`);
+    expect(utils.container).toHaveTextContent(`__result3`);
+  });
+});
+
+// regression https://github.com/trpc/trpc/issues/4802
+test('regression #4802: passes context to links', async () => {
+  const { client, App } = ctx;
+
+  function MyComponent() {
+    const results = client.useSuspenseQueries((t) => [
+      t.post.byId(
+        { id: '1' },
+        {
+          trpc: {
+            context: {
+              id: '1',
+            },
+          },
+        },
+      ),
+      t.post.byId(
+        { id: '2' },
+        {
+          trpc: {
+            context: {
+              id: '2',
+            },
+          },
+        },
+      ),
+    ]);
+    if (results.some((v) => !v.data)) {
+      return <>...</>;
+    }
+
+    return <pre>{JSON.stringify(results, null, 4)}</pre>;
+  }
+
+  const utils = render(
+    <App>
+      <MyComponent />
+    </App>,
+  );
+  await waitFor(() => {
+    expect(utils.container).toHaveTextContent(`__result1`);
+    expect(utils.container).toHaveTextContent(`__result2`);
+  });
+
+  expect(ctx.spyLink).toHaveBeenCalledTimes(2);
+  const ops = ctx.spyLink.mock.calls.map((it) => it[0]);
+
+  expect(ops[0]!.context).toEqual({
+    id: '1',
+  });
+  expect(ops[1]!.context).toEqual({
+    id: '2',
+  });
+});

--- a/www/docs/client/react/suspense.md
+++ b/www/docs/client/react/suspense.md
@@ -7,7 +7,7 @@ slug: /client/react/suspense
 
 :::info
 
-- `useSuspenseQuery` & `useSuspenseInfiniteQuery` are _experimental_ features
+- `useSuspenseQuery`, `useSuspenseInfiniteQuery` & `useSuspenseQueries` are _experimental_ features
 - Ensure you're on the latest version of React
 - If you use suspense with [tRPC's _automatic_ SSR in Next.js](/docs/client/nextjs/ssr), the full page will crash on the server if a query fails, even if you have an `<ErrorBoundary />`
 
@@ -118,4 +118,18 @@ function PostView() {
 
   return <>{/* ... */}</>;
 }
+```
+
+### `useSuspenseQueries()`
+
+Suspense equivalent of [`useQueries()`](./useQueries.md).
+
+```tsx
+const Component = (props: { postIds: string[] }) => {
+  const [posts, postQueries] = trpc.useSuspenseQueries((t) =>
+    props.postIds.map((id) => t.post.byId({ id })),
+  );
+
+  return <>{/* [...] */}</>;
+};
 ```


### PR DESCRIPTION
Closes #4454 

## 🎯 Changes

Works just like `useQueries` but supports Suspense. Like `useSuspenseQuery` returns a `[data, queries]` tuple of the results for easier renaming and iteration over the results.

Essentially a thin wrapper around the [`useSuspenseQueries`](https://tanstack.com/query/latest/docs/react/reference/useSuspenseQueries) hook added in TanStack Query v5.

```ts
const appRouter = t.router({
  foo: t.procedure.query(() => 'foo' as const),
  bar: t.procedure.query(() => 'bar' as const),
});

const [posts, postQueries] = client.useSuspenseQueries((t) => [t.foo(), t.bar() ]);
      // ^? ["foo", "bar"]
```

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
