### PR TITLE
05-05-stream-backpressure

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/stream/stream.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/stream.test.ts
@@ -394,13 +394,13 @@ test('e2e, client aborts request halfway through', async () => {
 });
 
 test.only('e2e, pause stream', async () => {
-  let yielded = 0
+  let yielded = 0;
   const data = {
     0: Promise.resolve({
       [Symbol.asyncIterator]: async function* () {
         for (let i = 0; i < 100; i++) {
           await new Promise((resolve) => setTimeout(resolve));
-          yielded = i
+          yielded = i;
           yield i;
         }
       },
@@ -413,8 +413,8 @@ test.only('e2e, pause stream', async () => {
   const server = createServer(stream, new AbortController());
 
   const res = await fetch(server.url);
-  await new Promise((resolve) => setTimeout(resolve, 100))
-  expect(yielded).toBe(0)
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  expect(yielded).toBe(0);
 
   const [head, meta] = await createJsonBatchStreamConsumer<typeof data>({
     from: res.body!,
@@ -427,12 +427,12 @@ test.only('e2e, pause stream', async () => {
     for await (const item of iterable) {
       aggregated.push(item);
       if (item === 50) {
-        break
+        break;
       }
     }
     expect(aggregated).toEqual(Array.from({ length: 51 }, (_, i) => i));
-    await new Promise((resolve) => setTimeout(resolve, 100))
-    expect(yielded).toBe(50)
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(yielded).toBe(50);
   }
 
   await meta.reader.closed;

--- a/packages/server/src/unstable-core-do-not-import/stream/stream.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/stream.ts
@@ -19,7 +19,7 @@ export function createReadableStream<TValue = unknown>() {
     start(c) {
       controller.close = () => {
         c.close();
-      }
+      };
       controller.enqueue = async (chunk: TValue) => {
         while (c.desiredSize! <= 0) {
           if (!pullPromise) {
@@ -175,7 +175,11 @@ export function createBatchStreamProducer(opts: ProducerOptions) {
     pending.add(idx);
     promise
       .then((it) => {
-        return controller.enqueue([idx, PROMISE_STATUS_FULFILLED, hydrate(it, path)]);
+        return controller.enqueue([
+          idx,
+          PROMISE_STATUS_FULFILLED,
+          hydrate(it, path),
+        ]);
       })
       .catch((err) => {
         opts.onError?.({ error: err, path });
@@ -471,7 +475,7 @@ export async function createJsonBatchStreamConsumer<THead>(opts: {
 
   async function end() {
     try {
-      const p: Promise<void>[] = []
+      const p: Promise<void>[] = [];
       for (const [_stream, controller] of chunkStreams.values()) {
         p.push(controller.enqueue(new StreamInterruptedError()));
       }

--- a/packages/server/src/unstable-core-do-not-import/stream/stream.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/stream.ts
@@ -20,11 +20,11 @@ export function createReadableStream<TValue = unknown>() {
     start(c) {
       obj.close = () => {
         c.close();
-      }
+      };
       obj.enqueue = async (chunk: TValue) => {
         if (c.desiredSize! > 0) {
           c.enqueue(chunk);
-          return
+          return;
         }
         while (c.desiredSize! <= 0) {
           if (!pullPromise) {
@@ -35,7 +35,7 @@ export function createReadableStream<TValue = unknown>() {
           await pullPromise;
         }
         c.enqueue(chunk);
-      }
+      };
     },
     pull() {
       pullResolve?.();
@@ -476,7 +476,7 @@ export async function createJsonBatchStreamConsumer<THead>(opts: {
 
   async function end() {
     try {
-      const p: Promise<void>[] = []
+      const p: Promise<void>[] = [];
       for (const s of chunkStreams.values()) {
         p.push(s.enqueue(new StreamInterruptedError()));
       }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -34,7 +34,7 @@ for (const pkg of dirs.sort()) {
 }
 
 export default defineConfig({
-  clearScreen: true,
+  clearScreen: false,
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
THIS PROBABLY SHOULDN'T BE MERGED AS IT DOES NOT WORK

Trying to allow client-server backpressure for async iterables as streams over the network.

`createReadableStream` uses a *pull* system instead of a *push* system, 
- will stop enqueuing when `controller.desiredSize <= 0`
- waits for the next `pull` call to start enqueueing again