### PR TITLE
docs: remove typo in v11 migration docs

### DIFF
--- a/www/docs/migration/migrate-from-v10-to-v11.mdx
+++ b/www/docs/migration/migrate-from-v10-to-v11.mdx
@@ -36,7 +36,7 @@ See [SSR docs](../client/nextjs/ssr.md)
 >
 > Only applies if you use data transformers.
 
-You now setup data transforemrs in the `links`-array instead of when you initialize the tRPC-client;
+You now setup data transformers in the `links`-array instead of when you initialize the tRPC-client;
 
 Wherever you have a HTTP Link you have to add `transformer: superjson` if you use transformers:
 


### PR DESCRIPTION
Closes #

## 🎯 Changes

This PR fixes a typo in the docs – located in the v10 to v11 migration [page](https://trpc.io/docs/migrate-from-v10-to-v11#transformers-are-moved-to-links-breaking).

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
