### PR TITLE
feat: add support for `satisfies` when creating routers

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,3 +241,5 @@ Also, if your company using tRPC and want to support long-term maintenance of tR
     <img src="./www/static/img/powered-by-vercel.svg" alt="Powered by Vercel" title="Powered by Vercel">
   </p>
 </a>
+
+<!-- test -->

--- a/packages/server/src/core/types.ts
+++ b/packages/server/src/core/types.ts
@@ -74,3 +74,7 @@ export type inferRouterOutputs<TRouter extends AnyRouter> = GetInferenceHelpers<
   'output',
   TRouter
 >;
+
+export type TRPCRouter = {
+  [key: string]: TRPCRouter | AnyProcedure;
+};

--- a/packages/tests/server/router-satisfies.test.ts
+++ b/packages/tests/server/router-satisfies.test.ts
@@ -1,0 +1,139 @@
+import { AddressInfo } from 'net';
+import { AnyRootConfig, initTRPC, TRPCRouter } from '@trpc/server';
+import { createHTTPServer } from '@trpc/server/adapters/standalone';
+import './___packages';
+import { createTRPCClient, httpLink } from '@trpc/client';
+import { konn } from 'konn';
+
+const createServer = (opts: { router: TRPCRouter; config: AnyRootConfig }) => {
+  const httpServer = createHTTPServer({
+    // pass the router in, which can be a stupid instance of an object
+    router: opts.router,
+    // pass the config in, which can be used to access transformer / error formatter
+    config: opts.config,
+  });
+
+  const server = httpServer.listen(0);
+  const httpPort = (server.address() as AddressInfo).port;
+  const httpUrl = `http://localhost:${httpPort}`;
+
+  return {
+    server,
+    httpPort,
+    httpUrl,
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        });
+      });
+    },
+  };
+};
+describe('happy path', () => {
+  const t = initTRPC
+    .context<{
+      superSecretTypeWeDontWantToLeakToNpm: string;
+    }>()
+    .meta<{
+      superSecretTypeWeDontWantToLeakToNpm: string;
+    }>()
+    .create();
+
+  const appRouter = {
+    hello: t.procedure.query(() => 'hello world'),
+  } satisfies TRPCRouter;
+
+  const ctx = konn()
+    .beforeEach(() => {
+      const server = createServer({ config: t._config, router: appRouter });
+      return {
+        server,
+      };
+    })
+    .afterEach(async (ctx) => {
+      await ctx.server?.close();
+    })
+    .done();
+
+  test('create server', async () => {
+    const { server } = ctx;
+
+    const res = await fetch(`${server.httpUrl}/hello`);
+    const json = await res.json();
+
+    expect(res.ok).toBe(true);
+    expect(json).toMatchInlineSnapshot();
+
+    await server.close();
+  });
+
+  test('create client', async () => {
+    // only picks the transformer and the error shape
+    // hides the Context, etc
+    const clientRouter = t.clientRouter(appRouter);
+
+    const client = createTRPCClient<typeof clientRouter>({
+      links: [httpLink({ url: ctx.server.httpUrl })],
+    });
+  });
+});
+
+describe('nested routes', () => {
+  const t = initTRPC
+    .context<{
+      superSecretTypeWeDontWantToLeakToNpm: string;
+    }>()
+    .meta<{
+      superSecretTypeWeDontWantToLeakToNpm: string;
+    }>()
+    .create();
+
+  const appRouter = {
+    one: {
+      two: {
+        three: {
+          hello: t.procedure.query(() => 'hello world'),
+        },
+      },
+    },
+  } satisfies TRPCRouter;
+
+  const ctx = konn()
+    .beforeEach(() => {
+      const server = createServer({ config: t._config, router: appRouter });
+      return {
+        server,
+      };
+    })
+    .afterEach(async (ctx) => {
+      await ctx.server?.close();
+    })
+    .done();
+
+  test('create server', async () => {
+    const { server } = ctx;
+
+    const res = await fetch(`${server.httpUrl}/one.two.three.hello`);
+    const json = await res.json();
+
+    expect(res.ok).toBe(true);
+    expect(json).toMatchInlineSnapshot();
+
+    await server.close();
+  });
+
+  test('create client', async () => {
+    // only picks the transformer and the error shape
+    // hides the Context, etc
+    const clientRouter = t.clientRouter(appRouter);
+
+    const client = createTRPCClient<typeof clientRouter>({
+      links: [httpLink({ url: ctx.server.httpUrl })],
+    });
+  });
+});


### PR DESCRIPTION
Idea for #5004

## 🎯 Changes

Allow using `satisfies` when creating router.

```ts
const appRouter = {
    hello: t.procedure.query(() => 'hello world'),
} satisfies TRPCRouter;
```

- This would prevent context etc from being visible when publishing on npm
- The client only technically really needs the error shape and to know if there's a transformer