### PR TITLE
feat: add fetchOptions to experimental_nextHttpLink

### DIFF
--- a/packages/next/src/app-dir/links/nextHttp.ts
+++ b/packages/next/src/app-dir/links/nextHttp.ts
@@ -11,6 +11,7 @@ import { generateCacheTag } from '../shared';
 interface NextLinkBaseOptions {
   revalidate?: number | false;
   batch?: boolean;
+  fetchOptions?: RequestInit;
 }
 
 interface NextLinkSingleOptions
@@ -48,6 +49,7 @@ export function experimental_nextHttpLink<TRouter extends AnyRouter>(
       ) => {
         return fetch(url, {
           ...fetchOpts,
+          ...opts.fetchOptions,
           // cache: 'no-cache',
           next: {
             revalidate,


### PR DESCRIPTION
With createTRPCNext, I pass a custom fetch to httpBatchLink to enable `mode: 'cors'` and `credentials: 'include'`. The fetch option is currently omitted in `experimental_nextHttpLink`.

I understand that this is an experimental API, so if you just want to close this PR and create an alternative solution, that works. I thought it might be a little more helpful to open a PR rather than an issue/discussion. Thank you!

## 🎯 Changes

Add `fetchOptions` to `NextLinkBaseOptions` which allow overriding the options being passed to fetch.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.

^^ Let me know if you'd like me to update any tests or docs.