### PR TITLE
feat(react-query): Pass useInfiniteQuery direction to procedure input

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,8 @@
   "search.exclude": {
     "/www/versioned_docs": true,
     "/www/.docusaurus": true,
-    "/www/build": true
+    "/www/build": true,
+    "**/dist": true
   },
   "workbench.colorCustomizations": {
     "titleBar.activeBackground": "#2596be",

--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -81,21 +81,22 @@ export interface ProcedureUseQuery<TDef extends ResolverDef> {
 /**
  * @remark `void` is here due to https://github.com/trpc/trpc/pull/4374
  */
-type CursorInput = {
+type CursorDirectionInput = {
   cursor?: any;
+  direction?: any;
 } | void;
 
 /**
  * @internal
  */
 export type MaybeDecoratedInfiniteQuery<TDef extends ResolverDef> =
-  TDef['input'] extends CursorInput
+  TDef['input'] extends CursorDirectionInput
     ? {
         /**
          * @link https://trpc.io/docs/v11/client/react/suspense#useinfinitesuspensequery
          */
         useInfiniteQuery: (
-          input: Omit<TDef['input'], 'cursor'>,
+          input: Omit<TDef['input'], 'cursor' | 'direction'>,
           opts: UseTRPCInfiniteQueryOptions<
             TDef['input'],
             TDef['output'],
@@ -110,7 +111,7 @@ export type MaybeDecoratedInfiniteQuery<TDef extends ResolverDef> =
          * @link https://trpc.io/docs/v11/client/react/suspense
          */
         useSuspenseInfiniteQuery: (
-          input: Omit<TDef['input'], 'cursor'>,
+          input: Omit<TDef['input'], 'cursor' | 'direction'>,
           opts: UseTRPCSuspenseInfiniteQueryOptions<
             TDef['input'],
             TDef['output'],

--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -81,22 +81,22 @@ export interface ProcedureUseQuery<TDef extends ResolverDef> {
 /**
  * @remark `void` is here due to https://github.com/trpc/trpc/pull/4374
  */
-type CursorDirectionInput = {
+type CursorInput = {
   cursor?: any;
-  direction?: any;
 } | void;
 
+type ReservedInfiniteQueryKeys = 'cursor' | 'direction';
 /**
  * @internal
  */
 export type MaybeDecoratedInfiniteQuery<TDef extends ResolverDef> =
-  TDef['input'] extends CursorDirectionInput
+  TDef['input'] extends CursorInput
     ? {
         /**
          * @link https://trpc.io/docs/v11/client/react/suspense#useinfinitesuspensequery
          */
         useInfiniteQuery: (
-          input: Omit<TDef['input'], 'cursor' | 'direction'>,
+          input: Omit<TDef['input'], ReservedInfiniteQueryKeys>,
           opts: UseTRPCInfiniteQueryOptions<
             TDef['input'],
             TDef['output'],

--- a/packages/react-query/src/internals/getClientArgs.ts
+++ b/packages/react-query/src/internals/getClientArgs.ts
@@ -6,14 +6,18 @@ import type { TRPCQueryKey } from './getQueryKey';
 export function getClientArgs<TOptions>(
   queryKey: TRPCQueryKey,
   opts: TOptions,
-  pageParam?: any,
+  infiniteParams?: {
+    pageParam: any;
+    direction: 'forward' | 'backward';
+  },
 ) {
   const path = queryKey[0];
   let input = queryKey[1]?.input;
-  if (pageParam) {
+  if (infiniteParams) {
     input = {
       ...(input ?? {}),
-      cursor: pageParam,
+      ...(infiniteParams.pageParam ? { cursor: infiniteParams.pageParam } : {}),
+      direction: infiniteParams.direction,
     };
   }
   return [path.join('.'), input, (opts as any)?.trpc] as const;

--- a/packages/react-query/src/internals/getQueryKey.test.ts
+++ b/packages/react-query/src/internals/getQueryKey.test.ts
@@ -102,4 +102,24 @@ test('getArrayQueryKey', () => {
         },
       ]
     `);
+  expect(
+    getQueryKeyInternal(
+      ['post', 'byId'],
+      { cursor: 'a', direction: 'forward', id: 1 },
+      'infinite',
+    ),
+  ).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        "post",
+        "byId",
+      ],
+      Object {
+        "input": Object {
+          "id": 1,
+        },
+        "type": "infinite",
+      },
+    ]
+  `);
 });

--- a/packages/react-query/src/internals/getQueryKey.ts
+++ b/packages/react-query/src/internals/getQueryKey.ts
@@ -40,21 +40,23 @@ export function getQueryKeyInternal(
     return splitPath.length ? [splitPath] : ([] as unknown as TRPCQueryKey);
   }
 
-  if (type === 'infinite' && isObject(input)) {
-    if ('direction' in input || 'cursor' in input) {
-      const {
-        cursor: _,
-        direction: __,
-        ...inputWithoutCursorAndDirection
-      } = input;
-      return [
-        splitPath,
-        {
-          input: inputWithoutCursorAndDirection,
-          type: 'infinite',
-        },
-      ];
-    }
+  if (
+    type === 'infinite' &&
+    isObject(input) &&
+    ('direction' in input || 'cursor' in input)
+  ) {
+    const {
+      cursor: _,
+      direction: __,
+      ...inputWithoutCursorAndDirection
+    } = input;
+    return [
+      splitPath,
+      {
+        input: inputWithoutCursorAndDirection,
+        type: 'infinite',
+      },
+    ];
   }
   return [
     splitPath,

--- a/packages/react-query/src/internals/getQueryKey.ts
+++ b/packages/react-query/src/internals/getQueryKey.ts
@@ -37,21 +37,41 @@ export function getQueryKeyInternal(
     return splitPath.length ? [splitPath] : ([] as unknown as TRPCQueryKey);
   }
 
-  if (
-    type === 'infinite' &&
-    input &&
-    typeof input === 'object' &&
-    'cursor' in input
-  ) {
-    const { cursor: _, ...inputWithoutCursor } = input;
-
-    return [
-      splitPath,
-      {
-        input: inputWithoutCursor,
-        type: 'infinite',
-      },
-    ];
+  if (type === 'infinite' && input && typeof input === 'object') {
+    if ('direction' in input && 'cursor' in input) {
+      const {
+        cursor: _,
+        direction: __,
+        ...inputWithoutCursorAndDirection
+      } = input;
+      return [
+        splitPath,
+        {
+          input: inputWithoutCursorAndDirection,
+          type: 'infinite',
+        },
+      ];
+    }
+    if ('cursor' in input) {
+      const { cursor: _, ...inputWithoutCursor } = input;
+      return [
+        splitPath,
+        {
+          input: inputWithoutCursor,
+          type: 'infinite',
+        },
+      ];
+    }
+    if ('direction' in input) {
+      const { direction: _, ...inputWithoutDirection } = input;
+      return [
+        splitPath,
+        {
+          input: inputWithoutDirection,
+          type: 'infinite',
+        },
+      ];
+    }
   }
   return [
     splitPath,
@@ -64,10 +84,13 @@ export function getQueryKeyInternal(
 
 type GetInfiniteQueryInput<
   TProcedureInput,
-  TInputWithoutCursor = Omit<TProcedureInput, 'cursor'>,
-> = keyof TInputWithoutCursor extends never
+  TInputWithoutCursorAndDirection = Omit<
+    TProcedureInput,
+    'cursor' | 'direction'
+  >,
+> = keyof TInputWithoutCursorAndDirection extends never
   ? undefined
-  : DeepPartial<TInputWithoutCursor> | undefined;
+  : DeepPartial<TInputWithoutCursorAndDirection> | undefined;
 
 /** @internal */
 export type GetQueryProcedureInput<TProcedureInput> = TProcedureInput extends {

--- a/packages/react-query/src/internals/getQueryKey.ts
+++ b/packages/react-query/src/internals/getQueryKey.ts
@@ -1,4 +1,7 @@
-import type { DeepPartial } from '@trpc/server/unstable-core-do-not-import';
+import {
+  isObject,
+  type DeepPartial,
+} from '@trpc/server/unstable-core-do-not-import';
 import type { DecoratedMutation, DecoratedQuery } from '../createTRPCReact';
 import type { DecorateRouterRecord } from '../shared';
 
@@ -37,8 +40,8 @@ export function getQueryKeyInternal(
     return splitPath.length ? [splitPath] : ([] as unknown as TRPCQueryKey);
   }
 
-  if (type === 'infinite' && input && typeof input === 'object') {
-    if ('direction' in input && 'cursor' in input) {
+  if (type === 'infinite' && isObject(input)) {
+    if ('direction' in input || 'cursor' in input) {
       const {
         cursor: _,
         direction: __,
@@ -48,26 +51,6 @@ export function getQueryKeyInternal(
         splitPath,
         {
           input: inputWithoutCursorAndDirection,
-          type: 'infinite',
-        },
-      ];
-    }
-    if ('cursor' in input) {
-      const { cursor: _, ...inputWithoutCursor } = input;
-      return [
-        splitPath,
-        {
-          input: inputWithoutCursor,
-          type: 'infinite',
-        },
-      ];
-    }
-    if ('direction' in input) {
-      const { direction: _, ...inputWithoutDirection } = input;
-      return [
-        splitPath,
-        {
-          input: inputWithoutDirection,
           type: 'infinite',
         },
       ];

--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -364,11 +364,10 @@ export function createRootHooks<
           };
 
           return client.query(
-            ...getClientArgs(
-              queryKey,
-              actualOpts,
-              queryFunctionContext.pageParam ?? opts.initialCursor,
-            ),
+            ...getClientArgs(queryKey, actualOpts, {
+              pageParam: queryFunctionContext.pageParam ?? opts.initialCursor,
+              direction: queryFunctionContext.direction,
+            }),
           );
         },
       },
@@ -417,11 +416,10 @@ export function createRootHooks<
           };
 
           return context.client.query(
-            ...getClientArgs(
-              queryKey,
-              actualOpts,
-              queryFunctionContext.pageParam ?? opts.initialCursor,
-            ),
+            ...getClientArgs(queryKey, actualOpts, {
+              pageParam: queryFunctionContext.pageParam ?? opts.initialCursor,
+              direction: queryFunctionContext.direction,
+            }),
           );
         },
       },

--- a/packages/react-query/src/utils/createUtilityFunctions.ts
+++ b/packages/react-query/src/utils/createUtilityFunctions.ts
@@ -42,9 +42,9 @@ export function createUtilityFunctions<TRouter extends AnyRouter>(
       return queryClient.fetchInfiniteQuery({
         ...opts,
         queryKey,
-        queryFn: ({ pageParam }) => {
+        queryFn: ({ pageParam, direction }) => {
           return untypedClient.query(
-            ...getClientArgs(queryKey, opts, pageParam),
+            ...getClientArgs(queryKey, opts, { pageParam, direction }),
           );
         },
         initialPageParam: opts?.initialCursor ?? null,
@@ -63,9 +63,9 @@ export function createUtilityFunctions<TRouter extends AnyRouter>(
       return queryClient.prefetchInfiniteQuery({
         ...opts,
         queryKey,
-        queryFn: ({ pageParam }) => {
+        queryFn: ({ pageParam, direction }) => {
           return untypedClient.query(
-            ...getClientArgs(queryKey, opts, pageParam),
+            ...getClientArgs(queryKey, opts, { pageParam, direction }),
           );
         },
         initialPageParam: opts?.initialCursor ?? null,

--- a/www/docs/client/react/useInfiniteQuery.md
+++ b/www/docs/client/react/useInfiniteQuery.md
@@ -28,6 +28,7 @@ export const appRouter = t.router({
       z.object({
         limit: z.number().min(1).max(100).nullish(),
         cursor: z.number().nullish(), // <-- "cursor" needs to exist, but can be any type
+        direction: z.union(z.enum(['forward', 'backward'])), // optional, useful for bi-directional query
       }),
     )
     .query(async (opts) => {

--- a/www/docs/migration/migrate-from-v10-to-v11.mdx
+++ b/www/docs/migration/migrate-from-v10-to-v11.mdx
@@ -30,6 +30,10 @@ See [SSR docs](../client/nextjs/ssr.md)
 > This is a draft document. It will be updated to a proper guide as we get closer to the v11 release.
 > The only major thing that will incur work for you is that you will need to do is to update TanStack Query to v5.0.0.
 
+### Added support for bi-directional support for infinite queries
+
+See [`useInfiniteQuery()`](../client/react/useInfiniteQuery.md)
+
 ### Added `inferProcedureBuilderResolverOptions<T>`-helper (non-breaking)
 
 Adds a helper to infer the options for a procedure builder resolver. This is useful if you want to create reusable functions for different procedures.


### PR DESCRIPTION
## 🎯 Changes

Pass direction from useInfiniteQuery function context (https://tanstack.com/query/v5/docs/framework/react/guides/query-functions#queryfunctioncontext) to procedure input in addition to page param.

This is useful for bi-directional infinite queries so you know in which direction to fetch.

Closes https://github.com/trpc/trpc/issues/5514

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
