### PR TITLE
Use Correct Achor Syntas for Link

### DIFF
--- a/www/docs/main/quickstart.mdx
+++ b/www/docs/main/quickstart.mdx
@@ -288,7 +288,7 @@ const appRouter = router({
 
   </TabItem>
   <TabItem value="valibot" label="Valibot">
-    With Valibot, you simply need to <code>wrap</code> your schema with [TypeSchema](https://typeschema.com).
+    With Valibot, you simply need to <code>wrap</code> your schema with <a href="https://typeschema.com">TypeSchema</a>.
 
 <br />
 <br />


### PR DESCRIPTION
Closes #5334 

## 🎯 Changes

The issue was the use of Markdown syntax for the link within JSX, and the Markdown link syntax ([TypeSchema](https://typeschema.com)) won't work directly in JSX. In JSX or HTML, the <a> tag is used to create a link. 

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
