### PR TITLE
return redirect

### DIFF
--- a/examples/.experimental/next-app-dir/src/app/posts/_data.ts
+++ b/examples/.experimental/next-app-dir/src/app/posts/_data.ts
@@ -30,7 +30,7 @@ export const addPost = nextProc
 
     await db.addPost(post);
     revalidatePath('/');
-    redirect(`/posts/${post.id}`, RedirectType.push);
+    return redirect(`/posts/${post.id}`, RedirectType.push);
   });
 
 export const listPosts = nextProc.query(async () => {

--- a/packages/server/src/adapters/next-app-dir/nextAppDirCaller.ts
+++ b/packages/server/src/adapters/next-app-dir/nextAppDirCaller.ts
@@ -12,6 +12,7 @@ import type {
   Simplify,
 } from '../../unstable-core-do-not-import/types';
 import { formDataToObject } from './formDataToObject';
+import { TRPCRedirectError } from './redirect';
 import { rethrowNextErrors } from './rethrowNextErrors';
 
 type ContextCallback<TContext> = object extends TContext
@@ -95,6 +96,10 @@ export function nextAppDirCaller<TContext>(
             path: '',
             input,
           })
+          .then((data) => {
+            if (data instanceof TRPCRedirectError) throw data;
+            return data;
+          })
           .catch(handleError);
       }
       case 'query': {
@@ -106,6 +111,10 @@ export function nextAppDirCaller<TContext>(
             getRawInput: async () => input,
             path: '',
             input,
+          })
+          .then((data) => {
+            if (data instanceof TRPCRedirectError) throw data;
+            return data;
           })
           .catch(handleError);
       }

--- a/packages/server/src/adapters/next-app-dir/redirect.ts
+++ b/packages/server/src/adapters/next-app-dir/redirect.ts
@@ -22,6 +22,7 @@ export class TRPCRedirectError extends TRPCError {
  * This provides better typesafety than the `next/navigation`'s `redirect()` since the action continues
  * to execute on the frontend even if Next's `redirect()` has a return type of `never`.
  * @public
+ * @remark You should only use this if you're also using `nextAppDirCaller`.
  */
 export const redirect = (url: URL | string, redirectType?: RedirectType) => {
   // We rethrow this internally so the returntype on the client is undefined.

--- a/packages/server/src/adapters/next-app-dir/redirect.ts
+++ b/packages/server/src/adapters/next-app-dir/redirect.ts
@@ -1,4 +1,4 @@
-import type { redirect as __redirect } from 'next/navigation';
+import type { RedirectType } from 'next/navigation';
 import { TRPCError } from '../../@trpc/server';
 
 /**
@@ -6,15 +6,14 @@ import { TRPCError } from '../../@trpc/server';
  */
 export class TRPCRedirectError extends TRPCError {
   public readonly args;
-  constructor(...args: Parameters<typeof __redirect>) {
-    const [url] = args;
+  constructor(url: URL | string, redirectType?: RedirectType) {
     super({
       // TODO(?): This should maybe a custom error code
       code: 'UNPROCESSABLE_CONTENT',
       message: `Redirect error to "${url}" that will be handled by Next.js`,
     });
 
-    this.args = args;
+    this.args = [url.toString(), redirectType] as const;
   }
 }
 
@@ -22,6 +21,6 @@ export class TRPCRedirectError extends TRPCError {
  * Like `next/navigation`'s `redirect()` but throws a `TRPCError` that later will be handled by Next.js
  * @public
  */
-export const redirect: typeof __redirect = (...args) => {
-  throw new TRPCRedirectError(...args);
+export const redirect = (url: URL | string, redirectType?: RedirectType) => {
+  return new TRPCRedirectError(url, redirectType);
 };

--- a/packages/server/src/adapters/next-app-dir/redirect.ts
+++ b/packages/server/src/adapters/next-app-dir/redirect.ts
@@ -19,8 +19,11 @@ export class TRPCRedirectError extends TRPCError {
 
 /**
  * Like `next/navigation`'s `redirect()` but throws a `TRPCError` that later will be handled by Next.js
+ * This provides better typesafety than the `next/navigation`'s `redirect()` since the action continues
+ * to execute on the frontend even if Next's `redirect()` has a return type of `never`.
  * @public
  */
 export const redirect = (url: URL | string, redirectType?: RedirectType) => {
-  return new TRPCRedirectError(url, redirectType);
+  // We rethrow this internally so the returntype on the client is undefined.
+  return new TRPCRedirectError(url, redirectType) as unknown as undefined;
 };


### PR DESCRIPTION
cause next's way of throwing causes the compiler to lie to us and easy to cause typemismatch on frontend

This way we get the proper returntype on the client, namely `undefined`
![CleanShot 2024-03-27 at 12 25 35](https://github.com/trpc/trpc/assets/51714798/53257af1-977c-4eb6-b5be-eceb48581acd)

The main difference is that you have to **return** the redirect since it doesn't throw inside the action.