### PR TITLE
HeadersInitEsque

### DIFF
--- a/packages/client/src/links/internals/httpUtils.ts
+++ b/packages/client/src/links/internals/httpUtils.ts
@@ -151,7 +151,13 @@ export async function fetchHTTPResponse(
   const url = opts.getUrl(opts);
   const body = opts.getBody(opts);
   const { type } = opts;
-  const resolvedHeaders = await opts.headers();
+  const resolvedHeaders = await (async () => {
+    const heads = await opts.headers();
+    if (Symbol.iterator in heads) {
+      return Object.fromEntries(heads);
+    }
+    return heads;
+  })();
   /* istanbul ignore if -- @preserve */
   if (type === 'subscription') {
     throw new Error('Subscriptions should use wsLink');

--- a/packages/client/src/links/types.ts
+++ b/packages/client/src/links/types.ts
@@ -39,7 +39,6 @@ export type Operation<TInput = unknown> = {
 
 interface HeadersInitEsque {
   [Symbol.iterator](): IterableIterator<[string, string]>;
-  entries(): IterableIterator<[string, string]>;
 }
 
 /**

--- a/packages/client/src/links/types.ts
+++ b/packages/client/src/links/types.ts
@@ -37,10 +37,17 @@ export type Operation<TInput = unknown> = {
   context: OperationContext;
 };
 
+interface HeadersInitEsque {
+  [Symbol.iterator](): IterableIterator<[string, string]>;
+  entries(): IterableIterator<[string, string]>;
+}
+
 /**
  * @internal
  */
-export type HTTPHeaders = Record<string, string[] | string | undefined>;
+export type HTTPHeaders =
+  | HeadersInitEsque
+  | Record<string, string[] | string | undefined>;
 
 /**
  * The default `fetch` implementation has an overloaded signature. By convention this library

--- a/packages/tests/server/headers.test.tsx
+++ b/packages/tests/server/headers.test.tsx
@@ -153,4 +153,43 @@ Object {
       }
     `);
   });
+
+  test('custom headers with Headers class - httpBatchLink', async () => {
+    const client = createTRPCClient<AppRouter>({
+      links: [
+        httpBatchLink({
+          url: httpUrl,
+          headers() {
+            const heads = new Headers();
+            heads.append('x-special', 'special header');
+            return heads;
+          },
+        }),
+      ],
+    });
+    expect(await client.hello.query()).toMatchInlineSnapshot(`
+      Object {
+        "x-special": "special header",
+      }
+    `);
+  });
+
+  test('custom headers with Headers class - httpLink', async () => {
+    const client = createTRPCClient<AppRouter>({
+      links: [
+        httpLink({
+          url: httpUrl,
+          headers() {
+            // return { foo: 'bar' };
+            return new Headers([['x-special', 'special header']]);
+          },
+        }),
+      ],
+    });
+    expect(await client.hello.query()).toMatchInlineSnapshot(`
+      Object {
+        "x-special": "special header",
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Allows returning a Headers object from `httpLinkOptions.headers`, mostly useful in Next.js when forwarding headers to CCs during SSR:

```ts
httpBatchLink({
  url: "...",
  headers: () => {
    const headers = new Headers(await props.headersPromise);
    // comes from a headers() call in parent SS ^^
    headers.set("foo", "bar");
    return headers;
  },
}),
```

Small and minor change so that `Object.fromEntries()` can be skipped in user-land