### PR TITLE
feat(next app dir): rethrow built-in Next errors

### DIFF
--- a/packages/next/src/app-dir/server.ts
+++ b/packages/next/src/app-dir/server.ts
@@ -155,13 +155,15 @@ export function experimental_createServerActionHandler<
           rawInput = transformer.input.deserialize(rawInput);
         }
 
-        const data = await proc({
-          input: undefined,
-          ctx,
-          path: 'serverAction',
-          getRawInput: async () => rawInput,
-          type: proc._def.type,
-        });
+        const data = proc._def.experimental_caller
+          ? await proc(rawInput)
+          : await proc({
+              input: undefined,
+              ctx,
+              path: '',
+              getRawInput: async () => rawInput,
+              type: proc._def.type,
+            });
 
         const transformedJSON = transformTRPCResponse(config, {
           result: {

--- a/packages/next/src/app-dir/server.ts
+++ b/packages/next/src/app-dir/server.ts
@@ -107,7 +107,6 @@ export function experimental_createServerActionHandler<
     normalizeFormData?: boolean;
     /**
      * Called when an error occurs in the handler
-     * Will not be called for errors that should be handled by Next.js if `rethrowNextErrorsEnabled` is `true`
      */
     onError?: (
       opts: ErrorHandlerOptions<TInstance['_config']['$types']['ctx']>,
@@ -173,7 +172,6 @@ export function experimental_createServerActionHandler<
         return transformedJSON;
       } catch (cause) {
         const error = getTRPCErrorFromUnknown(cause);
-        rethrowNextErrorsEnabled && rethrowNextErrors(error);
 
         opts.onError?.({
           ctx,
@@ -183,16 +181,16 @@ export function experimental_createServerActionHandler<
           type: proc._def.type,
         });
 
+        rethrowNextErrorsEnabled && rethrowNextErrors(error);
+
         const shape = getErrorShape({
           config,
           ctx,
           error,
           input: rawInput,
-          path: 'serverAction',
+          path: '',
           type: proc._def.type,
         });
-
-        // TODO: send the right HTTP header?!
 
         return transformTRPCResponse(t._config, {
           error: shape,

--- a/packages/next/src/app-dir/server.ts
+++ b/packages/next/src/app-dir/server.ts
@@ -70,7 +70,7 @@ export function experimental_createTRPCNextAppDirServer<
 /**
  * Rethrow errors that should be handled by Next.js
  */
-const rethrowNextErrors = (error: TRPCError) => {
+const throwNextErrors = (error: TRPCError) => {
   const { cause } = error;
   if (isRedirectError(cause) || isNotFoundError(cause)) {
     throw error.cause;
@@ -116,14 +116,14 @@ export function experimental_createServerActionHandler<
      * Rethrow errors that should be handled by Next.js
      * @default true
      */
-    rethrowNextErrorsEnabled?: boolean;
+    rethrowNextErrors?: boolean;
   },
 ) {
   const config = t._config;
   const {
     normalizeFormData = true,
     createContext,
-    rethrowNextErrorsEnabled = true,
+    rethrowNextErrors = true,
   } = opts;
 
   const transformer = config.transformer;
@@ -181,7 +181,7 @@ export function experimental_createServerActionHandler<
           type: proc._def.type,
         });
 
-        rethrowNextErrorsEnabled && rethrowNextErrors(error);
+        rethrowNextErrors && throwNextErrors(error);
 
         const shape = getErrorShape({
           config,

--- a/packages/server/src/unstable-core-do-not-import/procedure.ts
+++ b/packages/server/src/unstable-core-do-not-import/procedure.ts
@@ -44,6 +44,9 @@ export interface Procedure<
      * Meta is not inferrable on individual procedures, only on the router
      */
     meta: unknown;
+    experimental_caller: TDef['experimental_caller'] extends true
+      ? true
+      : false;
   };
   /**
    * @internal

--- a/packages/server/src/unstable-core-do-not-import/procedureBuilder.ts
+++ b/packages/server/src/unstable-core-do-not-import/procedureBuilder.ts
@@ -490,11 +490,10 @@ export function createBuilder<TContext, TMeta>(
 }
 
 function createResolver(
-  _def: AnyProcedureBuilderDef & { type: ProcedureType },
+  _defIn: AnyProcedureBuilderDef & { type: ProcedureType },
   resolver: AnyResolver,
 ) {
-  const finalBuilder = createNewBuilder(_def, {
-    type: _def.type,
+  const finalBuilder = createNewBuilder(_defIn, {
     resolver,
     middlewares: [
       async function resolveMiddleware(opts) {
@@ -508,6 +507,15 @@ function createResolver(
       },
     ],
   });
+  const _def: AnyProcedure['_def'] = {
+    ...finalBuilder._def,
+    type: _defIn.type,
+    experimental_caller: finalBuilder._def.caller ? true : false,
+    _input_in: null,
+    _output_out: null,
+    meta: finalBuilder._def.meta,
+  };
+
   const invoke = createProcedureCaller(finalBuilder._def);
   const callerOverride = finalBuilder._def.caller;
   if (!callerOverride) {
@@ -517,11 +525,11 @@ function createResolver(
     return callerOverride({
       args,
       invoke,
-      _def: finalBuilder._def as unknown as AnyProcedure['_def'],
+      _def: _def,
     });
   };
 
-  callerWrapper._def = finalBuilder._def;
+  callerWrapper._def = _def;
   return callerWrapper;
 }
 


### PR DESCRIPTION
Closes #

## 🎯 Changes

- Adds ability to automatically rethrow built-in Next.js errors in `experimental_createServerActionHandler()` 
- adds an `onError`-callback
- adds support for `experimental_caller` in server actions (I think!?)
- makes `createContext` in server actions optional if you have no context defined