### PR TITLE
fix(next): fix unintentional breaking change from prepass PR

### DIFF
--- a/.github/workflows/release-tmp.yml
+++ b/.github/workflows/release-tmp.yml
@@ -5,7 +5,7 @@ on:
     branches:
       # Replace this with the branch you want to release from
       # 👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇
-      - '01-26-no-proc-router-rec'
+      - '02-08-tmp'
       # 👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆
     paths:
       - '.github/workflows/release-tmp.yml'

--- a/packages/next/src/withTRPC.tsx
+++ b/packages/next/src/withTRPC.tsx
@@ -177,7 +177,7 @@ export function withTRPC<
           ...originalPageProps,
           ...pageProps,
         };
-        const getAppTreeProps = (props: Record<string, unknown>) =>
+        const getAppTreeProps = (props: Dict<unknown>) =>
           isApp ? { pageProps: props } : props;
 
         return getAppTreeProps(pageProps);

--- a/packages/next/src/withTRPC.tsx
+++ b/packages/next/src/withTRPC.tsx
@@ -157,7 +157,7 @@ export function withTRPC<
         WithTRPC,
       });
     } else if (AppOrPage.getInitialProps) {
-      // Support getInitialProps in wrapped components
+      // Allow combining `getServerSideProps` and `getInitialProps`
 
       WithTRPC.getInitialProps = async (appOrPageCtx: AppContextType) => {
         // Determine if we are wrapping an App component or a Page component.

--- a/packages/next/src/withTRPC.tsx
+++ b/packages/next/src/withTRPC.tsx
@@ -18,10 +18,12 @@ import type {
 import { createRootHooks, getQueryClient } from '@trpc/react-query/shared';
 import type {
   AnyRouter,
+  Dict,
   inferClientTypes,
   ResponseMeta,
 } from '@trpc/server/unstable-core-do-not-import';
 import type {
+  AppContextType,
   AppPropsType,
   NextComponentType,
   NextPageContext,
@@ -154,6 +156,32 @@ export function withTRPC<
         AppOrPage,
         WithTRPC,
       });
+    } else if (AppOrPage.getInitialProps) {
+      // Support getInitialProps in wrapped components
+
+      WithTRPC.getInitialProps = async (appOrPageCtx: AppContextType) => {
+        // Determine if we are wrapping an App component or a Page component.
+        const isApp = !!appOrPageCtx.Component;
+
+        // Run the wrapped component's getInitialProps function.
+        let pageProps: Dict<unknown> = {};
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const originalProps = await AppOrPage.getInitialProps!(
+          appOrPageCtx as any,
+        );
+        const originalPageProps = isApp
+          ? originalProps.pageProps ?? {}
+          : originalProps;
+
+        pageProps = {
+          ...originalPageProps,
+          ...pageProps,
+        };
+        const getAppTreeProps = (props: Record<string, unknown>) =>
+          isApp ? { pageProps: props } : props;
+
+        return getAppTreeProps(pageProps);
+      };
     }
 
     const displayName = AppOrPage.displayName ?? AppOrPage.name ?? 'Component';


### PR DESCRIPTION
Closes #

## 🎯 Changes

Accidentally did some breaking changes in #5426 to do when you combine `getServerSideProps` and `getInitialProps` which worked prior

Noticed when upgrading at work.

This is a complete hack but hopefully our pages-router-stuff won't be long-lived.


## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
