### PR TITLE
fix: custom websocket server not upgrading due to next 13.4.3+

### DIFF
--- a/examples/next-prisma-websockets-starter/src/server/prodServer.ts
+++ b/examples/next-prisma-websockets-starter/src/server/prodServer.ts
@@ -38,7 +38,7 @@ void app.prepare().then(() => {
   // so sockets stay open even when not HMR.
   const originalOn = server.on.bind(server);
   server.on = function (event, listener) {
-    return (event !== 'upgrade') ? originalOn(event, listener) : server;
+    return event !== 'upgrade' ? originalOn(event, listener) : server;
   };
   server.listen(port);
 

--- a/examples/next-prisma-websockets-starter/src/server/prodServer.ts
+++ b/examples/next-prisma-websockets-starter/src/server/prodServer.ts
@@ -34,6 +34,12 @@ void app.prepare().then(() => {
     });
   });
 
+  // Keep the next.js upgrade handler from being added to our custom server
+  // so sockets stay open even when not HMR.
+  const originalOn = server.on.bind(server);
+  server.on = function (event, listener) {
+    return (event !== 'upgrade') ? originalOn(event, listener) : server;
+  };
   server.listen(port);
 
   console.log(


### PR DESCRIPTION
Closes #4810 

## 🎯 Changes

It seems next v13.4.3 added a breaking change that causes sockets to be closed when not handled by HMR. As a result, websocket connections fail to upgrade. I've applied a fix from the following thread to address this issue for now:

https://github.com/vercel/next.js/issues/50461#issuecomment-1686773347