### PR TITLE
fix(react-query): get queryClient from trpc context

### DIFF
--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -8,7 +8,6 @@ import {
   useSuspenseQuery as __useSuspenseQuery,
   hashKey,
   skipToken,
-  useQueryClient,
 } from '@tanstack/react-query';
 import type { TRPCClientErrorLike } from '@trpc/client';
 import { createTRPCUntypedClient } from '@trpc/client';
@@ -267,8 +266,7 @@ export function createRootHooks<
     path: readonly string[],
     opts?: UseTRPCMutationOptions<unknown, TError, unknown, unknown>,
   ): UseTRPCMutationResult<unknown, TError, unknown, unknown> {
-    const { client } = useContext();
-    const queryClient = useQueryClient();
+    const { client, queryClient } = useContext();
 
     const mutationKey = getMutationKeyInternal(path);
 


### PR DESCRIPTION
## 🎯 Changes

this change keeps the same as `useQuery`, 
https://github.com/trpc/trpc/blob/a7c0ee0456e6dbcf8269c65047bdb0cc86dd4fbf/packages/react-query/src/shared/hooks/createHooksInternal.tsx#L134-L141


## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
