### PR TITLE
feat: add an onError option to RouterCaller

### DIFF
--- a/www/docs/server/server-side-calls.md
+++ b/www/docs/server/server-side-calls.md
@@ -291,3 +291,53 @@ export default async (
   }
 };
 ```
+
+### Error handling
+
+Either the createFactoryCaller or the createCaller function can take an error handler through the onError option. This can be used to throw errors that are not wrapped in a TRPCError, or respond to errors in some other way. Any handler passed to createCallerFactory will be called before the handler passed to createCaller.
+The handler is called with the same arguments as an error formatter would be, expect for the shape field:
+
+```ts twoslash
+{
+  ctx: unknown; // The request context
+  error: TRPCError; // The TRPCError that was thrown
+  path: string | undefined; // The path of the procedure that threw the error
+  input: unknown; // The input that was passed to the procedure
+  type: 'query' | 'mutation' | 'subscription' | 'unknown'; // The type of the procedure that threw the error
+}
+```
+
+```ts twoslash
+import { initTRPC } from '@trpc/server';
+
+const t = initTRPC.create();
+
+const router = t.router({
+  greeting: t.procedure.input(z.object({ name: z.string() })).query((opts) => {
+    if (opts.input.name === 'invalid') {
+      throw new Error('Invalid name');
+    }
+
+    return `Hello ${opts.input.name}`;
+  }),
+});
+
+const callerFactory = router.createCallerFactory({
+  onError: ({ error }) => {
+    console.error('An error occurred:', error);
+  },
+});
+
+const caller = callerFactory(
+  {},
+  {
+    onError: ({}) => {
+      throw new Error('This is a custom error');
+    },
+  },
+);
+
+// The following will log "An error occurred: Error: Invalid name", and then throw a plain error
+//  with the message "This is a custom error"
+caller.greeting({ name: 'invalid' });
+```


### PR DESCRIPTION
I came across #5413 while looking for a way to contribute, and the feature described seemed like something both nice to have and likely straightforward to implement, so I've given it a shot.
The original error will always be rethrown unless a different error is thrown in one of the handlers; doing otherwise would extend the caller's return type beyond that of the procedure.
I've opted not to implement it for the createCaller method on the router itself, since that one is deprecated.

Closes #5413

## 🎯 Changes

An error handler can now be provided to both the createCallerFactory and createCaller function, allowing unwrapped errors to be thrown when required, or to respond to errors in some other fashion. It is passed the same arguments as an ErrorFormatter would be, excluding shape, which wouldn't make sense in this context.

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
