### PR TITLE
docs: update invalidateQueries.md to use useUtils rather than useContext

### DIFF
--- a/www/versioned_docs/version-9.x/reactjs/invalidateQueries.md
+++ b/www/versioned_docs/version-9.x/reactjs/invalidateQueries.md
@@ -13,7 +13,7 @@ A typesafe wrapper around calling `queryClient.invalidateQueries()`, all it does
 import { trpc } from '../utils/trpc';
 
 // In component:
-const utils = trpc.useContext();
+const utils = trpc.useUtils();
 
 const mutation = trpc.useMutation('post.edit', {
   onSuccess(input) {


### PR DESCRIPTION
## 🎯 Changes

Updates the code example in `invalidateQueries.md` to use `trpc.useUtils` to call `utils.invalidateQueries`, rather than the old `trpc.useContext`. 

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
