### PR TITLE
chore: ban `@trpc/.*/src`-style `import`s

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -75,6 +75,18 @@ const config = {
       },
     ],
     'max-params': ['error', 3],
+    '@typescript-eslint/no-restricted-imports': [
+      'error',
+      {
+        patterns: [
+          {
+            group: ['@trpc/*/src'],
+            message: 'Remove the "`/src`" part of this import',
+            allowTypeImports: false,
+          },
+        ],
+      },
+    ],
   },
   overrides: [
     // {

--- a/packages/tests/server/TRPCError.test.ts
+++ b/packages/tests/server/TRPCError.test.ts
@@ -1,4 +1,4 @@
-import { getTRPCErrorFromUnknown, TRPCError } from '@trpc/server/src';
+import { getTRPCErrorFromUnknown, TRPCError } from '@trpc/server';
 
 test('should extend original Error class', () => {
   const trpcError = new TRPCError({ code: 'FORBIDDEN' });

--- a/packages/tests/server/___testHelpers.ts
+++ b/packages/tests/server/___testHelpers.ts
@@ -7,18 +7,15 @@ import {
   httpBatchLink,
   TRPCWebSocketClient,
   WebSocketClientOptions,
-} from '@trpc/client/src';
-import { WithTRPCConfig } from '@trpc/next/src';
-import { OnErrorFunction } from '@trpc/server/internals/types';
-import { AnyRouter as AnyNewRouter } from '@trpc/server/src';
+} from '@trpc/client';
+import { WithTRPCConfig } from '@trpc/next';
+import { AnyRouter as AnyNewRouter } from '@trpc/server';
 import {
   CreateHTTPHandlerOptions,
   createHTTPServer,
-} from '@trpc/server/src/adapters/standalone';
-import {
-  applyWSSHandler,
-  WSSHandlerOptions,
-} from '@trpc/server/src/adapters/ws';
+} from '@trpc/server/adapters/standalone';
+import { applyWSSHandler, WSSHandlerOptions } from '@trpc/server/adapters/ws';
+import { OnErrorFunction } from '@trpc/server/internals/types';
 import fetch from 'node-fetch';
 import { WebSocket, WebSocketServer } from 'ws';
 import './___packages';

--- a/packages/tests/server/abortQuery.test.ts
+++ b/packages/tests/server/abortQuery.test.ts
@@ -1,5 +1,5 @@
 import { routerToServerAndClientNew, waitMs } from './___testHelpers';
-import { initTRPC } from '@trpc/server/src/core';
+import { initTRPC } from '@trpc/server/core';
 
 const t = initTRPC.create();
 

--- a/packages/tests/server/adapters/awsLambda.test.tsx
+++ b/packages/tests/server/adapters/awsLambda.test.tsx
@@ -1,5 +1,5 @@
-import { initTRPC } from '@trpc/server/src';
-import * as trpcLambda from '@trpc/server/src/adapters/aws-lambda';
+import { initTRPC } from '@trpc/server';
+import * as trpcLambda from '@trpc/server/adapters/aws-lambda';
 import type { APIGatewayProxyEvent, APIGatewayProxyEventV2 } from 'aws-lambda';
 import { z } from 'zod';
 import {

--- a/packages/tests/server/adapters/express.test.tsx
+++ b/packages/tests/server/adapters/express.test.tsx
@@ -1,11 +1,7 @@
 import http from 'http';
 import { Context, router } from './__router';
-import {
-  createTRPCClient,
-  httpBatchLink,
-  TRPCClientError,
-} from '@trpc/client/src';
-import * as trpcExpress from '@trpc/server/src/adapters/express';
+import { createTRPCClient, httpBatchLink, TRPCClientError } from '@trpc/client';
+import * as trpcExpress from '@trpc/server/adapters/express';
 import express from 'express';
 import fetch from 'node-fetch';
 

--- a/packages/tests/server/adapters/fastify.test.ts
+++ b/packages/tests/server/adapters/fastify.test.ts
@@ -9,14 +9,14 @@ import {
   TRPCLink,
   unstable_httpBatchStreamLink,
   wsLink,
-} from '@trpc/client/src';
+} from '@trpc/client';
 import { initTRPC } from '@trpc/server';
 import {
   CreateFastifyContextOptions,
   fastifyTRPCPlugin,
   FastifyTRPCPluginOptions,
-} from '@trpc/server/src/adapters/fastify';
-import { observable } from '@trpc/server/src/observable';
+} from '@trpc/server/adapters/fastify';
+import { observable } from '@trpc/server/observable';
 import fastify from 'fastify';
 import fp from 'fastify-plugin';
 import fetch from 'node-fetch';

