### PR TITLE
fix: add missing 'express' import in adapters/express.md

### DIFF
--- a/www/docs/server/adapters/express.md
+++ b/www/docs/server/adapters/express.md
@@ -45,7 +45,6 @@ Implement your tRPC router. A sample router is given below:
 import { initTRPC } from '@trpc/server';
 import { z } from 'zod';
 
-
 export const t = initTRPC.create();
 
 export const appRouter = t.router({

--- a/www/docs/server/adapters/express.md
+++ b/www/docs/server/adapters/express.md
@@ -45,6 +45,7 @@ Implement your tRPC router. A sample router is given below:
 import { initTRPC } from '@trpc/server';
 import { z } from 'zod';
 
+
 export const t = initTRPC.create();
 
 export const appRouter = t.router({
@@ -75,6 +76,7 @@ tRPC includes an adapter for Express out of the box. This adapter lets you conve
 ```ts title='server.ts'
 import { initTRPC } from '@trpc/server';
 import * as trpcExpress from '@trpc/server/adapters/express';
+import express from 'express';
 
 // created for each request
 const createContext = ({


### PR DESCRIPTION
Added the necessary import statement for 'express' in adapters/express.md

Closes #5372

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?


- docs(server): add missing 'express' import in setup example

- Updated the code snippet in the server setup documentation to include the necessary 'express' module import statement. The absence of this import could lead to confusion for users following the example. With this addition, the documentation now accurately reflects the correct dependencies and ensures a smooth setup process for tRPC with Express.



## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
