### PR TITLE
chore(breaking): mv transformer from `createTRPCClient()` to links

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,7 +53,7 @@ const config = {
           'issue-\\d+-.*\\.test\\.tsx?$',
           '\\.(t|j)sx$',
           '@trpc/*',
-          'unstable-core-*',
+          'unstable-*',
           'script',
         ],
       },

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -4,8 +4,9 @@ on:
   push:
     branches:
       - 'next'
-      - 01-30-typed-links
+      - '01-30-typed-links'
     paths:
+      - '.github/workflows/release-next.yml'
       - 'packages/**'
       - '!packages/**/package.json'
       - '!packages/test/**'

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'next'
+      - 01-30-typed-links
     paths:
       - 'packages/**'
       - '!packages/**/package.json'

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - 'next'
-      - '01-30-typed-links'
+      # - '01-30-typed-links'
     paths:
       - '.github/workflows/release-next.yml'
       - 'packages/**'

--- a/examples/.experimental/next-app-dir/src/trpc/client.ts
+++ b/examples/.experimental/next-app-dir/src/trpc/client.ts
@@ -14,12 +14,12 @@ import { getUrl } from './shared';
 export const api = experimental_createTRPCNextAppDirClient<AppRouter>({
   config() {
     return {
-      transformer: superjson,
       links: [
         loggerLink({
           enabled: (op) => true,
         }),
         experimental_nextHttpLink({
+          transformer: superjson,
           batch: true,
           url: getUrl(),
           headers() {
@@ -33,7 +33,11 @@ export const api = experimental_createTRPCNextAppDirClient<AppRouter>({
   },
 });
 
-export const useAction = experimental_createActionHook({
-  links: [loggerLink(), experimental_serverActionLink()],
-  transformer: superjson,
+export const useAction = experimental_createActionHook<AppRouter>({
+  links: [
+    loggerLink(),
+    experimental_serverActionLink({
+      transformer: superjson,
+    }),
+  ],
 });

--- a/examples/.experimental/next-app-dir/src/trpc/server-http.ts
+++ b/examples/.experimental/next-app-dir/src/trpc/server-http.ts
@@ -9,7 +9,6 @@ import { getUrl } from './shared';
 export const api = experimental_createTRPCNextAppDirServer<AppRouter>({
   config() {
     return {
-      transformer: superjson,
       links: [
         loggerLink({
           enabled: (op) => true,
@@ -17,6 +16,7 @@ export const api = experimental_createTRPCNextAppDirServer<AppRouter>({
         experimental_nextHttpLink({
           batch: true,
           url: getUrl(),
+          transformer: superjson,
           headers() {
             return {
               cookie: cookies().toString(),

--- a/examples/.experimental/next-app-dir/src/trpc/server-invoker.ts
+++ b/examples/.experimental/next-app-dir/src/trpc/server-invoker.ts
@@ -4,7 +4,7 @@ import { experimental_createTRPCNextAppDirServer } from '@trpc/next/app-dir/serv
 import { auth } from '~/auth';
 import { appRouter } from '~/server/routers/_app';
 import { cookies } from 'next/headers';
-import SuperJSON from 'superjson';
+import superjson from 'superjson';
 
 /**
  * This client invokes procedures directly on the server without fetching over HTTP.
@@ -12,7 +12,6 @@ import SuperJSON from 'superjson';
 export const api = experimental_createTRPCNextAppDirServer<typeof appRouter>({
   config() {
     return {
-      transformer: SuperJSON,
       links: [
         loggerLink({
           enabled: (op) => true,
@@ -21,6 +20,7 @@ export const api = experimental_createTRPCNextAppDirServer<typeof appRouter>({
           // requests are cached for 5 seconds
           revalidate: 5,
           router: appRouter,
+          transformer: superjson,
           createContext: async () => {
             return {
               session: await auth(),

--- a/examples/.test/ssg-infinite-serialization/src/utils/trpc.ts
+++ b/examples/.test/ssg-infinite-serialization/src/utils/trpc.ts
@@ -27,7 +27,6 @@ export const trpc = createTRPCNext<AppRouter>({
       /**
        * @link https://trpc.io/docs/v11/data-transformers
        */
-      // transformer: superjson,
     };
   },
   ssr: false,

--- a/examples/.test/ssg/src/pages/_app.tsx
+++ b/examples/.test/ssg/src/pages/_app.tsx
@@ -1,8 +1,8 @@
 import type { AppType } from 'next/app';
 import { trpc } from '../utils/trpc';
 
-const MyApp: AppType = ({ Component, pageProps }) => {
-  return <Component {...pageProps} />;
+const MyApp: AppType = (props) => {
+  return <props.Component {...props.pageProps} />;
 };
 
 export default trpc.withTRPC(MyApp);

--- a/examples/.test/ssg/src/utils/trpc.ts
+++ b/examples/.test/ssg/src/utils/trpc.ts
@@ -22,12 +22,12 @@ export const trpc = createTRPCNext<AppRouter>({
       links: [
         httpBatchLink({
           url: getBaseUrl() + '/api/trpc',
+          /**
+           * @link https://trpc.io/docs/v11/data-transformers
+           */
+          transformer: superjson,
         }),
       ],
-      /**
-       * @link https://trpc.io/docs/v11/data-transformers
-       */
-      transformer: superjson,
     };
   },
   ssr: false,

--- a/examples/.test/ssg/src/utils/trpc.ts
+++ b/examples/.test/ssg/src/utils/trpc.ts
@@ -31,4 +31,5 @@ export const trpc = createTRPCNext<AppRouter>({
     };
   },
   ssr: false,
+  transformer: superjson,
 });

--- a/examples/fastify-server/src/client/index.ts
+++ b/examples/fastify-server/src/client/index.ts
@@ -15,14 +15,16 @@ async function start() {
   const urlEnd = `localhost:${port}${prefix}`;
   const wsClient = createWSClient({ url: `ws://${urlEnd}` });
   const trpc = createTRPCClient<AppRouter>({
-    transformer: superjson,
     links: [
       splitLink({
         condition(op) {
           return op.type === 'subscription';
         },
-        true: wsLink({ client: wsClient }),
-        false: httpBatchLink({ url: `http://${urlEnd}` }),
+        true: wsLink({ client: wsClient, transformer: superjson }),
+        false: httpBatchLink({
+          url: `http://${urlEnd}`,
+          transformer: superjson,
+        }),
       }),
     ],
   });

--- a/examples/next-prisma-starter/src/utils/trpc.ts
+++ b/examples/next-prisma-starter/src/utils/trpc.ts
@@ -52,10 +52,6 @@ export const trpc = createTRPCNext<AppRouter, SSRContext>({
      */
     return {
       /**
-       * @link https://trpc.io/docs/v11/data-transformers
-       */
-      transformer,
-      /**
        * @link https://trpc.io/docs/v11/client/links
        */
       links: [
@@ -85,6 +81,10 @@ export const trpc = createTRPCNext<AppRouter, SSRContext>({
             } = ctx.req.headers;
             return headers;
           },
+          /**
+           * @link https://trpc.io/docs/v11/data-transformers
+           */
+          transformer,
         }),
       ],
       /**
@@ -122,6 +122,10 @@ export const trpc = createTRPCNext<AppRouter, SSRContext>({
 
     return {};
   },
+  /**
+   * @link https://trpc.io/docs/v11/data-transformers
+   */
+  transformer,
 });
 
 export type RouterInput = inferRouterInputs<AppRouter>;

--- a/examples/next-prisma-todomvc/src/utils/trpc.ts
+++ b/examples/next-prisma-todomvc/src/utils/trpc.ts
@@ -36,10 +36,6 @@ export const trpc = createTRPCNext<AppRouter>({
      */
     return {
       /**
-       * @link https://trpc.io/docs/v11/data-transformers
-       */
-      transformer: superjson,
-      /**
        * @link https://trpc.io/docs/v11/client/links
        */
       links: [
@@ -51,6 +47,10 @@ export const trpc = createTRPCNext<AppRouter>({
         }),
         httpBatchLink({
           url: `${getBaseUrl()}/api/trpc`,
+          /**
+           * @link https://trpc.io/docs/v11/data-transformers
+           */
+          transformer: superjson,
         }),
       ],
       /**

--- a/examples/next-prisma-todomvc/src/utils/trpc.ts
+++ b/examples/next-prisma-todomvc/src/utils/trpc.ts
@@ -29,6 +29,7 @@ function getBaseUrl() {
  * @link https://trpc.io/docs/v11/react#3-create-trpc-hooks
  */
 export const trpc = createTRPCNext<AppRouter>({
+  transformer: superjson,
   config() {
     /**
      * If you want to use SSR, you need to use the server's full URL

--- a/examples/next-prisma-websockets-starter/src/utils/trpc.ts
+++ b/examples/next-prisma-websockets-starter/src/utils/trpc.ts
@@ -1,3 +1,4 @@
+import type { TRPCLink } from '@trpc/client';
 import {
   createWSClient,
   httpBatchLink,
@@ -18,9 +19,13 @@ const { publicRuntimeConfig } = getConfig();
 
 const { APP_URL, WS_URL } = publicRuntimeConfig;
 
-function getEndingLink(ctx: NextPageContext | undefined) {
+function getEndingLink(ctx: NextPageContext | undefined): TRPCLink<AppRouter> {
   if (typeof window === 'undefined') {
     return httpBatchLink({
+      /**
+       * @link https://trpc.io/docs/v11/data-transformers
+       */
+      transformer: superjson,
       url: `${APP_URL}/api/trpc`,
       headers() {
         if (!ctx?.req?.headers) {
@@ -37,8 +42,12 @@ function getEndingLink(ctx: NextPageContext | undefined) {
   const client = createWSClient({
     url: WS_URL,
   });
-  return wsLink<AppRouter>({
+  return wsLink({
     client,
+    /**
+     * @link https://trpc.io/docs/v11/data-transformers
+     */
+    transformer: superjson,
   });
 }
 
@@ -68,10 +77,6 @@ export const trpc = createTRPCNext<AppRouter>({
         getEndingLink(ctx),
       ],
       /**
-       * @link https://trpc.io/docs/v11/data-transformers
-       */
-      transformer: superjson,
-      /**
        * @link https://tanstack.com/query/v5/docs/reference/QueryClient
        */
       queryClientConfig: { defaultOptions: { queries: { staleTime: 60 } } },
@@ -81,6 +86,10 @@ export const trpc = createTRPCNext<AppRouter>({
    * @link https://trpc.io/docs/v11/ssr
    */
   ssr: true,
+  /**
+   * @link https://trpc.io/docs/v11/data-transformers
+   */
+  transformer: superjson,
 });
 
 // export const transformer = superjson;

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -34,6 +34,11 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./unstable-internals": {
+      "import": "./dist/unstable-internals.mjs",
+      "require": "./dist/unstable-internals.js",
+      "default": "./dist/unstable-internals.js"
     }
   },
   "files": [
@@ -41,6 +46,7 @@
     "src",
     "README.md",
     "package.json",
+    "unstable-internals",
     "!**/*.test.*"
   ],
   "dependencies": {},

--- a/packages/client/rollup.config.ts
+++ b/packages/client/rollup.config.ts
@@ -5,6 +5,7 @@ import { buildConfig } from '../../scripts/getRollupConfig';
 export const input = [
   //
   'src/index.ts',
+  'src/unstable-internals.ts',
 ];
 
 export default function rollup(): RollupOptions[] {

--- a/packages/client/src/internals/TRPCUntypedClient.ts
+++ b/packages/client/src/internals/TRPCUntypedClient.ts
@@ -7,7 +7,6 @@ import type {
   AnyRouter,
   CombinedDataTransformer,
   DataTransformerOptions,
-  inferRootTypes,
   TypeError,
 } from '@trpc/server/unstable-core-do-not-import';
 import { createChain } from '../links/internals/createChain';
@@ -18,27 +17,6 @@ import type {
   TRPCLink,
 } from '../links/types';
 import { TRPCClientError } from '../TRPCClientError';
-
-type CreateTRPCClientBaseOptions<TRouter extends AnyRouter> =
-  inferRootTypes<TRouter>['transformer'] extends false
-    ? {
-        /**
-         * Data transformer
-         *
-         * You must use the same transformer on the backend and frontend
-         * @link https://trpc.io/docs/v11/data-transformers
-         **/
-        transformer?: TypeError<'You must define a transformer on your your `initTRPC`-object first'>;
-      }
-    : {
-        /**
-         * Data transformer
-         *
-         * You must use the same transformer on the backend and frontend
-         * @link https://trpc.io/docs/v11/data-transformers
-         **/
-        transformer: DataTransformerOptions;
-      };
 
 type TRPCType = 'mutation' | 'query' | 'subscription';
 export interface TRPCRequestOptions {
@@ -58,10 +36,10 @@ export interface TRPCSubscriptionObserver<TValue, TError> {
 }
 
 /** @internal */
-export type CreateTRPCClientOptions<TRouter extends AnyRouter> =
-  | CreateTRPCClientBaseOptions<TRouter> & {
-      links: TRPCLink<TRouter>[];
-    };
+export type CreateTRPCClientOptions<TRouter extends AnyRouter> = {
+  links: TRPCLink<TRouter>[];
+  transformer?: TypeError<'The transformer property has moved to httpLink/httpBatchLink/wsLink'>;
+};
 
 /** @internal */
 export type UntypedClientProperties =

--- a/packages/client/src/links/HTTPBatchLinkOptions.ts
+++ b/packages/client/src/links/HTTPBatchLinkOptions.ts
@@ -1,16 +1,18 @@
+import type { AnyRootTypes } from '@trpc/server/unstable-core-do-not-import';
 import type { NonEmptyArray } from '../internals/types';
 import type { HTTPLinkBaseOptions } from './internals/httpUtils';
 import type { HTTPHeaders, Operation } from './types';
 
-export interface HTTPBatchLinkOptions extends HTTPLinkBaseOptions {
-  maxURLLength?: number;
-  /**
-   * Headers to be set on outgoing requests or a callback that of said headers
-   * @link http://trpc.io/docs/client/headers
-   */
-  headers?:
-    | HTTPHeaders
-    | ((opts: {
-        opList: NonEmptyArray<Operation>;
-      }) => HTTPHeaders | Promise<HTTPHeaders>);
-}
+export type HTTPBatchLinkOptions<TRoot extends AnyRootTypes> =
+  HTTPLinkBaseOptions<TRoot> & {
+    maxURLLength?: number;
+    /**
+     * Headers to be set on outgoing requests or a callback that of said headers
+     * @link http://trpc.io/docs/client/headers
+     */
+    headers?:
+      | HTTPHeaders
+      | ((opts: {
+          opList: NonEmptyArray<Operation>;
+        }) => HTTPHeaders | Promise<HTTPHeaders>);
+  };

--- a/packages/client/src/links/httpBatchLink.ts
+++ b/packages/client/src/links/httpBatchLink.ts
@@ -1,3 +1,4 @@
+import type { AnyRootTypes } from '@trpc/server/unstable-core-do-not-import';
 import type { NonEmptyArray } from '../internals/types';
 import type { HTTPBatchLinkOptions } from './HTTPBatchLinkOptions';
 import type { RequesterFn } from './internals/createHTTPBatchLink';
@@ -5,7 +6,10 @@ import { createHTTPBatchLink } from './internals/createHTTPBatchLink';
 import { jsonHttpRequester } from './internals/httpUtils';
 import type { Operation } from './types';
 
-const batchRequester: RequesterFn<HTTPBatchLinkOptions> = (requesterOpts) => {
+const batchRequester: RequesterFn<
+  AnyRootTypes,
+  HTTPBatchLinkOptions<AnyRootTypes>
+> = (requesterOpts) => {
   return (batchOps) => {
     const path = batchOps.map((op) => op.path).join(',');
     const inputs = batchOps.map((op) => op.input);

--- a/packages/client/src/links/httpBatchLink.ts
+++ b/packages/client/src/links/httpBatchLink.ts
@@ -6,10 +6,9 @@ import { createHTTPBatchLink } from './internals/createHTTPBatchLink';
 import { jsonHttpRequester } from './internals/httpUtils';
 import type { Operation } from './types';
 
-const batchRequester: RequesterFn<
-  AnyRootTypes,
-  HTTPBatchLinkOptions<AnyRootTypes>
-> = (requesterOpts) => {
+const batchRequester: RequesterFn<HTTPBatchLinkOptions<AnyRootTypes>> = (
+  requesterOpts,
+) => {
   return (batchOps) => {
     const path = batchOps.map((op) => op.path).join(',');
     const inputs = batchOps.map((op) => op.input);

--- a/packages/client/src/links/httpBatchStreamLink.ts
+++ b/packages/client/src/links/httpBatchStreamLink.ts
@@ -18,10 +18,9 @@ export type HTTPBatchStreamLinkOptions<TRoot extends AnyRootTypes> =
     textDecoder?: TextDecoderEsque;
   };
 
-const streamRequester: RequesterFn<
-  AnyRootTypes,
-  HTTPBatchStreamLinkOptions<AnyRootTypes>
-> = (requesterOpts) => {
+const streamRequester: RequesterFn<HTTPBatchStreamLinkOptions<AnyRootTypes>> = (
+  requesterOpts,
+) => {
   const textDecoder = getTextDecoder(requesterOpts.opts.textDecoder);
   return (batchOps, unitResolver) => {
     const path = batchOps.map((op) => op.path).join(',');

--- a/packages/client/src/links/httpBatchStreamLink.ts
+++ b/packages/client/src/links/httpBatchStreamLink.ts
@@ -1,3 +1,4 @@
+import type { AnyRootTypes } from '@trpc/server/unstable-core-do-not-import';
 import type { NonEmptyArray } from '../internals/types';
 import type { HTTPBatchLinkOptions } from './HTTPBatchLinkOptions';
 import type { RequesterFn } from './internals/createHTTPBatchLink';
@@ -7,18 +8,20 @@ import { streamingJsonHttpRequester } from './internals/parseJSONStream';
 import type { TextDecoderEsque } from './internals/streamingUtils';
 import type { Operation } from './types';
 
-export interface HTTPBatchStreamLinkOptions extends HTTPBatchLinkOptions {
-  /**
-   * Will default to the webAPI `TextDecoder`,
-   * but you can use this option if your client
-   * runtime doesn't provide it.
-   */
-  textDecoder?: TextDecoderEsque;
-}
+export type HTTPBatchStreamLinkOptions<TRoot extends AnyRootTypes> =
+  HTTPBatchLinkOptions<TRoot> & {
+    /**
+     * Will default to the webAPI `TextDecoder`,
+     * but you can use this option if your client
+     * runtime doesn't provide it.
+     */
+    textDecoder?: TextDecoderEsque;
+  };
 
-const streamRequester: RequesterFn<HTTPBatchStreamLinkOptions> = (
-  requesterOpts,
-) => {
+const streamRequester: RequesterFn<
+  AnyRootTypes,
+  HTTPBatchStreamLinkOptions<AnyRootTypes>
+> = (requesterOpts) => {
   const textDecoder = getTextDecoder(requesterOpts.opts.textDecoder);
   return (batchOps, unitResolver) => {
     const path = batchOps.map((op) => op.path).join(',');

--- a/packages/client/src/links/httpLink.ts
+++ b/packages/client/src/links/httpLink.ts
@@ -27,11 +27,9 @@ export type HTTPLinkOptions<TRoot extends AnyRootTypes> =
       | ((opts: { op: Operation }) => HTTPHeaders | Promise<HTTPHeaders>);
   };
 
-export function httpLinkFactory<TRoot extends AnyRootTypes>(factoryOpts: {
-  requester: Requester;
-}) {
+export function httpLinkFactory(factoryOpts: { requester: Requester }) {
   return <TRouter extends AnyRouter>(
-    opts: HTTPLinkOptions<TRoot>,
+    opts: HTTPLinkOptions<TRouter['_def']['_config']['$types']>,
   ): TRPCLink<TRouter> => {
     const resolvedOpts = resolveHTTPLinkOptions(opts);
 

--- a/packages/client/src/links/httpLink.ts
+++ b/packages/client/src/links/httpLink.ts
@@ -1,5 +1,8 @@
 import { observable } from '@trpc/server/observable';
-import type { AnyRouter } from '@trpc/server/unstable-core-do-not-import';
+import type {
+  AnyRootTypes,
+  AnyRouter,
+} from '@trpc/server/unstable-core-do-not-import';
 import { transformResult } from '@trpc/server/unstable-core-do-not-import';
 import { TRPCClientError } from '../TRPCClientError';
 import type {
@@ -13,19 +16,22 @@ import {
 } from './internals/httpUtils';
 import type { HTTPHeaders, Operation, TRPCLink } from './types';
 
-export interface HTTPLinkOptions extends HTTPLinkBaseOptions {
-  /**
-   * Headers to be set on outgoing requests or a callback that of said headers
-   * @link http://trpc.io/docs/client/headers
-   */
-  headers?:
-    | HTTPHeaders
-    | ((opts: { op: Operation }) => HTTPHeaders | Promise<HTTPHeaders>);
-}
+export type HTTPLinkOptions<TRoot extends AnyRootTypes> =
+  HTTPLinkBaseOptions<TRoot> & {
+    /**
+     * Headers to be set on outgoing requests or a callback that of said headers
+     * @link http://trpc.io/docs/client/headers
+     */
+    headers?:
+      | HTTPHeaders
+      | ((opts: { op: Operation }) => HTTPHeaders | Promise<HTTPHeaders>);
+  };
 
-export function httpLinkFactory(factoryOpts: { requester: Requester }) {
+export function httpLinkFactory<TRoot extends AnyRootTypes>(factoryOpts: {
+  requester: Requester;
+}) {
   return <TRouter extends AnyRouter>(
-    opts: HTTPLinkOptions,
+    opts: HTTPLinkOptions<TRoot>,
   ): TRPCLink<TRouter> => {
     const resolvedOpts = resolveHTTPLinkOptions(opts);
 

--- a/packages/client/src/links/internals/createHTTPBatchLink.ts
+++ b/packages/client/src/links/internals/createHTTPBatchLink.ts
@@ -42,7 +42,7 @@ export type RequesterFn<
  */
 export function createHTTPBatchLink<
   TRoot extends AnyRootTypes,
-  TOptions extends HTTPBatchLinkOptions<AnyRootTypes>,
+  TOptions extends HTTPBatchLinkOptions<TRoot>,
 >(requester: RequesterFn<TRoot, TOptions>) {
   return function httpBatchLink<TRouter extends AnyRouter>(
     opts: TOptions,

--- a/packages/client/src/links/internals/createHTTPBatchLink.ts
+++ b/packages/client/src/links/internals/createHTTPBatchLink.ts
@@ -1,5 +1,6 @@
 import { observable } from '@trpc/server/observable';
 import type {
+  AnyRootTypes,
   AnyRouter,
   ProcedureType,
 } from '@trpc/server/unstable-core-do-not-import';
@@ -19,7 +20,10 @@ import { getUrl, resolveHTTPLinkOptions } from './httpUtils';
 /**
  * @internal
  */
-export type RequesterFn<TOptions extends HTTPBatchLinkOptions> = (
+export type RequesterFn<
+  TRoot extends AnyRootTypes,
+  TOptions extends HTTPBatchLinkOptions<TRoot>,
+> = (
   requesterOpts: ResolvedHTTPLinkOptions & {
     runtime: TRPCClientRuntime;
     type: ProcedureType;
@@ -36,9 +40,10 @@ export type RequesterFn<TOptions extends HTTPBatchLinkOptions> = (
 /**
  * @internal
  */
-export function createHTTPBatchLink<TOptions extends HTTPBatchLinkOptions>(
-  requester: RequesterFn<TOptions>,
-) {
+export function createHTTPBatchLink<
+  TRoot extends AnyRootTypes,
+  TOptions extends HTTPBatchLinkOptions<AnyRootTypes>,
+>(requester: RequesterFn<TRoot, TOptions>) {
   return function httpBatchLink<TRouter extends AnyRouter>(
     opts: TOptions,
   ): TRPCLink<TRouter> {

--- a/packages/client/src/links/internals/createHTTPBatchLink.ts
+++ b/packages/client/src/links/internals/createHTTPBatchLink.ts
@@ -1,3 +1,4 @@
+import { getTransformer } from '@trpc/client/unstable-internals';
 import { observable } from '@trpc/server/observable';
 import type {
   AnyRootTypes,
@@ -49,6 +50,7 @@ export function createHTTPBatchLink<
   ): TRPCLink<TRouter> {
     const resolvedOpts = resolveHTTPLinkOptions(opts);
     const maxURLLength = opts.maxURLLength ?? Infinity;
+    const transformer = getTransformer(opts.transformer);
 
     // initialized config
     return (runtime) => {
@@ -63,7 +65,7 @@ export function createHTTPBatchLink<
 
           const url = getUrl({
             ...resolvedOpts,
-            runtime,
+            transformer,
             type,
             path,
             inputs,
@@ -100,10 +102,7 @@ export function createHTTPBatchLink<
           promise
             .then((res) => {
               _res = res;
-              const transformed = transformResult(
-                res.json,
-                runtime.transformer,
-              );
+              const transformed = transformResult(res.json, transformer.output);
 
               if (!transformed.ok) {
                 observer.error(

--- a/packages/client/src/links/internals/createHTTPBatchLink.ts
+++ b/packages/client/src/links/internals/createHTTPBatchLink.ts
@@ -1,4 +1,3 @@
-import { getTransformer } from '@trpc/client/unstable-internals';
 import { observable } from '@trpc/server/observable';
 import type {
   AnyRootTypes,
@@ -9,6 +8,7 @@ import type {
 import { transformResult } from '@trpc/server/unstable-core-do-not-import';
 import { dataLoader } from '../../internals/dataLoader';
 import { TRPCClientError } from '../../TRPCClientError';
+import { getTransformer } from '../../unstable-internals';
 import type { HTTPBatchLinkOptions } from '../HTTPBatchLinkOptions';
 import type {
   CancelFn,

--- a/packages/client/src/links/internals/createHTTPBatchLink.ts
+++ b/packages/client/src/links/internals/createHTTPBatchLink.ts
@@ -8,7 +8,6 @@ import type {
 import { transformResult } from '@trpc/server/unstable-core-do-not-import';
 import { dataLoader } from '../../internals/dataLoader';
 import { TRPCClientError } from '../../TRPCClientError';
-import { getTransformer } from '../../unstable-internals';
 import type { HTTPBatchLinkOptions } from '../HTTPBatchLinkOptions';
 import type {
   CancelFn,
@@ -47,7 +46,6 @@ export function createHTTPBatchLink(
   ): TRPCLink<TRouter> {
     const resolvedOpts = resolveHTTPLinkOptions(opts);
     const maxURLLength = opts.maxURLLength ?? Infinity;
-    const transformer = getTransformer(opts.transformer);
 
     // initialized config
     return (runtime) => {
@@ -62,7 +60,6 @@ export function createHTTPBatchLink(
 
           const url = getUrl({
             ...resolvedOpts,
-            transformer,
             type,
             path,
             inputs,
@@ -99,7 +96,10 @@ export function createHTTPBatchLink(
           promise
             .then((res) => {
               _res = res;
-              const transformed = transformResult(res.json, transformer.output);
+              const transformed = transformResult(
+                res.json,
+                resolvedOpts.transformer.output,
+              );
 
               if (!transformed.ok) {
                 observer.error(

--- a/packages/client/src/links/internals/createHTTPBatchLink.ts
+++ b/packages/client/src/links/internals/createHTTPBatchLink.ts
@@ -3,6 +3,7 @@ import { observable } from '@trpc/server/observable';
 import type {
   AnyRootTypes,
   AnyRouter,
+  inferRootTypes,
   ProcedureType,
 } from '@trpc/server/unstable-core-do-not-import';
 import { transformResult } from '@trpc/server/unstable-core-do-not-import';
@@ -21,10 +22,7 @@ import { getUrl, resolveHTTPLinkOptions } from './httpUtils';
 /**
  * @internal
  */
-export type RequesterFn<
-  TRoot extends AnyRootTypes,
-  TOptions extends HTTPBatchLinkOptions<TRoot>,
-> = (
+export type RequesterFn<TOptions extends HTTPBatchLinkOptions<AnyRootTypes>> = (
   requesterOpts: ResolvedHTTPLinkOptions & {
     runtime: TRPCClientRuntime;
     type: ProcedureType;
@@ -41,12 +39,11 @@ export type RequesterFn<
 /**
  * @internal
  */
-export function createHTTPBatchLink<
-  TRoot extends AnyRootTypes,
-  TOptions extends HTTPBatchLinkOptions<TRoot>,
->(requester: RequesterFn<TRoot, TOptions>) {
+export function createHTTPBatchLink(
+  requester: RequesterFn<HTTPBatchLinkOptions<AnyRootTypes>>,
+) {
   return function httpBatchLink<TRouter extends AnyRouter>(
-    opts: TOptions,
+    opts: HTTPBatchLinkOptions<inferRootTypes<TRouter>>,
   ): TRPCLink<TRouter> {
     const resolvedOpts = resolveHTTPLinkOptions(opts);
     const maxURLLength = opts.maxURLLength ?? Infinity;

--- a/packages/client/src/links/internals/httpUtils.ts
+++ b/packages/client/src/links/internals/httpUtils.ts
@@ -1,4 +1,3 @@
-import type { TransformerOptions } from '@trpc/client/unstable-internals';
 import type {
   AnyRootTypes,
   CombinedDataTransformer,
@@ -15,6 +14,7 @@ import type {
   ResponseEsque,
 } from '../../internals/types';
 import { TRPCClientError } from '../../TRPCClientError';
+import type { TransformerOptions } from '../../unstable-internals';
 import { getTransformer } from '../../unstable-internals';
 import type { TextDecoderEsque } from '../internals/streamingUtils';
 import type { HTTPHeaders, PromiseAndCancel } from '../types';

--- a/packages/client/src/links/internals/httpUtils.ts
+++ b/packages/client/src/links/internals/httpUtils.ts
@@ -1,4 +1,5 @@
 import type {
+  AnyRootTypes,
   ProcedureType,
   TRPCResponse,
 } from '@trpc/server/unstable-core-do-not-import';
@@ -22,7 +23,7 @@ import type {
 /**
  * @internal
  */
-export interface HTTPLinkBaseOptions {
+export type HTTPLinkBaseOptions<_TRoot extends AnyRootTypes> = {
   url: string | URL;
   /**
    * Add ponyfill for fetch
@@ -32,7 +33,8 @@ export interface HTTPLinkBaseOptions {
    * Add ponyfill for AbortController
    */
   AbortController?: AbortControllerEsque | null;
-}
+  // TODO: add transformers here
+};
 
 export interface ResolvedHTTPLinkOptions {
   url: string;
@@ -41,7 +43,7 @@ export interface ResolvedHTTPLinkOptions {
 }
 
 export function resolveHTTPLinkOptions(
-  opts: HTTPLinkBaseOptions,
+  opts: HTTPLinkBaseOptions<AnyRootTypes>,
 ): ResolvedHTTPLinkOptions {
   return {
     url: opts.url.toString().replace(/\/$/, ''), // Remove any trailing slashes

--- a/packages/client/src/links/internals/httpUtils.ts
+++ b/packages/client/src/links/internals/httpUtils.ts
@@ -34,7 +34,6 @@ export type HTTPLinkBaseOptions<
    * Add ponyfill for AbortController
    */
   AbortController?: AbortControllerEsque | null;
-  // TODO: add tranformers here
 } & TransformerOptions<TRoot>;
 
 export interface ResolvedHTTPLinkOptions {

--- a/packages/client/src/links/internals/httpUtils.ts
+++ b/packages/client/src/links/internals/httpUtils.ts
@@ -1,5 +1,4 @@
 import type { TransformerOptions } from '@trpc/client/unstable-internals';
-import { getTransformer } from '@trpc/client/unstable-internals';
 import type {
   AnyRootTypes,
   CombinedDataTransformer,
@@ -16,6 +15,7 @@ import type {
   ResponseEsque,
 } from '../../internals/types';
 import { TRPCClientError } from '../../TRPCClientError';
+import { getTransformer } from '../../unstable-internals';
 import type { TextDecoderEsque } from '../internals/streamingUtils';
 import type { HTTPHeaders, PromiseAndCancel } from '../types';
 

--- a/packages/client/src/links/internals/httpUtils.ts
+++ b/packages/client/src/links/internals/httpUtils.ts
@@ -17,11 +17,7 @@ import type {
 } from '../../internals/types';
 import { TRPCClientError } from '../../TRPCClientError';
 import type { TextDecoderEsque } from '../internals/streamingUtils';
-import type {
-  HTTPHeaders,
-  PromiseAndCancel,
-  TRPCClientRuntime,
-} from '../types';
+import type { HTTPHeaders, PromiseAndCancel } from '../types';
 
 /**
  * @internal
@@ -83,14 +79,14 @@ export interface HTTPResult {
 }
 
 type GetInputOptions = {
-  runtime: TRPCClientRuntime;
+  transformer: CombinedDataTransformer;
 } & ({ input: unknown } | { inputs: unknown[] });
 
 function getInput(opts: GetInputOptions) {
   return 'input' in opts
-    ? opts.runtime.transformer.serialize(opts.input)
+    ? opts.transformer.input.serialize(opts.input)
     : arrayToDict(
-        opts.inputs.map((_input) => opts.runtime.transformer.serialize(_input)),
+        opts.inputs.map((_input) => opts.transformer.input.serialize(_input)),
       );
 }
 

--- a/packages/client/src/links/types.ts
+++ b/packages/client/src/links/types.ts
@@ -1,8 +1,6 @@
 import type { Observable, Observer } from '@trpc/server/observable';
 import type {
-  AnyRouter,
-  CombinedDataTransformer,
-  DataTransformer,
+  TRPCInferrable,
   TRPCResultMessage,
   TRPCSuccessResponse,
 } from '@trpc/server/unstable-core-do-not-import';
@@ -59,9 +57,7 @@ export type TRPCFetch = (
 ) => Promise<ResponseEsque>;
 
 export interface TRPCClientRuntime {
-  transformer: DataTransformer;
-  // FIXME: we should be able to remove this - added as `withTRPC()` needs it, but we can have it as an extra option on SSR instead
-  combinedTransformer: CombinedDataTransformer;
+  // nothing here anymore
 }
 
 /**
@@ -78,7 +74,7 @@ export interface OperationResultEnvelope<TOutput> {
  * @internal
  */
 export type OperationResultObservable<
-  TRouter extends AnyRouter,
+  TRouter extends TRPCInferrable,
   TOutput,
 > = Observable<OperationResultEnvelope<TOutput>, TRPCClientError<TRouter>>;
 
@@ -86,7 +82,7 @@ export type OperationResultObservable<
  * @internal
  */
 export type OperationResultObserver<
-  TRouter extends AnyRouter,
+  TRouter extends TRPCInferrable,
   TOutput,
 > = Observer<OperationResultEnvelope<TOutput>, TRPCClientError<TRouter>>;
 
@@ -94,7 +90,7 @@ export type OperationResultObserver<
  * @internal
  */
 export type OperationLink<
-  TRouter extends AnyRouter,
+  TRouter extends TRPCInferrable,
   TInput = unknown,
   TOutput = unknown,
 > = (opts: {
@@ -105,6 +101,6 @@ export type OperationLink<
 /**
  * @public
  */
-export type TRPCLink<TRouter extends AnyRouter> = (
+export type TRPCLink<TRouter extends TRPCInferrable> = (
   opts: TRPCClientRuntime,
 ) => OperationLink<TRouter>;

--- a/packages/client/src/links/types.ts
+++ b/packages/client/src/links/types.ts
@@ -74,33 +74,35 @@ export interface OperationResultEnvelope<TOutput> {
  * @internal
  */
 export type OperationResultObservable<
-  TRouter extends TRPCInferrable,
+  TInferrable extends TRPCInferrable,
   TOutput,
-> = Observable<OperationResultEnvelope<TOutput>, TRPCClientError<TRouter>>;
+> = Observable<OperationResultEnvelope<TOutput>, TRPCClientError<TInferrable>>;
 
 /**
  * @internal
  */
 export type OperationResultObserver<
-  TRouter extends TRPCInferrable,
+  TInferrable extends TRPCInferrable,
   TOutput,
-> = Observer<OperationResultEnvelope<TOutput>, TRPCClientError<TRouter>>;
+> = Observer<OperationResultEnvelope<TOutput>, TRPCClientError<TInferrable>>;
 
 /**
  * @internal
  */
 export type OperationLink<
-  TRouter extends TRPCInferrable,
+  TInferrable extends TRPCInferrable,
   TInput = unknown,
   TOutput = unknown,
 > = (opts: {
   op: Operation<TInput>;
-  next: (op: Operation<TInput>) => OperationResultObservable<TRouter, TOutput>;
-}) => OperationResultObservable<TRouter, TOutput>;
+  next: (
+    op: Operation<TInput>,
+  ) => OperationResultObservable<TInferrable, TOutput>;
+}) => OperationResultObservable<TInferrable, TOutput>;
 
 /**
  * @public
  */
-export type TRPCLink<TRouter extends TRPCInferrable> = (
+export type TRPCLink<TInferrable extends TRPCInferrable> = (
   opts: TRPCClientRuntime,
-) => OperationLink<TRouter>;
+) => OperationLink<TInferrable>;

--- a/packages/client/src/links/wsLink.ts
+++ b/packages/client/src/links/wsLink.ts
@@ -2,6 +2,7 @@ import type { Observer, UnsubscribeFn } from '@trpc/server/observable';
 import { observable } from '@trpc/server/observable';
 import type {
   AnyRouter,
+  inferRootTypes,
   inferRouterError,
   MaybePromise,
   ProcedureType,
@@ -433,7 +434,7 @@ export type TRPCWebSocketClient = ReturnType<typeof createWSClient>;
 
 export type WebSocketLinkOptions<TRouter extends AnyRouter> = {
   client: TRPCWebSocketClient;
-} & TransformerOptions<TRouter['_def']['_config']>;
+} & TransformerOptions<inferRootTypes<TRouter>>;
 class TRPCWebSocketClosedError extends Error {
   constructor(message: string) {
     super(message);

--- a/packages/client/src/unstable-internals.ts
+++ b/packages/client/src/unstable-internals.ts
@@ -1,0 +1,80 @@
+import type {
+  AnyRootTypes,
+  CombinedDataTransformer,
+  DataTransformerOptions,
+  inferRootTypes,
+  TRPCInferrable,
+  TypeError,
+} from '@trpc/server/unstable-core-do-not-import';
+
+export type inferTransformerParameters<TInferrable extends TRPCInferrable> =
+  TRPCInferrable extends TInferrable
+    ? [
+        opts: TypeError<'You must define a generic parameter to this function or the parent function'>,
+      ]
+    : inferRootTypes<TInferrable> extends { transformer: false }
+    ? [
+        opts?: TransformerOptions<{
+          transformer: false;
+        }>,
+      ]
+    : [
+        opts: TransformerOptions<{
+          transformer: true;
+        }>,
+      ];
+
+export type TransformerOptionYes = {
+  /**
+   * Data transformer
+   *
+   * You must use the same transformer on the backend and frontend
+   * @link https://trpc.io/docs/v11/data-transformers
+   **/
+  transformer: DataTransformerOptions;
+};
+export type TransformerOptionNo = {
+  /**
+   * Data transformer
+   *
+   * You must use the same transformer on the backend and frontend
+   * @link https://trpc.io/docs/v11/data-transformers
+   **/
+  transformer?: TypeError<'You must define a transformer on your your `initTRPC`-object first'>;
+};
+export type TransformerOptions<
+  TRoot extends Pick<AnyRootTypes, 'transformer'>,
+> = TRoot['transformer'] extends false
+  ? TransformerOptionNo
+  : TransformerOptionYes;
+/**
+ * @internal
+ */
+
+export function getTransformer(
+  transformer:
+    | TransformerOptions<{ transformer: false }>['transformer']
+    | TransformerOptions<{ transformer: true }>['transformer']
+    | undefined,
+): CombinedDataTransformer {
+  const _transformer = transformer as CombinedDataTransformer | undefined;
+  if (!_transformer) {
+    return {
+      input: {
+        serialize: (data) => data,
+        deserialize: (data) => data,
+      },
+      output: {
+        serialize: (data) => data,
+        deserialize: (data) => data,
+      },
+    };
+  }
+  if ('input' in _transformer) {
+    return _transformer;
+  }
+  return {
+    input: _transformer,
+    output: _transformer,
+  };
+}

--- a/packages/client/src/unstable-internals.ts
+++ b/packages/client/src/unstable-internals.ts
@@ -23,7 +23,9 @@ export type inferTransformerParameters<TInferrable extends TRPCInferrable> =
           transformer: true;
         }>,
       ];
-
+export type CoercedTransformerParameters = {
+  transformer?: DataTransformerOptions;
+};
 export type TransformerOptionYes = {
   /**
    * Data transformer

--- a/packages/client/src/unstable-internals.ts
+++ b/packages/client/src/unstable-internals.ts
@@ -26,7 +26,8 @@ export type inferTransformerParameters<TInferrable extends TRPCInferrable> =
 export type CoercedTransformerParameters = {
   transformer?: DataTransformerOptions;
 };
-export type TransformerOptionYes = {
+
+type TransformerOptionYes = {
   /**
    * Data transformer
    *
@@ -35,7 +36,7 @@ export type TransformerOptionYes = {
    **/
   transformer: DataTransformerOptions;
 };
-export type TransformerOptionNo = {
+type TransformerOptionNo = {
   /**
    * Data transformer
    *
@@ -44,11 +45,12 @@ export type TransformerOptionNo = {
    **/
   transformer?: TypeError<'You must define a transformer on your your `initTRPC`-object first'>;
 };
+
 export type TransformerOptions<
   TRoot extends Pick<AnyRootTypes, 'transformer'>,
-> = TRoot['transformer'] extends false
-  ? TransformerOptionNo
-  : TransformerOptionYes;
+> = TRoot['transformer'] extends true
+  ? TransformerOptionYes
+  : TransformerOptionNo;
 /**
  * @internal
  */

--- a/packages/client/src/unstable-internals.ts
+++ b/packages/client/src/unstable-internals.ts
@@ -2,27 +2,9 @@ import type {
   AnyRootTypes,
   CombinedDataTransformer,
   DataTransformerOptions,
-  inferRootTypes,
-  TRPCInferrable,
   TypeError,
 } from '@trpc/server/unstable-core-do-not-import';
 
-export type inferTransformerParameters<TInferrable extends TRPCInferrable> =
-  TRPCInferrable extends TInferrable
-    ? [
-        opts: TypeError<'You must define a generic parameter to this function or the parent function'>,
-      ]
-    : inferRootTypes<TInferrable> extends { transformer: false }
-    ? [
-        opts?: TransformerOptions<{
-          transformer: false;
-        }>,
-      ]
-    : [
-        opts: TransformerOptions<{
-          transformer: true;
-        }>,
-      ];
 export type CoercedTransformerParameters = {
   transformer?: DataTransformerOptions;
 };

--- a/packages/client/src/unstable-internals.ts
+++ b/packages/client/src/unstable-internals.ts
@@ -43,7 +43,8 @@ export function getTransformer(
     | TransformerOptions<{ transformer: true }>['transformer']
     | undefined,
 ): CombinedDataTransformer {
-  const _transformer = transformer as CombinedDataTransformer | undefined;
+  const _transformer =
+    transformer as CoercedTransformerParameters['transformer'];
   if (!_transformer) {
     return {
       input: {

--- a/packages/client/turbo.json
+++ b/packages/client/turbo.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://turborepo.org/schema.json",
   "extends": ["//"],
-  "pipeline": { "codegen-entrypoints": { "outputs": ["package.json"] } }
+  "pipeline": {
+    "codegen-entrypoints": {
+      "outputs": ["package.json", "unstable-internals/**"]
+    }
+  }
 }

--- a/packages/next/src/app-dir/client.test.tsx
+++ b/packages/next/src/app-dir/client.test.tsx
@@ -408,4 +408,13 @@ describe('type tests', () => {
       await hook.mutateAsync(null);
     });
   });
+
+  test('makes sure we have defined a generic', async () => {
+    experimental_createActionHook(
+      // @ts-expect-error missing generic param
+      {
+        links: [],
+      },
+    );
+  });
 });

--- a/packages/next/src/app-dir/client.test.tsx
+++ b/packages/next/src/app-dir/client.test.tsx
@@ -172,10 +172,15 @@ describe('with transformer', () => {
     },
   });
 
-  const useAction = experimental_createActionHook({
-    links: [experimental_serverActionLink()],
-    transformer: superjson,
-  });
+  const useAction = experimental_createActionHook<(typeof instance)['_config']>(
+    {
+      links: [
+        experimental_serverActionLink({
+          transformer: superjson,
+        }),
+      ],
+    },
+  );
 
   test('pass a Date', async () => {
     const action = createAction(

--- a/packages/next/src/app-dir/client.test.tsx
+++ b/packages/next/src/app-dir/client.test.tsx
@@ -27,7 +27,7 @@ describe('without transformer', () => {
     },
   });
 
-  const useAction = experimental_createActionHook({
+  const useAction = experimental_createActionHook<typeof instance>({
     links: [experimental_serverActionLink()],
   });
 
@@ -172,15 +172,13 @@ describe('with transformer', () => {
     },
   });
 
-  const useAction = experimental_createActionHook<(typeof instance)['_config']>(
-    {
-      links: [
-        experimental_serverActionLink({
-          transformer: superjson,
-        }),
-      ],
-    },
-  );
+  const useAction = experimental_createActionHook<typeof instance>({
+    links: [
+      experimental_serverActionLink({
+        transformer: superjson,
+      }),
+    ],
+  });
 
   test('pass a Date', async () => {
     const action = createAction(
@@ -361,7 +359,7 @@ describe('type tests', () => {
     },
   });
 
-  const useAction = experimental_createActionHook({
+  const useAction = experimental_createActionHook<typeof instance>({
     links: [experimental_serverActionLink()],
   });
 

--- a/packages/next/src/app-dir/create-action-hook.tsx
+++ b/packages/next/src/app-dir/create-action-hook.tsx
@@ -5,8 +5,8 @@ import type {
 } from '@trpc/client';
 import { createTRPCUntypedClient, TRPCClientError } from '@trpc/client';
 import type {
+  CoercedTransformerParameters,
   inferTransformerParameters,
-  TransformerOptionYes,
 } from '@trpc/client/unstable-internals';
 import { getTransformer } from '@trpc/client/unstable-internals';
 import { observable } from '@trpc/server/observable';
@@ -74,7 +74,7 @@ type ActionContext = {
 export function experimental_serverActionLink<TRouter extends TRPCInferrable>(
   ...args: inferTransformerParameters<TRouter>
 ): TRPCLink<TRouter> {
-  const [opts] = args as [Partial<TransformerOptionYes>];
+  const [opts] = args as [CoercedTransformerParameters];
   const transformer = getTransformer(opts?.transformer);
   return () =>
     ({ op }) =>

--- a/packages/next/src/app-dir/create-action-hook.tsx
+++ b/packages/next/src/app-dir/create-action-hook.tsx
@@ -78,7 +78,7 @@ export function experimental_serverActionLink<
 >(
   ...args: TRPCInferrable extends TInferrable
     ? [
-        TypeError<'Generic parameter missing in `createActionHook<HERE>()` or experimental_serverActionLink<HERE>()'>,
+        TypeError<'Generic parameter missing in `experimental_createActionHook<HERE>()` or experimental_serverActionLink<HERE>()'>,
       ]
     : inferRootTypes<TInferrable>['transformer'] extends true
     ? [
@@ -133,7 +133,7 @@ export function experimental_createActionHook<
   TInferrable extends TRPCInferrable,
 >(
   opts: TRPCInferrable extends TInferrable
-    ? TypeError<'Generic parameter missing in `createActionHook<HERE>()`'>
+    ? TypeError<'Generic parameter missing in `experimental_createActionHook<HERE>()`'>
     : CreateTRPCClientOptions<TInferrable>,
 ) {
   type ActionContext = {

--- a/packages/next/src/app-dir/create-action-hook.tsx
+++ b/packages/next/src/app-dir/create-action-hook.tsx
@@ -1,8 +1,4 @@
-import type {
-  CreateTRPCClientOptions,
-  TRPCLink,
-  TRPCRequestOptions,
-} from '@trpc/client';
+import type { TRPCLink, TRPCRequestOptions } from '@trpc/client';
 import { createTRPCUntypedClient, TRPCClientError } from '@trpc/client';
 import type {
   CoercedTransformerParameters,
@@ -73,11 +69,7 @@ type ActionContext = {
 };
 
 type inferTransformerParameters<TInferrable extends TRPCInferrable> =
-  TRPCInferrable extends TInferrable
-    ? [
-        opts: TypeError<'You must define a generic parameter to this function or the parent function'>,
-      ]
-    : inferRootTypes<TInferrable> extends { transformer: false }
+  inferRootTypes<TInferrable> extends { transformer: false }
     ? [
         opts?: TransformerOptions<{
           transformer: false;
@@ -133,11 +125,17 @@ interface UseTRPCActionOptions<TDef extends ActionHandlerDef> {
 // ts-prune-ignore-next
 export function experimental_createActionHook<
   TInferrable extends TRPCInferrable,
->(opts: CreateTRPCClientOptions<TInferrable>) {
+>(
+  opts: TRPCInferrable extends TInferrable
+    ? TypeError<'Generic parameter missing to `createActionHook<HERE>()`'>
+    : TInferrable,
+) {
   type ActionContext = {
     _action: (...args: any[]) => Promise<any>;
   };
-  const client = createTRPCUntypedClient(opts);
+  const client = createTRPCUntypedClient(
+    opts as Exclude<typeof opts, TypeError<any>>,
+  );
   return function useAction<TDef extends ActionHandlerDef>(
     handler: TRPCActionHandler<TDef>,
     useActionOpts?: UseTRPCActionOptions<Simplify<TDef>>,

--- a/packages/next/src/app-dir/create-action-hook.tsx
+++ b/packages/next/src/app-dir/create-action-hook.tsx
@@ -78,7 +78,7 @@ export function experimental_serverActionLink<
 >(
   ...args: TRPCInferrable extends TInferrable
     ? [
-        TypeError<'Generic parameter missing to `createActionHook<HERE>()` or experimental_serverActionLink<HERE>()'>,
+        TypeError<'Generic parameter missing in `createActionHook<HERE>()` or experimental_serverActionLink<HERE>()'>,
       ]
     : inferRootTypes<TInferrable>['transformer'] extends true
     ? [
@@ -133,7 +133,7 @@ export function experimental_createActionHook<
   TInferrable extends TRPCInferrable,
 >(
   opts: TRPCInferrable extends TInferrable
-    ? TypeError<'Generic parameter missing to `createActionHook<HERE>()`'>
+    ? TypeError<'Generic parameter missing in `createActionHook<HERE>()`'>
     : CreateTRPCClientOptions<TInferrable>,
 ) {
   type ActionContext = {

--- a/packages/next/src/app-dir/create-action-hook.tsx
+++ b/packages/next/src/app-dir/create-action-hook.tsx
@@ -1,4 +1,8 @@
-import type { TRPCLink, TRPCRequestOptions } from '@trpc/client';
+import type {
+  CreateTRPCClientOptions,
+  TRPCLink,
+  TRPCRequestOptions,
+} from '@trpc/client';
 import { createTRPCUntypedClient, TRPCClientError } from '@trpc/client';
 import type {
   CoercedTransformerParameters,
@@ -122,19 +126,22 @@ interface UseTRPCActionOptions<TDef extends ActionHandlerDef> {
   onError?: (result: TRPCClientError<TDef['errorShape']>) => MaybePromise<void>;
 }
 
+type GenericMissing =
+  TypeError<'Generic parameter missing to `createActionHook<typeof t>()`'>;
+
 // ts-prune-ignore-next
 export function experimental_createActionHook<
   TInferrable extends TRPCInferrable,
 >(
   opts: TRPCInferrable extends TInferrable
-    ? TypeError<'Generic parameter missing to `createActionHook<HERE>()`'>
-    : TInferrable,
+    ? GenericMissing
+    : CreateTRPCClientOptions<TInferrable>,
 ) {
   type ActionContext = {
     _action: (...args: any[]) => Promise<any>;
   };
   const client = createTRPCUntypedClient(
-    opts as Exclude<typeof opts, TypeError<any>>,
+    opts as Exclude<typeof opts, GenericMissing>,
   );
   return function useAction<TDef extends ActionHandlerDef>(
     handler: TRPCActionHandler<TDef>,

--- a/packages/next/src/app-dir/create-action-hook.tsx
+++ b/packages/next/src/app-dir/create-action-hook.tsx
@@ -72,23 +72,26 @@ type ActionContext = {
   _action: (...args: any[]) => Promise<any>;
 };
 
-type inferTransformerParameters<TInferrable extends TRPCInferrable> =
-  inferRootTypes<TInferrable> extends { transformer: false }
+// ts-prune-ignore-next
+export function experimental_serverActionLink<
+  TInferrable extends TRPCInferrable,
+>(
+  ...args: TRPCInferrable extends TInferrable
     ? [
+        TypeError<'Generic parameter missing to `createActionHook<HERE>()` or experimental_serverActionLink<HERE>()'>,
+      ]
+    : inferRootTypes<TInferrable>['transformer'] extends true
+    ? [
+        opts: TransformerOptions<{
+          transformer: true;
+        }>,
+      ]
+    : [
         opts?: TransformerOptions<{
           transformer: false;
         }>,
       ]
-    : [
-        opts: TransformerOptions<{
-          transformer: true;
-        }>,
-      ];
-
-// ts-prune-ignore-next
-export function experimental_serverActionLink<
-  TInferrable extends TRPCInferrable,
->(...args: inferTransformerParameters<TInferrable>): TRPCLink<TInferrable> {
+): TRPCLink<TInferrable> {
   const [opts] = args as [CoercedTransformerParameters];
   const transformer = getTransformer(opts?.transformer);
   return () =>
@@ -125,23 +128,19 @@ interface UseTRPCActionOptions<TDef extends ActionHandlerDef> {
   onSuccess?: (result: TDef['output']) => MaybePromise<void> | void;
   onError?: (result: TRPCClientError<TDef['errorShape']>) => MaybePromise<void>;
 }
-
-type GenericMissing =
-  TypeError<'Generic parameter missing to `createActionHook<typeof t>()`'>;
-
 // ts-prune-ignore-next
 export function experimental_createActionHook<
   TInferrable extends TRPCInferrable,
 >(
   opts: TRPCInferrable extends TInferrable
-    ? GenericMissing
+    ? TypeError<'Generic parameter missing to `createActionHook<HERE>()` or experimental_serverActionLink<HERE>()'>
     : CreateTRPCClientOptions<TInferrable>,
 ) {
   type ActionContext = {
     _action: (...args: any[]) => Promise<any>;
   };
   const client = createTRPCUntypedClient(
-    opts as Exclude<typeof opts, GenericMissing>,
+    opts as Exclude<typeof opts, TypeError<any>>,
   );
   return function useAction<TDef extends ActionHandlerDef>(
     handler: TRPCActionHandler<TDef>,

--- a/packages/next/src/app-dir/create-action-hook.tsx
+++ b/packages/next/src/app-dir/create-action-hook.tsx
@@ -133,7 +133,7 @@ export function experimental_createActionHook<
   TInferrable extends TRPCInferrable,
 >(
   opts: TRPCInferrable extends TInferrable
-    ? TypeError<'Generic parameter missing to `createActionHook<HERE>()` or experimental_serverActionLink<HERE>()'>
+    ? TypeError<'Generic parameter missing to `createActionHook<HERE>()`'>
     : CreateTRPCClientOptions<TInferrable>,
 ) {
   type ActionContext = {

--- a/packages/next/src/app-dir/links/nextCache.ts
+++ b/packages/next/src/app-dir/links/nextCache.ts
@@ -9,6 +9,7 @@ import {
 import { observable } from '@trpc/server/observable';
 import type {
   AnyRouter,
+  inferRootTypes,
   inferRouterContext,
 } from '@trpc/server/unstable-core-do-not-import';
 import { callProcedure } from '@trpc/server/unstable-core-do-not-import';
@@ -20,7 +21,7 @@ type NextCacheLinkOptions<TRouter extends AnyRouter> = {
   createContext: () => Promise<inferRouterContext<TRouter>>;
   /** how many seconds the cache should hold before revalidating */
   revalidate?: number | false;
-} & TransformerOptions<TRouter['_def']['_config']['$types']>;
+} & TransformerOptions<inferRootTypes<TRouter>>;
 
 // ts-prune-ignore-next
 export function experimental_nextCacheLink<TRouter extends AnyRouter>(

--- a/packages/next/src/app-dir/links/nextHttp.ts
+++ b/packages/next/src/app-dir/links/nextHttp.ts
@@ -4,7 +4,10 @@ import type {
   TRPCLink,
 } from '@trpc/client';
 import { httpBatchLink, httpLink } from '@trpc/client';
-import type { AnyRouter } from '@trpc/server/unstable-core-do-not-import';
+import type {
+  AnyRootTypes,
+  AnyRouter,
+} from '@trpc/server/unstable-core-do-not-import';
 import { generateCacheTag } from '../shared';
 
 interface NextLinkBaseOptions {
@@ -14,13 +17,13 @@ interface NextLinkBaseOptions {
 
 interface NextLinkSingleOptions
   extends NextLinkBaseOptions,
-    Omit<HTTPLinkOptions, 'fetch'> {
+    Omit<HTTPLinkOptions<AnyRootTypes>, 'fetch'> {
   batch?: false;
 }
 
 interface NextLinkBatchOptions
   extends NextLinkBaseOptions,
-    Omit<HTTPBatchLinkOptions, 'fetch'> {
+    Omit<HTTPBatchLinkOptions<AnyRootTypes>, 'fetch'> {
   batch: true;
 }
 
@@ -42,7 +45,7 @@ export function experimental_nextHttpLink<TRouter extends AnyRouter>(
 
       const revalidate = requestRevalidate ?? opts.revalidate ?? false;
 
-      const _fetch: NonNullable<HTTPLinkOptions['fetch']> = (
+      const _fetch: NonNullable<HTTPLinkOptions<AnyRootTypes>['fetch']> = (
         url,
         fetchOpts,
       ) => {

--- a/packages/next/src/app-dir/links/nextHttp.ts
+++ b/packages/next/src/app-dir/links/nextHttp.ts
@@ -15,21 +15,21 @@ interface NextLinkBaseOptions {
   batch?: boolean;
 }
 
-interface NextLinkSingleOptions
-  extends NextLinkBaseOptions,
-    Omit<HTTPLinkOptions<AnyRootTypes>, 'fetch'> {
-  batch?: false;
-}
+type NextLinkSingleOptions<TRoot extends AnyRootTypes> = NextLinkBaseOptions &
+  Omit<HTTPLinkOptions<TRoot>, 'fetch'> & {
+    batch?: false;
+  };
 
-interface NextLinkBatchOptions
-  extends NextLinkBaseOptions,
-    Omit<HTTPBatchLinkOptions<AnyRootTypes>, 'fetch'> {
-  batch: true;
-}
+type NextLinkBatchOptions<TRoot extends AnyRootTypes> = NextLinkBaseOptions &
+  Omit<HTTPBatchLinkOptions<TRoot>, 'fetch'> & {
+    batch: true;
+  };
 
 // ts-prune-ignore-next
 export function experimental_nextHttpLink<TRouter extends AnyRouter>(
-  opts: NextLinkSingleOptions | NextLinkBatchOptions,
+  opts:
+    | NextLinkSingleOptions<TRouter['_def']['_config']['$types']>
+    | NextLinkBatchOptions<TRouter['_def']['_config']['$types']>,
 ): TRPCLink<TRouter> {
   return (runtime) => {
     return (ctx) => {
@@ -60,11 +60,11 @@ export function experimental_nextHttpLink<TRouter extends AnyRouter>(
       };
       const link = opts.batch
         ? httpBatchLink({
-            ...opts,
+            ...(opts as any),
             fetch: _fetch,
           })
         : httpLink({
-            ...opts,
+            ...(opts as any),
             fetch: _fetch,
           });
 

--- a/packages/next/src/app-dir/server.ts
+++ b/packages/next/src/app-dir/server.ts
@@ -8,6 +8,7 @@ import type {
   AnyRootTypes,
   AnyRouter,
   inferProcedureInput,
+  inferRootTypes,
   MaybePromise,
   RootConfig,
   Simplify,
@@ -77,7 +78,7 @@ export function experimental_createServerActionHandler<
 >(
   t: TInstance,
   opts: {
-    createContext: () => MaybePromise<TInstance['_config']['$types']['ctx']>;
+    createContext: () => MaybePromise<inferRootTypes<TInstance>['ctx']>;
     /**
      * Transform form data to a `Record` before passing it to the procedure
      * @default true
@@ -94,12 +95,12 @@ export function experimental_createServerActionHandler<
   return function createServerAction<TProc extends AnyProcedure>(
     proc: TProc,
   ): TRPCActionHandler<
-    Simplify<inferActionDef<TInstance['_config']['$types'], TProc>>
+    Simplify<inferActionDef<inferRootTypes<TInstance>, TProc>>
   > {
     return async function actionHandler(
       rawInput: FormData | inferProcedureInput<TProc>,
     ) {
-      const ctx: TInstance['_config']['$types']['ctx'] | undefined = undefined;
+      const ctx: inferRootTypes<TInstance>['ctx'] | undefined = undefined;
       try {
         const ctx = await createContext();
         if (normalizeFormData && isFormData(rawInput)) {

--- a/packages/next/src/withTRPC.tsx
+++ b/packages/next/src/withTRPC.tsx
@@ -23,7 +23,6 @@ import type {
 import { createRootHooks, getQueryClient } from '@trpc/react-query/shared';
 import type {
   AnyRouter,
-  CombinedDataTransformer,
   Dict,
   inferRootTypes,
   Maybe,
@@ -102,7 +101,6 @@ export function withTRPC<
     trpcClient: TRPCUntypedClient<TRouter>;
     ssrState: 'prepass';
     ssrContext: TSSRContext;
-    transformer: CombinedDataTransformer;
   };
   return (AppOrPage: NextComponentType<any, any, any>): NextComponentType => {
     const trpc = createRootHooks<TRouter, TSSRContext>(opts);

--- a/packages/next/src/withTRPC.tsx
+++ b/packages/next/src/withTRPC.tsx
@@ -138,7 +138,7 @@ export function withTRPC<
           return trpcState;
         }
 
-        return transformer.output.deserialize(trpcState);
+        return transformer.input.deserialize(trpcState);
         // eslint-disable-next-line react-hooks/exhaustive-deps
       }, [trpcState, trpcClient]);
 
@@ -264,7 +264,7 @@ export function withTRPC<
         };
 
         // dehydrate query client's state and add it to the props
-        pageProps['trpcState'] = transformer.output.serialize(
+        pageProps['trpcState'] = transformer.input.serialize(
           dehydratedCacheWithErrors,
         );
 

--- a/packages/next/src/withTRPC.tsx
+++ b/packages/next/src/withTRPC.tsx
@@ -138,7 +138,7 @@ export function withTRPC<
           return trpcState;
         }
 
-        return transformer.input.deserialize(trpcState);
+        return transformer.output.deserialize(trpcState);
         // eslint-disable-next-line react-hooks/exhaustive-deps
       }, [trpcState, trpcClient]);
 
@@ -264,7 +264,7 @@ export function withTRPC<
         };
 
         // dehydrate query client's state and add it to the props
-        pageProps['trpcState'] = transformer.input.serialize(
+        pageProps['trpcState'] = transformer.output.serialize(
           dehydratedCacheWithErrors,
         );
 

--- a/packages/next/src/withTRPC.tsx
+++ b/packages/next/src/withTRPC.tsx
@@ -213,7 +213,6 @@ export function withTRPC<
           queryClient,
           ssrState: 'prepass',
           ssrContext: ctx as TSSRContext,
-          transformer,
         };
         const prepassProps = {
           pageProps,

--- a/packages/next/src/withTRPC.tsx
+++ b/packages/next/src/withTRPC.tsx
@@ -24,6 +24,7 @@ import type {
   AnyRouter,
   CombinedDataTransformer,
   Dict,
+  inferRootTypes,
   Maybe,
   ResponseMeta,
 } from '@trpc/server/unstable-core-do-not-import';
@@ -78,7 +79,7 @@ export type WithTRPCSSROptions<TRouter extends AnyRouter> =
       ctx: NextPageContext;
       clientErrors: TRPCClientError<TRouter>[];
     }) => ResponseMeta;
-  } & TransformerOptions<TRouter['_def']['_config']['$types']>;
+  } & TransformerOptions<inferRootTypes<TRouter>>;
 
 export interface WithTRPCNoSSROptions<TRouter extends AnyRouter>
   extends WithTRPCOptions<TRouter> {

--- a/packages/next/src/withTRPC.tsx
+++ b/packages/next/src/withTRPC.tsx
@@ -10,6 +10,7 @@ import {
 } from '@tanstack/react-query';
 import type { CreateTRPCClientOptions, TRPCUntypedClient } from '@trpc/client';
 import { createTRPCUntypedClient } from '@trpc/client';
+import type { CoercedTransformerParameters } from '@trpc/client/unstable-internals';
 import {
   getTransformer,
   type TransformerOptions,
@@ -91,6 +92,9 @@ export function withTRPC<
   TSSRContext extends NextPageContext = NextPageContext,
 >(opts: WithTRPCNoSSROptions<TRouter> | WithTRPCSSROptions<TRouter>) {
   const { config: getClientConfig } = opts;
+  const transformer = getTransformer(
+    (opts as CoercedTransformerParameters).transformer,
+  );
 
   type TRPCPrepassProps = {
     config: WithTRPCConfig<TRouter>;
@@ -116,18 +120,17 @@ export function withTRPC<
         const config = getClientConfig({});
         const queryClient = getQueryClient(config);
         const trpcClient = trpc.createClient(config);
+
         return {
           abortOnUnmount: config.abortOnUnmount,
           queryClient,
           trpcClient,
           ssrState: opts.ssr ? ('mounting' as const) : (false as const),
           ssrContext: null,
-          transformer: getTransformer(config.transformer as any),
         };
       });
 
-      const { queryClient, trpcClient, ssrState, ssrContext, transformer } =
-        prepassProps;
+      const { queryClient, trpcClient, ssrState, ssrContext } = prepassProps;
 
       // allow normal components to be wrapped, not just app/pages
       const trpcState = props.pageProps?.trpcState;
@@ -205,8 +208,6 @@ export function withTRPC<
         const config = getClientConfig({ ctx });
         const trpcClient = createTRPCUntypedClient(config);
         const queryClient = getQueryClient(config);
-
-        const transformer = getTransformer(config.transformer as any);
 
         const trpcProp: TRPCPrepassProps = {
           config,

--- a/packages/next/src/withTRPC.tsx
+++ b/packages/next/src/withTRPC.tsx
@@ -65,10 +65,10 @@ export type WithTRPCConfig<TRouter extends AnyRouter> =
       abortOnUnmount?: boolean;
     };
 
-interface WithTRPCOptions<TRouter extends AnyRouter>
-  extends CreateTRPCReactOptions<TRouter> {
-  config: (info: { ctx?: NextPageContext }) => WithTRPCConfig<TRouter>;
-}
+type WithTRPCOptions<TRouter extends AnyRouter> =
+  CreateTRPCReactOptions<TRouter> & {
+    config: (info: { ctx?: NextPageContext }) => WithTRPCConfig<TRouter>;
+  } & TransformerOptions<inferRootTypes<TRouter>>;
 
 export type WithTRPCSSROptions<TRouter extends AnyRouter> =
   WithTRPCOptions<TRouter> & {
@@ -79,12 +79,12 @@ export type WithTRPCSSROptions<TRouter extends AnyRouter> =
       ctx: NextPageContext;
       clientErrors: TRPCClientError<TRouter>[];
     }) => ResponseMeta;
-  } & TransformerOptions<inferRootTypes<TRouter>>;
+  };
 
-export interface WithTRPCNoSSROptions<TRouter extends AnyRouter>
-  extends WithTRPCOptions<TRouter> {
-  ssr?: false;
-}
+export type WithTRPCNoSSROptions<TRouter extends AnyRouter> =
+  WithTRPCOptions<TRouter> & {
+    ssr?: false;
+  };
 
 export function withTRPC<
   TRouter extends AnyRouter,
@@ -132,14 +132,16 @@ export function withTRPC<
 
       // allow normal components to be wrapped, not just app/pages
       const trpcState = props.pageProps?.trpcState;
+
       const hydratedState: DehydratedState | undefined = React.useMemo(() => {
         if (!trpcState) {
           return trpcState;
         }
 
-        return transformer.output.deserialize(trpcState);
+        return transformer.input.deserialize(trpcState);
         // eslint-disable-next-line react-hooks/exhaustive-deps
       }, [trpcState, trpcClient]);
+
       return (
         <trpc.Provider
           abortOnUnmount={(prepassProps as any).abortOnUnmount ?? false}
@@ -262,7 +264,7 @@ export function withTRPC<
         };
 
         // dehydrate query client's state and add it to the props
-        pageProps['trpcState'] = transformer.output.serialize(
+        pageProps['trpcState'] = transformer.input.serialize(
           dehydratedCacheWithErrors,
         );
 

--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -27,7 +27,6 @@ import type {
   DefinedUseTRPCQueryOptions,
   DefinedUseTRPCQueryResult,
   TRPCProvider,
-  UseDehydratedState,
   UseTRPCInfiniteQueryOptions,
   UseTRPCInfiniteQueryResult,
   UseTRPCMutationOptions,
@@ -255,7 +254,6 @@ export type CreateTRPCReactBase<TRouter extends AnyRouter, TSSRContext> = {
   createClient: CreateClient<TRouter>;
   useQueries: TRPCUseQueries<TRouter>;
   useSuspenseQueries: TRPCUseSuspenseQueries<TRouter>;
-  useDehydratedState: UseDehydratedState<TRouter>;
 };
 
 export type CreateTRPCReact<

--- a/packages/react-query/src/server/ssgProxy.ts
+++ b/packages/react-query/src/server/ssgProxy.ts
@@ -18,6 +18,7 @@ import type {
   AnyRootTypes,
   AnyRouter,
   inferProcedureInput,
+  inferRootTypes,
   inferRouterContext,
   inferTransformedProcedureOutput,
   Maybe,
@@ -41,7 +42,7 @@ import { getQueryClient, getQueryType } from '../shared';
 type CreateSSGHelpersInternal<TRouter extends AnyRouter> = {
   router: TRouter;
   ctx: inferRouterContext<TRouter>;
-} & TransformerOptions<TRouter['_def']['_config']['$types']>;
+} & TransformerOptions<inferRootTypes<TRouter>>;
 
 interface CreateSSGHelpersExternal<TRouter extends AnyRouter> {
   client: inferRouterClient<TRouter> | TRPCUntypedClient<TRouter>;

--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -1,4 +1,3 @@
-import type { DehydratedState } from '@tanstack/react-query';
 import {
   useInfiniteQuery as __useInfiniteQuery,
   useMutation as __useMutation,
@@ -31,7 +30,6 @@ import type {
   CreateClient,
   TRPCProvider,
   TRPCQueryOptions,
-  UseDehydratedState,
   UseTRPCInfiniteQueryOptions,
   UseTRPCInfiniteQueryResult,
   UseTRPCMutationOptions,
@@ -490,20 +488,6 @@ export function createRootHooks<
     return [hook.map((h) => h.data), hook] as any;
   };
 
-  const useDehydratedState: UseDehydratedState<TRouter> = (
-    client,
-    trpcState,
-  ) => {
-    const transformed: DehydratedState | undefined = React.useMemo(() => {
-      if (!trpcState) {
-        return trpcState;
-      }
-
-      return client.runtime.transformer.deserialize(trpcState);
-    }, [trpcState, client]);
-    return transformed;
-  };
-
   return {
     Provider: TRPCProvider,
     createClient,
@@ -515,7 +499,6 @@ export function createRootHooks<
     useSuspenseQueries,
     useMutation,
     useSubscription,
-    useDehydratedState,
     useInfiniteQuery,
     useSuspenseInfiniteQuery,
   };

--- a/packages/server/src/unstable-core-do-not-import/TRPCInferrable.ts
+++ b/packages/server/src/unstable-core-do-not-import/TRPCInferrable.ts
@@ -1,16 +1,33 @@
 import type { AnyRootTypes, RootConfig } from './rootConfig';
-import type { AnyRouter } from './router';
 
+type RouterLike = {
+  _def: {
+    _config: RootConfig<AnyRootTypes>;
+  };
+};
+type InitLike = {
+  _config: RootConfig<AnyRootTypes>;
+};
+type RootConfigLike = {
+  $types: AnyRootTypes;
+};
+/**
+ * Anything that can be inferred to the root config types
+ */
 export type TRPCInferrable =
-  | AnyRouter
-  | AnyRootTypes
-  | RootConfig<AnyRootTypes>;
+  | RouterLike
+  | InitLike
+  | RootConfigLike
+  | AnyRootTypes;
+
 export type inferRootTypes<TInferrable extends TRPCInferrable> =
   TInferrable extends AnyRootTypes
     ? TInferrable
-    : TInferrable extends RootConfig<AnyRootTypes>
+    : TInferrable extends RootConfigLike
     ? TInferrable['$types']
-    : TInferrable extends AnyRouter
+    : TInferrable extends InitLike
+    ? TInferrable['_config']['$types']
+    : TInferrable extends RouterLike
     ? TInferrable['_def']['_config']['$types']
     : never;
 

--- a/packages/server/src/unstable-core-do-not-import/TRPCInferrable.ts
+++ b/packages/server/src/unstable-core-do-not-import/TRPCInferrable.ts
@@ -1,12 +1,22 @@
 import type { AnyRootTypes, RootConfig } from './rootConfig';
 
+/**
+ * Result of `initTRPC.create()`
+ */
 type InitLike = {
   _config: RootConfig<AnyRootTypes>;
 };
 
+/**
+ * Result of `initTRPC.create().router()`
+ */
 type RouterLike = {
   _def: InitLike;
 };
+
+/**
+ * Result of `initTRPC.create()._config`
+ */
 type RootConfigLike = {
   $types: AnyRootTypes;
 };

--- a/packages/server/src/unstable-core-do-not-import/TRPCInferrable.ts
+++ b/packages/server/src/unstable-core-do-not-import/TRPCInferrable.ts
@@ -1,12 +1,11 @@
 import type { AnyRootTypes, RootConfig } from './rootConfig';
 
-type RouterLike = {
-  _def: {
-    _config: RootConfig<AnyRootTypes>;
-  };
-};
 type InitLike = {
   _config: RootConfig<AnyRootTypes>;
+};
+
+type RouterLike = {
+  _def: InitLike;
 };
 type RootConfigLike = {
   $types: AnyRootTypes;

--- a/packages/server/src/unstable-core-do-not-import/TRPCInferrable.ts
+++ b/packages/server/src/unstable-core-do-not-import/TRPCInferrable.ts
@@ -1,10 +1,15 @@
-import type { AnyRootTypes } from './rootConfig';
+import type { AnyRootTypes, RootConfig } from './rootConfig';
 import type { AnyRouter } from './router';
 
-export type TRPCInferrable = AnyRouter | AnyRootTypes;
+export type TRPCInferrable =
+  | AnyRouter
+  | AnyRootTypes
+  | RootConfig<AnyRootTypes>;
 export type inferRootTypes<TInferrable extends TRPCInferrable> =
   TInferrable extends AnyRootTypes
     ? TInferrable
+    : TInferrable extends RootConfig<AnyRootTypes>
+    ? TInferrable['$types']
     : TInferrable extends AnyRouter
     ? TInferrable['_def']['_config']['$types']
     : never;

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -11,7 +11,8 @@
     "test-run:tsc": "tsc --noEmit --pretty",
     "test-watch": "vitest",
     "test-ci": "concurrently \"CI=true vitest --coverage\" npm:test-run:tsc",
-    "test-ui": "vitest --ui"
+    "test-ui": "vitest --ui",
+    "ts-watch": "tsc --watch"
   },
   "dependencies": {
     "@cloudflare/workers-types": "^4.0.0",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -11,8 +11,7 @@
     "test-run:tsc": "tsc --noEmit --pretty",
     "test-watch": "vitest",
     "test-ci": "concurrently \"CI=true vitest --coverage\" npm:test-run:tsc",
-    "test-ui": "vitest --ui",
-    "ts-watch": "tsc --watch"
+    "test-ui": "vitest --ui"
   },
   "dependencies": {
     "@cloudflare/workers-types": "^4.0.0",

--- a/packages/tests/server/___testHelpers.ts
+++ b/packages/tests/server/___testHelpers.ts
@@ -3,7 +3,7 @@ import type { AddressInfo } from 'net';
 import type { TRPCWebSocketClient, WebSocketClientOptions } from '@trpc/client';
 import { createTRPCClient, createWSClient, httpBatchLink } from '@trpc/client';
 import type { WithTRPCConfig } from '@trpc/next';
-import type { AnyRouter as AnyNewRouter } from '@trpc/server';
+import type { AnyRouter } from '@trpc/server';
 import type { CreateHTTPHandlerOptions } from '@trpc/server/adapters/standalone';
 import { createHTTPServer } from '@trpc/server/adapters/standalone';
 import type { WSSHandlerOptions } from '@trpc/server/adapters/ws';
@@ -16,19 +16,19 @@ import { WebSocket, WebSocketServer } from 'ws';
 globalThis.fetch = fetch as any;
 globalThis.WebSocket = WebSocket as any;
 
-export type CreateClientCallback = (opts: {
+export type CreateClientCallback<TRouter extends AnyRouter> = (opts: {
   httpUrl: string;
   wssUrl: string;
   wsClient: TRPCWebSocketClient;
-}) => Partial<WithTRPCConfig<AnyNewRouter>>;
+}) => Partial<WithTRPCConfig<TRouter>>;
 
-export function routerToServerAndClientNew<TRouter extends AnyNewRouter>(
+export function routerToServerAndClientNew<TRouter extends AnyRouter>(
   router: TRouter,
   opts?: {
     server?: Partial<CreateHTTPHandlerOptions<TRouter>>;
     wssServer?: Partial<WSSHandlerOptions<TRouter>>;
     wsClient?: Partial<WebSocketClientOptions>;
-    client?: Partial<WithTRPCConfig<TRouter>> | CreateClientCallback;
+    client?: Partial<WithTRPCConfig<TRouter>> | CreateClientCallback<TRouter>;
   },
 ) {
   // http

--- a/packages/tests/server/___testHelpers.ts
+++ b/packages/tests/server/___testHelpers.ts
@@ -23,6 +23,7 @@ export type CreateClientCallback<TRouter extends AnyRouter> = (opts: {
   httpUrl: string;
   wssUrl: string;
   wsClient: TRPCWebSocketClient;
+  transformer?: DataTransformerOptions;
 }) => Partial<WithTRPCConfig<TRouter>>;
 
 export function routerToServerAndClientNew<TRouter extends AnyRouter>(

--- a/packages/tests/server/___testHelpers.ts
+++ b/packages/tests/server/___testHelpers.ts
@@ -8,7 +8,10 @@ import type { CreateHTTPHandlerOptions } from '@trpc/server/adapters/standalone'
 import { createHTTPServer } from '@trpc/server/adapters/standalone';
 import type { WSSHandlerOptions } from '@trpc/server/adapters/ws';
 import { applyWSSHandler } from '@trpc/server/adapters/ws';
-import type { OnErrorFunction } from '@trpc/server/unstable-core-do-not-import';
+import type {
+  DataTransformerOptions,
+  OnErrorFunction,
+} from '@trpc/server/unstable-core-do-not-import';
 import fetch from 'node-fetch';
 import { WebSocket, WebSocketServer } from 'ws';
 
@@ -29,6 +32,7 @@ export function routerToServerAndClientNew<TRouter extends AnyRouter>(
     wssServer?: Partial<WSSHandlerOptions<TRouter>>;
     wsClient?: Partial<WebSocketClientOptions>;
     client?: Partial<WithTRPCConfig<TRouter>> | CreateClientCallback<TRouter>;
+    transformer?: DataTransformerOptions;
   },
 ) {
   // http
@@ -67,7 +71,12 @@ export function routerToServerAndClientNew<TRouter extends AnyRouter>(
     ...opts?.wsClient,
   });
   const trpcClientOptions = {
-    links: [httpBatchLink({ url: httpUrl })],
+    links: [
+      httpBatchLink({
+        url: httpUrl,
+        transformer: opts?.transformer as any,
+      }),
+    ],
     ...(opts?.client
       ? typeof opts.client === 'function'
         ? opts.client({ httpUrl, wssUrl, wsClient })

--- a/packages/tests/server/abortQuery.test.ts
+++ b/packages/tests/server/abortQuery.test.ts
@@ -20,7 +20,7 @@ describe('vanilla client procedure abortion', () => {
     const abortController = new AbortController();
     const signal = abortController.signal;
 
-    const { close, client } = routerToServerAndClientNew<Router>(router);
+    const { close, client } = routerToServerAndClientNew(router);
 
     const promise = client.testQuery.query(undefined, { signal });
     abortController.abort();
@@ -33,7 +33,7 @@ describe('vanilla client procedure abortion', () => {
     const abortController = new AbortController();
     const signal = abortController.signal;
 
-    const { close, client } = routerToServerAndClientNew<Router>(router);
+    const { close, client } = routerToServerAndClientNew(router);
 
     const promise = client.testMutation.mutate(undefined, { signal });
     abortController.abort();

--- a/packages/tests/server/links.test.ts
+++ b/packages/tests/server/links.test.ts
@@ -15,22 +15,7 @@ import { initTRPC } from '@trpc/server';
 import { observable, observableToPromise } from '@trpc/server/observable';
 import { z } from 'zod';
 
-const mockRuntime: TRPCClientRuntime = {
-  transformer: {
-    serialize: (v) => v,
-    deserialize: (v) => v,
-  },
-  combinedTransformer: {
-    input: {
-      serialize: (v) => v,
-      deserialize: (v) => v,
-    },
-    output: {
-      serialize: (v) => v,
-      deserialize: (v) => v,
-    },
-  },
-};
+const mockRuntime: TRPCClientRuntime = {};
 test('chainer', async () => {
   let attempt = 0;
   const serverCall = vi.fn();

--- a/packages/tests/server/react/__reactHelpers.tsx
+++ b/packages/tests/server/react/__reactHelpers.tsx
@@ -22,7 +22,7 @@ export function getServerAndReactClient<TRouter extends AnyRouter>(
   });
 
   const opts = routerToServerAndClientNew(appRouter, {
-    client: ({ wsClient, httpUrl }) => ({
+    client: (opts) => ({
       links: [
         () => {
           // here we just got initialized in the app - this happens once per app
@@ -36,8 +36,14 @@ export function getServerAndReactClient<TRouter extends AnyRouter>(
         },
         splitLink({
           condition: (op) => op.type === 'subscription',
-          true: wsLink({ client: wsClient }),
-          false: httpBatchLink({ url: httpUrl }),
+          true: wsLink({
+            client: opts.wsClient,
+            transformer: opts.transformer as any,
+          }),
+          false: httpBatchLink({
+            url: opts.httpUrl,
+            transformer: opts.transformer as any,
+          }),
         }),
       ],
     }),

--- a/packages/tests/server/react/createClient.test.tsx
+++ b/packages/tests/server/react/createClient.test.tsx
@@ -3,7 +3,6 @@ import { createQueryClient } from '../__queryClient';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, waitFor } from '@testing-library/react';
 import { createTRPCReact, httpBatchLink } from '@trpc/react-query';
-import { createServerSideHelpers } from '@trpc/react-query/server';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 import type { ReactNode } from 'react';
@@ -55,60 +54,6 @@ test('createClient()', async () => {
     }
 
     return <pre>{query1.data}</pre>;
-  }
-
-  const utils = render(
-    <App>
-      <MyComponent />
-    </App>,
-  );
-
-  await waitFor(() => {
-    expect(utils.container).toHaveTextContent('world');
-  });
-});
-
-test('useDehydratedState() - internal', async () => {
-  const { App, hooks, router } = ctx;
-
-  const ssg = createServerSideHelpers({ router, ctx: {} });
-  const res = await ssg.hello.fetch();
-  expect(res).toBe('world');
-  const dehydratedState = ssg.dehydrate();
-
-  function MyComponent() {
-    const utils = hooks.useUtils();
-
-    const state = hooks.useDehydratedState(utils.client, dehydratedState);
-    return <h1>{JSON.stringify(state)}</h1>;
-  }
-
-  const utils = render(
-    <App>
-      <MyComponent />
-    </App>,
-  );
-
-  await waitFor(() => {
-    expect(utils.container).toHaveTextContent('world');
-  });
-});
-
-test('useDehydratedState() - external', async () => {
-  const { App, hooks, client } = ctx;
-
-  const ssg = createServerSideHelpers({ client: client });
-  const res = await ssg.hello.fetch();
-  expect(res).toBe('world');
-  expectTypeOf(res).toMatchTypeOf<string>();
-
-  const dehydratedState = ssg.dehydrate();
-
-  function MyComponent() {
-    const utils = hooks.useUtils();
-
-    const state = hooks.useDehydratedState(utils.client, dehydratedState);
-    return <h1>{JSON.stringify(state)}</h1>;
   }
 
   const utils = render(

--- a/packages/tests/server/react/ssgExternal.test.ts
+++ b/packages/tests/server/react/ssgExternal.test.ts
@@ -87,7 +87,6 @@ test('prefetch faulty query and dehydrate', async () => {
   const { opts } = ctx;
   const ssg = createServerSideHelpers({
     client: opts.client,
-    transformer: SuperJSON,
   });
 
   await ssg.post.throwsError.prefetch();

--- a/packages/tests/server/regression/issue-2540-undefined-mutation.test.ts
+++ b/packages/tests/server/regression/issue-2540-undefined-mutation.test.ts
@@ -194,10 +194,10 @@ describe('with superjson', () => {
         const opts = routerToServerAndClientNew(appRouter, {
           client({ httpUrl }) {
             return {
-              transformer: superjson,
               links: [
                 httpLink({
                   url: httpUrl,
+                  transformer: superjson,
                 }),
               ],
             };
@@ -231,10 +231,10 @@ describe('with superjson', () => {
         const opts = routerToServerAndClientNew(appRouter, {
           client({ httpUrl }) {
             return {
-              transformer: superjson,
               links: [
                 httpBatchLink({
                   url: httpUrl,
+                  transformer: superjson,
                 }),
               ],
             };

--- a/packages/tests/server/regression/issue-3085-bad-responses.test.ts
+++ b/packages/tests/server/regression/issue-3085-bad-responses.test.ts
@@ -66,9 +66,9 @@ test('badly formatted superjson response', async () => {
       httpLink({
         url: server.url,
         fetch: fetch as any,
+        transformer: superjson,
       }),
     ],
-    transformer: superjson,
   });
 
   const error = await waitError(client.test.query(), TRPCClientError);
@@ -94,9 +94,9 @@ test('badly formatted superjson response', async () => {
       httpLink({
         url: server.url,
         fetch: fetch as any,
+        transformer: superjson,
       }),
     ],
-    transformer: superjson,
   });
 
   const error = await waitError(client.test.query(), TRPCClientError);

--- a/packages/tests/server/regression/issue-4130-ssr-different-transformers.test.tsx
+++ b/packages/tests/server/regression/issue-4130-ssr-different-transformers.test.tsx
@@ -33,12 +33,7 @@ const ctx = konn()
       foo: t.procedure.query(() => 'bar' as const),
     });
     const opts = routerToServerAndClientNew(appRouter, {
-      client(opts) {
-        return {
-          ...opts,
-          transformer,
-        };
-      },
+      transformer,
     });
 
     return opts;
@@ -60,6 +55,7 @@ test('withTRPC - SSR', async () => {
       return ctx.trpcClientOptions;
     },
     ssr: true,
+    transformer,
   });
 
   const App: AppType = () => {

--- a/packages/tests/server/regression/issue-4130-ssr-different-transformers.test.tsx
+++ b/packages/tests/server/regression/issue-4130-ssr-different-transformers.test.tsx
@@ -70,7 +70,7 @@ test('withTRPC - SSR', async () => {
     Component: <div />,
   } as any)) as Record<string, any>;
 
-  const trpcState: DehydratedState = transformer.output.deserialize(
+  const trpcState: DehydratedState = transformer.input.deserialize(
     props['pageProps'].trpcState,
   );
 

--- a/packages/tests/server/regression/serializable-inference.test.tsx
+++ b/packages/tests/server/regression/serializable-inference.test.tsx
@@ -70,10 +70,10 @@ describe('with transformer', () => {
       const opts = routerToServerAndClientNew(appRouter, {
         client({ httpUrl }) {
           return {
-            transformer: superjson,
             links: [
               httpLink({
                 url: httpUrl,
+                transformer: superjson,
               }),
             ],
           };

--- a/packages/tests/server/streaming.test.ts
+++ b/packages/tests/server/streaming.test.ts
@@ -155,11 +155,11 @@ describe('with transformer', () => {
         server: {},
         client(opts) {
           return {
-            transformer: superjson,
             links: [
               linkSpy,
               unstable_httpBatchStreamLink({
                 url: opts.httpUrl,
+                transformer: superjson,
               }),
             ],
           };

--- a/packages/tests/server/transformer.test.ts
+++ b/packages/tests/server/transformer.test.ts
@@ -35,8 +35,7 @@ test('superjson up and down', async () => {
   const { close, client } = routerToServerAndClientNew(router, {
     client({ httpUrl }) {
       return {
-        transformer,
-        links: [httpBatchLink({ url: httpUrl })],
+        links: [httpBatchLink({ url: httpUrl, transformer })],
       };
     },
   });
@@ -61,8 +60,7 @@ test('empty superjson up and down', async () => {
   const { close, client } = routerToServerAndClientNew(router, {
     client({ httpUrl }) {
       return {
-        transformer,
-        links: [httpBatchLink({ url: httpUrl })],
+        links: [httpBatchLink({ url: httpUrl, transformer })],
       };
     },
   });
@@ -89,8 +87,7 @@ test('wsLink: empty superjson up and down', async () => {
     client({ wssUrl }) {
       ws = createWSClient({ url: wssUrl });
       return {
-        transformer,
-        links: [wsLink({ client: ws })],
+        links: [wsLink({ client: ws, transformer })],
       };
     },
   });
@@ -123,8 +120,7 @@ test('devalue up and down', async () => {
   const { close, client } = routerToServerAndClientNew(router, {
     client({ httpUrl }) {
       return {
-        transformer,
-        links: [httpBatchLink({ url: httpUrl })],
+        links: [httpBatchLink({ url: httpUrl, transformer })],
       };
     },
   });
@@ -158,8 +154,7 @@ test('not batching: superjson up and devalue down', async () => {
   const { close, client } = routerToServerAndClientNew(router, {
     client({ httpUrl }) {
       return {
-        transformer,
-        links: [httpLink({ url: httpUrl })],
+        links: [httpLink({ url: httpUrl, transformer })],
       };
     },
   });
@@ -193,8 +188,7 @@ test('batching: superjson up and devalue down', async () => {
   const { close, client } = routerToServerAndClientNew(router, {
     client({ httpUrl }) {
       return {
-        transformer,
-        links: [httpBatchLink({ url: httpUrl })],
+        links: [httpBatchLink({ url: httpUrl, transformer })],
       };
     },
   });
@@ -227,8 +221,7 @@ test('batching: superjson up and f down', async () => {
 
   const { close, client } = routerToServerAndClientNew(router, {
     client: ({ httpUrl }) => ({
-      transformer,
-      links: [httpBatchLink({ url: httpUrl })],
+      links: [httpBatchLink({ url: httpUrl, transformer })],
     }),
   });
   const res = await client.hello.query(date);
@@ -277,8 +270,7 @@ test('all transformers running in correct order', async () => {
   const { close, client } = routerToServerAndClientNew(router, {
     client({ httpUrl }) {
       return {
-        transformer,
-        links: [httpBatchLink({ url: httpUrl })],
+        links: [httpBatchLink({ url: httpUrl, transformer })],
       };
     },
   });
@@ -311,8 +303,7 @@ describe('transformer on router', () => {
     const { close, client } = routerToServerAndClientNew(router, {
       client({ httpUrl }) {
         return {
-          transformer,
-          links: [httpBatchLink({ url: httpUrl })],
+          links: [httpBatchLink({ url: httpUrl, transformer })],
         };
       },
     });
@@ -344,8 +335,7 @@ describe('transformer on router', () => {
           url: wssUrl,
         });
         return {
-          transformer,
-          links: [wsLink({ client: wsClient })],
+          links: [wsLink({ client: wsClient, transformer })],
         };
       },
     });
@@ -384,8 +374,7 @@ describe('transformer on router', () => {
           url: wssUrl,
         });
         return {
-          transformer,
-          links: [wsLink({ client: wsClient })],
+          links: [wsLink({ client: wsClient, transformer })],
         };
       },
     });
@@ -437,8 +426,7 @@ describe('transformer on router', () => {
       },
       client({ httpUrl }) {
         return {
-          transformer,
-          links: [httpBatchLink({ url: httpUrl })],
+          links: [httpBatchLink({ url: httpUrl, transformer })],
         };
       },
     });
@@ -475,8 +463,7 @@ test('superjson - no input', async () => {
   const { close, httpUrl } = routerToServerAndClientNew(router, {
     client({ httpUrl }) {
       return {
-        transformer,
-        links: [httpBatchLink({ url: httpUrl })],
+        links: [httpBatchLink({ url: httpUrl, transformer })],
       };
     },
   });
@@ -514,8 +501,7 @@ describe('required transformers', () => {
     const router = t.router({});
 
     createTRPCClient<typeof router>({
-      links: [httpBatchLink({ url: '' })],
-      transformer,
+      links: [httpBatchLink({ url: '', transformer })],
     });
   });
 
@@ -527,12 +513,14 @@ describe('required transformers', () => {
     const router = t.router({});
     type Test = typeof t._config.$types.transformer;
 
-    createTRPCClient<typeof router>(
-      // @ts-expect-error missing transformer on frontend
-      {
-        links: [httpBatchLink({ url: '' })],
-      },
-    );
+    createTRPCClient<typeof router>({
+      links: [
+        httpBatchLink(
+          // @ts-expect-error missing transformer on frontend
+          { url: '' },
+        ),
+      ],
+    });
   });
 
   test('errors with transformer set on frontend but not on backend', () => {
@@ -569,8 +557,7 @@ test('tupleson', async () => {
   const { close, client } = routerToServerAndClientNew(router, {
     client({ httpUrl }) {
       return {
-        transformer,
-        links: [httpBatchLink({ url: httpUrl })],
+        links: [httpBatchLink({ url: httpUrl, transformer })],
       };
     },
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,55 +265,6 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3
 
-  examples/.test/big-router-declaration:
-    dependencies:
-      '@tanstack/react-query':
-        specifier: ^5.0.0
-        version: 5.0.0(react-dom@18.2.0)(react@18.2.0)
-      '@trpc/client':
-        specifier: npm:@trpc/client@next
-        version: link:../../../packages/client
-      '@trpc/next':
-        specifier: npm:@trpc/next@next
-        version: link:../../../packages/next
-      '@trpc/react-query':
-        specifier: npm:@trpc/react-query@next
-        version: link:../../../packages/react-query
-      '@trpc/server':
-        specifier: npm:@trpc/server@next
-        version: link:../../../packages/server
-      next:
-        specifier: ^14.0.1
-        version: 14.0.1(@babel/core@7.23.2)(react-dom@18.2.0)(react@18.2.0)
-      react:
-        specifier: ^18.2.0
-        version: 18.2.0
-      react-dom:
-        specifier: ^18.2.0
-        version: 18.2.0(react@18.2.0)
-      zod:
-        specifier: ^3.0.0
-        version: 3.22.4
-    devDependencies:
-      '@types/node':
-        specifier: ^20.10.0
-        version: 20.10.4
-      '@types/react':
-        specifier: ^18.2.33
-        version: 18.2.33
-      '@types/react-dom':
-        specifier: ^18.2.14
-        version: 18.2.14
-      eslint:
-        specifier: ^8.40.0
-        version: 8.40.0
-      tsx:
-        specifier: ^4.0.0
-        version: 4.6.2
-      typescript:
-        specifier: ^5.3.3
-        version: 5.3.3
-
   examples/.test/diagnostics-big-router:
     dependencies:
       '@tanstack/react-query':
@@ -1097,7 +1048,7 @@ importers:
         version: 2.8.8
       prisma:
         specifier: https://registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%40examplestrpc-next-prisma-starter
-        version: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252540examplestrpc-next-prisma-starter'
+        version: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252540examplestrpc-next-prisma-starter'
       start-server-and-test:
         specifier: ^1.12.0
         version: 1.14.0
@@ -1191,7 +1142,7 @@ importers:
         version: 4.1.5
       prisma:
         specifier: https://registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%40examplestrpc-next-prisma-todomvc
-        version: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252540examplestrpc-next-prisma-todomvc'
+        version: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252540examplestrpc-next-prisma-todomvc'
       start-server-and-test:
         specifier: ^1.12.0
         version: 1.14.0
@@ -1303,7 +1254,7 @@ importers:
         version: 2.8.8
       prisma:
         specifier: https://registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%40examplesnext-websockets-starter
-        version: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252540examplesnext-websockets-starter'
+        version: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252540examplesnext-websockets-starter'
       start-server-and-test:
         specifier: ^1.12.0
         version: 1.14.0
@@ -23435,7 +23386,7 @@ packages:
       prisma:
         optional: true
     dependencies:
-      prisma: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252540examplesnext-websockets-starter'
+      prisma: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252540examplesnext-websockets-starter'
     dev: false
 
   '@registry.npmjs.com/@prisma/client/-/client-5.8.1.tgz?id=examplestrpc-next-prisma-starter(prisma@5.8.1)':
@@ -23451,7 +23402,7 @@ packages:
       prisma:
         optional: true
     dependencies:
-      prisma: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252540examplestrpc-next-prisma-starter'
+      prisma: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252540examplestrpc-next-prisma-starter'
     dev: false
 
   '@registry.npmjs.com/@prisma/client/-/client-5.8.1.tgz?id=examplestrpc-next-prisma-todomvc(prisma@5.8.1)':
@@ -23467,10 +23418,10 @@ packages:
       prisma:
         optional: true
     dependencies:
-      prisma: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252540examplestrpc-next-prisma-todomvc'
+      prisma: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252540examplestrpc-next-prisma-todomvc'
     dev: false
 
-  '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252540examplesnext-websockets-starter':
+  '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252540examplesnext-websockets-starter':
     resolution: {tarball: https://registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%40examplesnext-websockets-starter}
     name: prisma
     version: 5.8.1
@@ -23480,7 +23431,7 @@ packages:
     dependencies:
       '@prisma/engines': 5.8.1
 
-  '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252540examplestrpc-next-prisma-starter':
+  '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252540examplestrpc-next-prisma-starter':
     resolution: {tarball: https://registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%40examplestrpc-next-prisma-starter}
     name: prisma
     version: 5.8.1
@@ -23490,7 +23441,7 @@ packages:
     dependencies:
       '@prisma/engines': 5.8.1
 
-  '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252540examplestrpc-next-prisma-todomvc':
+  '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252540examplestrpc-next-prisma-todomvc':
     resolution: {tarball: https://registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%40examplestrpc-next-prisma-todomvc}
     name: prisma
     version: 5.8.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,6 +265,55 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3
 
+  examples/.test/big-router-declaration:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.0.0
+        version: 5.0.0(react-dom@18.2.0)(react@18.2.0)
+      '@trpc/client':
+        specifier: npm:@trpc/client@next
+        version: link:../../../packages/client
+      '@trpc/next':
+        specifier: npm:@trpc/next@next
+        version: link:../../../packages/next
+      '@trpc/react-query':
+        specifier: npm:@trpc/react-query@next
+        version: link:../../../packages/react-query
+      '@trpc/server':
+        specifier: npm:@trpc/server@next
+        version: link:../../../packages/server
+      next:
+        specifier: ^14.0.1
+        version: 14.0.1(@babel/core@7.23.2)(react-dom@18.2.0)(react@18.2.0)
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
+      zod:
+        specifier: ^3.0.0
+        version: 3.22.4
+    devDependencies:
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.10.4
+      '@types/react':
+        specifier: ^18.2.33
+        version: 18.2.33
+      '@types/react-dom':
+        specifier: ^18.2.14
+        version: 18.2.14
+      eslint:
+        specifier: ^8.40.0
+        version: 8.40.0
+      tsx:
+        specifier: ^4.0.0
+        version: 4.6.2
+      typescript:
+        specifier: ^5.3.3
+        version: 5.3.3
+
   examples/.test/diagnostics-big-router:
     dependencies:
       '@tanstack/react-query':
@@ -1048,7 +1097,7 @@ importers:
         version: 2.8.8
       prisma:
         specifier: https://registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%40examplestrpc-next-prisma-starter
-        version: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252540examplestrpc-next-prisma-starter'
+        version: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252540examplestrpc-next-prisma-starter'
       start-server-and-test:
         specifier: ^1.12.0
         version: 1.14.0
@@ -1142,7 +1191,7 @@ importers:
         version: 4.1.5
       prisma:
         specifier: https://registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%40examplestrpc-next-prisma-todomvc
-        version: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252540examplestrpc-next-prisma-todomvc'
+        version: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252540examplestrpc-next-prisma-todomvc'
       start-server-and-test:
         specifier: ^1.12.0
         version: 1.14.0
@@ -1254,7 +1303,7 @@ importers:
         version: 2.8.8
       prisma:
         specifier: https://registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%40examplesnext-websockets-starter
-        version: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252540examplesnext-websockets-starter'
+        version: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252540examplesnext-websockets-starter'
       start-server-and-test:
         specifier: ^1.12.0
         version: 1.14.0
@@ -23386,7 +23435,7 @@ packages:
       prisma:
         optional: true
     dependencies:
-      prisma: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252540examplesnext-websockets-starter'
+      prisma: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252540examplesnext-websockets-starter'
     dev: false
 
   '@registry.npmjs.com/@prisma/client/-/client-5.8.1.tgz?id=examplestrpc-next-prisma-starter(prisma@5.8.1)':
@@ -23402,7 +23451,7 @@ packages:
       prisma:
         optional: true
     dependencies:
-      prisma: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252540examplestrpc-next-prisma-starter'
+      prisma: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252540examplestrpc-next-prisma-starter'
     dev: false
 
   '@registry.npmjs.com/@prisma/client/-/client-5.8.1.tgz?id=examplestrpc-next-prisma-todomvc(prisma@5.8.1)':
@@ -23418,10 +23467,10 @@ packages:
       prisma:
         optional: true
     dependencies:
-      prisma: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252540examplestrpc-next-prisma-todomvc'
+      prisma: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252540examplestrpc-next-prisma-todomvc'
     dev: false
 
-  '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252540examplesnext-websockets-starter':
+  '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252540examplesnext-websockets-starter':
     resolution: {tarball: https://registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%40examplesnext-websockets-starter}
     name: prisma
     version: 5.8.1
@@ -23431,7 +23480,7 @@ packages:
     dependencies:
       '@prisma/engines': 5.8.1
 
-  '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252540examplestrpc-next-prisma-starter':
+  '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252540examplestrpc-next-prisma-starter':
     resolution: {tarball: https://registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%40examplestrpc-next-prisma-starter}
     name: prisma
     version: 5.8.1
@@ -23441,7 +23490,7 @@ packages:
     dependencies:
       '@prisma/engines': 5.8.1
 
-  '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252540examplestrpc-next-prisma-todomvc':
+  '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252540examplestrpc-next-prisma-todomvc':
     resolution: {tarball: https://registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%40examplestrpc-next-prisma-todomvc}
     name: prisma
     version: 5.8.1

--- a/www/docs/client/links/httpBatchLink.md
+++ b/www/docs/client/links/httpBatchLink.md
@@ -20,6 +20,7 @@ const client = createTRPCClient<AppRouter>({
     httpBatchLink({
       url: 'http://localhost:3000',
     }),
+    // transformer,
   ],
 });
 ```
@@ -54,8 +55,13 @@ export interface HTTPLinkOptions {
    */
   AbortController?: typeof AbortController | null;
   /**
+   * Data transformer
+   * @link https://trpc.io/docs/data-transformers
+   **/
+  transformer?: DataTransformerOptions;
+  /**
    * Headers to be set on outgoing requests or a callback that of said headers
-   * @link http://trpc.io/docs/v10/header
+   * @link http://trpc.io/docs/header
    */
   headers?:
     | HTTPHeaders

--- a/www/docs/client/links/httpLink.md
+++ b/www/docs/client/links/httpLink.md
@@ -21,6 +21,7 @@ const client = createTRPCClient<AppRouter>({
   links: [
     httpLink({
       url: 'http://localhost:3000',
+      // transformer,
     }),
   ],
 });
@@ -41,6 +42,11 @@ export interface HTTPLinkOptions {
    * Add ponyfill for AbortController
    */
   AbortController?: typeof AbortController | null;
+  /**
+   * Data transformer
+   * @link https://trpc.io/docs/v11/data-transformers
+   **/
+  transformer?: DataTransformerOptions;
   /**
    * Headers to be set on outgoing requests or a callback that of said headers
    * @link http://trpc.io/docs/v10/header

--- a/www/docs/client/links/wsLink.md
+++ b/www/docs/client/links/wsLink.md
@@ -31,6 +31,11 @@ The `wsLink` function requires a `TRPCWebSocketClient` to be passed, which can b
 ```ts
 export interface WebSocketLinkOptions {
   client: TRPCWebSocketClient;
+  /**
+   * Data transformer
+   * @link https://trpc.io/docs/v11/data-transformers
+   **/
+  transformer?: DataTransformerOptions;
 }
 
 function createWSClient(opts: WebSocketClientOptions) => TRPCWebSocketClient

--- a/www/docs/client/nextjs/server-side-helpers.md
+++ b/www/docs/client/nextjs/server-side-helpers.md
@@ -45,7 +45,6 @@ const proxyClient = createTRPCClient<AppRouter>({
       url: 'http://localhost:3000/api/trpc',
     }),
   ],
-  transformer: superjson,
 });
 
 const helpers = createServerSideHelpers({

--- a/www/docs/client/nextjs/ssg.md
+++ b/www/docs/client/nextjs/ssg.md
@@ -117,7 +117,6 @@ import type { AppRouter } from './api/trpc/[trpc]';
 export const trpc = createTRPCNext<AppRouter>({
   config(opts) {
     return {
-      transformer: superjson,
       links: [
         httpBatchLink({
           url: `${getBaseUrl()}/api/trpc`,

--- a/www/docs/client/nextjs/ssr.md
+++ b/www/docs/client/nextjs/ssr.md
@@ -30,7 +30,6 @@ export const trpc = createTRPCNext<AppRouter>({
     if (typeof window !== 'undefined') {
       // during client requests
       return {
-        transformer: superjson, // optional - adds superjson serialization
         links: [
           httpBatchLink({
             url: '/api/trpc',
@@ -40,7 +39,6 @@ export const trpc = createTRPCNext<AppRouter>({
     }
 
     return {
-      transformer: superjson, // optional - adds superjson serialization
       links: [
         httpBatchLink({
           // The server needs to know your app's full url
@@ -81,7 +79,6 @@ export const trpc = createTRPCNext<AppRouter>({
     if (typeof window !== 'undefined') {
       // during client requests
       return {
-        transformer: superjson, // optional - adds superjson serialization
         links: [
           httpBatchLink({
             url: '/api/trpc',
@@ -91,7 +88,6 @@ export const trpc = createTRPCNext<AppRouter>({
     }
 
     return {
-      transformer: superjson, // optional - adds superjson serialization
       links: [
         httpBatchLink({
           // The server needs to know your app's full url

--- a/www/docs/migration/migrate-from-v10-to-v11.mdx
+++ b/www/docs/migration/migrate-from-v10-to-v11.mdx
@@ -75,7 +75,7 @@ Use `inferProcedureInput<TProcedure>` instead & `TRPCProcedureOptions` instead
 
 tl;dr - pnpm + TypeScript makes it too difficult to avoid _"The inferred type of 'createContext' cannot be named without a reference to [...]"_ errors.
 
-### Removed `@trpc/client/links/*`-entrypoints (breakings)
+### Removed `@trpc/client/links/*`-entrypoints (breaking)
 
 ```diff
 - import { httpBatchLink } from '@trpc/client/links/httpBatchLink';
@@ -111,7 +111,7 @@ https://github.com/trpc/trpc/pull/5226
 
 We have refactored our internal generics and made them more readable (TODO: link procedure builder sauce)
 
-### React is now >=18.2.0
+### React is now >=18.2.0 (breaking)
 
 Check their migration guide: https://react.dev/blog/2022/03/08/react-18-upgrade-guide
 
@@ -128,17 +128,17 @@ While we're not doing anything differently internally (just yet) this is help su
 
 Procedures in your router now only emit their input & output - where before they would also contain the full context object for every procedure, leading to unnecessary complexity in e.g. `.d.ts`.
 
-### React Query peerDep is now v5
+### React Query peerDep is now v5 (breaking)
 
 Check their migration guide: https://tanstack.com/query/v5/docs/framework/react/guides/migrating-to-v5
 
-### Exports names `AbcProxyXyz` has been renamed to `AbcXyz`
+### Exports names `AbcProxyXyz` has been renamed to `AbcXyz` (non-breaking)
 
 The proxy names were due to v9 using the `AbcXyz` names, these have been removed and the proxy ones have been renamed to the non-proxy names, e.g:
 
 - `createTRPCClient` was deprecated from v9, and is now completely removed. The `createTRPCProxyClient` has been renamed to `createTRPCClient` instead. `createTRPCProxyClient` is now marked as deprecated.
 
-### SSG Helpers
+### SSG Helpers (non-breaking for most)
 
 - `createSSGHelpers` were for v9 which has now been removed. the v10 equivalent `createProxySSGHelpers` have been renamed to `createSSGHelpers` now instead.
 - `createProxySSGHelpers` is now deprecated but aliased to `createSSGHelpers` for backwards compatibility.

--- a/www/docs/migration/migrate-from-v10-to-v11.mdx
+++ b/www/docs/migration/migrate-from-v10-to-v11.mdx
@@ -24,6 +24,10 @@ import { InstallSnippet } from '@site/src/components/InstallSnippet';
 > This is a draft document. It will be updated to a proper guide as we get closer to the v11 release.
 > The only major thing that will incur work for you is that you will need to do is to update TanStack Query to v5.0.0.
 
+### Breaking: transformers are moved to links
+
+You now setup data transforemrs in the `links`-array instead of when you initialize the tRPC-client;
+
 ### Added support for short-hand router definitions
 
 See [Merging routers](../server/merging-routers.md#defining-an-inline-sub-router-inline-sub-router)

--- a/www/docs/migration/migrate-from-v10-to-v11.mdx
+++ b/www/docs/migration/migrate-from-v10-to-v11.mdx
@@ -24,11 +24,11 @@ import { InstallSnippet } from '@site/src/components/InstallSnippet';
 > This is a draft document. It will be updated to a proper guide as we get closer to the v11 release.
 > The only major thing that will incur work for you is that you will need to do is to update TanStack Query to v5.0.0.
 
-### Breaking: transformers are moved to links
+### Transformers are moved to links (breaking)
 
 You now setup data transforemrs in the `links`-array instead of when you initialize the tRPC-client;
 
-### Added support for short-hand router definitions
+### Added support for short-hand router definitions (non-breaking)
 
 See [Merging routers](../server/merging-routers.md#defining-an-inline-sub-router-inline-sub-router)
 
@@ -45,7 +45,7 @@ const appRouter = router({
 });
 ```
 
-### Deleted `inferHandlerInput<T>` and `ProcedureArgs<T>`
+### Deleted `inferHandlerInput<T>` and `ProcedureArgs<T>` (non-breaking for most)
 
 > If these types mean nothing for you or your codebase, just ignore this
 
@@ -55,7 +55,7 @@ Use `inferProcedureInput<TProcedure>` instead & `TRPCProcedureOptions` instead
 
 tl;dr - pnpm + TypeScript makes it too difficult to avoid _"The inferred type of 'createContext' cannot be named without a reference to [...]"_ errors.
 
-### Removed `@trpc/client/links/*`-entrypoints
+### Removed `@trpc/client/links/*`-entrypoints (breakings)
 
 ```diff
 - import { httpBatchLink } from '@trpc/client/links/httpBatchLink';

--- a/www/docs/migration/migrate-from-v10-to-v11.mdx
+++ b/www/docs/migration/migrate-from-v10-to-v11.mdx
@@ -26,7 +26,27 @@ import { InstallSnippet } from '@site/src/components/InstallSnippet';
 
 ### Transformers are moved to links (breaking)
 
+> TypeScript will guide you through this migration
+>
+> Only applies if you use data transformers.
+
 You now setup data transforemrs in the `links`-array instead of when you initialize the tRPC-client;
+
+Wherever you have a HTTP Link you have to add `transformer: superjson` if you use transformers:
+
+```ts
+httpBatchLink({
+  url: '/api/trpc',
+  transformer: superjson, // <-- add this
+});
+```
+
+```ts
+createTRPCNext<AppRouter>({
+  // [..]
+  transformer: superjson, // <-- add this
+});
+```
 
 ### Added support for short-hand router definitions (non-breaking)
 
@@ -87,7 +107,7 @@ See [useSuspenseQueries](../client/react/suspense.md#usesuspensequeries)
 
 https://github.com/trpc/trpc/pull/5226
 
-### Refactor internal generics
+### Refactor internal generics (breaking)
 
 We have refactored our internal generics and made them more readable (TODO: link procedure builder sauce)
 
@@ -95,12 +115,12 @@ We have refactored our internal generics and made them more readable (TODO: link
 
 Check their migration guide: https://react.dev/blog/2022/03/08/react-18-upgrade-guide
 
-### `wsLink` improvements
+### `wsLink` improvements (minor)
 
 - Ability to pass a `Promise` in the `url`-callback if servers switch location during deploys
 - Added new `lazy` option that makes the websocket automatically disconnect when there are no pending requests
 
-### `rawInput` in middleware is now a `getRawInput`
+### `rawInput` in middleware is now a `getRawInput` (breaking)
 
 While we're not doing anything differently internally (just yet) this is help support a much requested feature in tRPC: content types other than JSON.
 

--- a/www/docs/server/data-transformers.md
+++ b/www/docs/server/data-transformers.md
@@ -30,9 +30,11 @@ export const t = initTRPC.create({
 });
 ```
 
-#### 3. Add to `createTRPCClient()`, `createTRPCNext()` or `createTRPCReact()`
+#### 3. Add to `httpLink()`, `wsLink()`, etc
 
-`createTRPCClient()`
+> TypeScript will instruct you where to add `transformer` as soon as you've added it on the `initTRPC`-object
+
+`createTRPCClient()`:
 
 ```ts title='src/app/_trpc/client.ts'
 import { createTRPCClient } from '@trpc/client';
@@ -40,56 +42,13 @@ import type { AppRouter } from '~/server/routers/_app';
 import superjson from 'superjson';
 
 export const client = createTRPCClient<AppRouter>({
-  transformer: superjson, // <--
-  // [...]
-});
-```
-
-`createTRPCNext()`
-
-```ts title='utils/trpc.ts'
-import { createTRPCNext } from '@trpc/next';
-import type { AppRouter } from '~/server/routers/_app';
-import superjson from 'superjson';
-
-// [...]
-
-export const trpc = createTRPCNext<AppRouter>({
-  config({ ctx }) {
-    return {
-      transformer: superjson, // <--
-    };
-  },
-  // [...]
-});
-```
-
-`createTRPCReact()`
-
-With React Query you need to pass the transformer to the createClient instance, as the `createTRPCReact` function does not accept the transformer as a parameter.
-
-```ts title='src/app/_trpc/client.ts'
-import type { AppRouter } from '@/server';
-import { createTRPCReact } from '@trpc/react-query';
-
-export const trpc = createTRPCReact<AppRouter>({});
-```
-
-```tsx title='src/app/_trpc/Provider.tsx'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import superjson from 'superjson';
-import { trpc } from './client';
-
-export default function Provider({ children }: { children: React.ReactNode }) {
-  const [queryClient] = useState(() => new QueryClient());
-  const [trpcClient] = useState(() =>
-    trpc.createClient({
-      transformer: superjson, // <--
+  links: [
+    httpLink({
+      url: 'http://localhost:3000',
+      // transformer: superjson
     }),
-  );
-
-  // [...]
-}
+  ],
+});
 ```
 
 ## Different transformers for upload and download
@@ -135,18 +94,6 @@ export const t = initTRPC.create({
 });
 
 export const appRouter = t.router({
-  // [...]
-});
-```
-
-#### 4. Add to `createTRPCClient()`
-
-```ts title='client.ts'
-import { createTRPCClient } from '@trpc/client';
-import { transformer } from '../utils/trpc';
-
-export const client = createTRPCClient<AppRouter>({
-  transformer, // <--
   // [...]
 });
 ```

--- a/www/docs/server/data-transformers.md
+++ b/www/docs/server/data-transformers.md
@@ -32,7 +32,7 @@ export const t = initTRPC.create({
 
 #### 3. Add to `httpLink()`, `wsLink()`, etc
 
-> TypeScript will instruct you where to add `transformer` as soon as you've added it on the `initTRPC`-object
+> TypeScript will guide you to where you need to add `transformer` as soon as you've added it on the `initTRPC`-object
 
 `createTRPCClient()`:
 


### PR DESCRIPTION
Closes #

## 🎯 Changes

### What

Breaking change.

- This moves `transformers:` from `createTRPCClient()` to links
- This will enable us to add support for tupleson without affecting `createTRPCClient` - it'll just be a link with tupleson options

### How

- Adds some more types to `TRPCInferrable`
- Move the transformer options thingie to links
- Add a hint on the old `createTRPCClient` et al
- [...]

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] Update examples
- [x] I have added or updated the tests related to the changes made.
