### PR TITLE
chore: root config transformer is a boolean

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/rootConfig.ts
+++ b/packages/server/src/unstable-core-do-not-import/rootConfig.ts
@@ -1,3 +1,4 @@
+import type { CombinedDataTransformer } from '.';
 import type { ErrorFormatter } from './error/formatter';
 import type { TRPCErrorShape } from './rpc';
 
@@ -9,7 +10,7 @@ export interface RootConfigTypes {
   ctx: object;
   meta: object;
   errorShape: unknown;
-  transformer: unknown;
+  transformer: boolean;
 }
 
 /**
@@ -32,7 +33,7 @@ export interface RuntimeConfig<TTypes extends RootConfigTypes> {
    * Use a data transformer
    * @link https://trpc.io/docs/v11/data-transformers
    */
-  transformer: TTypes['transformer'];
+  transformer: CombinedDataTransformer;
   /**
    * Use custom error formatting
    * @link https://trpc.io/docs/v11/error-formatting

--- a/packages/tests/server/initTRPC.test.ts
+++ b/packages/tests/server/initTRPC.test.ts
@@ -1,8 +1,5 @@
 import { initTRPC } from '@trpc/server';
-import type {
-  DataTransformerOptions,
-  DefaultDataTransformer,
-} from '@trpc/server/unstable-core-do-not-import';
+import type { DataTransformerOptions } from '@trpc/server/unstable-core-do-not-import';
 
 test('default transformer', () => {
   const t = initTRPC
@@ -16,10 +13,7 @@ test('default transformer', () => {
     foo: 'bar';
   }>();
 
-  expectTypeOf(t._config.transformer).toMatchTypeOf<DefaultDataTransformer>();
-  expectTypeOf(
-    router._def._config.transformer,
-  ).toMatchTypeOf<DefaultDataTransformer>();
+  expectTypeOf(t._config.$types.transformer).toEqualTypeOf<false>();
 });
 test('custom transformer', () => {
   const transformer: DataTransformerOptions = {
@@ -30,12 +24,8 @@ test('custom transformer', () => {
     transformer,
   });
   const router = t.router({});
-  expectTypeOf(
-    router._def._config.transformer,
-  ).toMatchTypeOf<DataTransformerOptions>();
-  expectTypeOf(
-    router._def._config.transformer,
-  ).not.toMatchTypeOf<DefaultDataTransformer>();
+
+  expectTypeOf(t._config.$types.transformer).toEqualTypeOf<true>();
 });
 
 test('meta typings', () => {


### PR DESCRIPTION
- A little less bloat in the RootConfig.
- `initTRPC` still needs a rewrite, it's awful, but that can be done separately without breaking changes