### PR TITLE
Add batchInterval option to dataLoader

### DIFF
--- a/packages/client/src/internals/dataLoader.ts
+++ b/packages/client/src/internals/dataLoader.ts
@@ -39,6 +39,7 @@ const throwFatalError = () => {
  */
 export function dataLoader<TKey, TValue>(
   batchLoader: BatchLoader<TKey, TValue>,
+  batchInterval = 0,
 ) {
   let pendingItems: BatchItem<TKey, TValue>[] | null = null;
   let dispatchTimer: ReturnType<typeof setTimeout> | null = null;
@@ -159,7 +160,7 @@ export function dataLoader<TKey, TValue>(
     });
 
     if (!dispatchTimer) {
-      dispatchTimer = setTimeout(dispatch);
+      dispatchTimer = setTimeout(dispatch, batchInterval);
     }
     const cancel = () => {
       item.aborted = true;

--- a/packages/client/src/links/HTTPBatchLinkOptions.ts
+++ b/packages/client/src/links/HTTPBatchLinkOptions.ts
@@ -6,6 +6,7 @@ import type { HTTPHeaders, Operation } from './types';
 export type HTTPBatchLinkOptions<TRoot extends AnyClientTypes> =
   HTTPLinkBaseOptions<TRoot> & {
     maxURLLength?: number;
+    batchInterval?: number;
     /**
      * Headers to be set on outgoing requests or a callback that of said headers
      * @link http://trpc.io/docs/client/headers

--- a/packages/client/src/links/internals/createHTTPBatchLink.ts
+++ b/packages/client/src/links/internals/createHTTPBatchLink.ts
@@ -78,7 +78,10 @@ export function createHTTPBatchLink(
         return { validate, fetch };
       };
 
-      const query = dataLoader<Operation, HTTPResult>(batchLoader('query'));
+      const query = dataLoader<Operation, HTTPResult>(
+        batchLoader('query'),
+        opts.batchInterval,
+      );
       const mutation = dataLoader<Operation, HTTPResult>(
         batchLoader('mutation'),
       );


### PR DESCRIPTION
## 🎯 Changes

Adds an option to `httpBatchLink` to configure a `batchInterval` in milliseconds.

This is an option that exists in [dataloader](https://github.com/graphql/dataloader?tab=readme-ov-file#batch-scheduling) and can be helpful if rendering of items in a list is spread out across multiple event loop ticks.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