--- a/packages/tests/server/adapters/next.test.ts
+++ b/packages/tests/server/adapters/next.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import { initTRPC } from '@trpc/server';
-import * as trpcNext from '@trpc/server/src/adapters/next';
+import * as trpcNext from '@trpc/server/adapters/next';
 
 function mockReq({
   query,

--- a/packages/tests/server/adapters/standalone.test.ts
+++ b/packages/tests/server/adapters/standalone.test.ts
@@ -1,15 +1,11 @@
 import { AddressInfo } from 'net';
 import { networkInterfaces } from 'os';
-import {
-  createTRPCClient,
-  httpBatchLink,
-  TRPCClientError,
-} from '@trpc/client/src';
+import { createTRPCClient, httpBatchLink, TRPCClientError } from '@trpc/client';
 import { initTRPC, TRPCError } from '@trpc/server';
 import {
   CreateHTTPHandlerOptions,
   createHTTPServer,
-} from '@trpc/server/src/adapters/standalone';
+} from '@trpc/server/adapters/standalone';
 import fetch from 'node-fetch';
 import { z } from 'zod';
 

--- a/packages/tests/server/caller.test.ts
+++ b/packages/tests/server/caller.test.ts
@@ -1,5 +1,5 @@
 import { waitError } from './___testHelpers';
-import { initTRPC, TRPCError } from '@trpc/server/src';
+import { initTRPC, TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
 const t = initTRPC

--- a/packages/tests/server/children.test.ts
+++ b/packages/tests/server/children.test.ts
@@ -1,5 +1,5 @@
 import { routerToServerAndClientNew } from './___testHelpers';
-import { initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server';
 
 test('children', async () => {
   const t = initTRPC.create();

--- a/packages/tests/server/clientInternals.test.ts
+++ b/packages/tests/server/clientInternals.test.ts
@@ -1,5 +1,5 @@
-import { getFetch } from '@trpc/client/src';
-import { getAbortController } from '@trpc/client/src/internals/getAbortController';
+import { getFetch } from '@trpc/client';
+import { getAbortController } from '@trpc/client/internals/getAbortController';
 
 describe('getAbortController() from..', () => {
   test('passed', () => {

--- a/packages/tests/server/createCaller.test.ts
+++ b/packages/tests/server/createCaller.test.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import './___packages';
 import { ignoreErrors } from './___testHelpers';
-import { initTRPC } from '@trpc/server/src/core';
+import { initTRPC } from '@trpc/server/core';
 
 describe('with context', () => {
   const t = initTRPC.context<{ foo: 'foo' }>().create();

--- a/packages/tests/server/createUntypedClient.test.ts
+++ b/packages/tests/server/createUntypedClient.test.ts
@@ -1,6 +1,6 @@
 import { ignoreErrors } from './___testHelpers';
-import { createTRPCUntypedClient } from '@trpc/client/src';
-import { Unsubscribable } from '@trpc/server/src/observable';
+import { createTRPCUntypedClient } from '@trpc/client';
+import { Unsubscribable } from '@trpc/server/observable';
 
 test('loosely typed parameters', () => {
   const client = createTRPCUntypedClient({

--- a/packages/tests/server/dataloader.test.ts
+++ b/packages/tests/server/dataloader.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { waitError, waitMs } from './___testHelpers';
-import { dataLoader } from '@trpc/client/src/internals/dataLoader';
+import { dataLoader } from '@trpc/client/internals/dataLoader';
 
 describe('basic', () => {
   const fetchFn = vi.fn();

--- a/packages/tests/server/errorFormatting.test.ts
+++ b/packages/tests/server/errorFormatting.test.ts
@@ -6,7 +6,7 @@ import {
   initTRPC,
   TRPCError,
 } from '@trpc/server';
-import { DefaultErrorData } from '@trpc/server/src/error/formatter';
+import { DefaultErrorData } from '@trpc/server/error/formatter';
 import { konn } from 'konn';
 import { z, ZodError } from 'zod';
 

--- a/packages/tests/server/errors.test.ts
+++ b/packages/tests/server/errors.test.ts
@@ -7,13 +7,13 @@ import {
   httpLink,
   TRPCClientError,
   TRPCLink,
-} from '@trpc/client/src';
+} from '@trpc/client';
+import { initTRPC } from '@trpc/server';
+import { CreateHTTPContextOptions } from '@trpc/server/adapters/standalone';
+import { TRPCError } from '@trpc/server/error/TRPCError';
+import { getMessageFromUnknownError } from '@trpc/server/error/utils';
+import { OnErrorFunction } from '@trpc/server/internals/types';
 import { observable } from '@trpc/server/observable';
-import { initTRPC } from '@trpc/server/src';
-import { CreateHTTPContextOptions } from '@trpc/server/src/adapters/standalone';
-import { TRPCError } from '@trpc/server/src/error/TRPCError';
-import { getMessageFromUnknownError } from '@trpc/server/src/error/utils';
-import { OnErrorFunction } from '@trpc/server/src/internals/types';
 import { konn } from 'konn';
 import fetch from 'node-fetch';
 import { z, ZodError } from 'zod';

--- a/packages/tests/server/headers.test.tsx
+++ b/packages/tests/server/headers.test.tsx
@@ -1,5 +1,5 @@
 import { routerToServerAndClientNew } from './___testHelpers';
-import { createTRPCClient, httpBatchLink, httpLink } from '@trpc/client/src';
+import { createTRPCClient, httpBatchLink, httpLink } from '@trpc/client';
 import { initTRPC } from '@trpc/server';
 import { Dict } from '@trpc/server/unstableInternalsExport';
 

--- a/packages/tests/server/index.test.ts
+++ b/packages/tests/server/index.test.ts
@@ -8,10 +8,10 @@ import {
   HTTPHeaders,
   TRPCClientError,
   wsLink,
-} from '@trpc/client/src';
+} from '@trpc/client';
 import { initTRPC, TRPCError } from '@trpc/server';
-import { CreateHTTPContextOptions } from '@trpc/server/src/adapters/standalone';
-import { observable } from '@trpc/server/src/observable';
+import { CreateHTTPContextOptions } from '@trpc/server/adapters/standalone';
+import { observable } from '@trpc/server/observable';
 import { Maybe } from '@trpc/server/unstableInternalsExport';
 import { z } from 'zod';
 

--- a/packages/tests/server/initTRPC.test.ts
+++ b/packages/tests/server/initTRPC.test.ts
@@ -2,7 +2,7 @@ import {
   DataTransformerOptions,
   DefaultDataTransformer,
   initTRPC,
-} from '@trpc/server/src';
+} from '@trpc/server';
 
 test('default transformer', () => {
   const t = initTRPC

--- a/packages/tests/server/isDev.test.ts
+++ b/packages/tests/server/isDev.test.ts
@@ -1,6 +1,6 @@
 import { routerToServerAndClientNew, waitError } from './___testHelpers';
-import { TRPCClientError } from '@trpc/client/src';
-import { initTRPC } from '@trpc/server/src';
+import { TRPCClientError } from '@trpc/client';
+import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 
 const createTestContext = (opts: { isDev: boolean }) =>

--- a/packages/tests/server/links.test.ts
+++ b/packages/tests/server/links.test.ts
@@ -8,11 +8,11 @@ import {
   TRPCClientError,
   TRPCClientRuntime,
   unstable_httpBatchStreamLink,
-} from '@trpc/client/src';
-import { createChain } from '@trpc/client/src/links/internals/createChain';
-import { retryLink } from '@trpc/client/src/links/internals/retryLink';
-import { AnyRouter, initTRPC } from '@trpc/server/src';
-import { observable, observableToPromise } from '@trpc/server/src/observable';
+} from '@trpc/client';
+import { createChain } from '@trpc/client/links/internals/createChain';
+import { retryLink } from '@trpc/client/links/internals/retryLink';
+import { AnyRouter, initTRPC } from '@trpc/server';
+import { observable, observableToPromise } from '@trpc/server/observable';
 import { z } from 'zod';
 
 const mockRuntime: TRPCClientRuntime = {

--- a/packages/tests/server/meta.test.ts
+++ b/packages/tests/server/meta.test.ts
@@ -1,5 +1,5 @@
 import { routerToServerAndClientNew } from './___testHelpers';
-import { initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 
 test('meta is undefined in a middleware', () => {

--- a/packages/tests/server/outputParser.test.ts
+++ b/packages/tests/server/outputParser.test.ts
@@ -1,6 +1,6 @@
 import { routerToServerAndClientNew } from './___testHelpers';
 import { wrap } from '@decs/typeschema';
-import { initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server';
 import myzod from 'myzod';
 import * as t from 'superstruct';
 import * as v from 'valibot';

--- a/packages/tests/server/rawFetch.test.tsx
+++ b/packages/tests/server/rawFetch.test.tsx
@@ -1,5 +1,5 @@
 import { routerToServerAndClientNew } from './___testHelpers';
-import { initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server';
 import { z } from 'zod';
 
 const factory = () => {

--- a/packages/tests/server/react/__reactHelpers.tsx
+++ b/packages/tests/server/react/__reactHelpers.tsx
@@ -7,10 +7,10 @@ import {
   Operation,
   splitLink,
   wsLink,
-} from '@trpc/client/src';
-import { createTRPCReact } from '@trpc/react-query/src';
-import { CreateTRPCReactBase } from '@trpc/react-query/src/createTRPCReact';
-import { AnyRouter } from '@trpc/server/src';
+} from '@trpc/client';
+import { createTRPCReact } from '@trpc/react-query';
+import { CreateTRPCReactBase } from '@trpc/react-query/createTRPCReact';
+import { AnyRouter } from '@trpc/server';
 import React, { ReactNode } from 'react';
 
 export function getServerAndReactClient<TRouter extends AnyRouter>(

--- a/packages/tests/server/react/createClient.test.tsx
+++ b/packages/tests/server/react/createClient.test.tsx
@@ -2,9 +2,9 @@ import { routerToServerAndClientNew } from '../___testHelpers';
 import { createQueryClient } from '../__queryClient';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, waitFor } from '@testing-library/react';
+import { createTRPCReact, httpBatchLink } from '@trpc/react-query';
 import { createServerSideHelpers } from '@trpc/react-query/server';
-import { createTRPCReact, httpBatchLink } from '@trpc/react-query/src';
-import { initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 import React, { ReactNode, useState } from 'react';
 

--- a/packages/tests/server/react/errors.test.tsx
+++ b/packages/tests/server/react/errors.test.tsx
@@ -1,6 +1,6 @@
 import { getServerAndReactClient } from './__reactHelpers';
 import { render, waitFor } from '@testing-library/react';
-import { TRPCClientError, TRPCClientErrorLike } from '@trpc/client/src';
+import { TRPCClientError, TRPCClientErrorLike } from '@trpc/client';
 import { initTRPC } from '@trpc/server';
 import { DefaultErrorData } from '@trpc/server/error/formatter';
 import { Maybe } from '@trpc/server/unstableInternalsExport';

--- a/packages/tests/server/react/formData.test.tsx
+++ b/packages/tests/server/react/formData.test.tsx
@@ -10,7 +10,7 @@ import {
   splitLink,
 } from '@trpc/client';
 import { createTRPCReact } from '@trpc/react-query';
-import { CreateTRPCReactBase } from '@trpc/react-query/src/createTRPCReact';
+import { CreateTRPCReactBase } from '@trpc/react-query/createTRPCReact';
 import { initTRPC } from '@trpc/server';
 import {
   experimental_createFileUploadHandler,

--- a/packages/tests/server/react/formatError.test.tsx
+++ b/packages/tests/server/react/formatError.test.tsx
@@ -2,7 +2,7 @@ import { createQueryClient } from '../__queryClient';
 import { createAppRouter } from './__testHelpers';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, waitFor } from '@testing-library/react';
-import { DefaultErrorShape } from '@trpc/server/src/error/formatter';
+import { DefaultErrorShape } from '@trpc/server/error/formatter';
 import React, { useEffect, useState } from 'react';
 
 let factory: ReturnType<typeof createAppRouter>;

--- a/packages/tests/server/react/invalidateQueries.test.tsx
+++ b/packages/tests/server/react/invalidateQueries.test.tsx
@@ -4,7 +4,7 @@ import { QueryClientProvider, useQueryClient } from '@tanstack/react-query';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getUntypedClient } from '@trpc/client';
-import { TRPCQueryKey } from '@trpc/react-query/src/internals/getQueryKey';
+import { TRPCQueryKey } from '@trpc/react-query/internals/getQueryKey';
 import React, { useState } from 'react';
 
 let factory: ReturnType<typeof createAppRouter>;

--- a/packages/tests/server/react/invalidateRouters.test.tsx
+++ b/packages/tests/server/react/invalidateRouters.test.tsx
@@ -3,7 +3,7 @@ import { getServerAndReactClient } from './__reactHelpers';
 import { useIsFetching } from '@tanstack/react-query';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 import React from 'react';
 import { z } from 'zod';

--- a/packages/tests/server/react/multiple-trpc-providers.test.tsx
+++ b/packages/tests/server/react/multiple-trpc-providers.test.tsx
@@ -2,8 +2,8 @@ import { routerToServerAndClientNew } from '../___testHelpers';
 import { createQueryClient } from '../__queryClient';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, waitFor } from '@testing-library/react';
-import { createTRPCReact, getUntypedClient } from '@trpc/react-query/src';
-import { initTRPC } from '@trpc/server/src';
+import { createTRPCReact, getUntypedClient } from '@trpc/react-query';
+import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 import React, { createContext } from 'react';
 

--- a/packages/tests/server/react/regression/issue-1645-setErrorStatusSSR.test.tsx
+++ b/packages/tests/server/react/regression/issue-1645-setErrorStatusSSR.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { createAppRouter } from '../__testHelpers';
-import { withTRPC } from '@trpc/next/src';
+import { withTRPC } from '@trpc/next';
 import { AppType } from 'next/dist/shared/lib/utils';
 import React from 'react';
 

--- a/packages/tests/server/react/regression/issue-3461-reserved-properties.test.tsx
+++ b/packages/tests/server/react/regression/issue-3461-reserved-properties.test.tsx
@@ -2,7 +2,7 @@ import { getServerAndReactClient } from '../__reactHelpers';
 import { render } from '@testing-library/react';
 import { createTRPCClient } from '@trpc/client';
 import { createServerSideHelpers } from '@trpc/react-query/server';
-import { initTRPC } from '@trpc/server/src/core';
+import { initTRPC } from '@trpc/server/core';
 import { IntersectionError } from '@trpc/server/unstableInternalsExport';
 import React from 'react';
 import { z } from 'zod';

--- a/packages/tests/server/react/regression/issue-4486-initialData-types.test.tsx
+++ b/packages/tests/server/react/regression/issue-4486-initialData-types.test.tsx
@@ -1,6 +1,6 @@
 import { ignoreErrors } from '../../___testHelpers';
 import { getServerAndReactClient } from '../__reactHelpers';
-import { initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 
 /**

--- a/packages/tests/server/react/ssg.test.ts
+++ b/packages/tests/server/react/ssg.test.ts
@@ -1,6 +1,6 @@
 import { InfiniteData } from '@tanstack/react-query';
 import { createServerSideHelpers } from '@trpc/react-query/server';
-import { initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server';
 import { z } from 'zod';
 
 const t = initTRPC.create();

--- a/packages/tests/server/react/ssgExternal.test.ts
+++ b/packages/tests/server/react/ssgExternal.test.ts
@@ -1,7 +1,7 @@
 import { getServerAndReactClient } from './__reactHelpers';
 import { InfiniteData } from '@tanstack/react-query';
 import { createServerSideHelpers } from '@trpc/react-query/server';
-import { initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 import SuperJSON from 'superjson';
 import { z } from 'zod';

--- a/packages/tests/server/react/trpc-options.test.tsx
+++ b/packages/tests/server/react/trpc-options.test.tsx
@@ -1,6 +1,6 @@
 import { getServerAndReactClient } from './__reactHelpers';
 import { render, waitFor } from '@testing-library/react';
-import { initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 import React, { useEffect } from 'react';
 import { z } from 'zod';

--- a/packages/tests/server/react/useMutation.test.tsx
+++ b/packages/tests/server/react/useMutation.test.tsx
@@ -1,7 +1,7 @@
 import { getServerAndReactClient } from './__reactHelpers';
 import { render, waitFor } from '@testing-library/react';
 import { inferReactQueryProcedureOptions } from '@trpc/react-query';
-import { initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 import React, { useEffect } from 'react';
 import { z } from 'zod';

--- a/packages/tests/server/react/useQueries.test.tsx
+++ b/packages/tests/server/react/useQueries.test.tsx
@@ -1,6 +1,6 @@
 import { getServerAndReactClient } from './__reactHelpers';
 import { render, waitFor } from '@testing-library/react';
-import { initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 import React from 'react';
 import { z } from 'zod';

--- a/packages/tests/server/react/useQuery.test.tsx
+++ b/packages/tests/server/react/useQuery.test.tsx
@@ -2,7 +2,7 @@ import { getServerAndReactClient } from './__reactHelpers';
 import { InfiniteData } from '@tanstack/react-query';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 import React, { useEffect } from 'react';
 import { z } from 'zod';

--- a/packages/tests/server/react/useSubscription.test.tsx
+++ b/packages/tests/server/react/useSubscription.test.tsx
@@ -1,8 +1,8 @@
 import { EventEmitter } from 'events';
 import { getServerAndReactClient } from './__reactHelpers';
 import { render, waitFor } from '@testing-library/react';
-import { initTRPC } from '@trpc/server/src';
-import { observable } from '@trpc/server/src/observable';
+import { initTRPC } from '@trpc/server';
+import { observable } from '@trpc/server/observable';
 import { konn } from 'konn';
 import React, { useState } from 'react';
 import { z } from 'zod';

--- a/packages/tests/server/react/useSuspenseInfiniteQuery.test.tsx
+++ b/packages/tests/server/react/useSuspenseInfiniteQuery.test.tsx
@@ -2,7 +2,7 @@ import { getServerAndReactClient } from './__reactHelpers';
 import { InfiniteData } from '@tanstack/react-query';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 import React, { Suspense } from 'react';
 import { z } from 'zod';

--- a/packages/tests/server/react/useSuspenseQueries.test.tsx
+++ b/packages/tests/server/react/useSuspenseQueries.test.tsx
@@ -1,6 +1,6 @@
 import { getServerAndReactClient } from './__reactHelpers';
 import { render, waitFor } from '@testing-library/react';
-import { initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 import React from 'react';
 import { z } from 'zod';

--- a/packages/tests/server/react/useSuspenseQuery.test.tsx
+++ b/packages/tests/server/react/useSuspenseQuery.test.tsx
@@ -1,6 +1,6 @@
 import { getServerAndReactClient } from './__reactHelpers';
 import { render, waitFor } from '@testing-library/react';
-import { initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 import React from 'react';
 import { z } from 'zod';

--- a/packages/tests/server/react/useUtils.test.tsx
+++ b/packages/tests/server/react/useUtils.test.tsx
@@ -2,7 +2,7 @@
 import { getServerAndReactClient } from './__reactHelpers';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { initTRPC } from '@trpc/server/src/core';
+import { initTRPC } from '@trpc/server/core';
 import { konn } from 'konn';
 import React, { useEffect, useState } from 'react';
 import { z } from 'zod';

--- a/packages/tests/server/react/withTRPC.test.tsx
+++ b/packages/tests/server/react/withTRPC.test.tsx
@@ -2,7 +2,7 @@
 import { createAppRouter } from './__testHelpers';
 import { DehydratedState } from '@tanstack/react-query';
 import { render, waitFor } from '@testing-library/react';
-import { withTRPC } from '@trpc/next/src';
+import { withTRPC } from '@trpc/next';
 import { konn } from 'konn';
 import { AppType, NextPageContext } from 'next/dist/shared/lib/utils';
 import React from 'react';

--- a/packages/tests/server/regression/issue-2506-headers-throwing.test.ts
+++ b/packages/tests/server/regression/issue-2506-headers-throwing.test.ts
@@ -1,6 +1,6 @@
 import { routerToServerAndClientNew, waitError } from '../___testHelpers';
-import { httpBatchLink, httpLink, TRPCClientError } from '@trpc/client/src';
-import { initTRPC } from '@trpc/server/src';
+import { httpBatchLink, httpLink, TRPCClientError } from '@trpc/client';
+import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 import { z } from 'zod';
 

--- a/packages/tests/server/regression/issue-2540-undefined-mutation.test.ts
+++ b/packages/tests/server/regression/issue-2540-undefined-mutation.test.ts
@@ -1,7 +1,7 @@
 // https://github.com/trpc/trpc/issues/2540
 import { routerToServerAndClientNew } from '../___testHelpers';
-import { httpBatchLink, httpLink } from '@trpc/client/src';
-import { initTRPC } from '@trpc/server/src';
+import { httpBatchLink, httpLink } from '@trpc/client';
+import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 import superjson from 'superjson';
 

--- a/packages/tests/server/regression/issue-2942-useInfiniteQuery-setData.test.tsx
+++ b/packages/tests/server/regression/issue-2942-useInfiniteQuery-setData.test.tsx
@@ -6,7 +6,7 @@ import {
 } from '@tanstack/react-query';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 import React from 'react';
 import { z } from 'zod';

--- a/packages/tests/server/regression/issue-3455-56-invalidate-queries.test.tsx
+++ b/packages/tests/server/regression/issue-3455-56-invalidate-queries.test.tsx
@@ -2,7 +2,7 @@ import { getServerAndReactClient } from '../react/__reactHelpers';
 import { useQuery } from '@tanstack/react-query';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 import React from 'react';
 import { z } from 'zod';

--- a/packages/tests/server/regression/issue-4049-stripped-undefined.test.tsx
+++ b/packages/tests/server/regression/issue-4049-stripped-undefined.test.tsx
@@ -1,7 +1,7 @@
 import { routerToServerAndClientNew } from '../___testHelpers';
-import { httpLink } from '@trpc/client/src';
+import { httpLink } from '@trpc/client';
 import { createTRPCReact } from '@trpc/react-query';
-import { initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 
 describe('undefined on server response is inferred on the client', () => {

--- a/packages/tests/server/regression/issue-4243-serialize-string.test.ts
+++ b/packages/tests/server/regression/issue-4243-serialize-string.test.ts
@@ -1,6 +1,6 @@
 import EventEmitter from 'events';
 import { initTRPC } from '@trpc/server';
-import * as trpcNext from '@trpc/server/src/adapters/next';
+import * as trpcNext from '@trpc/server/adapters/next';
 import { z } from 'zod';
 
 function mockReq(opts: {

--- a/packages/tests/server/regression/issue-4292-content-type-json-fallback.test.ts
+++ b/packages/tests/server/regression/issue-4292-content-type-json-fallback.test.ts
@@ -1,4 +1,4 @@
-import { getPostBody } from '@trpc/server/src/adapters/node-http/content-type/json/getPostBody';
+import { getPostBody } from '@trpc/server/adapters/node-http/content-type/json/getPostBody';
 
 test('POST w/o specifying content-type should work', async () => {
   {

--- a/packages/tests/server/regression/issue-4360-useInfiniteQuery-placeHolderData.test.tsx
+++ b/packages/tests/server/regression/issue-4360-useInfiniteQuery-placeHolderData.test.tsx
@@ -1,6 +1,6 @@
 import { ignoreErrors } from '../___testHelpers';
 import { getServerAndReactClient } from '../react/__reactHelpers';
-import { initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 import { z } from 'zod';
 

--- a/packages/tests/server/regression/issue-4527-nested-middleware-root-context.test.ts
+++ b/packages/tests/server/regression/issue-4527-nested-middleware-root-context.test.ts
@@ -1,4 +1,4 @@
-import { initTRPC, TRPCError } from '@trpc/server/src';
+import { initTRPC, TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
 test('root context override on nested middlewares', () => {

--- a/packages/tests/server/regression/issue-4750-no-cancel.test.ts
+++ b/packages/tests/server/regression/issue-4750-no-cancel.test.ts
@@ -1,7 +1,7 @@
 import { routerToServerAndClientNew, waitMs } from '../___testHelpers';
 import { httpBatchLink, httpLink } from '@trpc/client';
 import { AbortControllerEsque } from '@trpc/client/internals/types';
-import { initTRPC } from '@trpc/server/src/core';
+import { initTRPC } from '@trpc/server/core';
 
 const t = initTRPC.create();
 

--- a/packages/tests/server/regression/issue-4985-serialize-type.test.ts
+++ b/packages/tests/server/regression/issue-4985-serialize-type.test.ts
@@ -1,8 +1,4 @@
-import {
-  inferRouterInputs,
-  inferRouterOutputs,
-  initTRPC,
-} from '@trpc/server/src';
+import { inferRouterInputs, inferRouterOutputs, initTRPC } from '@trpc/server';
 import * as z from 'zod';
 
 describe('Serialization of Record types', () => {

--- a/packages/tests/server/regression/serializable-inference.test.tsx
+++ b/packages/tests/server/regression/serializable-inference.test.tsx
@@ -1,6 +1,6 @@
 import { routerToServerAndClientNew } from '../___testHelpers';
 import { httpLink } from '@trpc/client';
-import { inferRouterOutputs, initTRPC } from '@trpc/server/src';
+import { inferRouterOutputs, initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 import superjson from 'superjson';
 

--- a/packages/tests/server/responseMeta.test.ts
+++ b/packages/tests/server/responseMeta.test.ts
@@ -1,6 +1,6 @@
 import { IncomingMessage, ServerResponse } from 'http';
 import { routerToServerAndClientNew } from './___testHelpers';
-import { initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server';
 import fetch from 'node-fetch';
 
 test('set custom headers in beforeEnd', async () => {

--- a/packages/tests/server/router.test.ts
+++ b/packages/tests/server/router.test.ts
@@ -1,5 +1,5 @@
 import './___packages';
-import { initTRPC } from '@trpc/server/src/core';
+import { initTRPC } from '@trpc/server/core';
 
 const t = initTRPC.create();
 

--- a/packages/tests/server/routerMeta.test.ts
+++ b/packages/tests/server/routerMeta.test.ts
@@ -1,6 +1,6 @@
 import { routerToServerAndClientNew } from './___testHelpers';
-import { inferRouterMeta, initTRPC } from '@trpc/server/src';
-import { observable } from '@trpc/server/src/observable';
+import { inferRouterMeta, initTRPC } from '@trpc/server';
+import { observable } from '@trpc/server/observable';
 
 test('route meta types', async () => {
   const testMeta = { data: 'foo' };

--- a/packages/tests/server/smoke.test.ts
+++ b/packages/tests/server/smoke.test.ts
@@ -1,9 +1,9 @@
 import { EventEmitter } from 'events';
 import { routerToServerAndClientNew, waitError } from './___testHelpers';
 import { waitFor } from '@testing-library/react';
-import { getUntypedClient, TRPCClientError, wsLink } from '@trpc/client/src';
-import { inferProcedureOutput, initTRPC } from '@trpc/server/src';
-import { observable, Unsubscribable } from '@trpc/server/src/observable';
+import { getUntypedClient, TRPCClientError, wsLink } from '@trpc/client';
+import { inferProcedureOutput, initTRPC } from '@trpc/server';
+import { observable, Unsubscribable } from '@trpc/server/observable';
 import { z } from 'zod';
 
 const t = initTRPC

--- a/packages/tests/server/transformer.test.ts
+++ b/packages/tests/server/transformer.test.ts
@@ -13,7 +13,7 @@ import {
   initTRPC,
   TRPCError,
 } from '@trpc/server';
-import { observable } from '@trpc/server/src/observable';
+import { observable } from '@trpc/server/observable';
 import { uneval } from 'devalue';
 import superjson from 'superjson';
 import { createTson, tsonDate } from 'tupleson';

--- a/packages/tests/server/validators.test.ts
+++ b/packages/tests/server/validators.test.ts
@@ -2,7 +2,7 @@ import { AsyncLocalStorage } from 'async_hooks';
 import { routerToServerAndClientNew, waitError } from './___testHelpers';
 import { wrap } from '@decs/typeschema';
 import * as S from '@effect/schema/Schema';
-import { initTRPC } from '@trpc/server/src';
+import { initTRPC } from '@trpc/server';
 import * as arktype from 'arktype';
 import myzod from 'myzod';
 import * as T from 'runtypes';

--- a/packages/tests/server/websockets.test.ts
+++ b/packages/tests/server/websockets.test.ts
@@ -8,12 +8,12 @@ import {
   wsLink,
 } from '@trpc/client';
 import { AnyRouter, initTRPC, TRPCError } from '@trpc/server';
-import { applyWSSHandler } from '@trpc/server/src/adapters/ws';
-import { observable, Observer } from '@trpc/server/src/observable';
+import { applyWSSHandler } from '@trpc/server/adapters/ws';
+import { observable, Observer } from '@trpc/server/observable';
 import {
   TRPCClientOutgoingMessage,
   TRPCRequestMessage,
-} from '@trpc/server/src/rpc';
+} from '@trpc/server/rpc';
 import WebSocket, { Server } from 'ws';
 import { z } from 'zod';
 


### PR DESCRIPTION
Closes #

## 🎯 Changes

Replace e.g. `import {} from '@trpc/server/src'` -> `import {} from '@trpc/server'` 