### PR TITLE
chore: move some tests to be contextual

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ pnpm test-watch react
 pnpm test-watch 3085
 ```
 
-Testing is currently coalesced in [./packages/tests](./packages/tests); we import the different libs from here, this makes it easier for us to do integration testing + getting test coverage on the whole codebase.
+Test are mainly coalesced in [./packages/tests](./packages/tests); we import the different libs from here, this makes it easier for us to do integration testing.
 
 ### Linting
 

--- a/packages/server/src/unstable-core-do-not-import/initTRPC.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/initTRPC.test.ts
@@ -1,8 +1,8 @@
-import { initTRPC } from '@trpc/server';
+import { initTRPC } from './initTRPC';
 import type {
   CombinedDataTransformer,
   DataTransformerOptions,
-} from '@trpc/server/unstable-core-do-not-import';
+} from './transformer';
 
 test('default transformer', () => {
   const t = initTRPC

--- a/packages/server/src/unstable-core-do-not-import/router.mergeRouters.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/router.mergeRouters.test.ts
@@ -1,6 +1,6 @@
-import type { TRPCRouterRecord } from '@trpc/server';
-import { initTRPC } from '@trpc/server';
-import type { inferRootTypes } from '@trpc/server/unstable-core-do-not-import';
+import type { inferRootTypes } from '.';
+import type { TRPCRouterRecord } from '..';
+import { initTRPC } from '..';
 
 test('mergeRouters', async () => {
   const t = initTRPC.create();

--- a/packages/server/src/unstable-core-do-not-import/router.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/router.test.ts
@@ -1,4 +1,4 @@
-import { initTRPC } from '@trpc/server';
+import { initTRPC } from './initTRPC';
 
 const t = initTRPC.create();
 

--- a/packages/server/src/unstable-core-do-not-import/router.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/router.test.ts
@@ -1,4 +1,4 @@
-import { initTRPC } from './initTRPC';
+import { initTRPC } from '..';
 
 const t = initTRPC.create();
 


### PR DESCRIPTION
Ref #4465

## 🎯 Changes

- Unit tests should sit next to the units
- Integration tests should live in `packages/tests`
- _We should probably add a `@trpc/test-lib` as well for utils_

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
