### PR TITLE
fix(ws): use websocket OPEN reference (next)

### DIFF
--- a/packages/server/src/adapters/ws.ts
+++ b/packages/server/src/adapters/ws.ts
@@ -260,9 +260,9 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
       }
     });
 
-    // ws.WebSocket errors should be handled, as otherwise unhandled exceptions will crash Node.js.
+    // WebSocket errors should be handled, as otherwise unhandled exceptions will crash Node.js.
     // This line was introduced after the following error brought down production systems:
-    // "RangeError: Invalid ws.WebSocket frame: RSV2 and RSV3 must be clear"
+    // "RangeError: Invalid WebSocket frame: RSV2 and RSV3 must be clear"
     // Here is the relevant discussion: https://github.com/websockets/ws/issues/1354#issuecomment-774616962
     client.on('error', (cause) => {
       opts.onError?.({

--- a/packages/server/src/adapters/ws.ts
+++ b/packages/server/src/adapters/ws.ts
@@ -21,6 +21,7 @@ import type ws from 'ws';
 import type { NodeHTTPCreateContextFnOptions } from './node-http';
 
 /**
+ * Importing ws causes a build error
  * @see https://github.com/trpc/trpc/pull/5279
  */
 const WEBSOCKET_OPEN = 1; /* ws.WebSocket.OPEN */

--- a/packages/server/src/adapters/ws.ts
+++ b/packages/server/src/adapters/ws.ts
@@ -17,19 +17,19 @@ import type {
   TRPCResponseMessage,
 } from '@trpc/core/rpc';
 import { parseTRPCMessage } from '@trpc/core/rpc';
-import type { WebSocket, WebSocketServer } from 'ws';
+import type ws from 'ws';
 import type { NodeHTTPCreateContextFnOptions } from './node-http';
 
 /**
  * @see https://github.com/trpc/trpc/pull/5279
  */
-const WEBSOCKET_OPEN = 1; /* WebSocket.OPEN */
+const WEBSOCKET_OPEN = 1; /* ws.WebSocket.OPEN */
 
 /**
  * @public
  */
 export type CreateWSSContextFnOptions = Omit<
-  NodeHTTPCreateContextFnOptions<IncomingMessage, WebSocket>,
+  NodeHTTPCreateContextFnOptions<IncomingMessage, ws.WebSocket>,
   'info'
 >;
 
@@ -60,7 +60,7 @@ export type WSSHandlerOptions<TRouter extends AnyRouter> = BaseHandlerOptions<
          **/
         createContext: CreateWSSContextFn<TRouter>;
       }) & {
-    wss: WebSocketServer;
+    wss: ws.WebSocketServer;
     process?: NodeJS.Process;
   };
 
@@ -260,9 +260,9 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
       }
     });
 
-    // WebSocket errors should be handled, as otherwise unhandled exceptions will crash Node.js.
+    // ws.WebSocket errors should be handled, as otherwise unhandled exceptions will crash Node.js.
     // This line was introduced after the following error brought down production systems:
