### PR TITLE
docs: minor spelling mistake update in merging-routers.md

### DIFF
--- a/www/docs/server/merging-routers.md
+++ b/www/docs/server/merging-routers.md
@@ -11,7 +11,7 @@ Writing all API-code in your code in the same file is not a great idea. It's eas
 
 When you define an inline sub-router, you can represent your router as a plain object.
 
-In the below example, `nested1` and `neested2` are equal:
+In the below example, `nested1` and `nested2` are equal:
 
 ```ts twoslash title="server/_app.ts"
 // @filename: trpc.ts


### PR DESCRIPTION
## 🎯 Changes

Updates `merging-routers.md` to correct a minor spelling mistake: 

> `neested2` -> `nested2`

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
