### PR TITLE
feat: add trpc-rabbitmq & trpc-mqtt to the awesome-trpc list

### DIFF
--- a/www/docs/community/awesome-trpc.mdx
+++ b/www/docs/community/awesome-trpc.mdx
@@ -65,6 +65,8 @@ A collection of resources on tRPC.
 | k6-trpc - k6 compatible tRPC client                                                                 | https://github.com/dextertanyj/k6-trpc                                |
 | trpc-token-refresh-link - Link to refresh access tokens and refresh tokens                          | https://github.com/larskarbo/trpc-token-refresh-link                  |
 | trpc-bun-adapter - tRPC adapter for Bun runtime environment                                         | https://github.com/cah4a/trpc-bun-adapter                             |
+| trpc-rabbitmq - tRPC adapter using RabbitMQ as a transport layer                                    | https://github.com/imxeno/trpc-rabbitmq                               |
+| trpc-mqtt - tRPC adapter using MQTT as a transport layer                                            | https://github.com/edorgeville/trpc-mqtt                              |
 
 ## 🍀 Starting points, example projects, etc
 


### PR DESCRIPTION
Hi, 
I wrote [trpc-mqtt](https://github.com/imxeno/trpc-rabbitmq) a while ago, an MQTT adapter. It is based on [trpc-rabbitmq](https://github.com/imxeno/trpc-rabbitmq).
I have been using it in production for the past year with great success. A few people seem to have stumbled upon it an starred my repo. I'd like to add my package to the docs, as well as its inspiration.
Thank you for the great work :)
Cheers,
Erwan

## 🎯 Changes

 - add trpc-rabbitmq & trpc-mqtt to the awesome-trpc list

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
