### PR TITLE
chore: remove `name:` from jobs in ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,8 +44,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/setup
 
-      - name: Build tRPC, then test
-        run: pnpm turbo --filter "@trpc/*" build
+      - run: pnpm turbo --filter "@trpc/*" build
       - run: pnpm test-ci
 
       - uses: codecov/codecov-action@v4
@@ -103,8 +102,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/setup
 
-      - name: Build trpc
-        run: pnpm turbo --filter "@trpc/*" build --force
+      - run: pnpm turbo --filter "@trpc/*" build
 
       - name: Install playwright ???
         # Seems like some of playwright's system deps aren't being cached, so we're making sure they are installed
@@ -145,8 +143,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/setup
 
-      - name: Build trpc
-        run: pnpm turbo --filter "@trpc/*" build
+      - run: pnpm turbo --filter "@trpc/*" build
 
       - uses: denoland/setup-deno@v1
         with:
@@ -184,8 +181,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/setup
 
-      - name: Build trpc
-        run: pnpm turbo --filter "@trpc/*" build
+      - run: pnpm turbo --filter "@trpc/*" build
 
       - uses: oven-sh/setup-bun@v1
         with:
@@ -236,8 +232,7 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/setup
 
-      - name: Build trpc
-        run: pnpm turbo --filter "@trpc/*" build
+      - run: pnpm turbo --filter "@trpc/*" build
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,14 +21,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: ./.github/setup
 
-      - name: Build
-        run: pnpm turbo --filter "@trpc/*" build
+      - run: pnpm turbo --filter "@trpc/*" build
   test:
     timeout-minutes: 10
     env:
@@ -38,8 +36,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: ./.github/setup
@@ -96,8 +93,7 @@ jobs:
             vercel-edge-runtime,
           ]
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: ./.github/setup
@@ -112,12 +108,9 @@ jobs:
             then pnpm playwright install chromium;
           fi
 
-      - name: Run test-dev
-        run: pnpm turbo --filter ./examples/${{ matrix.dir }} test-dev
-      - name: Run build
-        run: pnpm turbo --filter ./examples/${{ matrix.dir }} build type-check --force
-      - name: Run test-start
-        run: pnpm turbo --filter ./examples/${{ matrix.dir }} test-start
+      - run: pnpm turbo --filter ./examples/${{ matrix.dir }} test-dev
+      - run: pnpm turbo --filter ./examples/${{ matrix.dir }} build type-check --force
+      - run: pnpm turbo --filter ./examples/${{ matrix.dir }} test-start
 
   e2e-deno:
     # only run on PRs
@@ -137,8 +130,7 @@ jobs:
       matrix:
         dir: [deno-deploy]
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: ./.github/setup
@@ -151,9 +143,7 @@ jobs:
 
       - run: deno --version
 
-      - name: run test
-        if: ${{ matrix.dir == 'deno-deploy' }}
-        run: |
+      - run: |
           cd ./examples/${{ matrix.dir }}
           pnpm dlx start-server-and-test "deno run --allow-net=:8000 --allow-env ./src/index.ts" http://127.0.0.1:8000 "deno run --allow-net --allow-env ./src/client.ts"
 
@@ -175,8 +165,7 @@ jobs:
         dir: [bun]
         os: [ubuntu-latest]
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: ./.github/setup
@@ -189,12 +178,9 @@ jobs:
 
       - run: bun --version
 
-      - name: Run test-dev
-        run: pnpm turbo --filter ./examples/${{ matrix.dir }} test-dev
-      - name: Run build
-        run: pnpm turbo --filter ./examples/${{ matrix.dir }} build type-check
-      - name: Run test-start
-        run: pnpm turbo --filter ./examples/${{ matrix.dir }} test-start
+      - run: pnpm turbo --filter ./examples/${{ matrix.dir }} test-dev
+      - run: pnpm turbo --filter ./examples/${{ matrix.dir }} build type-check
+      - run: pnpm turbo --filter ./examples/${{ matrix.dir }} test-start
 
   e2e-legacy-node:
     # only run on PRs
@@ -226,8 +212,7 @@ jobs:
           ]
         node-start: ['18.x']
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: ./.github/setup
@@ -246,9 +231,6 @@ jobs:
           if grep --silent '"@playwright/test"';
             then pnpm playwright install chromium;
           fi
-      - name: Run test-dev
-        run: pnpm turbo --filter ./examples/${{ matrix.dir }} test-dev
-      - name: Run build
-        run: pnpm turbo --filter ./examples/${{ matrix.dir }} build type-check
-      - name: Run test-start
-        run: pnpm turbo --filter ./examples/${{ matrix.dir }} test-start
+      - run: pnpm turbo --filter ./examples/${{ matrix.dir }} test-dev
+      - run: pnpm turbo --filter ./examples/${{ matrix.dir }} build type-check
+      - run: pnpm turbo --filter ./examples/${{ matrix.dir }} test-start


### PR DESCRIPTION
it just obfuscates what's going on for me