### PR TITLE
feat(server): add ability to have a parser as a callback

### DIFF
--- a/packages/server/src/core/internals/getParseFn.ts
+++ b/packages/server/src/core/internals/getParseFn.ts
@@ -5,11 +5,6 @@ export type ParseFn<TType> = (value: unknown) => Promise<TType> | TType;
 export function getParseFn<TType>(procedureParser: Parser): ParseFn<TType> {
   const parser = procedureParser as any;
 
-  if (typeof parser === 'function') {
-    // ParserCustomValidatorEsque
-    return parser;
-  }
-
   if (typeof parser.parseAsync === 'function') {
     // ParserZodEsque
     return parser.parseAsync.bind(parser);

--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -88,7 +88,7 @@ export interface ProcedureBuilder<
    * @see https://trpc.io/docs/server/validators
    */
   input<$Parser extends Parser>(
-    schema: $Parser | ParserCallback<TContext, $Parser>
+    schema: $Parser | ParserCallback<TContext, $Parser>,
   ): ProcedureBuilder<
     TContext,
     TMeta,

--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -133,20 +133,12 @@ export interface ProcedureBuilder<
    * @see https://trpc.io/docs/server/middlewares
    */
   use<$ContextOverridesOut>(
-    fn:
-      | MiddlewareBuilder<
-          Overwrite<TContext, TContextOverrides>,
-          TMeta,
-          $ContextOverridesOut,
-          TInputIn
-        >
-      | MiddlewareFunction<
-          TContext,
-          TMeta,
-          TContextOverrides,
-          $ContextOverridesOut,
-          TInputIn
-        >,
+    fn: MiddlewareBuilder<
+      Overwrite<TContext, TContextOverrides>,
+      TMeta,
+      $ContextOverridesOut,
+      TInputIn
+    >,
   ): ProcedureBuilder<
     TContext,
     TMeta,

--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -88,17 +88,7 @@ export interface ProcedureBuilder<
    * @see https://trpc.io/docs/server/validators
    */
   input<$Parser extends Parser>(
-    schema: TInputOut extends UnsetMarker
-      ? $Parser | ParserCallback<TContext, $Parser>
-      : inferParser<$Parser>['out'] extends Record<string, unknown> | undefined
-      ? TInputOut extends Record<string, unknown> | undefined
-        ? undefined extends inferParser<$Parser>['out'] // if current is optional the previous must be too
-          ? undefined extends TInputOut
-            ? $Parser | ParserCallback<TContext, $Parser>
-            : ErrorMessage<'Cannot chain an optional parser to a required parser'>
-          : $Parser | ParserCallback<TContext, $Parser>
-        : ErrorMessage<'All input parsers did not resolve to an object'>
-      : ErrorMessage<'All input parsers did not resolve to an object'>,
+    schema: $Parser | ParserCallback<TContext, $Parser>
   ): ProcedureBuilder<
     TContext,
     TMeta,

--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -8,7 +8,7 @@ import {
   MiddlewareFunction,
   MiddlewareResult,
 } from '../middleware';
-import { inferParser, Parser } from '../parser';
+import { inferParser, Parser, ParserCallback } from '../parser';
 import {
   AnyMutationProcedure,
   AnyProcedure,
@@ -89,14 +89,14 @@ export interface ProcedureBuilder<
    */
   input<$Parser extends Parser>(
     schema: TInputOut extends UnsetMarker
-      ? $Parser
+      ? $Parser | ParserCallback<TContext, $Parser>
       : inferParser<$Parser>['out'] extends Record<string, unknown> | undefined
       ? TInputOut extends Record<string, unknown> | undefined
         ? undefined extends inferParser<$Parser>['out'] // if current is optional the previous must be too
           ? undefined extends TInputOut
-            ? $Parser
+            ? $Parser | ParserCallback<TContext, $Parser>
             : ErrorMessage<'Cannot chain an optional parser to a required parser'>
-          : $Parser
+          : $Parser | ParserCallback<TContext, $Parser>
         : ErrorMessage<'All input parsers did not resolve to an object'>
       : ErrorMessage<'All input parsers did not resolve to an object'>,
   ): ProcedureBuilder<

--- a/packages/server/src/core/parser.ts
+++ b/packages/server/src/core/parser.ts
@@ -32,7 +32,7 @@ export type ParserScaleEsque<TInput> = {
 
 export type ParserWithoutInput<TInput> =
   // if you play with this: try toggling the below on and off
-  | ParserCustomValidatorEsque<TInput>
+  // | ParserCustomValidatorEsque<TInput>
   | ParserMyZodEsque<TInput>
   | ParserScaleEsque<TInput>
   | ParserSuperstructEsque<TInput>
@@ -49,7 +49,7 @@ export type ParserCallback<TContext, TParser extends Parser> = (opts: {
   ctx: TContext;
 }) => TParser;
 
-type inferParserInner<TParser extends Parser> =
+export type inferParser<TParser extends Parser> =
   TParser extends ParserWithInputOutput<infer $TIn, infer $TOut>
     ? {
         in: $TIn;
@@ -62,9 +62,9 @@ type inferParserInner<TParser extends Parser> =
       }
     : never;
 
-export type inferParser<TParser extends Parser | ParserCallback<any, any>> =
-  TParser extends ParserCallback<any, infer $Parser>
-    ? inferParserInner<$Parser>
-    : TParser extends Parser
-    ? inferParserInner<TParser>
-    : never;
+// export type inferParser<TParser extends Parser | ParserCallback<any, any>> =
+//   TParser extends ParserCallback<any, infer $Parser>
+//     ? inferParserInner<$Parser>
+//     : TParser extends Parser
+//     ? inferParserInner<TParser>
+//     : never;

--- a/packages/server/src/core/parser.ts
+++ b/packages/server/src/core/parser.ts
@@ -32,7 +32,7 @@ export type ParserScaleEsque<TInput> = {
 
 export type ParserWithoutInput<TInput> =
   // if you play with this: try toggling the below on and off
-  // | ParserCustomValidatorEsque<TInput>
+  | ParserCustomValidatorEsque<TInput>
   | ParserMyZodEsque<TInput>
   | ParserScaleEsque<TInput>
   | ParserSuperstructEsque<TInput>

--- a/packages/server/src/core/parser.ts
+++ b/packages/server/src/core/parser.ts
@@ -8,8 +8,17 @@ export type ParserMyZodEsque<TInput> = {
   parse: (input: any) => TInput;
 };
 
+export type ParserArkTypeEsque<TInput> = {
+  assert: (input: unknown) => TInput;
+  node: any;
+};
+
 export type ParserSuperstructEsque<TInput> = {
   create: (input: unknown) => TInput;
+};
+
+export type RuntypesEsque<TInput> = {
+  check: (input: any) => TInput;
 };
 
 export type ParserCustomValidatorEsque<TInput> = (
@@ -22,6 +31,7 @@ export type ParserYupEsque<TInput> = {
 
 export type ParserScaleEsque<TInput> = {
   assert(value: unknown): asserts value is TInput;
+  decode(array: Uint8Array): any;
 };
 
 export type ParserWithoutInput<TInput> =
@@ -30,7 +40,9 @@ export type ParserWithoutInput<TInput> =
   | ParserMyZodEsque<TInput>
   | ParserScaleEsque<TInput>
   | ParserSuperstructEsque<TInput>
-  | ParserYupEsque<TInput>;
+  | ParserYupEsque<TInput>
+  | ParserArkTypeEsque<TInput>
+  | RuntypesEsque<TInput>;
 
 export type ParserWithInputOutput<TInput, TParsedInput> = ParserZodEsque<
   TInput,
@@ -47,13 +59,13 @@ export type ParserCallback<TContext, TParser extends Parser> = (opts: {
 export type inferParser<TParser extends Parser> =
   TParser extends ParserWithInputOutput<infer $TIn, infer $TOut>
     ? {
-        in: $TIn;
-        out: $TOut;
+        in: Awaited<$TIn>;
+        out: Awaited<$TOut>;
       }
     : TParser extends ParserWithoutInput<infer $InOut>
     ? {
-        in: $InOut;
-        out: $InOut;
+        in: Awaited<$InOut>;
+        out: Awaited<$InOut>;
       }
     : never;
 

--- a/packages/server/src/core/parser.ts
+++ b/packages/server/src/core/parser.ts
@@ -31,7 +31,8 @@ export type ParserScaleEsque<TInput> = {
 };
 
 export type ParserWithoutInput<TInput> =
-  | ParserCustomValidatorEsque<TInput>
+  // if you play with this: try toggling the below on and off
+  // | ParserCustomValidatorEsque<TInput>
   | ParserMyZodEsque<TInput>
   | ParserScaleEsque<TInput>
   | ParserSuperstructEsque<TInput>
@@ -43,7 +44,12 @@ export type ParserWithInputOutput<TInput, TParsedInput> =
 
 export type Parser = ParserWithInputOutput<any, any> | ParserWithoutInput<any>;
 
-export type inferParser<TParser extends Parser> =
+export type ParserCallback<TContext, TParser extends Parser> = (opts: {
+  input: unknown;
+  ctx: TContext;
+}) => TParser;
+
+type inferParserInner<TParser extends Parser> =
   TParser extends ParserWithInputOutput<infer $TIn, infer $TOut>
     ? {
         in: $TIn;
@@ -54,4 +60,11 @@ export type inferParser<TParser extends Parser> =
         in: $InOut;
         out: $InOut;
       }
+    : never;
+
+export type inferParser<TParser extends Parser | ParserCallback<any, any>> =
+  TParser extends ParserCallback<any, infer $Parser>
+    ? inferParserInner<$Parser>
+    : TParser extends Parser
+    ? inferParserInner<TParser>
     : never;

--- a/packages/tests/server/validators.test.ts
+++ b/packages/tests/server/validators.test.ts
@@ -140,8 +140,9 @@ test('zod transform mixed input/output', async () => {
 test('valibot', async () => {
   const t = initTRPC.create();
 
+  const wrapped = wrap(v.number());
   const router = t.router({
-    num: t.procedure.input(wrap(v.number())).query(({ input }) => {
+    num: t.procedure.input(wrapped).query(({ input }) => {
       expectTypeOf(input).toBeNumber();
       return {
         input,
@@ -317,9 +318,10 @@ test('myzod', async () => {
 test('arktype schema - [not officially supported]', async () => {
   const t = initTRPC.create();
 
+  const type = arktype.type({ text: 'string' }).assert;
   const router = t.router({
     num: t.procedure
-      .input(arktype.type({ text: 'string' }).assert)
+      .input(type)
       .query(({ input }) => {
         expectTypeOf(input).toMatchTypeOf<{ text: string }>();
         return {
@@ -347,6 +349,7 @@ test('effect schema - [not officially supported]', async () => {
       .input(S.parseSync(S.struct({ text: S.string })))
       .query(({ input }) => {
         expectTypeOf(input).toMatchTypeOf<{ text: string }>();
+        expectTypeOf(input.text).not.toBeAny()
         return {
           input,
         };
@@ -453,7 +456,7 @@ test('input callback', async () => {
     num: t.procedure
       .input((opts) => {
         const { ctx } = opts;
-        expectTypeOf(ctx).toBeObject<Context>();
+        expectTypeOf(ctx).toMatchTypeOf<Context>();
 
         if (ctx.foo !== 'bar') {
           throw new Error('Not expected context');

--- a/packages/tests/server/validators.test.ts
+++ b/packages/tests/server/validators.test.ts
@@ -318,7 +318,7 @@ test('myzod', async () => {
 test('arktype schema - [not officially supported]', async () => {
   const t = initTRPC.create();
 
-  const type = arktype.type({ text: 'string' }).assert;
+  const type = arktype.type({ text: 'string' });
   const router = t.router({
     num: t.procedure
       .input(type)


### PR DESCRIPTION
Closes #1963

## 🎯 Changes

- Not working. 
- Only had a stab at getting the types to, the JS-part is usually easy after
- Exact API doesn't have to look like this
- It seems challenging to support both `ParserCustomValidatorEsque` **and** a callback like this, so we might get forced to make the API look differently
- Discuss over at #1963, not here