### PR TITLE
chore(react-query): simplify `useHookResult()`

### DIFF
--- a/packages/react-query/src/internals/useHookResult.ts
+++ b/packages/react-query/src/internals/useHookResult.ts
@@ -1,18 +1,16 @@
 import * as React from 'react';
-
-export interface TRPCHookResult {
-  trpc: {
-    path: string;
-  };
-}
+import type { TRPCHookResult } from '../shared/hooks/types';
 
 /**
  * Makes a stable reference of the `trpc` prop
  */
-export function useHookResult(
-  value: TRPCHookResult['trpc'],
-): TRPCHookResult['trpc'] {
-  const ref = React.useRef(value);
-  ref.current.path = value.path;
-  return ref.current;
+export function useHookResult(value: {
+  path: string[];
+}): TRPCHookResult['trpc'] {
+  return React.useMemo(
+    () => ({
+      path: value.path.join('.'),
+    }),
+    [value.path],
+  );
 }

--- a/packages/react-query/src/internals/useHookResult.ts
+++ b/packages/react-query/src/internals/useHookResult.ts
@@ -7,10 +7,11 @@ import type { TRPCHookResult } from '../shared/hooks/types';
 export function useHookResult(value: {
   path: string[];
 }): TRPCHookResult['trpc'] {
+  const path = value.path.join('.');
   return React.useMemo(
     () => ({
-      path: value.path.join('.'),
+      path,
     }),
-    [value.path],
+    [path],
   );
 }

--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -182,7 +182,7 @@ export function createRootHooks<
     ) as UseTRPCQueryResult<unknown, TError>;
 
     hook.trpc = useHookResult({
-      path: path.join('.'),
+      path,
     });
 
     return hook;
@@ -221,7 +221,7 @@ export function createRootHooks<
     ) as UseTRPCQueryResult<unknown, TError>;
 
     hook.trpc = useHookResult({
-      path: path.join('.'),
+      path,
     });
 
     return [hook.data, hook as any];
@@ -259,7 +259,7 @@ export function createRootHooks<
     ) as UseTRPCMutationResult<unknown, TError, unknown, unknown>;
 
     hook.trpc = useHookResult({
-      path: path.join('.'),
+      path,
     });
 
     return hook;
@@ -376,7 +376,7 @@ export function createRootHooks<
     ) as UseTRPCInfiniteQueryResult<unknown, TError, unknown>;
 
     hook.trpc = useHookResult({
-      path: path.join('.'),
+      path,
     });
     return hook;
   }
@@ -429,7 +429,7 @@ export function createRootHooks<
     ) as UseTRPCInfiniteQueryResult<unknown, TError, unknown>;
 
     hook.trpc = useHookResult({
-      path: path.join('.'),
+      path,
     });
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/react-query/src/shared/hooks/types.ts
+++ b/packages/react-query/src/shared/hooks/types.ts
@@ -29,7 +29,6 @@ import type {
 import type { ReactNode } from 'react';
 import type { TRPCContextProps } from '../../internals/context';
 import type { TRPCQueryKey } from '../../internals/getQueryKey';
-import type { TRPCHookResult } from '../../internals/useHookResult';
 
 export type OutputWithCursor<TData, TCursor = any> = {
   cursor: TCursor | null;
@@ -226,3 +225,9 @@ export type UseTRPCSuspenseInfiniteQueryResult<TData, TError, TInput> = [
  */
 export type UseTRPCMutationResult<TData, TError, TVariables, TContext> =
   TRPCHookResult & UseMutationResult<TData, TError, TVariables, TContext>;
+
+export interface TRPCHookResult {
+  trpc: {
+    path: string;
+  };
+}


### PR DESCRIPTION
Ref #5429

## 🎯 Changes

Simplifies `useHookResult()`