### PR TITLE
feat: add ability to have a parser as a callback

### DIFF
--- a/packages/server/src/core/internals/getParseFn.ts
+++ b/packages/server/src/core/internals/getParseFn.ts
@@ -2,13 +2,10 @@ import { Parser } from '../parser';
 
 export type ParseFn<TType> = (value: unknown) => Promise<TType> | TType;
 
-export function getParseFn<TType>(procedureParser: Parser): ParseFn<TType> {
+export function getParseFnInner<TType>(
+  procedureParser: Parser,
+): ParseFn<TType> | null {
   const parser = procedureParser as any;
-
-  if (typeof parser === 'function') {
-    // ParserCustomValidatorEsque
-    return parser;
-  }
 
   if (typeof parser.parseAsync === 'function') {
     // ParserZodEsque
@@ -37,6 +34,16 @@ export function getParseFn<TType>(procedureParser: Parser): ParseFn<TType> {
       parser.assert(value);
       return value as TType;
     };
+  }
+
+  return null;
+}
+
+export function getParseFn<TType>(procedureParser: Parser): ParseFn<TType> {
+  const parse = getParseFnInner<TType>(procedureParser);
+
+  if (parse !== null) {
+    return parse;
   }
 
   throw new Error('Could not find a validator fn');

--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -32,8 +32,6 @@ type IntersectIfDefined<TType, TWith> = UnsetMarker extends TType
   ? TWith
   : Simplify<TType & TWith>;
 
-type ErrorMessage<TMessage extends string> = TMessage;
-
 export type ProcedureBuilderDef<TMeta> = {
   procedure: true;
   inputs: (Parser | ParserCallback<any, any>)[];

--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -8,7 +8,12 @@ import {
   MiddlewareFunction,
   MiddlewareResult,
 } from '../middleware';
-import { inferParser, Parser, ParserCallback } from '../parser';
+import {
+  inferParser,
+  InputParserCallback,
+  OutputParserCallback,
+  Parser,
+} from '../parser';
 import {
   AnyMutationProcedure,
   AnyProcedure,
@@ -34,8 +39,8 @@ type IntersectIfDefined<TType, TWith> = UnsetMarker extends TType
 
 export type ProcedureBuilderDef<TMeta> = {
   procedure: true;
-  inputs: (Parser | ParserCallback<any, any>)[];
-  output?: Parser | ParserCallback<any, any>;
+  inputs: (Parser | InputParserCallback<any, any>)[];
+  output?: Parser | OutputParserCallback<any, any>;
   meta?: TMeta;
   resolver?: ProcedureBuilderResolver;
   middlewares: AnyMiddlewareFunction[];
@@ -84,7 +89,7 @@ export interface ProcedureBuilder<
    * Add an input parser to the procedure.
    * @see https://trpc.io/docs/server/validators
    */
-  input<$Parser extends Parser | ParserCallback<TContext, any>>(
+  input<$Parser extends Parser | InputParserCallback<TContext, any>>(
     schema: $Parser,
   ): ProcedureBuilder<
     TContext,
@@ -99,7 +104,7 @@ export interface ProcedureBuilder<
    * Add an output parser to the procedure.
    * @see https://trpc.io/docs/server/validators
    */
-  output<$Parser extends Parser | ParserCallback<TContext, any>>(
+  output<$Parser extends Parser | OutputParserCallback<TContext, any>>(
     schema: $Parser,
   ): ProcedureBuilder<
     TContext,

--- a/packages/server/src/core/internals/procedureBuilder.ts
+++ b/packages/server/src/core/internals/procedureBuilder.ts
@@ -39,8 +39,8 @@ type IntersectIfDefined<TType, TWith> = UnsetMarker extends TType
 
 export type ProcedureBuilderDef<TMeta> = {
   procedure: true;
-  inputs: (Parser | InputParserCallback<any, any>)[];
-  output?: Parser | OutputParserCallback<any, any>;
+  inputs: (Parser | InputParserCallback)[];
+  output?: Parser | OutputParserCallback;
   meta?: TMeta;
   resolver?: ProcedureBuilderResolver;
   middlewares: AnyMiddlewareFunction[];

--- a/packages/server/src/core/middleware.ts
+++ b/packages/server/src/core/middleware.ts
@@ -2,7 +2,7 @@ import { TRPCError } from '../error/TRPCError';
 import { Simplify } from '../types';
 import { getParseFn, getParseFnInner } from './internals/getParseFn';
 import { GetRawInputFn, MiddlewareMarker, Overwrite } from './internals/utils';
-import { Parser, ParserCallback } from './parser';
+import { InputParserCallback, OutputParserCallback, Parser } from './parser';
 import { ProcedureType } from './types';
 
 /**
@@ -178,7 +178,7 @@ function isPlainObject(obj: unknown) {
  * Please note, `trpc-openapi` uses this function.
  */
 export function createInputMiddleware(
-  parserOrCb: Parser | ParserCallback<any, any>,
+  parserOrCb: Parser | InputParserCallback<any, any>,
 ) {
   const inputMiddleware: AnyMiddlewareFunction =
     async function inputValidatorMiddleware(opts) {
@@ -226,7 +226,7 @@ export function createInputMiddleware(
  * @internal
  */
 export function createOutputMiddleware(
-  parserOrCb: Parser | ParserCallback<any, any>,
+  parserOrCb: Parser | OutputParserCallback<any, any>,
 ) {
   const outputMiddleware: AnyMiddlewareFunction =
     async function outputValidatorMiddleware(opts) {
@@ -241,7 +241,7 @@ export function createOutputMiddleware(
         if (typeof parserOrCb === 'function') {
           const cbResult = await parserOrCb({
             ctx: opts.ctx,
-            input: result.data,
+            output: result.data,
           });
 
           const parse = getParseFnInner(cbResult);

--- a/packages/server/src/core/middleware.ts
+++ b/packages/server/src/core/middleware.ts
@@ -178,7 +178,7 @@ function isPlainObject(obj: unknown) {
  * Please note, `trpc-openapi` uses this function.
  */
 export function createInputMiddleware(
-  parserOrCb: Parser | InputParserCallback<any, any>,
+  parserOrCb: Parser | InputParserCallback,
 ) {
   const inputMiddleware: AnyMiddlewareFunction =
     async function inputValidatorMiddleware(opts) {
@@ -226,7 +226,7 @@ export function createInputMiddleware(
  * @internal
  */
 export function createOutputMiddleware(
-  parserOrCb: Parser | OutputParserCallback<any, any>,
+  parserOrCb: Parser | OutputParserCallback,
 ) {
   const outputMiddleware: AnyMiddlewareFunction =
     async function outputValidatorMiddleware(opts) {

--- a/packages/server/src/core/parser.ts
+++ b/packages/server/src/core/parser.ts
@@ -48,17 +48,15 @@ export type ParserCallback<TParam, TContext, TCallbackResult> = (
   } & TParam,
 ) => TCallbackResult;
 
-export type InputParserCallback<TContext, TCallbackResult> = ParserCallback<
-  { input: unknown },
-  TContext,
-  TCallbackResult
->;
+export type InputParserCallback<
+  TContext = any,
+  TCallbackResult = any,
+> = ParserCallback<{ input: unknown }, TContext, TCallbackResult>;
 
-export type OutputParserCallback<TContext, TCallbackResult> = ParserCallback<
-  { output: unknown },
-  TContext,
-  TCallbackResult
->;
+export type OutputParserCallback<
+  TContext = any,
+  TCallbackResult = any,
+> = ParserCallback<{ output: unknown }, TContext, TCallbackResult>;
 
 export type inferParser<
   TParser extends Parser | ParserCallback<any, any, any>,

--- a/packages/server/src/core/parser.ts
+++ b/packages/server/src/core/parser.ts
@@ -42,19 +42,33 @@ export type inferParserInner<TParser extends Parser> =
       }
     : never;
 
-export type ParserCallback<TContext, TCallbackResult> = (opts: {
-  input: unknown;
-  ctx: TContext;
-}) => TCallbackResult;
+export type ParserCallback<TParam, TContext, TCallbackResult> = (
+  opts: {
+    ctx: TContext;
+  } & TParam,
+) => TCallbackResult;
 
-export type inferParser<TParser extends Parser | ParserCallback<any, any>> =
-  TParser extends ParserCallback<any, infer $CallbackResult>
-    ? Awaited<$CallbackResult> extends Parser
-      ? inferParserInner<Awaited<$CallbackResult>>
-      : {
-          in: Awaited<$CallbackResult>;
-          out: Awaited<$CallbackResult>;
-        }
-    : TParser extends Parser
-    ? inferParserInner<TParser>
-    : never;
+export type InputParserCallback<TContext, TCallbackResult> = ParserCallback<
+  { input: unknown },
+  TContext,
+  TCallbackResult
+>;
+
+export type OutputParserCallback<TContext, TCallbackResult> = ParserCallback<
+  { output: unknown },
+  TContext,
+  TCallbackResult
+>;
+
+export type inferParser<
+  TParser extends Parser | ParserCallback<any, any, any>,
+> = TParser extends ParserCallback<any, any, infer $CallbackResult>
+  ? Awaited<$CallbackResult> extends Parser
+    ? inferParserInner<Awaited<$CallbackResult>>
+    : {
+        in: Awaited<$CallbackResult>;
+        out: Awaited<$CallbackResult>;
+      }
+  : TParser extends Parser
+  ? inferParserInner<TParser>
+  : never;

--- a/packages/tests/server/outputParser.test.ts
+++ b/packages/tests/server/outputParser.test.ts
@@ -311,8 +311,8 @@ test('validator fn', async () => {
   const trpc = initTRPC.create();
   const router = trpc.router({
     q: trpc.procedure
-      .input((value: unknown) => value as number | string)
-      .output((value: unknown) => {
+      .input(({ input: value }) => value as number | string)
+      .output(({ input: value }) => {
         if (typeof (value as any).input === 'string') {
           return value as { input: string };
         }
@@ -344,8 +344,9 @@ test('async validator fn', async () => {
   const trpc = initTRPC.create();
   const router = trpc.router({
     q: trpc.procedure
-      .input((value: unknown) => value as number | string)
-      .output(async (value: any): Promise<{ input: string }> => {
+      .input(({ input: value }) => value as number | string)
+      .output(async ({ input }): Promise<{ input: string }> => {
+        const value: any = input;
         if (value && typeof value.input === 'string') {
           return { input: value.input };
         }

--- a/packages/tests/server/outputParser.test.ts
+++ b/packages/tests/server/outputParser.test.ts
@@ -312,7 +312,7 @@ test('validator fn', async () => {
   const router = trpc.router({
     q: trpc.procedure
       .input(({ input: value }) => value as number | string)
-      .output(({ input: value }) => {
+      .output(({ output: value }) => {
         if (typeof (value as any).input === 'string') {
           return value as { input: string };
         }
@@ -345,8 +345,8 @@ test('async validator fn', async () => {
   const router = trpc.router({
     q: trpc.procedure
       .input(({ input: value }) => value as number | string)
-      .output(async ({ input }): Promise<{ input: string }> => {
-        const value: any = input;
+      .output(async ({ output }): Promise<{ input: string }> => {
+        const value: any = output;
         if (value && typeof value.input === 'string') {
           return { input: value.input };
         }


### PR DESCRIPTION
Closes #1963 

Continous from #5234

## 🎯 Changes

 - ParserCustomValidatorEsque signature is changed
 ```ts
.input(({input}) => Parser | value))
.output(({output}) => Parser | value))
```

usage) 
```ts
.input(z.number())
.input(({ctx, input}) => z.number()))
.input(({ctx, input}) => input as string))
 ```
 
## Todo

 - [x] change output cb's value name input -> output
 - [ ] need to clean up
 - [ ] ~codemod for ParserCustomValidatorEsque sigs~

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
