### PR TITLE
fix(server): use the recommended connection handler from @fastify/websocket to avoid triggering stream backpressure (#5530)

### DIFF
--- a/packages/server/src/adapters/fastify/fastifyTRPCPlugin.ts
+++ b/packages/server/src/adapters/fastify/fastifyTRPCPlugin.ts
@@ -60,9 +60,9 @@ export function fastifyTRPCPlugin<TRouter extends AnyRouter>(
       ...(opts.trpcOptions as unknown as WSSHandlerOptions<TRouter>),
     });
 
-    fastify.get(prefix ?? '/', { websocket: true }, ({ socket }, req) => {
-      onConnection(socket, req.raw);
-    });
+    fastify.get(prefix ?? '/', { websocket: true }, ({ socket }, req) =>
+      onConnection(socket, req.raw),
+    );
   }
 
   done();

--- a/packages/server/src/adapters/fastify/fastifyTRPCPlugin.ts
+++ b/packages/server/src/adapters/fastify/fastifyTRPCPlugin.ts
@@ -14,7 +14,7 @@ import type { FastifyHandlerOptions } from '.';
 import type { AnyRouter } from '../../@trpc/server';
 import type { NodeHTTPCreateContextFnOptions } from '../node-http';
 import type { WSSHandlerOptions } from '../ws';
