### PR TITLE
chore(www): drop `t.middleware()` as a recommendation in the docs

### DIFF
--- a/examples/.experimental/next-formdata/src/server/trpc.ts
+++ b/examples/.experimental/next-formdata/src/server/trpc.ts
@@ -44,4 +44,3 @@ const t = initTRPC.context<Context>().create({
 export const publicProcedure = t.procedure;
 
 export const router = t.router;
-export const middleware = t.middleware;

--- a/examples/.test/ssg/src/server/trpc.ts
+++ b/examples/.test/ssg/src/server/trpc.ts
@@ -28,8 +28,3 @@ export const router = t.router;
  * @see https://trpc.io/docs/procedures
  **/
 export const publicProcedure = t.procedure;
-
-/**
- * @see https://trpc.io/docs/middlewares
- */
-export const middleware = t.middleware;

--- a/examples/next-edge-runtime/src/server/trpc.ts
+++ b/examples/next-edge-runtime/src/server/trpc.ts
@@ -17,4 +17,3 @@ const t = initTRPC.create();
 export const publicProcedure = t.procedure;
 
 export const router = t.router;
-export const middleware = t.middleware;

--- a/examples/next-minimal-starter/src/server/trpc.ts
+++ b/examples/next-minimal-starter/src/server/trpc.ts
@@ -17,4 +17,3 @@ const t = initTRPC.create();
 export const publicProcedure = t.procedure;
 
 export const router = t.router;
-export const middleware = t.middleware;

--- a/examples/next-prisma-starter/src/server/trpc.ts
+++ b/examples/next-prisma-starter/src/server/trpc.ts
@@ -38,11 +38,6 @@ export const router = t.router;
 export const publicProcedure = t.procedure;
 
 /**
- * @see https://trpc.io/docs/middlewares
- */
-export const middleware = t.middleware;
-
-/**
  * Merge multiple routers together
  * @see https://trpc.io/docs/merging-routers
  */

--- a/examples/next-prisma-websockets-starter/src/server/trpc.ts
+++ b/examples/next-prisma-websockets-starter/src/server/trpc.ts
@@ -38,23 +38,21 @@ export const router = t.router;
 export const publicProcedure = t.procedure;
 
 /**
- * @see https://trpc.io/docs/middlewares
- */
-export const middleware = t.middleware;
-
-/**
  * @see https://trpc.io/docs/merging-routers
  */
 export const mergeRouters = t.mergeRouters;
 
-const isAuthed = middleware(({ next, ctx }) => {
-  const user = ctx.session?.user;
+/**
+ * Protected base procedure
+ */
+export const authedProcedure = t.procedure.use(function isAuthed(opts) {
+  const user = opts.ctx.session?.user;
 
   if (!user?.name) {
     throw new TRPCError({ code: 'UNAUTHORIZED' });
   }
 
-  return next({
+  return opts.next({
     ctx: {
       user: {
         ...user,
@@ -63,8 +61,3 @@ const isAuthed = middleware(({ next, ctx }) => {
     },
   });
 });
-
-/**
- * Protected base procedure
- */
-export const authedProcedure = t.procedure.use(isAuthed);

--- a/examples/soa/server-lib/index.ts
+++ b/examples/soa/server-lib/index.ts
@@ -19,11 +19,6 @@ export const router = t.router;
 export const publicProcedure = t.procedure;
 
 /**
- * @see https://trpc.io/docs/middlewares
- */
-export const middleware = t.middleware;
-
-/**
  * @see https://trpc.io/docs/merging-routers
  */
 export const mergeRouters = t.mergeRouters;

--- a/www/docs/migration/migrate-from-v9-to-v10.mdx
+++ b/www/docs/migration/migrate-from-v9-to-v10.mdx
@@ -206,7 +206,7 @@ const appRouter = trpc
   });
 
 // v10
-export const isAuthed = t.middleware((opts) => {
+const protectedProcedure = t.procedure.use((opts) => {
   const { ctx } = opts;
   if (!ctx.user) {
     throw new TRPCError({ code: 'UNAUTHORIZED' });
@@ -220,9 +220,6 @@ export const isAuthed = t.middleware((opts) => {
     },
   });
 });
-
-// Reusable:
-const protectedProcedure = t.procedure.use(isAuthed);
 
 const appRouter = t.router({
   greeting: protectedProcedure.query((opts) => {

--- a/www/docs/migration/migrate-from-v9-to-v10.mdx
+++ b/www/docs/migration/migrate-from-v9-to-v10.mdx
@@ -86,11 +86,6 @@ export const router = t.router;
 export const publicProcedure = t.procedure;
 
 /**
- * @see https://trpc.io/docs/v10/middlewares
- */
-export const middleware = t.middleware;
-
-/**
  * @see https://trpc.io/docs/v10/merging-routers
  */
 export const mergeRouters = t.mergeRouters;

--- a/www/docs/server/authorization.md
+++ b/www/docs/server/authorization.md
@@ -71,9 +71,10 @@ import { initTRPC, TRPCError } from '@trpc/server';
 
 export const t = initTRPC.context<Context>().create();
 
-
 // you can reuse this for any procedure
-export const protectedProcedure = t.procedure.use(async function isAuthed(opts) {
+export const protectedProcedure = t.procedure.use(async function isAuthed(
+  opts,
+) {
   const { ctx } = opts;
   // `ctx.user` is nullable
   if (!ctx.user) {
@@ -88,7 +89,7 @@ export const protectedProcedure = t.procedure.use(async function isAuthed(opts) 
       // ^?
     },
   });
-}));
+});
 
 t.router({
   // this is accessible for everyone

--- a/www/docs/server/authorization.md
+++ b/www/docs/server/authorization.md
@@ -71,20 +71,24 @@ import { initTRPC, TRPCError } from '@trpc/server';
 
 export const t = initTRPC.context<Context>().create();
 
-const isAuthed = t.middleware((opts) => {
-  const { ctx } = opts;
-  if (!ctx.user?.isAdmin) {
-    throw new TRPCError({ code: 'UNAUTHORIZED' });
-  }
-  return opts.next({
-    ctx: {
-      user: ctx.user,
-    },
-  });
-});
 
 // you can reuse this for any procedure
-export const protectedProcedure = t.procedure.use(isAuthed);
+export const protectedProcedure = t.procedure.use(async function isAuthed(opts) {
+  const { ctx } = opts;
+  // `ctx.user` is nullable
+  if (!ctx.user) {
+    //     ^?
+    throw new TRPCError({ code: 'UNAUTHORIZED' });
+  }
+
+  return opts.next({
+    ctx: {
+      // ✅ user value is known to be non-null now
+      user: ctx.user,
+      // ^?
+    },
+  });
+}));
 
 t.router({
   // this is accessible for everyone

--- a/www/docs/server/context.md
+++ b/www/docs/server/context.md
@@ -124,8 +124,8 @@ export const publicProcedure = t.procedure;
 /**
  * Protected procedure
  */
-export const protectedProcedure = t.procedure.use(function isAuthed({ next, ctx }) {
-  if (!ctx.session?.user?.email) {
+export const protectedProcedure = t.procedure.use(function isAuthed(opts) {
+  if (!opts.ctx.session?.user?.email) {
     throw new TRPCError({
       code: 'UNAUTHORIZED',
     });
@@ -133,7 +133,7 @@ export const protectedProcedure = t.procedure.use(function isAuthed({ next, ctx 
   return next({
     ctx: {
       // Infers the `session` as non-nullable
-      session: ctx.session,
+      session: opts.ctx.session,
     },
   });
 });

--- a/www/docs/server/context.md
+++ b/www/docs/server/context.md
@@ -113,7 +113,7 @@ import { Context } from './context';
 
 const t = initTRPC.context<Context>().create();
 
-export const middleware = t.middleware;
+
 export const router = t.router;
 
 /**

--- a/www/docs/server/context.md
+++ b/www/docs/server/context.md
@@ -113,7 +113,18 @@ import { Context } from './context';
 
 const t = initTRPC.context<Context>().create();
 
-const isAuthed = t.middleware(({ next, ctx }) => {
+export const middleware = t.middleware;
+export const router = t.router;
+
+/**
+ * Unprotected procedure
+ */
+export const publicProcedure = t.procedure;
+
+/**
+ * Protected procedure
+ */
+export const protectedProcedure = t.procedure.use(function isAuthed({ next, ctx }) {
   if (!ctx.session?.user?.email) {
     throw new TRPCError({
       code: 'UNAUTHORIZED',
@@ -126,19 +137,6 @@ const isAuthed = t.middleware(({ next, ctx }) => {
     },
   });
 });
-
-export const middleware = t.middleware;
-export const router = t.router;
-
-/**
- * Unprotected procedure
- */
-export const publicProcedure = t.procedure;
-
-/**
- * Protected procedure
- */
-export const protectedProcedure = t.procedure.use(isAuthed);
 ```
 
 <!-- prettier-ignore-end -->

--- a/www/docs/server/merging-routers.md
+++ b/www/docs/server/merging-routers.md
@@ -15,7 +15,7 @@ import { initTRPC } from '@trpc/server';
 const t = initTRPC.create();
 
 
-export const middleware = t.middleware;
+
 export const router = t.router;
 export const publicProcedure = t.procedure;
 
@@ -80,7 +80,6 @@ import { initTRPC } from '@trpc/server';
 const t = initTRPC.create();
 
 
-export const middleware = t.middleware;
 export const router = t.router;
 export const publicProcedure = t.procedure;
 export const mergeRouters = t.mergeRouters;

--- a/www/docs/server/metadata.md
+++ b/www/docs/server/metadata.md
@@ -42,7 +42,6 @@ interface Meta {
 
 export const t = initTRPC.context<Context>().meta<Meta>().create();
 
-
 export const authedProcedure = t.procedure.use(async (opts) => {
   const { meta, next, ctx } = opts;
   // only check authorization if enabled

--- a/www/docs/server/metadata.md
+++ b/www/docs/server/metadata.md
@@ -42,7 +42,8 @@ interface Meta {
 
 export const t = initTRPC.context<Context>().meta<Meta>().create();
 
-const isAuthed = t.middleware(async (opts) => {
+
+export const authedProcedure = t.procedure.use(async (opts) => {
   const { meta, next, ctx } = opts;
   // only check authorization if enabled
   if (meta?.authRequired && !ctx.user) {
@@ -50,8 +51,6 @@ const isAuthed = t.middleware(async (opts) => {
   }
   return next();
 });
-
-export const authedProcedure = t.procedure.use(isAuthed);
 
 export const appRouter = t.router({
   hello: authedProcedure.meta({ authRequired: false }).query(() => {

--- a/www/docs/server/middlewares.md
+++ b/www/docs/server/middlewares.md
@@ -174,10 +174,11 @@ import { initTRPC, TRPCError } from '@trpc/server';
 const t = initTRPC.create();
 const publicProcedure = t.procedure;
 const router = t.router;
+const middleware = t.middleware;
 
 // ---cut---
 
-const fooMiddleware = middleware((opts) => {
+const fooMiddleware = t.middleware((opts) => {
   return opts.next({
     ctx: {
       foo: 'foo' as const,

--- a/www/docs/server/middlewares.md
+++ b/www/docs/server/middlewares.md
@@ -140,7 +140,7 @@ type Context = {
   };
 };
 
-const isAuthed = middleware((opts) => {
+const protectedProcedure = publicProcedure.use(async function isAuthed(opts) {
   const { ctx } = opts;
   // `ctx.user` is nullable
   if (!ctx.user) {
@@ -155,9 +155,8 @@ const isAuthed = middleware((opts) => {
       // ^?
     },
   });
-});
+}));
 
-const protectedProcedure = publicProcedure.use(isAuthed);
 protectedProcedure.query(({ ctx }) => ctx.user);
 //                                        ^?
 ```

--- a/www/docs/server/middlewares.md
+++ b/www/docs/server/middlewares.md
@@ -23,7 +23,6 @@ interface Context {
 }
 
 const t = initTRPC.context<Context>().create();
-export const middleware = t.middleware;
 export const publicProcedure = t.procedure;
 export const router = t.router;
 
@@ -75,7 +74,7 @@ In the example below timings for queries are logged automatically.
 import { initTRPC } from '@trpc/server';
 const t = initTRPC.create();
 
-export const middleware = t.middleware;
+
 export const publicProcedure = t.procedure;
 export const router = t.router;
 
@@ -129,7 +128,7 @@ import { initTRPC, TRPCError } from '@trpc/server';
 const t = initTRPC.context<Context>().create();
 const publicProcedure = t.procedure;
 const router = t.router;
-const middleware = t.middleware;
+
 
 // ---cut---
 
@@ -178,7 +177,6 @@ import { initTRPC, TRPCError } from '@trpc/server';
 const t = initTRPC.create();
 const publicProcedure = t.procedure;
 const router = t.router;
-const middleware = t.middleware;
 
 // ---cut---
 

--- a/www/docs/server/middlewares.md
+++ b/www/docs/server/middlewares.md
@@ -26,7 +26,7 @@ const t = initTRPC.context<Context>().create();
 export const publicProcedure = t.procedure;
 export const router = t.router;
 
-const isAdmin = middleware(async (opts) => {
+export const adminProcedure = publicProcedure.use(async (opts) => {
   const { ctx } = opts;
   if (!ctx.user?.isAdmin) {
     throw new TRPCError({ code: 'UNAUTHORIZED' });
@@ -37,8 +37,6 @@ const isAdmin = middleware(async (opts) => {
     },
   });
 });
-
-export const adminProcedure = publicProcedure.use(isAdmin);
 ```
 
 ```ts twoslash
@@ -80,7 +78,8 @@ export const router = t.router;
 
 declare function logMock(...args: any[]): void;
 // ---cut---
-const loggerMiddleware = middleware(async (opts) => {
+
+export const loggedProcedure = publicProcedure.use(async (opts) => {
   const start = Date.now();
 
   const result = await opts.next();
@@ -94,8 +93,6 @@ const loggerMiddleware = middleware(async (opts) => {
 
   return result;
 });
-
-export const loggedProcedure = publicProcedure.use(loggerMiddleware);
 ```
 
 ```ts twoslash

--- a/www/docs/server/middlewares.md
+++ b/www/docs/server/middlewares.md
@@ -126,7 +126,6 @@ const t = initTRPC.context<Context>().create();
 const publicProcedure = t.procedure;
 const router = t.router;
 
-
 // ---cut---
 
 type Context = {
@@ -151,7 +150,7 @@ const protectedProcedure = publicProcedure.use(async function isAuthed(opts) {
       // ^?
     },
   });
-}));
+});
 
 protectedProcedure.query(({ ctx }) => ctx.user);
 //                                        ^?

--- a/www/docs/server/routers.md
+++ b/www/docs/server/routers.md
@@ -21,7 +21,6 @@ import { initTRPC } from '@trpc/server';
 const t = initTRPC.create();
 
 export const router = t.router;
-export const middleware = t.middleware;
 export const publicProcedure = t.procedure;
 ```
 
@@ -39,7 +38,7 @@ import { initTRPC } from '@trpc/server';
 const t = initTRPC.create();
 
 
-export const middleware = t.middleware;
+
 export const publicProcedure = t.procedure;
 export const router = t.router;
 

--- a/www/docs/server/server-side-calls.md
+++ b/www/docs/server/server-side-calls.md
@@ -194,7 +194,7 @@ type Context = {
 };
 const t = initTRPC.context<Context>().create();
 
-const isAuthed = t.middleware((opts) => {
+const protectedProcedure = t.procedure.use((opts) => {
   const { ctx } = opts;
   if (!ctx.user) {
     throw new TRPCError({
@@ -210,8 +210,6 @@ const isAuthed = t.middleware((opts) => {
     },
   });
 });
-
-const protectedProcedure = t.procedure.use(isAuthed);
 
 const router = t.router({
   secret: protectedProcedure.query((opts) => opts.ctx.user),


### PR DESCRIPTION
Closes #

## 🎯 Changes

- I don't see the point of defining a `const isAuthed = t.middleware(() => ...)` over defining it inline, I think inline is cleaner and should be the recommended pattern
- Using `t.middleware` is rarely needed.