### PR TITLE
fix(server): remove extra export for router

### DIFF
--- a/packages/server/src/unstable-core-do-not-import.ts
+++ b/packages/server/src/unstable-core-do-not-import.ts
@@ -23,7 +23,6 @@ export * from './unstable-core-do-not-import/procedure';
 export * from './unstable-core-do-not-import/procedureBuilder';
 export * from './unstable-core-do-not-import/rootConfig';
 export * from './unstable-core-do-not-import/router';
-export * from './unstable-core-do-not-import/router';
 export * from './unstable-core-do-not-import/rpc';
 export * from './unstable-core-do-not-import/transformer';
 export * from './unstable-core-do-not-import/types';


### PR DESCRIPTION
## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?
- Removed extra export statement for `'./unstable-core-do-not-import/router'` in `unstable-core-do-not-import.ts` file

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
