### PR TITLE
feat: add 'none' color option to default logger, add withContext option

### DIFF
--- a/packages/client/src/links/loggerLink.ts
+++ b/packages/client/src/links/loggerLink.ts
@@ -49,6 +49,8 @@ type LoggerLinkFn<TRouter extends AnyRouter> = (
   opts: LoggerLinkFnOptions<TRouter>,
 ) => void;
 
+type ColorMode = 'ansi' | 'css' | 'none';
+
 export interface LoggerLinkOptions<TRouter extends AnyRouter> {
   logger?: LoggerLinkFn<TRouter>;
   enabled?: EnabledFn<TRouter>;
@@ -60,7 +62,12 @@ export interface LoggerLinkOptions<TRouter extends AnyRouter> {
    * Color mode
    * @default typeof window === 'undefined' ? 'ansi' : 'css'
    */
-  colorMode?: 'ansi' | 'css';
+  colorMode?: ColorMode;
+
+  /**
+   * Include context in the log
+   */
+  withContext?: boolean;
 }
 
 function isFormData(value: unknown): value is FormData {
@@ -96,15 +103,18 @@ const palettes = {
 
 function constructPartsAndArgs(
   opts: LoggerLinkFnOptions<any> & {
-    colorMode: 'ansi' | 'css';
+    colorMode: ColorMode;
+    withContext?: boolean;
   },
 ) {
-  const { direction, type, path, id, input } = opts;
+  const { direction, type, withContext, path, id, input } = opts;
 
   const parts: string[] = [];
   const args: any[] = [];
 
-  if (opts.colorMode === 'ansi') {
+  if (opts.colorMode === 'none') {
+    parts.push(direction === 'up' ? '>>' : '<<', type, `#${id}`, path);
+  } else if (opts.colorMode === 'ansi') {
     const [lightRegular, darkRegular] = palettes.ansi.regular[type];
     const [lightBold, darkBold] = palettes.ansi.bold[type];
     const reset = '\x1b[0m';
@@ -118,46 +128,38 @@ function constructPartsAndArgs(
       path,
       reset,
     );
-
-    if (direction === 'up') {
-      args.push({ input: opts.input });
-    } else {
-      args.push({
-        input: opts.input,
-        // strip context from result cause it's too noisy in terminal wihtout collapse mode
-        result: 'result' in opts.result ? opts.result.result : opts.result,
-        elapsedMs: opts.elapsedMs,
-      });
-    }
-
-    return { parts, args };
-  }
-
-  const [light, dark] = palettes.css[type];
-  const css = `
+  } else {
+    // css color mode
+    const [light, dark] = palettes.css[type];
+    const css = `
     background-color: #${direction === 'up' ? light : dark};
     color: ${direction === 'up' ? 'black' : 'white'};
     padding: 2px;
   `;
 
-  parts.push(
-    '%c',
-    direction === 'up' ? '>>' : '<<',
-    type,
-    `#${id}`,
-    `%c${path}%c`,
-    '%O',
-  );
-  args.push(css, `${css}; font-weight: bold;`, `${css}; font-weight: normal;`);
+    parts.push(
+      '%c',
+      direction === 'up' ? '>>' : '<<',
+      type,
+      `#${id}`,
+      `%c${path}%c`,
+      '%O',
+    );
+    args.push(
+      css,
+      `${css}; font-weight: bold;`,
+      `${css}; font-weight: normal;`,
+    );
+  }
 
   if (direction === 'up') {
-    args.push({ input, context: opts.context });
+    args.push(withContext ? { input, context: opts.context } : { input });
   } else {
     args.push({
       input,
       result: opts.result,
       elapsedMs: opts.elapsedMs,
-      context: opts.context,
+      ...(withContext && { context: opts.context }),
     });
   }
 
@@ -169,9 +171,11 @@ const defaultLogger =
   <TRouter extends AnyRouter>({
     c = console,
     colorMode = 'css',
+    withContext,
   }: {
     c?: ConsoleEsque;
-    colorMode?: 'ansi' | 'css';
+    colorMode?: ColorMode;
+    withContext?: boolean;
   }): LoggerLinkFn<TRouter> =>
   (props) => {
     const rawInput = props.input;
@@ -183,6 +187,7 @@ const defaultLogger =
       ...props,
       colorMode,
       input,
+      withContext,
     });
 
     const fn: 'error' | 'log' =
@@ -205,7 +210,10 @@ export function loggerLink<TRouter extends AnyRouter = AnyRouter>(
 
   const colorMode =
     opts.colorMode ?? (typeof window === 'undefined' ? 'ansi' : 'css');
-  const { logger = defaultLogger({ c: opts.console, colorMode }) } = opts;
+  const withContext = opts.withContext ?? colorMode === 'css';
+  const {
+    logger = defaultLogger({ c: opts.console, colorMode, withContext }),
+  } = opts;
 
   return () => {
     return ({ op, next }) => {


### PR DESCRIPTION
Closes #

## 🎯 Changes

Adds a `none` color option to the default `loggerLink`, and adds a `withContext` option to the logger