### PR TITLE
docs: update error.cause comment

### DIFF
--- a/packages/server/src/error/TRPCError.ts
+++ b/packages/server/src/error/TRPCError.ts
@@ -45,7 +45,7 @@ export class TRPCError extends Error {
     this.name = 'TRPCError';
 
     if (!this.cause) {
-      // idk why this is needed, but it is
+      // < ES2023/ < Node 16.9.0 compatability
       this.cause = cause;
     }
   }


### PR DESCRIPTION
Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

Fixes a comment (spotted in [a meme](https://www.reddit.com/r/ProgrammerHumor/comments/190uii9/icanrelatetothis/))

`error.cause` was added in ES2022, and supported in Node in 16.9.0, so older Node types or runtimes might not have it. That seems to be why that was needed.
 
<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
