### PR TITLE
feat: allow passing a function to `createCaller`

### DIFF
--- a/packages/server/src/core/router.ts
+++ b/packages/server/src/core/router.ts
@@ -51,7 +51,7 @@ export type RouterCaller<TDef extends AnyRouterDef> = (
   /**
    * @note
    * If passing a function, we recommend it's a cached function
-   * e.g. wrapped in `React.cache` to avoid invoking it unnecessarily
+   * e.g. wrapped in `React.cache` to avoid unnecessary computations
    */
   ctx:
     | TDef['_config']['$types']['ctx']

--- a/packages/server/src/core/router.ts
+++ b/packages/server/src/core/router.ts
@@ -2,6 +2,7 @@ import { defaultFormatter } from '../error/formatter';
 import { TRPCError } from '../error/TRPCError';
 import { createRecursiveProxy } from '../shared/createProxy';
 import { defaultTransformer } from '../transformer';
+import { MaybePromise } from '../types';
 import { AnyRootConfig } from './internals/config';
 import { omitPrototype } from './internals/omitPrototype';
 import { ProcedureCallOptions } from './internals/procedureBuilder';
@@ -47,7 +48,14 @@ type DecoratedProcedureRecord<TProcedures extends ProcedureRouterRecord> = {
  * @internal
  */
 export type RouterCaller<TDef extends AnyRouterDef> = (
-  ctx: TDef['_config']['$types']['ctx'],
+  /**
+   * @note
+   * If passing a function, we recommend it's a cached function
+   * e.g. wrapped in `React.cache` to avoid invoking it unnecessarily
+   */
+  ctx:
+    | TDef['_config']['$types']['ctx']
+    | (() => MaybePromise<TDef['_config']['$types']['ctx']>),
 ) => DecoratedProcedureRecord<TDef['record']>;
 
 export interface Router<TDef extends AnyRouterDef> {

--- a/packages/tests/server/createCaller.test.ts
+++ b/packages/tests/server/createCaller.test.ts
@@ -46,6 +46,42 @@ describe('with context', () => {
     });
   });
 });
+describe('with async context', () => {
+  const createContext = async () => {
+    return {
+      userId: '1',
+    };
+  };
+  const t = initTRPC.context<typeof createContext>().create();
+
+  const appRouter = t.router({
+    hello: t.procedure
+      .input(
+        z.object({
+          who: z.string(),
+        }),
+      )
+      .query((opts) => `hello ${opts.input.who} - ${opts.ctx.userId}` as const),
+  });
+
+  const createCaller = t.createCallerFactory(appRouter);
+
+  test('ugly RSC caller requires nested awaits', async () => {
+    const trpc = async () => createCaller(await createContext());
+
+    const hello = await (await trpc()).hello({ who: 'world' });
+    expect(hello).toEqual('hello world - 1');
+    expectTypeOf<`hello ${string} - ${string}`>(hello);
+  });
+
+  test('nicer RSC caller by passing fn', async () => {
+    const trpc = createCaller(createContext);
+
+    const hello = await trpc.hello({ who: 'world' });
+    expect(hello).toEqual('hello world - 1');
+    expectTypeOf<`hello ${string} - ${string}`>(hello);
+  });
+});
 test('docs', async () => {
   type Context = {
     foo: string;

--- a/packages/tests/server/createCaller.test.ts
+++ b/packages/tests/server/createCaller.test.ts
@@ -81,6 +81,12 @@ describe('with async context', () => {
     expect(hello).toEqual('hello world - 1');
     expectTypeOf<`hello ${string} - ${string}`>(hello);
   });
+
+  test('mismatching return type', async () => {
+    const badCreateContext = async () => 'foo' as const;
+    // @ts-expect-error - Type '() => Promise<"foo">' is not assignable to type '() => Promise<{ userId: string; }>'.
+    createCaller(badCreateContext);
+  });
 });
 test('docs', async () => {
   type Context = {


### PR DESCRIPTION
This will allow making some nicer RSC-like-clients:

### Before
```ts
const createCaller = t.createCallerFactory(appRouter);

// ...

const trpc = async () => createCaller(await createContext());

async function MyComponent() {
  const posts = await (await trpc()).post.all();

  // ...
}
```

### After
```ts
const createCaller = t.createCallerFactory(appRouter);

// ...

const trpc = createCaller(createContext)

async function MyComponent() {
  const posts = await trpc.post.all();

  // ...
}
```