### PR TITLE
docs: replace @decs/typeschema with @typeschema/valibot

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/parser.ts
+++ b/packages/server/src/unstable-core-do-not-import/parser.ts
@@ -1,4 +1,4 @@
-// zod / @decs/typeschema
+// zod / typeschema
 export type ParserZodEsque<TInput, TParsedInput> = {
   _input: TInput;
   _output: TParsedInput;

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@cloudflare/workers-types": "^4.0.0",
-    "@decs/typeschema": "^0.12.0",
     "@fastify/busboy": "^2.0.0",
     "@fastify/websocket": "^7.1.2",
     "@miniflare/core": "^2.9.0",
@@ -29,6 +28,7 @@
     "@trpc/react-query": "10.45.1",
     "@trpc/server": "^10.45.1",
     "@types/node": "^20.10.0",
+    "@typeschema/valibot": "^0.13.0",
     "@vitest/coverage-istanbul": "^1.2.2",
     "@vitest/ui": "^1.2.2",
     "abort-controller": "^3.0.0",

--- a/packages/tests/server/outputParser.test.ts
+++ b/packages/tests/server/outputParser.test.ts
@@ -1,6 +1,6 @@
 import { routerToServerAndClientNew } from './___testHelpers';
-import { wrap } from '@typeschema/valibot';
 import { initTRPC } from '@trpc/server';
+import { wrap } from '@typeschema/valibot';
 import myzod from 'myzod';
 import * as t from 'superstruct';
 import * as v from 'valibot';

--- a/packages/tests/server/outputParser.test.ts
+++ b/packages/tests/server/outputParser.test.ts
@@ -1,5 +1,5 @@
 import { routerToServerAndClientNew } from './___testHelpers';
-import { wrap } from '@decs/typeschema';
+import { wrap } from '@typeschema/valibot';
 import { initTRPC } from '@trpc/server';
 import myzod from 'myzod';
 import * as t from 'superstruct';

--- a/packages/tests/server/validators.test.ts
+++ b/packages/tests/server/validators.test.ts
@@ -1,7 +1,7 @@
 import { AsyncLocalStorage } from 'async_hooks';
 import { routerToServerAndClientNew, waitError } from './___testHelpers';
-import { wrap } from '@typeschema/valibot';
 import { initTRPC } from '@trpc/server';
+import { wrap } from '@typeschema/valibot';
 import * as arktype from 'arktype';
 import myzod from 'myzod';
 import * as T from 'runtypes';

--- a/packages/tests/server/validators.test.ts
+++ b/packages/tests/server/validators.test.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from 'async_hooks';
 import { routerToServerAndClientNew, waitError } from './___testHelpers';
-import { wrap } from '@decs/typeschema';
+import { wrap } from '@typeschema/valibot';
 import { initTRPC } from '@trpc/server';
 import * as arktype from 'arktype';
 import myzod from 'myzod';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1039,7 +1039,7 @@ importers:
         version: 2.8.8
       prisma:
         specifier: https://registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%40examplestrpc-next-prisma-starter
-        version: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%25252525252525252525252525252525252525252525252525252525252540examplestrpc-next-prisma-starter'
+        version: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252525252525252525252525252525252525252525252525252525252540examplestrpc-next-prisma-starter'
       start-server-and-test:
         specifier: ^1.12.0
         version: 1.14.0
@@ -1133,7 +1133,7 @@ importers:
         version: 4.1.5
       prisma:
         specifier: https://registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%40examplestrpc-next-prisma-todomvc
-        version: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%25252525252525252525252525252525252525252525252525252525252540examplestrpc-next-prisma-todomvc'
+        version: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252525252525252525252525252525252525252525252525252525252540examplestrpc-next-prisma-todomvc'
       start-server-and-test:
         specifier: ^1.12.0
         version: 1.14.0
@@ -1239,7 +1239,7 @@ importers:
         version: 2.8.8
       prisma:
         specifier: https://registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%40examplesnext-websockets-starter
-        version: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%25252525252525252525252525252525252525252525252525252525252540examplesnext-websockets-starter'
+        version: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252525252525252525252525252525252525252525252525252525252540examplesnext-websockets-starter'
       start-server-and-test:
         specifier: ^1.12.0
         version: 1.14.0
@@ -1590,9 +1590,6 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.0.0
         version: 4.20230215.0
-      '@decs/typeschema':
-        specifier: ^0.12.0
-        version: 0.12.0(arktype@1.0.14-alpha)(runtypes@6.6.0)(superstruct@1.0.3)(valibot@0.29.0)(vite@5.0.12)(yup@1.0.0)(zod@3.22.4)
       '@fastify/busboy':
         specifier: ^2.0.0
         version: 2.0.0
@@ -1632,6 +1629,9 @@ importers:
       '@types/node':
         specifier: ^20.10.0
         version: 20.10.4
+      '@typeschema/valibot':
+        specifier: ^0.13.0
+        version: 0.13.0(valibot@0.29.0)
       '@vitest/coverage-istanbul':
         specifier: ^1.2.2
         version: 1.2.2(vitest@1.2.2)
@@ -1816,9 +1816,6 @@ importers:
       '@babel/preset-env':
         specifier: ^7.23.2
         version: 7.23.2(@babel/core@7.23.2)
-      '@decs/typeschema':
-        specifier: ^0.12.0
-        version: 0.12.0(ajv@6.12.6)(arktype@1.0.14-alpha)(runtypes@6.6.0)(superstruct@1.0.3)(valibot@0.29.0)(yup@1.0.0)(zod@3.22.4)
       '@octokit/graphql':
         specifier: ^7.0.0
         version: 7.0.0
@@ -1840,6 +1837,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.14
         version: 18.2.14
+      '@typeschema/valibot':
+        specifier: ^0.13.0
+        version: 0.13.0(valibot@0.29.0)
       arktype:
         specifier: 1.0.14-alpha
         version: 1.0.14-alpha
@@ -4243,130 +4243,6 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
-
-  /@decs/typeschema@0.12.0(ajv@6.12.6)(arktype@1.0.14-alpha)(runtypes@6.6.0)(superstruct@1.0.3)(valibot@0.29.0)(yup@1.0.0)(zod@3.22.4):
-    resolution: {integrity: sha512-ltkDEpJvQ2LWCltsk2tzjO+rnCzdZzmgq6whYxDKac0wB0AqH8eYKdOcyWr0TklemDaebCdOpUACiMn7j1OZzQ==}
-    peerDependencies:
-      '@deepkit/type': ^1.0.1-alpha.97
-      '@effect/data': ^0.18.6
-      '@effect/schema': ^0.36.5
-      '@sinclair/typebox': ^0.31.15
-      ajv: ^8.12.0
-      arktype: ^1.0.21-alpha
-      fp-ts: ^2.16.1
-      io-ts: ^2.2.20
-      joi: ^17.10.2
-      ow: ^0.28.2
-      runtypes: ^6.7.0
-      superstruct: ^1.0.3
-      valibot: ^0.17.0
-      vite: ^4.4.10
-      yup: ^1.2.0
-      zod: ^3.22.2
-    peerDependenciesMeta:
-      '@deepkit/type':
-        optional: true
-      '@effect/data':
-        optional: true
-      '@effect/schema':
-        optional: true
-      '@sinclair/typebox':
-        optional: true
-      ajv:
-        optional: true
-      arktype:
-        optional: true
-      fp-ts:
-        optional: true
-      io-ts:
-        optional: true
-      joi:
-        optional: true
-      ow:
-        optional: true
-      runtypes:
-        optional: true
-      superstruct:
-        optional: true
-      valibot:
-        optional: true
-      vite:
-        optional: true
-      yup:
-        optional: true
-      zod:
-        optional: true
-    dependencies:
-      ajv: 6.12.6
-      arktype: 1.0.14-alpha
-      runtypes: 6.6.0
-      superstruct: 1.0.3
-      valibot: 0.29.0
-      yup: 1.0.0
-      zod: 3.22.4
-    dev: true
-
-  /@decs/typeschema@0.12.0(arktype@1.0.14-alpha)(runtypes@6.6.0)(superstruct@1.0.3)(valibot@0.29.0)(vite@5.0.12)(yup@1.0.0)(zod@3.22.4):
-    resolution: {integrity: sha512-ltkDEpJvQ2LWCltsk2tzjO+rnCzdZzmgq6whYxDKac0wB0AqH8eYKdOcyWr0TklemDaebCdOpUACiMn7j1OZzQ==}
-    peerDependencies:
-      '@deepkit/type': ^1.0.1-alpha.97
-      '@effect/data': ^0.18.6
-      '@effect/schema': ^0.36.5
-      '@sinclair/typebox': ^0.31.15
-      ajv: ^8.12.0
-      arktype: ^1.0.21-alpha
-      fp-ts: ^2.16.1
-      io-ts: ^2.2.20
-      joi: ^17.10.2
-      ow: ^0.28.2
-      runtypes: ^6.7.0
-      superstruct: ^1.0.3
-      valibot: ^0.17.0
-      vite: ^4.4.10
-      yup: ^1.2.0
-      zod: ^3.22.2
-    peerDependenciesMeta:
-      '@deepkit/type':
-        optional: true
-      '@effect/data':
-        optional: true
-      '@effect/schema':
-        optional: true
-      '@sinclair/typebox':
-        optional: true
-      ajv:
-        optional: true
-      arktype:
-        optional: true
-      fp-ts:
-        optional: true
-      io-ts:
-        optional: true
-      joi:
-        optional: true
-      ow:
-        optional: true
-      runtypes:
-        optional: true
-      superstruct:
-        optional: true
-      valibot:
-        optional: true
-      vite:
-        optional: true
-      yup:
-        optional: true
-      zod:
-        optional: true
-    dependencies:
-      arktype: 1.0.14-alpha
-      runtypes: 6.6.0
-      superstruct: 1.0.3
-      valibot: 0.29.0
-      vite: 5.0.12(@types/node@20.10.4)
-      yup: 1.0.0
-      zod: 3.22.4
-    dev: false
 
   /@docsearch/css@3.3.0:
     resolution: {integrity: sha512-rODCdDtGyudLj+Va8b6w6Y85KE85bXRsps/R4Yjwt5vueXKXZQKYw0aA9knxLBT6a/bI/GMrAcmCR75KYOM6hg==}
@@ -8772,6 +8648,30 @@ packages:
     dependencies:
       '@types/yargs-parser': 21.0.0
     dev: false
+
+  /@typeschema/core@0.13.0:
+    resolution: {integrity: sha512-L0Rci3EFuq4QySNZezT+W6aINc7iQAh2EUslez5Kge0OEnw/Nd9UEbq9w7m1OKk20SoS27sZo3iANe0yFDHjyw==}
+    peerDependencies:
+      '@types/json-schema': ^7.0.15
+    peerDependenciesMeta:
+      '@types/json-schema':
+        optional: true
+
+  /@typeschema/valibot@0.13.0(valibot@0.29.0):
+    resolution: {integrity: sha512-nfGB2LQzJbn6YgvwGLmbhZkrsPFo/ZoDYcIncXmNNA1qJD9q4qefC8nv+uAaZR7J8icg5lNbGHxXYnqd3VN76g==}
+    peerDependencies:
+      '@gcornut/valibot-json-schema': ^0.0.23
+      valibot: ^0.27.1
+    peerDependenciesMeta:
+      '@gcornut/valibot-json-schema':
+        optional: true
+      valibot:
+        optional: true
+    dependencies:
+      '@typeschema/core': 0.13.0
+      valibot: 0.29.0
+    transitivePeerDependencies:
+      - '@types/json-schema'
 
   /@typescript-eslint/eslint-plugin@7.0.1(@typescript-eslint/parser@7.0.1)(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-OLvgeBv3vXlnnJGIAgCLYKjgMEU+wBGj07MQ/nxAaON+3mLzX7mJbhRYrVGiVvFiXtwFlkcBa/TtmglHy0UbzQ==}
@@ -23158,7 +23058,7 @@ packages:
       prisma:
         optional: true
     dependencies:
-      prisma: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%25252525252525252525252525252525252525252525252525252525252540examplesnext-websockets-starter'
+      prisma: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252525252525252525252525252525252525252525252525252525252540examplesnext-websockets-starter'
     dev: false
 
   '@registry.npmjs.com/@prisma/client/-/client-5.8.1.tgz?id=examplestrpc-next-prisma-starter(prisma@5.8.1)':
@@ -23174,7 +23074,7 @@ packages:
       prisma:
         optional: true
     dependencies:
-      prisma: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%25252525252525252525252525252525252525252525252525252525252540examplestrpc-next-prisma-starter'
+      prisma: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252525252525252525252525252525252525252525252525252525252540examplestrpc-next-prisma-starter'
     dev: false
 
   '@registry.npmjs.com/@prisma/client/-/client-5.8.1.tgz?id=examplestrpc-next-prisma-todomvc(prisma@5.8.1)':
@@ -23190,10 +23090,10 @@ packages:
       prisma:
         optional: true
     dependencies:
-      prisma: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%25252525252525252525252525252525252525252525252525252525252540examplestrpc-next-prisma-todomvc'
+      prisma: '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252525252525252525252525252525252525252525252525252525252540examplestrpc-next-prisma-todomvc'
     dev: false
 
-  '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%25252525252525252525252525252525252525252525252525252525252540examplesnext-websockets-starter':
+  '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252525252525252525252525252525252525252525252525252525252540examplesnext-websockets-starter':
     resolution: {tarball: https://registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%40examplesnext-websockets-starter}
     name: prisma
     version: 5.8.1
@@ -23203,7 +23103,7 @@ packages:
     dependencies:
       '@prisma/engines': 5.8.1
 
-  '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%25252525252525252525252525252525252525252525252525252525252540examplestrpc-next-prisma-starter':
+  '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252525252525252525252525252525252525252525252525252525252540examplestrpc-next-prisma-starter':
     resolution: {tarball: https://registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%40examplestrpc-next-prisma-starter}
     name: prisma
     version: 5.8.1
@@ -23213,7 +23113,7 @@ packages:
     dependencies:
       '@prisma/engines': 5.8.1
 
-  '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%25252525252525252525252525252525252525252525252525252525252540examplestrpc-next-prisma-todomvc':
+  '@registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%2525252525252525252525252525252525252525252525252525252525252540examplestrpc-next-prisma-todomvc':
     resolution: {tarball: https://registry.npmjs.com/prisma/-/prisma-5.8.1.tgz?id=%40examplestrpc-next-prisma-todomvc}
     name: prisma
     version: 5.8.1

--- a/www/docs/main/quickstart.mdx
+++ b/www/docs/main/quickstart.mdx
@@ -302,7 +302,7 @@ const appRouter = router({
 import { db } from './db';
 import { publicProcedure, router } from './trpc';
 // ---cut---
-import { wrap } from '@decs/typeschema';
+import { wrap } from '@typeschema/valibot';
 import { string } from 'valibot';
 
 const appRouter = router({

--- a/www/docs/server/validators.md
+++ b/www/docs/server/validators.md
@@ -365,8 +365,8 @@ export type AppRouter = typeof appRouter;
 ### With [Valibot](https://github.com/fabian-hiller/valibot)
 
 ```ts twoslash
-import { wrap } from '@typeschema/valibot';
 import { initTRPC } from '@trpc/server';
+import { wrap } from '@typeschema/valibot';
 import { object, string } from 'valibot';
 
 export const t = initTRPC.create();

--- a/www/docs/server/validators.md
+++ b/www/docs/server/validators.md
@@ -365,7 +365,7 @@ export type AppRouter = typeof appRouter;
 ### With [Valibot](https://github.com/fabian-hiller/valibot)
 
 ```ts twoslash
-import { wrap } from '@decs/typeschema';
+import { wrap } from '@typeschema/valibot';
 import { initTRPC } from '@trpc/server';
 import { object, string } from 'valibot';
 

--- a/www/package.json
+++ b/www/package.json
@@ -64,7 +64,6 @@
   "devDependencies": {
     "@babel/core": "^7.23.2",
     "@babel/preset-env": "^7.23.2",
-    "@decs/typeschema": "^0.12.0",
     "@octokit/graphql": "^7.0.0",
     "@octokit/graphql-schema": "^14.0.0",
     "@tsconfig/docusaurus": "^2.0.0",
@@ -72,6 +71,7 @@
     "@types/oauth": "^0.9.1",
     "@types/react": "^18.2.33",
     "@types/react-dom": "^18.2.14",
+    "@typeschema/valibot": "^0.13.0",
     "arktype": "1.0.14-alpha",
     "autoprefixer": "^10.4.7",
     "docusaurus-plugin-typedoc": "^1.0.0-next.12",


### PR DESCRIPTION
## 🎯 Changes

`@decs/typeschema` was restructured (decs/typeschema#32) and now we recommend using `@typeschema/valibot` for Valibot support on tRPC

This PR replaces the package on docs and tests

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
