### PR TITLE
chore: better error for mismatched content-type

### DIFF
--- a/packages/server/src/adapters/aws-lambda/content-type/json/index.ts
+++ b/packages/server/src/adapters/aws-lambda/content-type/json/index.ts
@@ -29,7 +29,9 @@ export const getLambdaHTTPJSONContentTypeHandler: <
   TEvent extends APIGatewayEvent,
 >() => LambdaHTTPContentTypeHandler<TRouter, TEvent> = () => ({
   name: 'lambda-json',
-  isMatch: (contentType) => contentType.startsWith('application/json'),
+  isMatch: (headers) => {
+    return !!headers.get('content-type')?.startsWith('application/json');
+  },
   getInputs: async (opts, info) => {
     function getRawProcedureInputOrThrow() {
       const { event, req } = opts;

--- a/packages/server/src/adapters/aws-lambda/content-type/json/index.ts
+++ b/packages/server/src/adapters/aws-lambda/content-type/json/index.ts
@@ -29,9 +29,7 @@ export const getLambdaHTTPJSONContentTypeHandler: <
   TEvent extends APIGatewayEvent,
 >() => LambdaHTTPContentTypeHandler<TRouter, TEvent> = () => ({
   name: 'lambda-json',
-  isMatch(opts) {
-    return !!opts.event.headers['Content-Type']?.startsWith('application/json');
-  },
+  isMatch: (contentType) => contentType.startsWith('application/json'),
   getInputs: async (opts, info) => {
     function getRawProcedureInputOrThrow() {
       const { event, req } = opts;

--- a/packages/server/src/adapters/content-handlers/selectContentHandlerOrUnsupportedMediaType.ts
+++ b/packages/server/src/adapters/content-handlers/selectContentHandlerOrUnsupportedMediaType.ts
@@ -1,20 +1,35 @@
 import { TRPCError } from '../../@trpc/server';
-import type { BaseContentTypeHandler } from '../../@trpc/server/http';
+import type {
+  BaseContentTypeHandler,
+  HTTPHeaders,
+} from '../../@trpc/server/http';
+
+interface MinimalHandlerOpts {
+  req: {
+    headers: HTTPHeaders | Headers;
+  };
+}
 
 export function selectContentHandlerOrUnsupportedMediaType<
-  THandlerOpts,
+  THandlerOpts extends MinimalHandlerOpts,
   THandler extends BaseContentTypeHandler<THandlerOpts>,
 >(handlers: THandler[], opts: THandlerOpts) {
-  const handler = handlers.find((handler) => handler.isMatch(opts));
+  const contentType = new Headers(opts.req.headers as HeadersInit).get(
+    'content-type',
+  );
+
+  const error = new TRPCError({
+    code: 'UNSUPPORTED_MEDIA_TYPE',
+    message: `Invalid Content-Type header '${contentType}'. This request may not be supported by your tRPC Adapter, or possibly by tRPC at all`,
+  });
+
+  if (typeof contentType !== 'string') {
+    return [undefined, error] as const;
+  }
+
+  const handler = handlers.find((handler) => handler.isMatch(contentType));
   if (!handler) {
-    return [
-      undefined,
-      new TRPCError({
-        code: 'UNSUPPORTED_MEDIA_TYPE',
-        message:
-          'Invalid Content-Type header. This request may not be supported by your tRPC Adapter, or possibly by tRPC at all',
-      }),
-    ] as const;
+    return [undefined, error] as const;
   }
 
   return [handler] as const;

--- a/packages/server/src/adapters/fastify/content-type/json/index.ts
+++ b/packages/server/src/adapters/fastify/content-type/json/index.ts
@@ -22,7 +22,9 @@ export const getFastifyHTTPJSONContentTypeHandler: <
   TResponse extends FastifyReply,
 >() => FastifyHTTPContentTypeHandler<TRouter, TRequest, TResponse> = () => ({
   name: 'fastify-json',
-  isMatch: (contentType) => contentType.startsWith('application/json'),
+  isMatch: (headers) => {
+    return !!headers.get('content-type')?.startsWith('application/json');
+  },
   getInputs: async (opts, info) => {
     async function getRawProcedureInputOrThrow() {
       const { req } = opts;

--- a/packages/server/src/adapters/fastify/content-type/json/index.ts
+++ b/packages/server/src/adapters/fastify/content-type/json/index.ts
@@ -22,9 +22,7 @@ export const getFastifyHTTPJSONContentTypeHandler: <
   TResponse extends FastifyReply,
 >() => FastifyHTTPContentTypeHandler<TRouter, TRequest, TResponse> = () => ({
   name: 'fastify-json',
-  isMatch(opts) {
-    return !!opts.req.headers['content-type']?.startsWith('application/json');
-  },
+  isMatch: (contentType) => contentType.startsWith('application/json'),
   getInputs: async (opts, info) => {
     async function getRawProcedureInputOrThrow() {
       const { req } = opts;

--- a/packages/server/src/adapters/fetch/content-type/json/index.ts
+++ b/packages/server/src/adapters/fetch/content-type/json/index.ts
@@ -18,11 +18,7 @@ export const getFetchHTTPJSONContentTypeHandler: <
   TRouter extends AnyRouter,
 >() => FetchHTTPContentTypeHandler<TRouter> = () => ({
   name: 'fetch-json',
-  isMatch(opts) {
-    return !!opts.req.headers
-      .get('content-type')
-      ?.startsWith('application/json');
-  },
+  isMatch: (contentType) => contentType.startsWith('application/json'),
   getInputs: async (opts, info) => {
     async function getRawProcedureInputOrThrow() {
       const { req } = opts;

--- a/packages/server/src/adapters/fetch/content-type/json/index.ts
+++ b/packages/server/src/adapters/fetch/content-type/json/index.ts
@@ -18,7 +18,9 @@ export const getFetchHTTPJSONContentTypeHandler: <
   TRouter extends AnyRouter,
 >() => FetchHTTPContentTypeHandler<TRouter> = () => ({
   name: 'fetch-json',
-  isMatch: (contentType) => contentType.startsWith('application/json'),
+  isMatch: (headers) => {
+    return !!headers.get('content-type')?.startsWith('application/json');
+  },
   getInputs: async (opts, info) => {
     async function getRawProcedureInputOrThrow() {
       const { req } = opts;

--- a/packages/server/src/adapters/node-http/content-type/form-data/index.ts
+++ b/packages/server/src/adapters/node-http/content-type/form-data/index.ts
@@ -10,12 +10,7 @@ export const getFormDataContentTypeHandler: <
   TResponse extends NodeHTTPResponse,
 >() => NodeHTTPContentTypeHandler<TRouter, TRequest, TResponse> = () => ({
   name: 'node-http-formdata',
-  isMatch(opts) {
-    return (
-      opts.req.headers['content-type']?.startsWith('multipart/form-data') ??
-      false
-    );
-  },
+  isMatch: (contentType) => contentType.startsWith('multipart/form-data'),
   async getInputs(opts, inputOpts) {
     if (inputOpts.isBatchCall) {
       throw new Error('Batch calls not supported for form-data');

--- a/packages/server/src/adapters/node-http/content-type/form-data/index.ts
+++ b/packages/server/src/adapters/node-http/content-type/form-data/index.ts
@@ -10,7 +10,9 @@ export const getFormDataContentTypeHandler: <
   TResponse extends NodeHTTPResponse,
 >() => NodeHTTPContentTypeHandler<TRouter, TRequest, TResponse> = () => ({
   name: 'node-http-formdata',
-  isMatch: (contentType) => contentType.startsWith('multipart/form-data'),
+  isMatch: (headers) => {
+    return !!headers.get('content-type')?.startsWith('multipart/form-data');
+  },
   async getInputs(opts, inputOpts) {
     if (inputOpts.isBatchCall) {
       throw new Error('Batch calls not supported for form-data');

--- a/packages/server/src/adapters/node-http/content-type/json/index.ts
+++ b/packages/server/src/adapters/node-http/content-type/json/index.ts
@@ -14,7 +14,9 @@ export const getNodeHTTPJSONContentTypeHandler: <
   TResponse extends NodeHTTPResponse,
 >() => NodeHTTPContentTypeHandler<TRouter, TRequest, TResponse> = () => ({
   name: 'node-http-json',
-  isMatch: (contentType) => contentType.startsWith('application/json'),
+  isMatch: (headers) => {
+    return !!headers.get('content-type')?.startsWith('application/json');
+  },
   getInputs: async (opts, info) => {
     const bodyResult = await getPostBody(opts);
     if (!bodyResult.ok) {

--- a/packages/server/src/adapters/node-http/content-type/json/index.ts
+++ b/packages/server/src/adapters/node-http/content-type/json/index.ts
@@ -14,9 +14,7 @@ export const getNodeHTTPJSONContentTypeHandler: <
   TResponse extends NodeHTTPResponse,
 >() => NodeHTTPContentTypeHandler<TRouter, TRequest, TResponse> = () => ({
   name: 'node-http-json',
-  isMatch(opts) {
-    return !!opts.req.headers['content-type']?.startsWith('application/json');
-  },
+  isMatch: (contentType) => contentType.startsWith('application/json'),
   getInputs: async (opts, info) => {
     const bodyResult = await getPostBody(opts);
     if (!bodyResult.ok) {

--- a/packages/server/src/adapters/node-http/content-type/octet/index.ts
+++ b/packages/server/src/adapters/node-http/content-type/octet/index.ts
@@ -10,13 +10,7 @@ export const getOctetContentTypeHandler: <
   TResponse extends NodeHTTPResponse,
 >() => NodeHTTPContentTypeHandler<TRouter, TRequest, TResponse> = () => ({
   name: 'node-http-octet',
-  isMatch(opts) {
-    return (
-      opts.req.headers['content-type']?.startsWith(
-        'application/octet-stream',
-      ) ?? false
-    );
-  },
+  isMatch: (contentType) => contentType.startsWith('application/octet-stream'),
   async getInputs(opts, inputOpts) {
     if (inputOpts.isBatchCall) {
       throw new Error('Batch calls not supported for octet-stream');

--- a/packages/server/src/adapters/node-http/content-type/octet/index.ts
+++ b/packages/server/src/adapters/node-http/content-type/octet/index.ts
@@ -10,7 +10,11 @@ export const getOctetContentTypeHandler: <
   TResponse extends NodeHTTPResponse,
 >() => NodeHTTPContentTypeHandler<TRouter, TRequest, TResponse> = () => ({
   name: 'node-http-octet',
-  isMatch: (contentType) => contentType.startsWith('application/octet-stream'),
+  isMatch: (headers) => {
+    return !!headers
+      .get('content-type')
+      ?.startsWith('application/octet-stream');
+  },
   async getInputs(opts, inputOpts) {
     if (inputOpts.isBatchCall) {
       throw new Error('Batch calls not supported for octet-stream');

--- a/packages/server/src/unstable-core-do-not-import/http/contentType.ts
+++ b/packages/server/src/unstable-core-do-not-import/http/contentType.ts
@@ -13,7 +13,7 @@ export type BodyResult =
 
 export type BaseContentTypeHandler<TOptions> = {
   name: string;
-  isMatch(opts: TOptions): boolean;
+  isMatch(contentType: string): boolean;
   getInputs: (
     opts: TOptions,
     info: {

--- a/packages/server/src/unstable-core-do-not-import/http/contentType.ts
+++ b/packages/server/src/unstable-core-do-not-import/http/contentType.ts
@@ -13,7 +13,7 @@ export type BodyResult =
 
 export type BaseContentTypeHandler<TOptions> = {
   name: string;
-  isMatch(contentType: string): boolean;
+  isMatch(headers: Headers): boolean;
   getInputs: (
     opts: TOptions,
     info: {

--- a/packages/tests/server/adapters/standalone.test.ts
+++ b/packages/tests/server/adapters/standalone.test.ts
@@ -207,7 +207,7 @@ test('force content-type on mutations', async () => {
             "path": "mut",
             "stack": "[redacted]",
           },
-          "message": "Invalid Content-Type header 'null'. This request may not be supported by your tRPC Adapter, or possibly by tRPC at all",
+          "message": "No Content-Type header detected on the incoming request. This request may not be supported by your tRPC Adapter, or possibly by tRPC at all",
         },
       }
     `);

--- a/packages/tests/server/adapters/standalone.test.ts
+++ b/packages/tests/server/adapters/standalone.test.ts
@@ -207,7 +207,7 @@ test('force content-type on mutations', async () => {
             "path": "mut",
             "stack": "[redacted]",
           },
-          "message": "Invalid Content-Type header. This request may not be supported by your tRPC Adapter, or possibly by tRPC at all",
+          "message": "Invalid Content-Type header 'null'. This request may not be supported by your tRPC Adapter, or possibly by tRPC at all",
         },
       }
     `);


### PR DESCRIPTION
Closes #5653

- improves error by providing the received content type to the error
- uses `Headers` (Node18+) whose `.get()` is case-insensitive