### PR TITLE
docs: Astro API Route handler in fetch.mdx

### DIFF
--- a/www/docs/server/adapters/fetch.mdx
+++ b/www/docs/server/adapters/fetch.mdx
@@ -189,7 +189,7 @@ import type { APIRoute } from 'astro';
 import { createContext } from '../../server/context';
 import { appRouter } from '../../server/router';
 
-export const all: APIRoute = (opts) => {
+export const ALL: APIRoute = (opts) => {
   return fetchRequestHandler({
     endpoint: '/trpc',
     req: opts.request,


### PR DESCRIPTION
## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

It fixes the runtimes-specific setup docs for Astro.

Astro API Route handlers must be written in caps. "all" -> "ALL"
I got this message:
[router] No API Route handler exists for the method "GET" for the route /trpc/trpc. Found handlers: "prerender", "all"
One of the exported handlers is "all" (lowercase), did you mean to export 'ALL'?

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
