### PR TITLE
fix: remove named imports from react

### DIFF
--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -13,7 +13,7 @@ import type {
   ProtectedIntersection,
 } from '@trpc/core';
 import { createFlatProxy } from '@trpc/core';
-import { useMemo } from 'react';
+import * as React from 'react';
 import type {
   TRPCUseQueries,
   TRPCUseSuspenseQueries,
@@ -288,7 +288,7 @@ export function createHooksInternal<
       return () => {
         const context = trpc.useUtils();
         // create a stable reference of the utils context
-        return useMemo(() => {
+        return React.useMemo(() => {
           return (createReactQueryUtils as any)(context);
         }, [context]);
       };

--- a/packages/react-query/src/internals/context.tsx
+++ b/packages/react-query/src/internals/context.tsx
@@ -20,7 +20,7 @@ import type {
   TRPCUntypedClient,
 } from '@trpc/client';
 import type { AnyRouter, DistributiveOmit } from '@trpc/core';
-import { createContext } from 'react';
+import * as React from 'react';
 import type { ExtractCursorType } from '../shared';
 import type { TRPCQueryKey } from './getQueryKey';
 
@@ -226,4 +226,4 @@ export interface TRPCQueryUtils<TRouter extends AnyRouter> {
     queryKey: TRPCQueryKey,
   ) => InfiniteData<unknown> | undefined;
 }
-export const TRPCContext = createContext(null as any);
+export const TRPCContext = React.createContext?.(null as any);

--- a/packages/react-query/src/internals/useHookResult.ts
+++ b/packages/react-query/src/internals/useHookResult.ts
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import * as React from 'react';
 
 export interface TRPCHookResult {
   trpc: {
@@ -12,7 +12,7 @@ export interface TRPCHookResult {
 export function useHookResult(
   value: TRPCHookResult['trpc'],
 ): TRPCHookResult['trpc'] {
-  const ref = useRef(value);
+  const ref = React.useRef(value);
   ref.current.path = value.path;
   return ref.current;
 }

--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -13,7 +13,7 @@ import {
 import type { TRPCClientErrorLike } from '@trpc/client';
 import { createTRPCUntypedClient } from '@trpc/client';
 import type { AnyRouter } from '@trpc/core';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import * as React from 'react';
 import type { SSRState, TRPCContextState } from '../../internals/context';
 import { TRPCContext } from '../../internals/context';
 import { getClientArgs } from '../../internals/getClientArgs';
@@ -69,9 +69,11 @@ export function createRootHooks<
 
   const TRPCProvider: TRPCProvider<TRouter, TSSRContext> = (props) => {
     const { abortOnUnmount = false, client, queryClient, ssrContext } = props;
-    const [ssrState, setSSRState] = useState<SSRState>(props.ssrState ?? false);
+    const [ssrState, setSSRState] = React.useState<SSRState>(
+      props.ssrState ?? false,
+    );
 
-    const fns = useMemo(
+    const fns = React.useMemo(
       () =>
         createUtilityFunctions({
           client,
@@ -80,7 +82,7 @@ export function createRootHooks<
       [client, queryClient],
     );
 
-    const contextValue = useMemo<ProviderContext>(
+    const contextValue = React.useMemo<ProviderContext>(
       () => ({
         abortOnUnmount,
         queryClient,
@@ -92,7 +94,7 @@ export function createRootHooks<
       [abortOnUnmount, client, fns, queryClient, ssrContext, ssrState],
     );
 
-    useEffect(() => {
+    React.useEffect(() => {
       // Only updating state to `mounted` if we are using SSR.
       // This makes it so we don't have an unnecessary re-render when opting out of SSR.
       setSSRState((state) => (state ? 'mounted' : false));
@@ -275,10 +277,10 @@ export function createRootHooks<
     const queryKey = hashKey(getQueryKeyInternal(path, input, 'any'));
     const { client } = useContext();
 
-    const optsRef = useRef<typeof opts>(opts);
+    const optsRef = React.useRef<typeof opts>(opts);
     optsRef.current = opts;
 
-    useEffect(() => {
+    React.useEffect(() => {
       if (!enabled) {
         return;
       }
@@ -492,7 +494,7 @@ export function createRootHooks<
     client,
     trpcState,
   ) => {
-    const transformed: DehydratedState | undefined = useMemo(() => {
+    const transformed: DehydratedState | undefined = React.useMemo(() => {
       if (!trpcState) {
         return trpcState;
       }


### PR DESCRIPTION
Fixes:

```sh
You're importing a component that needs createContext. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.
Learn more: https://nextjs.org/docs/getting-started/react-essentials

   ╭─[/Users/julius/dev/trpc/packages/react-query/dist/utilsProxy-5402e992.mjs:1:1]
 1 │ import { createTRPCClientProxy } from '@trpc/client';
 2 │ import { createFlatProxy, createRecursiveProxy } from '@trpc/core';
 3 │ import { createContext } from 'react';
   ·          ─────────────
 4 │
 5 │ /**
 6 │  * To allow easy interactions with groups of related queries, such as
   ╰────

Maybe one of these should be marked as a client entry with "use client":
  ../../trpc/packages/react-query/dist/utilsProxy-5402e992.mjs
  ../../trpc/packages/react-query/dist/server/index.mjs
  ./src/app/layout.tsx
 ⚠ Fast Refresh had to perform a full reload due to a runtime error.
 ⨯ ../../trpc/packages/react-query/dist/utilsProxy-659744c7.mjs
ReactServerComponentsError:
```