### PR TITLE
fix(react-query): no ref in `useHookResult()`

### DIFF
--- a/packages/react-query/src/internals/useHookResult.ts
+++ b/packages/react-query/src/internals/useHookResult.ts
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useMemo } from 'react';
 
 export interface TRPCHookResult {
   trpc: {
@@ -12,7 +12,6 @@ export interface TRPCHookResult {
 export function useHookResult(
   value: TRPCHookResult['trpc'],
 ): TRPCHookResult['trpc'] {
-  const ref = useRef(value);
-  ref.current.path = value.path;
-  return ref.current;
+  const { path } = value;
+  return useMemo(() => ({ path }), [path]);
 }


### PR DESCRIPTION
Might close #5429

## 🎯 Changes

Skip using `useRef`, use `useMemo()` instead

Not sure how _"Cannot assign to read-only property 'path'"_ can happen, but this should make it impossible since it'll return a new obj every time instead
