### PR TITLE
chore(deps): Remove unused dependency aws-lambda

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -138,7 +138,6 @@
     "@types/react-dom": "^18.2.14",
     "@types/ws": "^8.2.0",
     "@web3-storage/multipart-parser": "^1.0.0",
-    "aws-lambda": "^1.0.7",
     "devalue": "^4.0.0",
     "eslint": "^8.56.0",
     "express": "^4.17.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1533,9 +1533,6 @@ importers:
       '@web3-storage/multipart-parser':
         specifier: ^1.0.0
         version: 1.0.0
-      aws-lambda:
-        specifier: ^1.0.7
-        version: 1.0.7
       devalue:
         specifier: ^4.0.0
         version: 4.3.0
@@ -9688,16 +9685,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /aws-lambda@1.0.7:
-    resolution: {integrity: sha512-9GNFMRrEMG5y3Jvv+V4azWvc+qNWdWLTjDdhf/zgMlz8haaaLWv0xeAIWxz9PuWUBawsVxy0zZotjCdR3Xq+2w==}
-    hasBin: true
-    dependencies:
-      aws-sdk: 2.1261.0
-      commander: 3.0.2
-      js-yaml: 3.14.1
-      watchpack: 2.4.0
-    dev: true
-
   /aws-sdk@2.1261.0:
     resolution: {integrity: sha512-Lumifi52Vj6ss1tlZ9Z+BvJ+Yk2MTwPQyrDCZh79xggFgXYoDU/g4rZUr47/1AXBZje3mVkLeRM15hvUwKlTaA==}
     engines: {node: '>= 10.0.0'}
@@ -10640,10 +10627,6 @@ packages:
 
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
-
-  /commander@3.0.2:
-    resolution: {integrity: sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==}
-    dev: true
 
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -13909,6 +13892,7 @@ packages:
 
   /glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+    dev: false
 
   /glob@10.2.7:
     resolution: {integrity: sha512-jTKehsravOJo8IJxUGfZILnkvVJM/MOfHRs8QcXolVef2zNI9Tqyy5+SeuOAZd3upViEZQLyFpQhYiHLrMUNmA==}
@@ -22551,6 +22535,7 @@ packages:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
+    dev: false
 
   /wbuf@1.7.3:
     resolution: {integrity: sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==}


### PR DESCRIPTION
Removes an unused dependency.

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?
The `aws-lambda` package is a poorly-named CLI tool, and not actually types for AWS Lambda events. 
https://www.npmjs.com/package/aws-lambda

This PR removes the unused dev dependency. I've confirmed the types used by the server are still valid:
<img width="1640" alt="Screenshot 2024-04-13 at 9 32 34 AM" src="https://github.com/trpc/trpc/assets/1598537/43178bb3-de71-4311-815d-ae59caebd1ad">

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
