### PR TITLE
chore: delete version from `package.json`s that don't need it

### DIFF
--- a/examples/.experimental/next-app-dir/package.json
+++ b/examples/.experimental/next-app-dir/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@examples/next-app-dir",
   "private": true,
-  "version": "10.45.1",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/examples/.experimental/next-app-dir/package.json
+++ b/examples/.experimental/next-app-dir/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@examples/next-app-dir",
   "private": true,
-  "version": "10.45.0",
+  "version": "10.45.1",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/examples/.experimental/next-formdata/package.json
+++ b/examples/.experimental/next-formdata/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@examples/next-formdata",
-  "version": "10.45.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/examples/.experimental/next-formdata/package.json
+++ b/examples/.experimental/next-formdata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/next-formdata",
-  "version": "10.45.0",
+  "version": "10.45.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/examples/.test/diagnostics-big-router/package.json
+++ b/examples/.test/diagnostics-big-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/diagnostics-big-router-declaration",
-  "version": "10.45.1",
+  
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/examples/.test/diagnostics-big-router/package.json
+++ b/examples/.test/diagnostics-big-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/diagnostics-big-router-declaration",
-  "version": "10.45.0",
+  "version": "10.45.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/examples/.test/diagnostics-big-router/package.json
+++ b/examples/.test/diagnostics-big-router/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@examples/diagnostics-big-router-declaration",
-  
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/examples/.test/internal-types-export/package.json
+++ b/examples/.test/internal-types-export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/internal-types-export",
-  "version": "10.45.1",
+  
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/.test/internal-types-export/package.json
+++ b/examples/.test/internal-types-export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/internal-types-export",
-  "version": "10.45.0",
+  "version": "10.45.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/.test/internal-types-export/package.json
+++ b/examples/.test/internal-types-export/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@examples/internal-types-export",
-  
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/.test/ssg/package.json
+++ b/examples/.test/ssg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/test-ssg",
-  "version": "10.45.0",
+  "version": "10.45.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/examples/.test/ssg/package.json
+++ b/examples/.test/ssg/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@examples/test-ssg",
-  
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/examples/.test/ssg/package.json
+++ b/examples/.test/ssg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/test-ssg",
-  "version": "10.45.1",
+  
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/examples/bun/package.json
+++ b/examples/bun/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@examples/bun",
   "private": true,
