### PR TITLE
fix(client): createInnerProxy exclude apply bind and call

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/createProxy.ts
+++ b/packages/server/src/unstable-core-do-not-import/createProxy.ts
@@ -20,13 +20,20 @@ function createInnerProxy(callback: ProxyCallback, path: string[]) {
     },
     apply(_1, _2, args) {
       const lastOfPath = path[path.length - 1];
-      const isCallBindApply =
-        lastOfPath === 'apply' ||
-        lastOfPath === 'bind' ||
-        lastOfPath === 'call';
+
+      const isCall = lastOfPath === 'call';
+      if (isCall) {
+        return callback({
+          args: args.length >= 2 ? [args[1]] : [],
+          path: path.slice(0, -1),
+        });
+      }
+
+      const isApply = lastOfPath === 'apply';
+
       return callback({
-        args: isCallBindApply ? (args.length >= 2 ? args[1] : []) : args,
-        path: isCallBindApply ? path.slice(0, -1) : path,
+        args: isApply ? (args.length >= 2 ? args[1] : []) : args,
+        path: isApply ? path.slice(0, -1) : path,
       });
     },
   });

--- a/packages/server/src/unstable-core-do-not-import/createProxy.ts
+++ b/packages/server/src/unstable-core-do-not-import/createProxy.ts
@@ -19,10 +19,14 @@ function createInnerProxy(callback: ProxyCallback, path: string[]) {
       return createInnerProxy(callback, [...path, key]);
     },
     apply(_1, _2, args) {
-      const isApply = path[path.length - 1] === 'apply';
+      const lastOfPath = path[path.length - 1];
+      const isCallBindApply =
+        lastOfPath === 'apply' ||
+        lastOfPath === 'bind' ||
+        lastOfPath === 'call';
       return callback({
-        args: isApply ? (args.length >= 2 ? args[1] : []) : args,
-        path: isApply ? path.slice(0, -1) : path,
+        args: isCallBindApply ? (args.length >= 2 ? args[1] : []) : args,
+        path: isCallBindApply ? path.slice(0, -1) : path,
       });
     },
   });

--- a/packages/tests/server/index.test.ts
+++ b/packages/tests/server/index.test.ts
@@ -611,3 +611,57 @@ describe('apply()', () => {
     await close();
   });
 });
+
+describe('call()', () => {
+  test('query without input', async () => {
+    const t = initTRPC.create();
+    const router = t.router({
+      hello: t.procedure.query(() => 'world'),
+    });
+    const { close, client } = routerToServerAndClientNew(router);
+    expect(await client.hello.query.call(this)).toBe('world');
+    await close();
+  });
+
+  test('query with input', async () => {
+    const t = initTRPC.create();
+    const router = t.router({
+      helloinput: t.procedure
+        .input(z.string())
+        .query(({ input }) => `hello ${input}`),
+    });
+    const { close, client } = routerToServerAndClientNew(router);
+    expect(await client.helloinput.query.call(this, 'world')).toBe(
+      'hello world',
+    );
+    await close();
+  });
+
+  test('query with object input', async () => {
+    const t = initTRPC.create();
+    const router = t.router({
+      helloinput: t.procedure
+        .input(z.object({ text: z.string() }))
+        .query(({ input }) => `hello ${input.text}`),
+    });
+    const { close, client } = routerToServerAndClientNew(router);
+    expect(await client.helloinput.query.call(this, { text: 'world' })).toBe(
+      'hello world',
+    );
+    await close();
+  });
+
+  test('query with array input', async () => {
+    const t = initTRPC.create();
+    const router = t.router({
+      helloinput: t.procedure
+        .input(z.string().array())
+        .query(({ input }) => `hello ${input.join(' ')}`),
+    });
+    const { close, client } = routerToServerAndClientNew(router);
+    expect(await client.helloinput.query.call(this, ['world'])).toBe(
+      'hello world',
+    );
+    await close();
+  });
+});


### PR DESCRIPTION
Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

bug fix: check `.call` and `apply` method for `createInnerProxy`

followup of: https://github.com/trpc/trpc/pull/3973

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
