### PR TITLE
fix: pass-through all options to `resolveHTTPResponse`

### DIFF
--- a/packages/server/src/adapters/aws-lambda/index.ts
+++ b/packages/server/src/adapters/aws-lambda/index.ts
@@ -116,9 +116,7 @@ export function awsLambdaRequestHandler<
     };
 
     const response = await resolveHTTPResponse({
-      router: opts.router,
-      batching: opts.batching,
-      responseMeta: opts?.responseMeta,
+      ...opts,
       createContext,
       req,
       path,

--- a/packages/server/src/adapters/aws-lambda/utils.ts
+++ b/packages/server/src/adapters/aws-lambda/utils.ts
@@ -19,9 +19,8 @@ import type { AnyRouter, inferRouterContext } from '../../@trpc/server'; // impo
 // @trpc/server
 import { TRPCError } from '../../@trpc/server';
 import type {
+  HTTPBaseHandlerOptions,
   HTTPHeaders,
-  OnErrorFunction,
-  ResponseMetaFn,
   TRPCRequestInfo,
 } from '../../@trpc/server/http';
 
@@ -50,27 +49,21 @@ export type AWSLambdaOptions<
   TRouter extends AnyRouter,
   TEvent extends APIGatewayEvent,
 > =
-  | {
-      router: TRouter;
-      batching?: {
-        enabled: boolean;
-      };
-      onError?: OnErrorFunction<TRouter, TEvent>;
-      responseMeta?: ResponseMetaFn<TRouter>;
-    } & (
-      | {
-          /**
-           * @link https://trpc.io/docs/v11/context
-           **/
-          createContext: AWSLambdaCreateContextFn<TRouter, TEvent>;
-        }
-      | {
-          /**
-           * @link https://trpc.io/docs/v11/context
-           **/
-          createContext?: AWSLambdaCreateContextFn<TRouter, TEvent>;
-        }
-    );
+  | HTTPBaseHandlerOptions<TRouter, TEvent> &
+      (
+        | {
+            /**
+             * @link https://trpc.io/docs/v11/context
+             **/
+            createContext: AWSLambdaCreateContextFn<TRouter, TEvent>;
+          }
+        | {
+            /**
+             * @link https://trpc.io/docs/v11/context
+             **/
+            createContext?: AWSLambdaCreateContextFn<TRouter, TEvent>;
+          }
+      );
 
 export function isPayloadV1(
   event: APIGatewayEvent,

--- a/packages/server/src/adapters/fastify/fastifyRequestHandler.ts
+++ b/packages/server/src/adapters/fastify/fastifyRequestHandler.ts
@@ -109,12 +109,9 @@ export async function fastifyRequestHandler<
   };
 
   resolveHTTPResponse({
+    ...opts,
     req,
     createContext,
-    path: opts.path,
-    router: opts.router,
-    batching: opts.batching,
-    responseMeta: opts.responseMeta,
     onError(o) {
       opts?.onError?.({ ...o, req: opts.req });
     },

--- a/packages/server/src/adapters/fetch/fetchRequestHandler.ts
+++ b/packages/server/src/adapters/fetch/fetchRequestHandler.ts
@@ -118,12 +118,10 @@ export async function fetchRequestHandler<TRouter extends AnyRouter>(
   };
 
   resolveHTTPResponse({
+    ...opts,
     req,
     createContext,
     path,
-    router: opts.router,
-    batching: opts.batching,
-    responseMeta: opts.responseMeta,
     onError(o) {
       opts?.onError?.({ ...o, req: opts.req });
     },


### PR DESCRIPTION
Closes #5550
