### PR TITLE
docs: optional req res for inner context fixes #5344

### DIFF
--- a/www/docs/server/context.md
+++ b/www/docs/server/context.md
@@ -174,6 +174,7 @@ interface CreateInnerContextOptions extends Partial<CreateNextContextOptions> {
  */
 export async function createContextInner(opts?: CreateInnerContextOptions) {
   return {
+    ...opts,
     prisma,
     session: opts.session,
   };


### PR DESCRIPTION
Closes #5344

## 🎯 Changes

Code sample update in docs. Provide `req` and `res` to context when using outer/inner context.
