### PR TITLE
chore: named-exports in core package

### DIFF
--- a/packages/core/src/http/index.ts
+++ b/packages/core/src/http/index.ts
@@ -1,5 +1,25 @@
-export * from './getHTTPStatusCode';
-export * from './resolveHTTPResponse';
-export * from './types';
-export * from './batchStreamFormatter';
-export * from './contentType';
+export {
+  getHTTPStatusCode,
+  getHTTPStatusCodeFromError,
+} from './getHTTPStatusCode';
+export { resolveHTTPResponse } from './resolveHTTPResponse';
+export {
+  BaseHandlerOptions,
+  HTTPBaseHandlerOptions,
+  HTTPHeaders,
+  HTTPRequest,
+  HTTPResponse,
+  OnErrorFunction,
+  ProcedureCall,
+  ResolveHTTPRequestOptionsContextFn,
+  ResponseChunk,
+  ResponseMeta,
+  ResponseMetaFn,
+  TRPCRequestInfo,
+} from './types';
+export { getBatchStreamFormatter } from './batchStreamFormatter';
+export {
+  BaseContentTypeHandler,
+  BodyResult,
+  getJsonContentTypeInputs,
+} from './contentType';

--- a/packages/core/src/http/index.ts
+++ b/packages/core/src/http/index.ts
@@ -3,7 +3,7 @@ export {
   getHTTPStatusCodeFromError,
 } from './getHTTPStatusCode';
 export { resolveHTTPResponse } from './resolveHTTPResponse';