-  "version": "10.45.0",
+  "version": "10.45.1",
   "scripts": {
     "build": "bun build src/index.ts --outdir ./dist && bun build src/client.ts --outdir ./dist",
     "dev:server": "bun run src/index.ts --watch",

--- a/examples/bun/package.json
+++ b/examples/bun/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@examples/bun",
   "private": true,
-  "version": "10.45.1",
   "scripts": {
     "build": "bun build src/index.ts --outdir ./dist && bun build src/client.ts --outdir ./dist",
     "dev:server": "bun run src/index.ts --watch",

--- a/examples/cloudflare-workers/package.json
+++ b/examples/cloudflare-workers/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@examples/cloudflare-workers",
-  "version": "10.45.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/cloudflare-workers/package.json
+++ b/examples/cloudflare-workers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/cloudflare-workers",
-  "version": "10.45.0",
+  "version": "10.45.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/express-minimal/package.json
+++ b/examples/express-minimal/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@examples/express-minimal",
-  "version": "10.45.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/express-minimal/package.json
+++ b/examples/express-minimal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/express-minimal",
-  "version": "10.45.0",
+  "version": "10.45.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/express-server/package.json
+++ b/examples/express-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/express-server",
-  "version": "10.45.0",
+  "version": "10.45.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/express-server/package.json
+++ b/examples/express-server/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@examples/express-server",
-  "version": "10.45.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/fastify-server/package.json
+++ b/examples/fastify-server/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@examples/fastify-server",
-  "version": "10.45.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/fastify-server/package.json
+++ b/examples/fastify-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/fastify-server",
-  "version": "10.45.0",
+  "version": "10.45.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/lambda-api-gateway/package.json
+++ b/examples/lambda-api-gateway/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@examples/lambda-api-gateway",
   "private": true,
-  "version": "10.45.0",
+  "version": "10.45.1",
   "type": "module",
   "main": "index.js",
   "license": "MIT",

--- a/examples/lambda-api-gateway/package.json
+++ b/examples/lambda-api-gateway/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@examples/lambda-api-gateway",
   "private": true,
-  "version": "10.45.1",
   "type": "module",
   "main": "index.js",
   "license": "MIT",

--- a/examples/minimal-react/client/package.json
+++ b/examples/minimal-react/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@examples/minimal-react-client",
   "private": true,
-  "version": "10.45.0",
+  "version": "10.45.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/examples/minimal-react/client/package.json
+++ b/examples/minimal-react/client/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@examples/minimal-react-client",
   "private": true,
-  "version": "10.45.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/examples/minimal-react/package.json
+++ b/examples/minimal-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@examples/minimal-react",
   "private": true,
-  "version": "10.45.0",
+  "version": "10.45.1",
   "workspaces": [
     "client",
     "server"

--- a/examples/minimal-react/package.json
+++ b/examples/minimal-react/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@examples/minimal-react",
   "private": true,
-  "version": "10.45.1",
   "workspaces": [
     "client",
     "server"

--- a/examples/minimal-react/server/package.json
+++ b/examples/minimal-react/server/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@examples/minimal-react-server",
-  "version": "10.45.1",
   "private": true,
   "scripts": {
     "build": "tsc",

--- a/examples/minimal-react/server/package.json
+++ b/examples/minimal-react/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/minimal-react-server",
-  "version": "10.45.0",
+  "version": "10.45.1",
   "private": true,
   "scripts": {
     "build": "tsc",

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@examples/minimal",
   "private": true,
-  "version": "10.45.0",
+  "version": "10.45.1",
   "type": "module",
   "scripts": {
     "build": "tsc",

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@examples/minimal",
   "private": true,
-  "version": "10.45.1",
   "type": "module",
   "scripts": {
     "build": "tsc",

--- a/examples/next-big-router/package.json
+++ b/examples/next-big-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/next-big-router",
-  "version": "10.45.0",
+  "version": "10.45.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/examples/next-big-router/package.json
+++ b/examples/next-big-router/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@examples/next-big-router",
-  "version": "10.45.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/examples/next-edge-runtime/package.json
+++ b/examples/next-edge-runtime/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@examples/next-edge-runtime",
-  "version": "10.45.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/examples/next-edge-runtime/package.json
+++ b/examples/next-edge-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/next-edge-runtime",
-  "version": "10.45.0",
+  "version": "10.45.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/examples/next-minimal-starter/package.json
+++ b/examples/next-minimal-starter/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@examples/next-minimal",
-  "version": "10.45.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/examples/next-minimal-starter/package.json
+++ b/examples/next-minimal-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/next-minimal",
-  "version": "10.45.0",
+  "version": "10.45.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/examples/next-prisma-starter/package.json
+++ b/examples/next-prisma-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/trpc-next-prisma-starter",
-  "version": "10.45.0",
+  "version": "10.45.1",
   "private": true,
   "engines": {
     "node": ">=18.0.0"

--- a/examples/next-prisma-starter/package.json
+++ b/examples/next-prisma-starter/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@examples/trpc-next-prisma-starter",
-  "version": "10.45.1",
   "private": true,
   "engines": {
     "node": ">=18.0.0"

--- a/examples/next-prisma-todomvc/package.json
+++ b/examples/next-prisma-todomvc/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@examples/trpc-next-prisma-todomvc",
-  "version": "10.45.1",
   "private": true,
   "engines": {
     "node": ">=18.15.0"

--- a/examples/next-prisma-todomvc/package.json
+++ b/examples/next-prisma-todomvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/trpc-next-prisma-todomvc",
-  "version": "10.45.0",
+  "version": "10.45.1",
   "private": true,
   "engines": {
     "node": ">=18.15.0"

--- a/examples/next-prisma-websockets-starter/package.json
+++ b/examples/next-prisma-websockets-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/next-websockets-starter",
-  "version": "10.45.0",
+  "version": "10.45.1",
   "private": true,
   "engines": {
     "node": ">=18.15.0"

--- a/examples/next-prisma-websockets-starter/package.json
+++ b/examples/next-prisma-websockets-starter/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@examples/next-websockets-starter",
-  "version": "10.45.1",
   "private": true,
   "engines": {
     "node": ">=18.15.0"

--- a/examples/soa/package.json
+++ b/examples/soa/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@examples/soa",
   "private": true,
-  "version": "10.45.1",
   "type": "module",
   "scripts": {
     "build": "tsc",

--- a/examples/soa/package.json
+++ b/examples/soa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@examples/soa",
   "private": true,
-  "version": "10.45.0",
+  "version": "10.45.1",
   "type": "module",
   "scripts": {
     "build": "tsc",

--- a/examples/standalone-server/package.json
+++ b/examples/standalone-server/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@examples/standalone-server",
-  "version": "10.45.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/standalone-server/package.json
+++ b/examples/standalone-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/standalone-server",
-  "version": "10.45.0",
+  "version": "10.45.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/vercel-edge-runtime/package.json
+++ b/examples/vercel-edge-runtime/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@examples/vercel-edge-runtime",
-  "version": "10.45.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/vercel-edge-runtime/package.json
+++ b/examples/vercel-edge-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@examples/vercel-edge-runtime",
-  "version": "10.45.0",
+  "version": "10.45.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "10.45.0",
+  "version": "10.45.1",
   "registry": "https://registry.npmjs.org/",
   "npmClient": "pnpm",
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/client",
-  "version": "10.45.0",
+  "version": "10.45.1",
   "description": "The tRPC client library",
   "author": "KATT",
   "license": "MIT",
@@ -77,11 +77,11 @@
   ],
   "dependencies": {},
   "peerDependencies": {
-    "@trpc/server": "^10.45.0"
+    "@trpc/server": "^10.45.1"
   },
   "devDependencies": {
     "@testing-library/dom": "^9.0.0",
-    "@trpc/server": "^10.45.0",
+    "@trpc/server": "^10.45.1",
     "@types/isomorphic-fetch": "^0.0.39",
     "@types/node": "^20.10.0",
     "eslint": "^8.40.0",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/next",
-  "version": "10.45.0",
+  "version": "10.45.1",
   "description": "The tRPC Next.js library",
   "author": "KATT",
   "license": "MIT",
@@ -75,8 +75,8 @@
   "peerDependencies": {
     "@tanstack/react-query": "^5.0.0",
     "@trpc/client": "10.45.1",
-    "@trpc/react-query": "10.45.0",
-    "@trpc/server": "^10.45.0",
+    "@trpc/react-query": "10.45.1",
+    "@trpc/server": "^10.45.1",
     "next": "*",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
@@ -92,8 +92,8 @@
   "devDependencies": {
     "@tanstack/react-query": "^5.0.0",
     "@trpc/client": "10.45.1",
-    "@trpc/react-query": "10.45.0",
-    "@trpc/server": "^10.45.0",
+    "@trpc/react-query": "10.45.1",
+    "@trpc/server": "^10.45.1",
     "@types/express": "^4.17.17",
     "@types/node": "^20.10.0",
     "@types/react": "^18.2.33",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -74,7 +74,7 @@
   "dependencies": {},
   "peerDependencies": {
     "@tanstack/react-query": "^5.0.0",
-    "@trpc/client": "10.45.0",
+    "@trpc/client": "10.45.1",
     "@trpc/react-query": "10.45.0",
     "@trpc/server": "^10.45.0",
     "next": "*",
@@ -91,7 +91,7 @@
   },
   "devDependencies": {
     "@tanstack/react-query": "^5.0.0",
-    "@trpc/client": "10.45.0",
+    "@trpc/client": "10.45.1",
     "@trpc/react-query": "10.45.0",
     "@trpc/server": "^10.45.0",
     "@types/express": "^4.17.17",

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -59,14 +59,14 @@
   "dependencies": {},
   "peerDependencies": {
     "@tanstack/react-query": "^5.0.0",
-    "@trpc/client": "10.45.0",
+    "@trpc/client": "10.45.1",
     "@trpc/server": "^10.45.0",
     "react": ">=18.2.0",
     "react-dom": ">=18.2.0"
   },
   "devDependencies": {
     "@tanstack/react-query": "^5.0.0",
-    "@trpc/client": "10.45.0",
+    "@trpc/client": "10.45.1",
     "@trpc/server": "^10.45.0",
     "@types/express": "^4.17.17",
     "@types/node": "^20.10.0",

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/react-query",
-  "version": "10.45.0",
+  "version": "10.45.1",
   "description": "The tRPC React library",
   "author": "KATT",
   "license": "MIT",
@@ -60,14 +60,14 @@
   "peerDependencies": {
     "@tanstack/react-query": "^5.0.0",
     "@trpc/client": "10.45.1",
-    "@trpc/server": "^10.45.0",
+    "@trpc/server": "^10.45.1",
     "react": ">=18.2.0",
     "react-dom": ">=18.2.0"
   },
   "devDependencies": {
     "@tanstack/react-query": "^5.0.0",
     "@trpc/client": "10.45.1",
-    "@trpc/server": "^10.45.0",
+    "@trpc/server": "^10.45.1",
     "@types/express": "^4.17.17",
     "@types/node": "^20.10.0",
     "@types/react": "^18.2.33",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/server",
-  "version": "10.45.0",
+  "version": "10.45.1",
   "description": "The tRPC server library",
   "author": "KATT",
   "license": "MIT",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@trpc/tests",
-  "version": "10.45.1",
   "private": true,
   "scripts": {
     "codegen:bigBoi": "tsx ../../scripts/generateBigBoi.ts",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/tests",
-  "version": "10.45.0",
+  "version": "10.45.1",
   "private": true,
   "scripts": {
     "codegen:bigBoi": "tsx ../../scripts/generateBigBoi.ts",
@@ -25,10 +25,10 @@
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
-    "@trpc/client": "10.45.0",
-    "@trpc/next": "10.45.0",
-    "@trpc/react-query": "10.45.0",
-    "@trpc/server": "^10.45.0",
+    "@trpc/client": "10.45.1",
+    "@trpc/next": "10.45.1",
+    "@trpc/react-query": "10.45.1",
+    "@trpc/server": "^10.45.1",
     "@types/node": "^20.10.0",
     "@vitest/coverage-istanbul": "^0.32.0",
     "@vitest/ui": "^0.32.0",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -25,7 +25,7 @@
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
-    "@trpc/client": "10.45.1",
+    "@trpc/client": "10.45.0",
     "@trpc/next": "10.45.0",
     "@trpc/react-query": "10.45.0",
     "@trpc/server": "^10.45.0",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -25,7 +25,7 @@
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
-    "@trpc/client": "10.45.0",
+    "@trpc/client": "10.45.1",
     "@trpc/next": "10.45.0",
     "@trpc/react-query": "10.45.0",
     "@trpc/server": "^10.45.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1378,7 +1378,7 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0
       '@trpc/server':
-        specifier: ^10.45.0
+        specifier: ^10.45.1
         version: link:../server
       '@types/isomorphic-fetch':
         specifier: ^0.0.39
@@ -1415,12 +1415,12 @@ importers:
         version: 5.0.0(react-dom@18.2.0)(react@18.2.0)
       '@trpc/client':
         specifier: 10.45.1
-        version: 10.45.1(@trpc/server@packages+server)
+        version: link:../client
       '@trpc/react-query':
-        specifier: 10.45.0
+        specifier: 10.45.1
         version: link:../react-query
       '@trpc/server':
-        specifier: ^10.45.0
+        specifier: ^10.45.1
         version: link:../server
       '@types/express':
         specifier: ^4.17.17
@@ -1466,9 +1466,9 @@ importers:
         version: 5.0.0(react-dom@18.2.0)(react@18.2.0)
       '@trpc/client':
         specifier: 10.45.1
-        version: 10.45.1(@trpc/server@packages+server)
+        version: link:../client
       '@trpc/server':
-        specifier: ^10.45.0
+        specifier: ^10.45.1
         version: link:../server
       '@types/express':
         specifier: ^4.17.17
@@ -1637,15 +1637,15 @@ importers:
         version: 14.4.3(@testing-library/dom@9.0.0)
       '@trpc/client':
         specifier: 10.45.1
-        version: 10.45.1(@trpc/server@packages+server)
+        version: link:../client
       '@trpc/next':
-        specifier: 10.45.0
+        specifier: 10.45.1
         version: link:../next
       '@trpc/react-query':
-        specifier: 10.45.0
+        specifier: 10.45.1
         version: link:../react-query
       '@trpc/server':
-        specifier: ^10.45.0
+        specifier: ^10.45.1
         version: link:../server
       '@types/node':
         specifier: ^20.10.0
@@ -1774,16 +1774,16 @@ importers:
         specifier: ^1.6.22
         version: 1.6.22(react@18.2.0)
       '@trpc/client':
-        specifier: ^10.45.0
+        specifier: ^10.45.1
         version: link:../packages/client
       '@trpc/next':
-        specifier: ^10.45.0
+        specifier: ^10.45.1
         version: link:../packages/next
       '@trpc/react-query':
-        specifier: ^10.45.0
+        specifier: ^10.45.1
         version: link:../packages/react-query
       '@trpc/server':
-        specifier: ^10.45.0
+        specifier: ^10.45.1
         version: link:../packages/server
       '@visx/hierarchy':
         specifier: ^3.0.0
@@ -8282,13 +8282,6 @@ packages:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
     dev: false
-
-  /@trpc/client@10.45.1(@trpc/server@packages+server):
-    resolution: {integrity: sha512-nVbAk1xpIiI64WgzXGgfxPOGgHoYvffn1IsjV1D/Ri7DL4BKuo2qtZ7UQ+OuHkzH2M8j4ikSVBDpk545fOdvpw==}
-    peerDependencies:
-      '@trpc/server': 10.45.1
-    dependencies:
-      '@trpc/server': link:packages/server
 
   /@trysound/sax@0.2.0:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1051,7 +1051,7 @@ importers:
         version: 2.8.8
       prisma:
         specifier: https://registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%40examplestrpc-next-prisma-starter
-        version: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252525252525252540examplestrpc-next-prisma-starter'
+        version: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252525252525252540examplestrpc-next-prisma-starter'
       start-server-and-test:
         specifier: ^1.12.0
         version: 1.14.0
@@ -1145,7 +1145,7 @@ importers:
         version: 4.1.5
       prisma:
         specifier: https://registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%40examplestrpc-next-prisma-todomvc
-        version: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252525252525252540examplestrpc-next-prisma-todomvc'
+        version: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252525252525252540examplestrpc-next-prisma-todomvc'
       start-server-and-test:
         specifier: ^1.12.0
         version: 1.14.0
@@ -1257,7 +1257,7 @@ importers:
         version: 2.8.8
       prisma:
         specifier: https://registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%40examplesnext-websockets-starter
-        version: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252525252525252540examplesnext-websockets-starter'
+        version: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252525252525252540examplesnext-websockets-starter'
       start-server-and-test:
         specifier: ^1.12.0
         version: 1.14.0
@@ -1414,8 +1414,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0(react-dom@18.2.0)(react@18.2.0)
       '@trpc/client':
-        specifier: 10.45.0
-        version: link:../client
+        specifier: 10.45.1
+        version: 10.45.1(@trpc/server@packages+server)
       '@trpc/react-query':
         specifier: 10.45.0
         version: link:../react-query
@@ -1465,8 +1465,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0(react-dom@18.2.0)(react@18.2.0)
       '@trpc/client':
-        specifier: 10.45.0
-        version: link:../client
+        specifier: 10.45.1
+        version: 10.45.1(@trpc/server@packages+server)
       '@trpc/server':
         specifier: ^10.45.0
         version: link:../server
@@ -1636,8 +1636,8 @@ importers:
         specifier: ^14.4.3
         version: 14.4.3(@testing-library/dom@9.0.0)
       '@trpc/client':
-        specifier: 10.45.0
-        version: link:../client
+        specifier: 10.45.1
+        version: 10.45.1(@trpc/server@packages+server)
       '@trpc/next':
         specifier: 10.45.0
         version: link:../next
@@ -8282,6 +8282,13 @@ packages:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
     dev: false
+
+  /@trpc/client@10.45.1(@trpc/server@packages+server):
+    resolution: {integrity: sha512-nVbAk1xpIiI64WgzXGgfxPOGgHoYvffn1IsjV1D/Ri7DL4BKuo2qtZ7UQ+OuHkzH2M8j4ikSVBDpk545fOdvpw==}
+    peerDependencies:
+      '@trpc/server': 10.45.1
+    dependencies:
+      '@trpc/server': link:packages/server
 
   /@trysound/sax@0.2.0:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -23372,7 +23379,7 @@ packages:
       prisma:
         optional: true
     dependencies:
-      prisma: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252525252525252540examplesnext-websockets-starter'
+      prisma: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252525252525252540examplesnext-websockets-starter'
     dev: false
 
   '@registry.npmjs.com/@prisma/client/-/client-5.8.1.tgz?id=examplestrpc-next-prisma-starter(prisma@5.8.1)':
@@ -23388,7 +23395,7 @@ packages:
       prisma:
         optional: true
     dependencies:
-      prisma: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252525252525252540examplestrpc-next-prisma-starter'
+      prisma: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252525252525252540examplestrpc-next-prisma-starter'
     dev: false
 
   '@registry.npmjs.com/@prisma/client/-/client-5.8.1.tgz?id=examplestrpc-next-prisma-todomvc(prisma@5.8.1)':
@@ -23404,10 +23411,10 @@ packages:
       prisma:
         optional: true
     dependencies:
-      prisma: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252525252525252540examplestrpc-next-prisma-todomvc'
+      prisma: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252525252525252540examplestrpc-next-prisma-todomvc'
     dev: false
 
-  '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252525252525252540examplesnext-websockets-starter':
+  '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252525252525252540examplesnext-websockets-starter':
     resolution: {tarball: https://registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%40examplesnext-websockets-starter}
     name: prisma
     version: 5.8.1
@@ -23417,7 +23424,7 @@ packages:
     dependencies:
       '@prisma/engines': 5.8.1
 
-  '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252525252525252540examplestrpc-next-prisma-starter':
+  '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252525252525252540examplestrpc-next-prisma-starter':
     resolution: {tarball: https://registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%40examplestrpc-next-prisma-starter}
     name: prisma
     version: 5.8.1
@@ -23427,7 +23434,7 @@ packages:
     dependencies:
       '@prisma/engines': 5.8.1
 
-  '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252525252525252540examplestrpc-next-prisma-todomvc':
+  '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%252525252525252525252540examplestrpc-next-prisma-todomvc':
     resolution: {tarball: https://registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%40examplestrpc-next-prisma-todomvc}
     name: prisma
     version: 5.8.1

--- a/www/package.json
+++ b/www/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www",
-  "version": "10.45.0",
+  "version": "10.45.1",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
@@ -31,10 +31,10 @@
     "@docusaurus/theme-common": "^2.4.1",
     "@docusaurus/types": "^2.4.1",
     "@mdx-js/react": "^1.6.22",
-    "@trpc/client": "^10.45.0",
-    "@trpc/next": "^10.45.0",
-    "@trpc/react-query": "^10.45.0",
-    "@trpc/server": "^10.45.0",
+    "@trpc/client": "^10.45.1",
+    "@trpc/next": "^10.45.1",
+    "@trpc/react-query": "^10.45.1",
+    "@trpc/server": "^10.45.1",
     "@visx/hierarchy": "^3.0.0",
     "@visx/responsive": "^3.0.0",
     "clsx": "^2.0.0",

--- a/www/package.json
+++ b/www/package.json
@@ -1,6 +1,5 @@
 {
   "name": "www",
-  "version": "10.45.1",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
Closes #

## 🎯 Changes

- deletes `"version":` from examples, www, etc
- bumps to `10.45.1` so that Renovate doesn't complain