### PR TITLE
docs: Fix tanstack.com links

### DIFF
--- a/examples/next-prisma-starter/src/utils/trpc.ts
+++ b/examples/next-prisma-starter/src/utils/trpc.ts
@@ -88,7 +88,7 @@ export const trpc = createTRPCNext<AppRouter, SSRContext>({
         }),
       ],
       /**
-       * @link https://tanstack.com/query/v5/docs/react/reference/QueryClient
+       * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient
        */
       // queryClientConfig: { defaultOptions: { queries: { staleTime: 60 } } },
     };

--- a/examples/next-prisma-todomvc/src/utils/trpc.ts
+++ b/examples/next-prisma-todomvc/src/utils/trpc.ts
@@ -54,7 +54,7 @@ export const trpc = createTRPCNext<AppRouter>({
         }),
       ],
       /**
-       * @link https://tanstack.com/query/v5/docs/react/reference/QueryClient
+       * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient
        */
       // queryClientConfig: { defaultOptions: { queries: { staleTime: 60 } } },
     };

--- a/examples/next-prisma-websockets-starter/src/utils/trpc.ts
+++ b/examples/next-prisma-websockets-starter/src/utils/trpc.ts
@@ -72,7 +72,7 @@ export const trpc = createTRPCNext<AppRouter>({
        */
       transformer: superjson,
       /**
-       * @link https://tanstack.com/query/v5/docs/react/reference/QueryClient
+       * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient
        */
       queryClientConfig: { defaultOptions: { queries: { staleTime: 60 } } },
     };

--- a/packages/react-query/src/internals/context.tsx
+++ b/packages/react-query/src/internals/context.tsx
@@ -117,14 +117,14 @@ export interface TRPCContextState<
  */
 export interface TRPCQueryUtils<TRouter extends AnyRouter> {
   /**
-   * @link https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientfetchquery
+   * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientfetchquery
    */
   fetchQuery: (
     queryKey: TRPCQueryKey,
     opts?: TRPCFetchQueryOptions<unknown, TRPCClientError<TRouter>>,
   ) => Promise<unknown>;
   /**
-   * @link https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientfetchinfinitequery
+   * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientfetchinfinitequery
    */
   fetchInfiniteQuery: (
     queryKey: TRPCQueryKey,
@@ -135,7 +135,7 @@ export interface TRPCQueryUtils<TRouter extends AnyRouter> {
     >,
   ) => Promise<InfiniteData<unknown, unknown>>;
   /**
-   * @link https://tanstack.com/query/v5/docs/react/guides/prefetching
+   * @link https://tanstack.com/query/v5/docs/framework/react/guides/prefetching
    */
   prefetchQuery: (
     queryKey: TRPCQueryKey,
@@ -143,7 +143,7 @@ export interface TRPCQueryUtils<TRouter extends AnyRouter> {
   ) => Promise<void>;
 
   /**
-   * @link https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientprefetchinfinitequery
+   * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientprefetchinfinitequery
    */
   prefetchInfiniteQuery: (
     queryKey: TRPCQueryKey,
@@ -155,7 +155,7 @@ export interface TRPCQueryUtils<TRouter extends AnyRouter> {
   ) => Promise<void>;
 
   /**
-   * @link https://tanstack.com/query/v5/docs/react/reference/QueryClient#queryclientensurequerydata
+   * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientensurequerydata
    */
   ensureQueryData: (
     queryKey: TRPCQueryKey,
@@ -163,7 +163,7 @@ export interface TRPCQueryUtils<TRouter extends AnyRouter> {
   ) => Promise<unknown>;
 
   /**
-   * @link https://tanstack.com/query/v5/docs/react/guides/query-invalidation
+   * @link https://tanstack.com/query/v5/docs/framework/react/guides/query-invalidation
    */
   invalidateQueries: (
     queryKey: TRPCQueryKey,
@@ -172,7 +172,7 @@ export interface TRPCQueryUtils<TRouter extends AnyRouter> {
   ) => Promise<void>;
 
   /**
-   * @link https://tanstack.com/query/v5/docs/react/reference/QueryClient#queryclientresetqueries
+   * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientresetqueries
    */
   resetQueries: (
     queryKey: TRPCQueryKey,
@@ -181,7 +181,7 @@ export interface TRPCQueryUtils<TRouter extends AnyRouter> {
   ) => Promise<void>;
 
   /**
-   * @link https://tanstack.com/query/v5/docs/react/reference/QueryClient#queryclientrefetchqueries
+   * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientrefetchqueries
    */
   refetchQueries: (
     queryKey: TRPCQueryKey,
@@ -190,7 +190,7 @@ export interface TRPCQueryUtils<TRouter extends AnyRouter> {
   ) => Promise<void>;
 
   /**
-   * @link https://tanstack.com/query/v5/docs/react/guides/query-cancellation
+   * @link https://tanstack.com/query/v5/docs/framework/react/guides/query-cancellation
    */
   cancelQuery: (
     queryKey: TRPCQueryKey,
@@ -198,7 +198,7 @@ export interface TRPCQueryUtils<TRouter extends AnyRouter> {
   ) => Promise<void>;
 
   /**
-   * @link https://tanstack.com/query/v5/docs/react/reference/QueryClient#queryclientsetquerydata
+   * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientsetquerydata
    */
   setQueryData: (
     queryKey: TRPCQueryKey,
@@ -207,11 +207,11 @@ export interface TRPCQueryUtils<TRouter extends AnyRouter> {
   ) => void;
 
   /**
-   * @link https://tanstack.com/query/v5/docs/react/reference/QueryClient#queryclientgetquerydata
+   * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientgetquerydata
    */
   getQueryData: (queryKey: TRPCQueryKey) => unknown;
   /**
-   * @link https://tanstack.com/query/v5/docs/react/reference/QueryClient#queryclientsetquerydata
+   * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientsetquerydata
    */
   setInfiniteQueryData: (
     queryKey: TRPCQueryKey,
@@ -223,7 +223,7 @@ export interface TRPCQueryUtils<TRouter extends AnyRouter> {
   ) => void;
 
   /**
-   * @link https://tanstack.com/query/v5/docs/react/reference/QueryClient#queryclientgetquerydata
+   * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientgetquerydata
    */
   getInfiniteQueryData: (
     queryKey: TRPCQueryKey,

--- a/packages/react-query/src/server/ssgProxy.ts
+++ b/packages/react-query/src/server/ssgProxy.ts
@@ -53,7 +53,7 @@ type DecorateProcedure<
   TProcedure extends AnyProcedure,
 > = {
   /**
-   * @link https://tanstack.com/query/v5/docs/react/guides/prefetching
+   * @link https://tanstack.com/query/v5/docs/framework/react/guides/prefetching
    */
   fetch(
     input: inferProcedureInput<TProcedure>,
@@ -64,7 +64,7 @@ type DecorateProcedure<
   ): Promise<inferTransformedProcedureOutput<TConfig, TProcedure>>;
 
   /**
-   * @link https://tanstack.com/query/v5/docs/react/guides/prefetching
+   * @link https://tanstack.com/query/v5/docs/framework/react/guides/prefetching
    */
   fetchInfinite(
     input: inferProcedureInput<TProcedure>,
@@ -81,7 +81,7 @@ type DecorateProcedure<
   >;
 
   /**
-   * @link https://tanstack.com/query/v5/docs/react/guides/prefetching
+   * @link https://tanstack.com/query/v5/docs/framework/react/guides/prefetching
    */
   prefetch(
     input: inferProcedureInput<TProcedure>,
@@ -92,7 +92,7 @@ type DecorateProcedure<
   ): Promise<void>;
 
   /**
-   * @link https://tanstack.com/query/v5/docs/react/guides/prefetching
+   * @link https://tanstack.com/query/v5/docs/framework/react/guides/prefetching
    */
   prefetchInfinite(
     input: inferProcedureInput<TProcedure>,

--- a/packages/react-query/src/shared/proxy/utilsProxy.ts
+++ b/packages/react-query/src/shared/proxy/utilsProxy.ts
@@ -43,7 +43,7 @@ type DecorateProcedure<
   TProcedure extends AnyQueryProcedure,
 > = {
   /**
-   * @link https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientfetchquery
+   * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientfetchquery
    */
   fetch(
     input: inferProcedureInput<TProcedure>,
@@ -54,7 +54,7 @@ type DecorateProcedure<
   ): Promise<inferTransformedProcedureOutput<TConfig, TProcedure>>;
 
   /**
-   * @link https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientfetchinfinitequery
+   * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientfetchinfinitequery
    */
   fetchInfinite(
     input: inferProcedureInput<TProcedure>,
@@ -71,7 +71,7 @@ type DecorateProcedure<
   >;
 
   /**
-   * @link https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientprefetchquery
+   * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientprefetchquery
    */
   prefetch(
     input: inferProcedureInput<TProcedure>,
@@ -82,7 +82,7 @@ type DecorateProcedure<
   ): Promise<void>;
 
   /**
-   * @link https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientprefetchinfinitequery
+   * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientprefetchinfinitequery
    */
   prefetchInfinite(
     input: inferProcedureInput<TProcedure>,
@@ -94,7 +94,7 @@ type DecorateProcedure<
   ): Promise<void>;
 
   /**
-   * @link https://tanstack.com/query/v5/docs/react/reference/QueryClient#queryclientensurequerydata
+   * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientensurequerydata
    */
   ensureData(
     input: inferProcedureInput<TProcedure>,
@@ -105,7 +105,7 @@ type DecorateProcedure<
   ): Promise<inferTransformedProcedureOutput<TConfig, TProcedure>>;
 
   /**
-   * @link https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientinvalidatequeries
+   * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientinvalidatequeries
    */
   invalidate(
     input?: DeepPartial<inferProcedureInput<TProcedure>>,
@@ -128,7 +128,7 @@ type DecorateProcedure<
   ): Promise<void>;
 
   /**
-   * @link https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientrefetchqueries
+   * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientrefetchqueries
    */
   refetch(
     input?: inferProcedureInput<TProcedure>,
@@ -137,7 +137,7 @@ type DecorateProcedure<
   ): Promise<void>;
 
   /**
-   * @link https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientcancelqueries
+   * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientcancelqueries
    */
   cancel(
     input?: inferProcedureInput<TProcedure>,
@@ -145,7 +145,7 @@ type DecorateProcedure<
   ): Promise<void>;
 
   /**
-   * @link https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientresetqueries
+   * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientresetqueries
    */
   reset(
     input?: inferProcedureInput<TProcedure>,
@@ -153,7 +153,7 @@ type DecorateProcedure<
   ): Promise<void>;
 
   /**
-   * @link https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientsetquerydata
+   * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientsetquerydata
    */
   setData(
     /**
@@ -168,7 +168,7 @@ type DecorateProcedure<
   ): void;
 
   /**
-   * @link https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientsetquerydata
+   * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientsetquerydata
    */
   setInfiniteData(
     input: inferProcedureInput<TProcedure>,
@@ -188,14 +188,14 @@ type DecorateProcedure<
   ): void;
 
   /**
-   * @link https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientgetquerydata
+   * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientgetquerydata
    */
   getData(
     input?: inferProcedureInput<TProcedure>,
   ): inferTransformedProcedureOutput<TConfig, TProcedure> | undefined;
 
   /**
-   * @link https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientgetquerydata
+   * @link https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientgetquerydata
    */
   getInfiniteData(
     input?: inferProcedureInput<TProcedure>,
@@ -215,7 +215,7 @@ type DecorateRouter = {
   /**
    * Invalidate the full router
    * @link https://trpc.io/docs/v10/useContext#query-invalidation
-   * @link https://tanstack.com/query/v5/docs/react/guides/query-invalidation
+   * @link https://tanstack.com/query/v5/docs/framework/react/guides/query-invalidation
    */
   invalidate(
     input?: undefined,

--- a/www/blog/2023-01-14-typescript-performance-lessons.md
+++ b/www/blog/2023-01-14-typescript-performance-lessons.md
@@ -91,7 +91,7 @@ type DecorateProcedure<
   TProcedure extends AnyQueryProcedure,
 > = {
   /**
-   * @link https://tanstack.com/query/v4/docs/react/guides/query-invalidation
+   * @link https://tanstack.com/query/v4/docs/framework/react/guides/query-invalidation
    */
   invalidate(
     input?: inferProcedureInput<TProcedure>,
@@ -115,7 +115,7 @@ export type DecoratedProcedureUtilsRecord<TRouter extends AnyRouter> =
 
 Okay, now we have some things to unpack and learn about. Let's figure out what this code is doing first.
 
-We have a recursive type `DecoratedProcedureUtilsRecord` that walks through all the procedures in the router and "decorates" (adds methods to) them with React Query utilities like [`invalidateQueries`](https://tanstack.com/query/v4/docs/guides/query-invalidation).
+We have a recursive type `DecoratedProcedureUtilsRecord` that walks through all the procedures in the router and "decorates" (adds methods to) them with React Query utilities like [`invalidateQueries`](https://tanstack.com/query/v4/docs/framework//react/guides/query-invalidation).
 
 In tRPC v10 we still support old `v9` routers, but `v10` clients cannot call procedures from `v9` routers. So for each procedure we check if it's a `v9` procedure (`extends LegacyV9ProcedureTag`) and strip it out if so. It's all a lot of work for TypeScript to do...**if it's not lazily evaluated**.
 

--- a/www/docs/client/nextjs/server-side-helpers.md
+++ b/www/docs/client/nextjs/server-side-helpers.md
@@ -70,7 +70,7 @@ return {
 
 The rule of thumb is `prefetch` for queries that you know you'll need on the client, and `fetch` for queries that you want to use the result of on the server.
 
-The functions are all wrappers around react-query functions. Please check out [their docs](https://tanstack.com/query/v5/docs/react/overview) to learn more about them in detail.
+The functions are all wrappers around react-query functions. Please check out [their docs](https://tanstack.com/query/v5/docs/framework/react/overview) to learn more about them in detail.
 
 :::info
 For a full example, see our [E2E SSG test example](https://github.com/trpc/trpc/tree/next/examples/.test/ssg)

--- a/www/docs/client/nextjs/setup.mdx
+++ b/www/docs/client/nextjs/setup.mdx
@@ -235,8 +235,8 @@ The `config`-argument is a function that returns an object that configures the t
 - **Required**:
 - `links` to customize the flow of data between tRPC Client and the tRPC Server. [Read more](/docs/client/links).
 - Optional:
-- `queryClientConfig`: a configuration object for the React Query `QueryClient` used internally by the tRPC React hooks: [QueryClient docs](https://tanstack.com/query/v5/docs/reference/QueryClient)
-- `queryClient`: a React Query [QueryClient instance](https://tanstack.com/query/v5/docs/reference/QueryClient)
+- `queryClientConfig`: a configuration object for the React Query `QueryClient` used internally by the tRPC React hooks: [QueryClient docs](https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient)
+- `queryClient`: a React Query [QueryClient instance](https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient)
   - **Note:** You can only provide either a `queryClient` or a `queryClientConfig`.
 - `transformer`: a transformer applied to outgoing payloads. Read more about [Data Transformers](/docs/server/data-transformers)
 - `abortOnUnmount`: determines if in-flight requests will be cancelled on component unmount. This defaults to `false`.

--- a/www/docs/client/react/createTRPCQueryUtils.md
+++ b/www/docs/client/react/createTRPCQueryUtils.md
@@ -5,7 +5,7 @@ sidebar_label: createTRPCQueryUtils()
 slug: /client/react/createTRPCQueryUtils
 ---
 
-Similar to `useUtils`, `createTRPCQueryUtils` is a function that gives you access to helpers that let you manage the cached data of the queries you execute via `@trpc/react-query`. These helpers are actually thin wrappers around `@tanstack/react-query`'s [`queryClient`](https://tanstack.com/query/v5/docs/reference/QueryClient) methods. If you want more in-depth information about options and usage patterns for `useUtils` helpers than what we provide here, we will link to their respective `@tanstack/react-query` docs so you can refer to them accordingly.
+Similar to `useUtils`, `createTRPCQueryUtils` is a function that gives you access to helpers that let you manage the cached data of the queries you execute via `@trpc/react-query`. These helpers are actually thin wrappers around `@tanstack/react-query`'s [`queryClient`](https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient) methods. If you want more in-depth information about options and usage patterns for `useUtils` helpers than what we provide here, we will link to their respective `@tanstack/react-query` docs so you can refer to them accordingly.
 
 :::note
 

--- a/www/docs/client/react/setup.mdx
+++ b/www/docs/client/react/setup.mdx
@@ -53,7 +53,7 @@ export const trpc = createTRPCReact<AppRouter>();
 
 ### 4. Add tRPC providers
 
-Create a tRPC client, and wrap your application in the tRPC Provider, as below. You will also need to set up and connect React Query, which [they document in more depth](https://tanstack.com/query/latest/docs/react/quick-start).
+Create a tRPC client, and wrap your application in the tRPC Provider, as below. You will also need to set up and connect React Query, which [they document in more depth](https://tanstack.com/query/latest/docs/framework/react/quick-start).
 
 :::tip
 If you already use React Query in your application, you **should** re-use the `QueryClient` and `QueryClientProvider` you already have.

--- a/www/docs/client/react/useInfiniteQuery.md
+++ b/www/docs/client/react/useInfiniteQuery.md
@@ -8,7 +8,7 @@ slug: /client/react/useInfiniteQuery
 :::info
 
 - Your procedure needs to accept a `cursor` input of any type (`string`, `number`, etc) to expose this hook.
-- For more details on infinite queries read the [react-query docs](https://tanstack.com/query/v5/docs/react/reference/useInfiniteQuery)
+- For more details on infinite queries read the [react-query docs](https://tanstack.com/query/v5/docs/framework/react/reference/useInfiniteQuery)
 - In this example we're using Prisma - see their docs on [cursor-based pagination](https://www.prisma.io/docs/concepts/components/prisma-client/pagination#cursor-based-pagination)
 
 :::

--- a/www/docs/client/react/useMutation.md
+++ b/www/docs/client/react/useMutation.md
@@ -6,10 +6,10 @@ slug: /client/react/useMutation
 ---
 
 :::note
-The hooks provided by `@trpc/react-query` are a thin wrapper around @tanstack/react-query. For in-depth information about options and usage patterns, refer to their docs on [mutations](https://tanstack.com/query/v5/docs/react/guides/mutations).
+The hooks provided by `@trpc/react-query` are a thin wrapper around @tanstack/react-query. For in-depth information about options and usage patterns, refer to their docs on [mutations](https://tanstack.com/query/v5/docs/framework/react/guides/mutations).
 :::
 
-Works like react-query's mutations - [see their docs](https://tanstack.com/query/v5/docs/react/guides/mutations).
+Works like react-query's mutations - [see their docs](https://tanstack.com/query/v5/docs/framework/react/guides/mutations).
 
 ### Example
 

--- a/www/docs/client/react/useQueries.md
+++ b/www/docs/client/react/useQueries.md
@@ -15,7 +15,7 @@ While fetching multiple types in a `useQueries` hook is possible, there is not m
 
 ## Usage
 
-The useQueries hook is the same as that of [@tanstack/query useQueries](https://tanstack.com/query/v5/docs/react/reference/useQueries). The only difference is that you pass in a function that returns an array of queries instead of an array of queries inside an object parameter.
+The useQueries hook is the same as that of [@tanstack/query useQueries](https://tanstack.com/query/v5/docs/framework/react/reference/useQueries). The only difference is that you pass in a function that returns an array of queries instead of an array of queries inside an object parameter.
 
 :::tip
 When you're using the [`httpBatchLink`](/docs/client/links/httpBatchLink) or [`wsLink`](/docs/client/links/wsLink), the below will end up being only 1 HTTP call to your server. Additionally, if the underlying procedure is using something like Prisma's `findUnique()` it will [automatically batch](https://www.prisma.io/docs/guides/performance-and-optimization/query-optimization-performance#solving-n1-in-graphql-with-findunique-and-prismas-dataloader) & do exactly 1 database query as a well.
@@ -33,7 +33,7 @@ const Component = (props: { postIds: string[] }) => {
 
 ### Providing options to individual queries
 
-You can also pass in any normal query options to the second parameter of any of the query calls in the array such as `enabled`, `suspense`, `refetchOnWindowFocus`...etc. For a complete overview of all the available options, see the [tanstack useQuery](https://tanstack.com/query/v5/docs/react/reference/useQuery) documentation.
+You can also pass in any normal query options to the second parameter of any of the query calls in the array such as `enabled`, `suspense`, `refetchOnWindowFocus`...etc. For a complete overview of all the available options, see the [tanstack useQuery](https://tanstack.com/query/v5/docs/framework/react/reference/useQuery) documentation.
 
 ```tsx
 const Component = () => {

--- a/www/docs/client/react/useQuery.md
+++ b/www/docs/client/react/useQuery.md
@@ -6,7 +6,7 @@ slug: /client/react/useQuery
 ---
 
 :::note
-The hooks provided by `@trpc/react-query` are a thin wrapper around @tanstack/react-query. For in-depth information about options and usage patterns, refer to their docs on [queries](https://tanstack.com/query/v5/docs/react/guides/queries).
+The hooks provided by `@trpc/react-query` are a thin wrapper around @tanstack/react-query. For in-depth information about options and usage patterns, refer to their docs on [queries](https://tanstack.com/query/v5/docs/framework/react/guides/queries).
 :::
 
 ```tsx

--- a/www/docs/client/react/useUtils.mdx
+++ b/www/docs/client/react/useUtils.mdx
@@ -5,7 +5,7 @@ sidebar_label: useUtils()
 slug: /client/react/useUtils
 ---
 
-`useUtils` is a hook that gives you access to helpers that let you manage the cached data of the queries you execute via `@trpc/react-query`. These helpers are actually thin wrappers around `@tanstack/react-query`'s [`queryClient`](https://tanstack.com/query/v5/docs/reference/QueryClient) methods. If you want more in-depth information about options and usage patterns for `useContext` helpers than what we provide here, we will link to their respective `@tanstack/react-query` docs so you can refer to them accordingly.
+`useUtils` is a hook that gives you access to helpers that let you manage the cached data of the queries you execute via `@trpc/react-query`. These helpers are actually thin wrappers around `@tanstack/react-query`'s [`queryClient`](https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient) methods. If you want more in-depth information about options and usage patterns for `useContext` helpers than what we provide here, we will link to their respective `@tanstack/react-query` docs so you can refer to them accordingly.
 
 :::note
 
@@ -73,18 +73,18 @@ These are the helpers you'll get access to via `useUtils`. The table below will 
 
 | tRPC helper wrapper | `@tanstack/react-query` helper method                                                                                            |
 | ------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `fetch`             | [`queryClient.fetchQuery`](https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientfetchquery)                       |
-| `prefetch`          | [`queryClient.prefetchQuery`](https://tanstack.com/query/v5/docs/guides/prefetching)                                             |
-| `fetchInfinite`     | [`queryClient.fetchInfiniteQuery`](https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientfetchinfinitequery)       |
-| `prefetchInfinite`  | [`queryClient.prefetchInfiniteQuery`](https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientprefetchinfinitequery) |
-| `ensureData`        | [`queryClient.ensureData`](https://tanstack.com/query/v5/docs/react/reference/QueryClient#queryclientensurequerydata)            |
-| `invalidate`        | [`queryClient.invalidateQueries`](https://tanstack.com/query/v5/docs/guides/query-invalidation)                                  |
-| `refetch`           | [`queryClient.refetchQueries`](https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientrefetchqueries)               |
-| `cancel`            | [`queryClient.cancelQueries`](https://tanstack.com/query/v5/docs/guides/query-cancellation)                                      |
-| `setData`           | [`queryClient.setQueryData`](https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientsetquerydata)                   |
-| `getData`           | [`queryClient.getQueryData`](https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientgetquerydata)                   |
-| `setInfiniteData`   | [`queryClient.setInfiniteQueryData`](https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientsetquerydata)           |
-| `getInfiniteData`   | [`queryClient.getInfiniteData`](https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientgetquerydata)                |
+| `fetch`             | [`queryClient.fetchQuery`](https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientfetchquery)                       |
+| `prefetch`          | [`queryClient.prefetchQuery`](https://tanstack.com/query/v5/docs/framework/react/guides/prefetching)                                             |
+| `fetchInfinite`     | [`queryClient.fetchInfiniteQuery`](https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientfetchinfinitequery)       |
+| `prefetchInfinite`  | [`queryClient.prefetchInfiniteQuery`](https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientprefetchinfinitequery) |
+| `ensureData`        | [`queryClient.ensureData`](https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientensurequerydata)            |
+| `invalidate`        | [`queryClient.invalidateQueries`](https://tanstack.com/query/v5/docs/framework/react/guides/query-invalidation)                                  |
+| `refetch`           | [`queryClient.refetchQueries`](https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientrefetchqueries)               |
+| `cancel`            | [`queryClient.cancelQueries`](https://tanstack.com/query/v5/docs/framework/react/guides/query-cancellation)                                      |
+| `setData`           | [`queryClient.setQueryData`](https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientsetquerydata)                   |
+| `getData`           | [`queryClient.getQueryData`](https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientgetquerydata)                   |
+| `setInfiniteData`   | [`queryClient.setInfiniteQueryData`](https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientsetquerydata)           |
+| `getInfiniteData`   | [`queryClient.getInfiniteData`](https://tanstack.com/query/v5/docs/framework/react/reference/QueryClient#queryclientgetquerydata)                |
 
 ### ❓ The function I want isn't here!
 

--- a/www/docs/migration/migrate-from-v10-to-v11.mdx
+++ b/www/docs/migration/migrate-from-v10-to-v11.mdx
@@ -89,7 +89,7 @@ Procedures in your router now only emit their input & output - where before they
 
 ### React Query peerDep is now v5
 
-Check their migration guide: https://tanstack.com/query/v5/docs/react/guides/migrating-to-v5
+Check their migration guide: https://tanstack.com/query/v5/docs/framework/react/guides/migrating-to-v5
 
 ### Exports names `AbcProxyXyz` has been renamed to `AbcXyz`
 


### PR DESCRIPTION
Closes https://github.com/TanStack/query/issues/6772

## 🎯 Changes

Some tanstack query paths have changed, and currently redirect back to the overview doc. It seems like some of these links were also previously broken. All links should now be functional.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
