### PR TITLE
Export `TRPCBuilder` class from `@trpc/server` package

### DIFF
--- a/packages/server/src/@trpc/server/index.ts
+++ b/packages/server/src/@trpc/server/index.ts
@@ -35,6 +35,7 @@ export {
   type MutationProcedure as TRPCMutationProcedure,
   type QueryProcedure as TRPCQueryProcedure,
   type SubscriptionProcedure as TRPCSubscriptionProcedure,
+  type TRPCBuilder,
 } from '../../unstable-core-do-not-import';
 
 export type {

--- a/packages/server/src/unstable-core-do-not-import/initTRPC.ts
+++ b/packages/server/src/unstable-core-do-not-import/initTRPC.ts
@@ -149,3 +149,4 @@ class TRPCBuilder<TContext extends object, TMeta extends object> {
  * @link https://trpc.io/docs/v11/quickstart
  */
 export const initTRPC = new TRPCBuilder();
+export type { TRPCBuilder };


### PR DESCRIPTION
Closes #5666

## 🎯 Changes

This change exports the `TRPCBuilder` class from `@trpc/server` package.

I don't know what the reasoning is specfically for keeping the entire `TRPCBuilder` class private, but given that exposing instances of that class to the user is required in order to use it, keeping the class private seems like it might have been to coerce users into using the `initTRPC....` functions instead of instantiating the class directly.

For this reason, I exported only the type of the class so that the type could be used to explicitly define context and/or meta types in JavaScript land...

```js
import { initTRPC } from '@trpc/server';

/** @type {import("@trpc/server").TRPCBuilder<{ ctx: MyContext }>} */
const init = initTRPC.context();

const t = init.create();
// Define procedures on `t` like usual with a context of type
// `MyContext`...
````

Since the main purpose of exporting the `TRPCBuilder` class is to allow JS users to specify the builder type returned from `initTRPC` in their code, it seemed reasonable to colocate the type with the `initTRPC` singleton.

If exporting the whole class would be preferable for some reason, that seems entirely feasible and does not expose any new API surface area since the class has no constructor.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] ~~I have added or updated the tests related to the changes made.~~
