### PR TITLE
fix(server): handle large POST bodies in node-http

### DIFF
--- a/packages/server/src/adapters/node-http/incomingMessageToRequest.test.ts
+++ b/packages/server/src/adapters/node-http/incomingMessageToRequest.test.ts
@@ -71,19 +71,40 @@ test('basic POST', async () => {
 test('POST with body', async () => {
   const server = createServer({ maxBodySize: null });
 
-  await server.fetch(
-    {
-      method: 'POST',
-      body: JSON.stringify({ hello: 'world' }),
-      headers: {
-        'content-type': 'application/json',
+  {
+    // handles small text
+
+    await server.fetch(
+      {
+        method: 'POST',
+        body: JSON.stringify({ hello: 'world' }),
+        headers: {
+          'content-type': 'application/json',
+        },
       },
-    },
-    async (request) => {
-      expect(request.method).toBe('POST');
-      expect(await request.json()).toEqual({ hello: 'world' });
-    },
-  );
+      async (request) => {
+        expect(request.method).toBe('POST');
+        expect(await request.json()).toEqual({ hello: 'world' });
+      },
+    );
+  }
+  {
+    // handles a body that is long enough to come in multiple chunks
+
+    const body = '0'.repeat(2 ** 17);
+    const bodyLength = body.length;
+
+    await server.fetch(
+      {
+        method: 'POST',
+        body,
+      },
+      async (request) => {
+        expect(request.method).toBe('POST');
+        expect((await request.text()).length).toBe(bodyLength);
+      },
+    );
+  }
 
   await server.close();
 });

--- a/packages/server/src/adapters/node-http/incomingMessageToRequest.ts
+++ b/packages/server/src/adapters/node-http/incomingMessageToRequest.ts
@@ -17,32 +17,32 @@ function incomingMessageToBodyStream(
   type Value = Buffer | Uint8Array | string | null;
   let size = 0;
   const maxBodySize = opts.maxBodySize;
+  let hasClosed = false;
 
-  let controller: ReadableStreamDefaultController<Value> =
-    null as unknown as ReadableStreamDefaultController<Value>;
   const stream = new ReadableStream<Value>({
-    start(c) {
-      controller = c;
-    },
-    async pull(c) {
-      const chunk: Value = req.read();
-
-      if (chunk) {
+    start(controller) {
+      req.on('data', (chunk) => {
         size += chunk.length;
-      }
-      if (maxBodySize !== null && size > maxBodySize) {
-        controller.error(
-          new TRPCError({
-            code: 'PAYLOAD_TOO_LARGE',
-          }),
-        );
-        return;
-      }
-      if (chunk === null) {
-        c.close();
-        return;
-      }
-      controller.enqueue(chunk);
+        if (maxBodySize != null && size > maxBodySize) {
+          controller.error(
+            new TRPCError({
+              code: 'PAYLOAD_TOO_LARGE',
+            }),
+          );
+          // an error is thrown if we try to close the controller after
+          // erroring, so track the closure
+          hasClosed = true;
+          return;
+        }
+        controller.enqueue(chunk);
+      });
+      req.on('end', () => {
+        if (hasClosed) {
+          return;
+        }
+        hasClosed = true;
+        controller.close();
+      });
     },
     cancel() {
       req.destroy();

--- a/packages/server/src/adapters/node-http/incomingMessageToRequest.ts
+++ b/packages/server/src/adapters/node-http/incomingMessageToRequest.ts
@@ -36,7 +36,7 @@ function incomingMessageToBodyStream(
         }
         controller.enqueue(chunk);
       });
-      req.on('end', () => {
+      req.once('end', () => {
         if (hasClosed) {
           return;
         }


### PR DESCRIPTION
Closes #5725

## 🎯 Changes

Fixes a bug where node-http server would truncate POST bodies.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
