### PR TITLE
docs: add react query data transformer example

### DIFF
--- a/www/docs/server/data-transformers.md
+++ b/www/docs/server/data-transformers.md
@@ -30,9 +30,11 @@ export const t = initTRPC.create({
 });
 ```
 
-#### 3. Add to `createTRPCClient()` or `createTRPCNext()`
+#### 3. Add to `createTRPCClient()`, `createTRPCNext()` or `CreateTRPCReact`
 
-```ts
+`createTRPCClient()`
+
+```ts title='src/app/_trpc/client.ts'
 import { createTRPCClient } from '@trpc/client';
 import type { AppRouter } from '~/server/routers/_app';
 import superjson from 'superjson';
@@ -42,6 +44,8 @@ export const client = createTRPCClient<AppRouter>({
   // [...]
 });
 ```
+
+`createTRPCNext()`
 
 ```ts title='utils/trpc.ts'
 import { createTRPCNext } from '@trpc/next';
@@ -58,6 +62,34 @@ export const trpc = createTRPCNext<AppRouter>({
   },
   // [...]
 });
+```
+
+`createTRPCReact()` for React Query
+
+```ts title='src/app/_trpc/client.ts'
+import type { AppRouter } from '@/server';
+import { createTRPCReact } from '@trpc/react-query';
+
+export const trpc = createTRPCReact<AppRouter>({});
+```
+
+With React Query you need to pass the transformer to the createClient instance, as the `createTRPCReact` function does not accept the transformer as a parameter.
+
+```tsx title='src/app/_trpc/Provider.tsx'
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import superjson from "superjson";
+
+import { trpc } from "./client";
+export default function Provider({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+  const [trpcClient] = useState(() =>
+    trpc.createClient({
+      transformer: superjson, // <--
+    })
+  );
+
+  // [...]
+}
 ```
 
 ## Different transformers for upload and download

--- a/www/docs/server/data-transformers.md
+++ b/www/docs/server/data-transformers.md
@@ -30,7 +30,7 @@ export const t = initTRPC.create({
 });
 ```
 
-#### 3. Add to `createTRPCClient()`, `createTRPCNext()` or `CreateTRPCReact`
+#### 3. Add to `createTRPCClient()`, `createTRPCNext()` or `createTRPCReact()`
 
 `createTRPCClient()`
 
@@ -64,7 +64,9 @@ export const trpc = createTRPCNext<AppRouter>({
 });
 ```
 
-`createTRPCReact()` for React Query
+`createTRPCReact()`
+
+With React Query you need to pass the transformer to the createClient instance, as the `createTRPCReact` function does not accept the transformer as a parameter.
 
 ```ts title='src/app/_trpc/client.ts'
 import type { AppRouter } from '@/server';
@@ -72,8 +74,6 @@ import { createTRPCReact } from '@trpc/react-query';
 
 export const trpc = createTRPCReact<AppRouter>({});
 ```
-
-With React Query you need to pass the transformer to the createClient instance, as the `createTRPCReact` function does not accept the transformer as a parameter.
 
 ```tsx title='src/app/_trpc/Provider.tsx'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/www/docs/server/data-transformers.md
+++ b/www/docs/server/data-transformers.md
@@ -76,16 +76,16 @@ export const trpc = createTRPCReact<AppRouter>({});
 With React Query you need to pass the transformer to the createClient instance, as the `createTRPCReact` function does not accept the transformer as a parameter.
 
 ```tsx title='src/app/_trpc/Provider.tsx'
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import superjson from "superjson";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import superjson from 'superjson';
+import { trpc } from './client';
 
-import { trpc } from "./client";
 export default function Provider({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
   const [trpcClient] = useState(() =>
     trpc.createClient({
       transformer: superjson, // <--
-    })
+    }),
   );
 
   // [...]


### PR DESCRIPTION
## 🎯 Changes

No code changes, this PR updates the data transformer docs to include an example of using the data transformer with the TRPC React Query wrapper '@trpc/react-query'. It was not intuitive to use with React Query as the `CreateTRPCReact()` differs from `CreateTRPCNext()/createTRPCClient()` as it doesn't accept a transformer.

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
