### PR TITLE
chore(server): ban `import`s of `@trpc/core` in adapters

### DIFF
--- a/examples/.experimental/next-app-dir/package.json
+++ b/examples/.experimental/next-app-dir/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@hookform/resolvers": "^2.9.11",
     "@tanstack/react-query": "^5.0.0",
+    "@tanstack/react-query-devtools": "^5.0.0",
     "@trpc/client": "^10.45.0",
     "@trpc/next": "^10.45.0",
     "@trpc/react-query": "^10.45.0",

--- a/examples/.experimental/next-app-dir/src/app/client/hydration/Providers.tsx
+++ b/examples/.experimental/next-app-dir/src/app/client/hydration/Providers.tsx
@@ -1,15 +1,12 @@
 'use client';
 
 import type { DehydratedState } from '@tanstack/react-query';
-import {
-  HydrationBoundary,
-  QueryClientProvider,
-} from '@tanstack/react-query';
+import { HydrationBoundary, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import { useState, type ReactNode } from 'react';
-import { api } from '~/trpc/client';
-import { createTRPCReact } from "@trpc/react-query";
+import { createTRPCReact } from '@trpc/react-query';
 import type { AppRouter } from '~/server/routers/_app';
+import { api } from '~/trpc/client';
+import { useState, type ReactNode } from 'react';
 import { getQueryClient, getTrpcClient } from './getTrpcClient';
 
 type Props = {
@@ -17,14 +14,12 @@ type Props = {
   dehydrateState?: DehydratedState;
 };
 
-
 export const trpc = createTRPCReact<AppRouter>({});
 
 const Providers = (props: {
   children: ReactNode;
   dehydrateState?: DehydratedState;
 }) => {
-
   const hydratedState = trpc.useDehydratedState(
     getTrpcClient(),
     props.dehydrateState,

--- a/examples/.experimental/next-app-dir/src/app/client/hydration/Providers.tsx
+++ b/examples/.experimental/next-app-dir/src/app/client/hydration/Providers.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import type { DehydratedState } from '@tanstack/react-query';
+import {
+  HydrationBoundary,
+  QueryClientProvider,
+} from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { useState, type ReactNode } from 'react';
+import { api } from '~/trpc/client';
+import { createTRPCReact } from "@trpc/react-query";
+import type { AppRouter } from '~/server/routers/_app';
+import { getQueryClient, getTrpcClient } from './getTrpcClient';
+
+type Props = {
+  children: ReactNode;
+  dehydrateState?: DehydratedState;
+};
+
+
+export const trpc = createTRPCReact<AppRouter>({});
+
+const Providers = (props: {
+  children: ReactNode;
+  dehydrateState?: DehydratedState;
+}) => {
+
+  const hydratedState = trpc.useDehydratedState(
+    getTrpcClient(),
+    props.dehydrateState,
+  );
+
+  return (
+    <trpc.Provider client={getTrpcClient()} queryClient={getQueryClient()}>
+      <QueryClientProvider client={getQueryClient()}>
+        <HydrationBoundary state={hydratedState}>
+          {props.children}
+        </HydrationBoundary>
+        <ReactQueryDevtools initialIsOpen={false} />
+      </QueryClientProvider>
+    </trpc.Provider>
+  );
+};
+
+export default Providers;

--- a/examples/.experimental/next-app-dir/src/app/client/hydration/getTrpcClient.tsx
+++ b/examples/.experimental/next-app-dir/src/app/client/hydration/getTrpcClient.tsx
@@ -1,0 +1,17 @@
+'use client';
+import { QueryClient } from '@tanstack/react-query';
+import { httpBatchLink } from '@trpc/client';
+import { cache } from 'react';
+import superjson from 'superjson';
+import { getUrl } from '~/trpc/shared';
+import { trpc } from './Providers';
+
+export const getQueryClient = cache(() => new QueryClient());
+export const getTrpcClient = cache(() => trpc.createClient({
+  links: [
+    httpBatchLink({
+      url: getUrl(),
+    }),
+  ],
+  transformer: superjson
+}));

--- a/examples/.experimental/next-app-dir/src/app/client/hydration/getTrpcClient.tsx
+++ b/examples/.experimental/next-app-dir/src/app/client/hydration/getTrpcClient.tsx
@@ -1,17 +1,20 @@
 'use client';
+
 import { QueryClient } from '@tanstack/react-query';
 import { httpBatchLink } from '@trpc/client';
+import { getUrl } from '~/trpc/shared';
 import { cache } from 'react';
 import superjson from 'superjson';
-import { getUrl } from '~/trpc/shared';
 import { trpc } from './Providers';
 
 export const getQueryClient = cache(() => new QueryClient());
-export const getTrpcClient = cache(() => trpc.createClient({
-  links: [
-    httpBatchLink({
-      url: getUrl(),
-    }),
-  ],
-  transformer: superjson
-}));
+export const getTrpcClient = cache(() =>
+  trpc.createClient({
+    links: [
+      httpBatchLink({
+        url: getUrl(),
+      }),
+    ],
+    transformer: superjson,
+  }),
+);

--- a/examples/.experimental/next-app-dir/src/app/client/hydration/page.tsx
+++ b/examples/.experimental/next-app-dir/src/app/client/hydration/page.tsx
@@ -2,7 +2,6 @@ import { dehydrate } from '@tanstack/react-query';
 import { createServerSideHelpers } from '@trpc/react-query/server';
 import { appRouter } from '~/server/routers/_app';
 
-
 export default async function Page(props: { children: React.ReactNode }) {
   // THIS THROWS useContext error
   const helpers = createServerSideHelpers({

--- a/examples/.experimental/next-app-dir/src/app/client/hydration/page.tsx
+++ b/examples/.experimental/next-app-dir/src/app/client/hydration/page.tsx
@@ -1,0 +1,28 @@
+import { dehydrate } from '@tanstack/react-query';
+import { createServerSideHelpers } from '@trpc/react-query/server';
+import { appRouter } from '~/server/routers/_app';
+
+
+export default async function Page(props: { children: React.ReactNode }) {
+  // THIS THROWS useContext error
+  const helpers = createServerSideHelpers({
+    router: appRouter,
+    ctx: {
+      headers: {},
+      session: null,
+    },
+  });
+
+  await helpers.greeting.fetch({
+    text: '__FROM RSC__',
+  });
+  const dehydratedState = dehydrate(helpers.queryClient);
+
+  return (
+    <html lang="en">
+      <body>
+        <Providers dehydrateState={dehydratedState}>{props.children}</Providers>
+      </body>
+    </html>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.0.0
         version: 5.0.0(react-dom@18.2.0)(react@18.2.0)
+      '@tanstack/react-query-devtools':
+        specifier: ^5.0.0
+        version: 5.0.0(@tanstack/react-query@5.0.0)(react-dom@18.2.0)(react@18.2.0)
       '@trpc/client':
         specifier: ^10.45.0
         version: link:../../../packages/client
@@ -8541,7 +8544,6 @@ packages:
 
   /@tanstack/query-devtools@5.0.0:
     resolution: {integrity: sha512-WATg9+nreAmtTRHzxvCFN6j4ucUVbkJNd8ErcYmf7Y6GsJw/BGscd4rWS7cdAP7zfTcPjHjGaRB041pcv8dNvA==}
-    dev: true
 
   /@tanstack/react-query-devtools@5.0.0(@tanstack/react-query@5.0.0)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-4yw29d89eOqUmliRKGmEOjuq2AGSM3i4jjw/YFMrErg0neVITy2bkoU3fPXZ339czlupqq0b4e20uFVtqkEqGQ==}
@@ -8554,7 +8556,6 @@ packages:
       '@tanstack/react-query': 5.0.0(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
 
   /@tanstack/react-query@5.0.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-diQoC8FNBcO5Uf5yuaJlXthTtbO1xM8kzOX+pSBUMT9n/cqQ/u1wJGCtukvhDWA+6j07WmIj4bfqNbd2KOB6jQ==}


### PR DESCRIPTION
Closes #5308

## 🎯 Changes

Idea - if we ban `import`s from adapters in `@trpc/core` we _should_ be able to ensure that anyone can build a trpc adapter