-export {
+export type {
   BaseHandlerOptions,
   HTTPBaseHandlerOptions,
   HTTPHeaders,
@@ -17,9 +17,7 @@ export {
   ResponseMetaFn,
   TRPCRequestInfo,
 } from './types';
+
 export { getBatchStreamFormatter } from './batchStreamFormatter';
-export {
-  BaseContentTypeHandler,
-  BodyResult,
-  getJsonContentTypeInputs,
-} from './contentType';
+export type { BaseContentTypeHandler, BodyResult } from './contentType';
+export { getJsonContentTypeInputs } from './contentType';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,7 +75,6 @@ export {
   procedureTypes,
 } from './types';
 export { type DefaultErrorShape } from './error/formatter';
-export * from './transformer';
 
 export { mergeRouters } from './internals/mergeRouters';
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,15 +2,14 @@
  * @remark Do not `import` anything from `@trpc/core` it will be unreliable between minor versions of tRPC
  */
 
-export {
+export type {
   CombinedDataTransformer,
   CombinedDataTransformerClient,
   DataTransformer,
   DataTransformerOptions,
   DefaultDataTransformer,
-  defaultTransformer,
-  getDataTransformer,
 } from './transformer';
+export { defaultTransformer, getDataTransformer } from './transformer';
 export {
   TRPCError,
   getCauseFromUnknown,
@@ -46,7 +45,7 @@ export {
 } from './middleware';
 export type { MiddlewareFunction, MiddlewareBuilder } from './middleware';
 export { initTRPC } from './initTRPC';
-export {
+export type {
   DeepPartial,
   Dict,
   DistributiveOmit,
@@ -72,20 +71,20 @@ export {
   inferRouterInputs,
   inferRouterMeta,
   inferRouterOutputs,
-  procedureTypes,
 } from './types';
-export { type DefaultErrorShape } from './error/formatter';
+export { procedureTypes } from './types';
+export type { DefaultErrorShape } from './error/formatter';
 
 export { mergeRouters } from './internals/mergeRouters';
-export {
+export type {
   AnyProcedureBuilderDef,
   ProcedureBuilder,
   ProcedureBuilderDef,
   ProcedureBuilderResolver,
   ProcedureCallOptions,
-  createBuilder,
 } from './internals/procedureBuilder';
-export {
+export { createBuilder } from './internals/procedureBuilder';
+export type {
   DefaultValue,
   GetRawInputFn,
   MiddlewareMarker,
@@ -93,21 +92,19 @@ export {
   PickFirstDefined,
   UnsetMarker,
   ValidateShape,
-  isObject,
-  middlewareMarker,
-  unsetMarker,
 } from './internals/utils';
-export {
+export { isObject, middlewareMarker, unsetMarker } from './internals/utils';
+export type {
   AnyRootConfig,
   CreateRootConfigTypes,
   RootConfig,
   RootConfigTypes,
   RuntimeConfig,
-  isServerDefault,
 } from './internals/config';
+export { isServerDefault } from './internals/config';
 
 export { createFlatProxy, createRecursiveProxy } from './shared/createProxy';
-export {
+export type {
   inferTransformedProcedureOutput,
   inferTransformedSubscriptionOutput,
 } from './shared/jsonify';
@@ -118,4 +115,8 @@ export type { SerializeObject, Serialize } from './shared/serialize';
 
 export { getErrorShape } from './shared/getErrorShape';
 
-export { TRPCInferrable, inferConfig, inferErrorShape } from './shared/types';
+export type {
+  TRPCInferrable,
+  inferConfig,
+  inferErrorShape,
+} from './shared/types';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,8 +2,20 @@
  * @remark Do not `import` anything from `@trpc/core` it will be unreliable between minor versions of tRPC
  */
 
-export * from './transformer';
-export * from './error/TRPCError';
+export {
+  CombinedDataTransformer,
+  CombinedDataTransformerClient,
+  DataTransformer,
+  DataTransformerOptions,
+  DefaultDataTransformer,
+  defaultTransformer,
+  getDataTransformer,
+} from './transformer';
+export {
+  TRPCError,
+  getCauseFromUnknown,
+  getTRPCErrorFromUnknown,
+} from './error/TRPCError';
 export type {
   AnyRouter,
   ProcedureRecord,
@@ -22,6 +34,9 @@ export type {
   AnySubscriptionProcedure,
   ProcedureArgs,
   ProcedureOptions,
+  MutationProcedure,
+  QueryProcedure,
+  SubscriptionProcedure,
 } from './procedure';
 export type { inferParser } from './parser';
 export {
@@ -31,26 +46,77 @@ export {
 } from './middleware';
 export type { MiddlewareFunction, MiddlewareBuilder } from './middleware';
 export { initTRPC } from './initTRPC';
-export * from './types';
+export {
+  DeepPartial,
+  Dict,
+  DistributiveOmit,
+  Filter,
+  FilterKeys,
+  InferLast,
+  IntersectionError,
+  Maybe,
+  MaybePromise,
+  ProcedureType,
+  ProtectedIntersection,
+  Simplify,
+  Unwrap,
+  WithoutIndexSignature,
+  inferHandlerInput,
+  inferProcedureInput,
+  inferProcedureOutput,
+  inferProcedureParams,
+  inferRouterConfig,
+  inferRouterContext,
+  inferRouterDef,
+  inferRouterError,
+  inferRouterInputs,
+  inferRouterMeta,
+  inferRouterOutputs,
+  procedureTypes,
+} from './types';
 export { type DefaultErrorShape } from './error/formatter';
-export type { RootConfig, AnyRootConfig } from './internals/config';
 export * from './transformer';
 
 export { mergeRouters } from './internals/mergeRouters';
-export * from './internals/procedureBuilder';
-export * from './internals/utils';
-export * from './internals/config';
+export {
+  AnyProcedureBuilderDef,
+  ProcedureBuilder,
+  ProcedureBuilderDef,
+  ProcedureBuilderResolver,
+  ProcedureCallOptions,
+  createBuilder,
+} from './internals/procedureBuilder';
+export {
+  DefaultValue,
+  GetRawInputFn,
+  MiddlewareMarker,
+  Overwrite,
+  PickFirstDefined,
+  UnsetMarker,
+  ValidateShape,
+  isObject,
+  middlewareMarker,
+  unsetMarker,
+} from './internals/utils';
+export {
+  AnyRootConfig,
+  CreateRootConfigTypes,
+  RootConfig,
+  RootConfigTypes,
+  RuntimeConfig,
+  isServerDefault,
+} from './internals/config';
 
-export * from './procedure';
-
-export * from './types';
-export * from './shared/createProxy';
-export * from './shared/jsonify';
-export * from './shared/transformTRPCResponse';
+export { createFlatProxy, createRecursiveProxy } from './shared/createProxy';
+export {
+  inferTransformedProcedureOutput,
+  inferTransformedSubscriptionOutput,
+} from './shared/jsonify';
+export { transformTRPCResponse } from './shared/transformTRPCResponse';
 
 // For `.d.ts` files https://github.com/trpc/trpc/issues/3943
 export type { SerializeObject, Serialize } from './shared/serialize';
 
-export * from './shared/getErrorShape';
+export { getErrorShape } from './shared/getErrorShape';
 
-export * from './shared/types';
+export { TRPCInferrable, inferConfig, inferErrorShape } from './shared/types';

--- a/packages/core/src/observable/index.ts
+++ b/packages/core/src/observable/index.ts
@@ -1,5 +1,6 @@
-export { inferObservableValue, isObservable, observable } from './observable';
-export {
+export { isObservable, observable } from './observable';
+export type { inferObservableValue } from './observable';
+export type {
   MonoTypeOperatorFunction,
   Observable,
   Observer,

--- a/packages/core/src/observable/index.ts
+++ b/packages/core/src/observable/index.ts
@@ -1,4 +1,15 @@
-export * from './observable';
-export * from './types';
-export * from './operators';
+export { inferObservableValue, isObservable, observable } from './observable';
+export {
+  MonoTypeOperatorFunction,
+  Observable,
+  Observer,
+  OperatorFunction,
+  Subscribable,
+  SubscriptionLike,
+  TeardownLogic,
+  UnaryFunction,
+  Unsubscribable,
+  UnsubscribeFn,
+} from './types';
+export { map, share, tap } from './operators';
 export { observableToPromise } from './internals/observableToPromise';

--- a/packages/core/src/rpc/index.ts
+++ b/packages/core/src/rpc/index.ts
@@ -1,3 +1,25 @@
-export * from './codes';
-export * from './envelopes';
-export * from './parseTRPCMessage';
+export {
+  TRPC_ERROR_CODES_BY_KEY,
+  TRPC_ERROR_CODES_BY_NUMBER,
+  TRPC_ERROR_CODE_KEY,
+  TRPC_ERROR_CODE_NUMBER,
+} from './codes';
+export {
+  JSONRPC2,
+  TRPCClientIncomingMessage,
+  TRPCClientIncomingRequest,
+  TRPCClientOutgoingMessage,
+  TRPCClientOutgoingRequest,
+  TRPCErrorResponse,
+  TRPCErrorShape,
+  TRPCReconnectNotification,
+  TRPCRequest,
+  TRPCRequestMessage,
+  TRPCResponse,
+  TRPCResponseMessage,
+  TRPCResult,
+  TRPCResultMessage,
+  TRPCSubscriptionStopNotification,
+  TRPCSuccessResponse,
+} from './envelopes';
+export { parseTRPCMessage } from './parseTRPCMessage';

--- a/packages/core/src/rpc/index.ts
+++ b/packages/core/src/rpc/index.ts
@@ -1,10 +1,6 @@
-export {
-  TRPC_ERROR_CODES_BY_KEY,
-  TRPC_ERROR_CODES_BY_NUMBER,
-  TRPC_ERROR_CODE_KEY,
-  TRPC_ERROR_CODE_NUMBER,
-} from './codes';
-export {
+export { TRPC_ERROR_CODES_BY_KEY, TRPC_ERROR_CODES_BY_NUMBER } from './codes';
+export type { TRPC_ERROR_CODE_KEY, TRPC_ERROR_CODE_NUMBER } from './codes';
+export type {
   JSONRPC2,
   TRPCClientIncomingMessage,
   TRPCClientIncomingRequest,


### PR DESCRIPTION
just converts `export * from 'x'` to export everything but named from all public entrypoints (they which are specified in rollup config) (in core package only)