-    // "RangeError: Invalid WebSocket frame: RSV2 and RSV3 must be clear"
+    // "RangeError: Invalid ws.WebSocket frame: RSV2 and RSV3 must be clear"
     // Here is the relevant discussion: https://github.com/websockets/ws/issues/1354#issuecomment-774616962
     client.on('error', (cause) => {
       opts.onError?.({

--- a/packages/server/src/adapters/ws.ts
+++ b/packages/server/src/adapters/ws.ts
@@ -17,7 +17,8 @@ import type {
   TRPCResponseMessage,
 } from '@trpc/core/rpc';
 import { parseTRPCMessage } from '@trpc/core/rpc';
-import type { WebSocket, WebSocketServer } from 'ws';
+import { WebSocket } from 'ws';
+import type { WebSocketServer } from 'ws';
 import type { NodeHTTPCreateContextFnOptions } from './node-http';
 
 /**
@@ -183,7 +184,7 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
           },
         });
         /* istanbul ignore next -- @preserve */
-        if (client.readyState !== client.OPEN) {
+        if (client.readyState !== WebSocket.OPEN) {
           // if the client got disconnected whilst initializing the subscription
           // no need to send stopped message if the client is disconnected
           sub.unsubscribe();
@@ -318,7 +319,7 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
       };
       const data = JSON.stringify(response);
       for (const client of wss.clients) {
-        if (client.readyState === 1 /* ws.OPEN */) {
+        if (client.readyState === WebSocket.OPEN) {
           client.send(data);
         }
       }

--- a/packages/server/src/adapters/ws.ts
+++ b/packages/server/src/adapters/ws.ts
@@ -17,9 +17,13 @@ import type {
   TRPCResponseMessage,
 } from '@trpc/core/rpc';
 import { parseTRPCMessage } from '@trpc/core/rpc';
-import { WebSocket } from 'ws';
-import type { WebSocketServer } from 'ws';
+import type { WebSocket, WebSocketServer } from 'ws';
 import type { NodeHTTPCreateContextFnOptions } from './node-http';
+
+/**
+ * @see https://github.com/trpc/trpc/pull/5279
+ */
+const WEBSOCKET_OPEN = 1; /* WebSocket.OPEN */
 
 /**
  * @public
@@ -184,7 +188,7 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
           },
         });
         /* istanbul ignore next -- @preserve */
-        if (client.readyState !== WebSocket.OPEN) {
+        if (client.readyState !== WEBSOCKET_OPEN) {
           // if the client got disconnected whilst initializing the subscription
           // no need to send stopped message if the client is disconnected
           sub.unsubscribe();
@@ -319,7 +323,7 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
       };
       const data = JSON.stringify(response);
       for (const client of wss.clients) {
-        if (client.readyState === WebSocket.OPEN) {
+        if (client.readyState === WEBSOCKET_OPEN) {
           client.send(data);
         }
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -690,7 +690,7 @@ importers:
         version: 2.5.0
       ws:
         specifier: ^8.0.0
-        version: 8.11.0
+        version: 8.16.0
       zod:
         specifier: ^3.0.0
         version: 3.22.4
@@ -700,7 +700,7 @@ importers:
         version: 20.10.4
       '@types/ws':
         specifier: ^8.2.0
-        version: 8.5.4
+        version: 8.5.10
       esbuild:
         specifier: ^0.17.10
         version: 0.17.10
@@ -1268,7 +1268,7 @@ importers:
         version: 4.6.2
       ws:
         specifier: ^8.0.0
-        version: 8.11.0
+        version: 8.16.0
       zod:
         specifier: ^3.0.0
         version: 3.22.4
@@ -1287,7 +1287,7 @@ importers:
         version: 18.2.33
       '@types/ws':
         specifier: ^8.2.0
-        version: 8.5.4
+        version: 8.5.10
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.2.1
         version: 6.2.1(@typescript-eslint/parser@6.2.1)(eslint@8.40.0)(typescript@5.3.3)
@@ -1380,7 +1380,7 @@ importers:
         version: link:../../packages/server
       ws:
         specifier: ^8.0.0
-        version: 8.11.0
+        version: 8.16.0
       zod:
         specifier: ^3.0.0
         version: 3.22.4
@@ -1390,7 +1390,7 @@ importers:
         version: 20.10.4
       '@types/ws':
         specifier: ^8.2.0
-        version: 8.5.4
+        version: 8.5.10
       esbuild:
         specifier: ^0.17.10
         version: 0.17.10
@@ -1632,7 +1632,7 @@ importers:
         version: 18.2.14
       '@types/ws':
         specifier: ^8.2.0
-        version: 8.5.4
+        version: 8.5.10
       '@web3-storage/multipart-parser':
         specifier: ^1.0.0
         version: 1.0.0
@@ -1695,7 +1695,7 @@ importers:
         version: 0.32.0(@vitest/ui@0.32.0)(jsdom@23.0.0)
       ws:
         specifier: ^8.0.0
-        version: 8.11.0
+        version: 8.16.0
       yup:
         specifier: ^1.0.0
         version: 1.0.0
@@ -1848,7 +1848,7 @@ importers:
         version: 2.12.0(vitest@0.32.0)
       ws:
         specifier: ^8.0.0
-        version: 8.11.0
+        version: 8.16.0
       yup:
         specifier: ^1.0.0
         version: 1.0.0
@@ -6149,7 +6149,7 @@ packages:
     resolution: {integrity: sha512-OBaPR3KVkDmhJpCy+RtM8CwwV67ieRRbvWtpHqRNoMt+AnHLBiNmrTwHs3/DKjmnI1cqdGTaQ+NhKtDtkk1l/Q==}
     dependencies:
       fastify-plugin: 4.5.0
-      ws: 8.11.0
+      ws: 8.16.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -6928,7 +6928,7 @@ packages:
       kleur: 4.1.5
       selfsigned: 2.1.1
       undici: 5.9.1
-      ws: 8.15.1
+      ws: 8.16.0
       youch: 2.2.2
     transitivePeerDependencies:
       - bufferutil
@@ -6945,7 +6945,7 @@ packages:
       kleur: 4.1.5
       selfsigned: 2.1.1
       undici: 5.9.1
-      ws: 8.15.1
+      ws: 8.16.0
       youch: 2.2.2
     transitivePeerDependencies:
       - bufferutil
@@ -7209,7 +7209,7 @@ packages:
       '@miniflare/core': 2.10.0
       '@miniflare/shared': 2.10.0
       undici: 5.9.1
-      ws: 8.15.1
+      ws: 8.16.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -7222,7 +7222,7 @@ packages:
       '@miniflare/core': 2.11.0
       '@miniflare/shared': 2.11.0
       undici: 5.9.1
-      ws: 8.15.1
+      ws: 8.16.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -7235,7 +7235,7 @@ packages:
       '@miniflare/core': 2.12.0
       '@miniflare/shared': 2.12.0
       undici: 5.11.0
-      ws: 8.15.1
+      ws: 8.16.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -9044,8 +9044,8 @@ packages:
     resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
     dev: false
 
-  /@types/ws@8.5.4:
-    resolution: {integrity: sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==}
+  /@types/ws@8.5.10:
+    resolution: {integrity: sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==}
     dependencies:
       '@types/node': 20.10.4
 
@@ -15792,7 +15792,7 @@ packages:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.0.0
-      ws: 8.15.1
+      ws: 8.16.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -20859,7 +20859,7 @@ packages:
       p-retry: 5.1.2
       serverless: 3.25.0
       velocityjs: 2.0.6
-      ws: 8.11.0
+      ws: 8.16.0
     transitivePeerDependencies:
       - aws-crt
       - bufferutil
@@ -23200,7 +23200,7 @@ packages:
       '@types/serve-index': 1.9.1
       '@types/serve-static': 1.15.0
       '@types/sockjs': 0.3.33
-      '@types/ws': 8.5.4
+      '@types/ws': 8.5.10
       ansi-html-community: 0.0.8
       bonjour-service: 1.0.14
       chokidar: 3.5.3
@@ -23223,7 +23223,7 @@ packages:
       spdy: 4.0.2
       webpack: 5.75.0(@swc/core@1.3.3)
       webpack-dev-middleware: 5.3.3(webpack@5.75.0)
-      ws: 8.15.1
+      ws: 8.16.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -23583,20 +23583,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  /ws@8.11.0:
-    resolution: {integrity: sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  /ws@8.15.1:
-    resolution: {integrity: sha512-W5OZiCjXEmk0yZ66ZN82beM5Sz7l7coYxpRkzS+p9PP+ToQry8szKh+61eNktr7EA9DOwvFGhfC605jDHbP6QQ==}
+  /ws@8.16.0:
+    resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1


### PR DESCRIPTION
Closes #5268

## 🎯 Changes

This fix removes the need for magic values and references OPEN value from WebSocket in place of relying on instance value.
It fixes when using subscriptions when running trpc from bun.

As discussed here https://github.com/trpc/trpc/issues/5268

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] (not necessary) I have added or updated the tests related to the changes made.