-import { applyWSSHandler } from '../ws';
+import { getWSConnectionHandler } from '../ws';
 import { fastifyRequestHandler } from './fastifyRequestHandler';
 
 export interface FastifyTRPCPluginOptions<TRouter extends AnyRouter> {
@@ -43,7 +43,6 @@ export function fastifyTRPCPlugin<TRouter extends AnyRouter>(
   );
 
   let prefix = opts.prefix ?? '';
-  const websocketPrefix = prefix;
 
   // https://github.com/fastify/fastify-plugin/blob/fe079bef6557a83794bf437e14b9b9edb8a74104/plugin.js#L11
   // @ts-expect-error property 'default' does not exists on type ...
@@ -57,13 +56,13 @@ export function fastifyTRPCPlugin<TRouter extends AnyRouter>(
   });
 
   if (opts.useWSS) {
-    applyWSSHandler<TRouter>({
+    const onConnection = getWSConnectionHandler<TRouter>({
       ...(opts.trpcOptions as unknown as WSSHandlerOptions<TRouter>),
-      prefix: websocketPrefix,
-      wss: fastify.websocketServer,
     });
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    fastify.get(prefix ?? '/', { websocket: true }, () => {});
+
+    fastify.get(prefix ?? '/', { websocket: true }, ({ socket }, req) => {
+      onConnection(socket, req.raw);
+    });
   }
 
   done();

--- a/packages/server/src/adapters/ws.ts
+++ b/packages/server/src/adapters/ws.ts
@@ -44,42 +44,39 @@ export type CreateWSSContextFn<TRouter extends AnyRouter> = (
   opts: CreateWSSContextFnOptions,
 ) => MaybePromise<inferRouterContext<TRouter>>;
 
+export type WSConnectionHandlerOptions<TRouter extends AnyRouter> =
+  BaseHandlerOptions<TRouter, IncomingMessage> &
+    (object extends inferRouterContext<TRouter>
+      ? {
+          /**
+           * @link https://trpc.io/docs/v11/context
+           **/
+          createContext?: CreateWSSContextFn<TRouter>;
+        }
+      : {
+          /**
+           * @link https://trpc.io/docs/v11/context
+           **/
+          createContext: CreateWSSContextFn<TRouter>;
+        });
+
 /**
  * Web socket server handler
  */
-export type WSSHandlerOptions<TRouter extends AnyRouter> = BaseHandlerOptions<
-  TRouter,
-  IncomingMessage
-> &
-  (object extends inferRouterContext<TRouter>
-    ? {
-        /**
-         * @link https://trpc.io/docs/v11/context
-         **/
-        createContext?: CreateWSSContextFn<TRouter>;
-      }
-    : {
-        /**
-         * @link https://trpc.io/docs/v11/context
-         **/
-        createContext: CreateWSSContextFn<TRouter>;
-      }) & {
+export type WSSHandlerOptions<TRouter extends AnyRouter> =
+  WSConnectionHandlerOptions<TRouter> & {
     wss: ws.WebSocketServer;
     process?: NodeJS.Process;
     prefix?: string;
   };
 
-export function applyWSSHandler<TRouter extends AnyRouter>(
-  opts: WSSHandlerOptions<TRouter>,
+export function getWSConnectionHandler<TRouter extends AnyRouter>(
+  opts: WSConnectionHandlerOptions<TRouter>,
 ) {
-  const { wss, createContext, router, prefix } = opts;
-
+  const { createContext, router } = opts;
   const { transformer } = router._def._config;
-  wss.on('connection', async (client, req) => {
-    if (prefix && !req.url?.startsWith(prefix)) {
-      return;
-    }
 
+  return async (client: ws.WebSocket, req: IncomingMessage) => {
     const clientSubscriptions = new Map<number | string, Unsubscribable>();
 
     function respond(untransformedJSON: TRPCResponseMessage) {
@@ -322,6 +319,21 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
       }
     }
     await createContextAsync();
+  };
+}
+
+export function applyWSSHandler<TRouter extends AnyRouter>(
+  opts: WSSHandlerOptions<TRouter>,
+) {
+  const { wss, prefix } = opts;
+
+  const onConnection = getWSConnectionHandler(opts);
+  wss.on('connection', (client, req) => {
+    if (prefix && !req.url?.startsWith(prefix)) {
+      return;
+    }
+
+    onConnection(client, req);
   });
 
   return {

--- a/packages/server/src/adapters/ws.ts
+++ b/packages/server/src/adapters/ws.ts
@@ -328,12 +328,12 @@ export function applyWSSHandler<TRouter extends AnyRouter>(
   const { wss, prefix } = opts;
 
   const onConnection = getWSConnectionHandler(opts);
-  wss.on('connection', (client, req) => {
+  wss.on('connection', async (client, req) => {
     if (prefix && !req.url?.startsWith(prefix)) {
       return;
     }
 
-    onConnection(client, req);
+    await onConnection(client, req);
   });
 
   return {

--- a/packages/tests/server/adapters/fastify.test.ts
+++ b/packages/tests/server/adapters/fastify.test.ts
@@ -51,6 +51,9 @@ function createAppRouter() {
     ping: publicProcedure.query(() => {
       return 'pong';
     }),
+    echo: publicProcedure.input(z.string()).query(({ input }) => {
+      return input;
+    }),
     hello: publicProcedure
       .input(
         z
@@ -532,5 +535,26 @@ describe('regression #4820 - content type parser already set', () => {
 
   test('query', async () => {
     expect(await app.client.ping.query()).toMatchInlineSnapshot(`"pong"`);
+  });
+});
+
+// https://github.com/trpc/trpc/issues/5530
+describe('issue #5530 - cannot receive new WebSocket messages after receiving 16 kB', () => {
+  beforeEach(async () => {
+    app = await createApp();
+  });
+
+  afterEach(async () => {
+    await app.stop();
+  });
+
+  test('query', async () => {
+    const data = 'A'.repeat(8192);
+
+    for (let i = 0; i < 4; i++) {
+      expect(await app.client.echo.query(data)).toMatchInlineSnapshot(
+        `"${data}"`,
+      );
+    }
   });
 });


### PR DESCRIPTION
Closes #5530

## 🎯 Changes

I've moved connection event handler creation into a separate function to allow for it being used directly inside of the `@fastify/websocket` connection callback.

Also, I deliberately left prefix handling in `applyWSSHandler`, so we can leave routing to fastify itself.

For future consideration - might be worth using something in line of the following to stay compatible with future versions of `@fastify/websocket` (if my changes get approved) alongside with backwards compatibility:

```ts
    fastify.get(prefix ?? '/', { websocket: true }, (connection, req) => {
      onConnection('socket' in connection ? connection.socket : connection, req.raw);
    });
```

There's a chance they might end up just exposing the raw `WebSocket` object on their end from the handler, but this isn't guaranteed to happen.

Update: I've submitted a PR to `@fastify/websocket` as well, might be worth checking out with regards to compatibility: https://github.com/fastify/fastify-websocket/pull/290

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
