### PR TITLE
docs: Clarify how to use tRPC in Next.js Route Handlers

### DIFF
--- a/www/docs/server/adapters/nextjs.md
+++ b/www/docs/server/adapters/nextjs.md
@@ -104,7 +104,7 @@ If you're trying out the Next.js App Router and want to use [route handlers](htt
 import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
 import { appRouter } from '~/server/api/router';
 
-const handler = (req: Request) => {
+function handler(req: Request) {
   return fetchRequestHandler({
     endpoint: '/api/trpc',
     req,

--- a/www/docs/server/adapters/nextjs.md
+++ b/www/docs/server/adapters/nextjs.md
@@ -104,13 +104,14 @@ If you're trying out the Next.js App Router and want to use [route handlers](htt
 import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
 import { appRouter } from '~/server/api/router';
 
-const handler = (req: Request) =>
-  fetchRequestHandler({
+const handler = (req: Request) => {
+  return fetchRequestHandler({
     endpoint: '/api/trpc',
     req,
     router: appRouter,
     createContext: () => ({ ... })
   });
+}
 
 export { handler as GET, handler as POST };
 ```


### PR DESCRIPTION
Closes #N/A

## 🎯 Changes

Make the example code clearer on how to use tRPC in Next.js App Router Route Handlers.

## Why?

The existing example code is already correct, however it could cause some confusion, since it uses the `const x = y => z` syntax (which is not immediately clear that the function returns `z` especially for JavaScript beginners).

In the Next.js Discord server, there has been [at least one help question](https://nextjs-forum.com/post/1238455667056971856) where the user tries to do this

```tsx
import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
import { appRouter } from "@/server";

function handler(req: Request) {
  fetchRequestHandler({
    endpoint: "/api/trpc",
    req,
    router: appRouter,
    createContext: () => ({}),
  });
}

export { handler as GET, handler as POST };
```

and it doesn't work because the returned value of `fetchRequestHandler` is not returned again.

This PR slightly improves the example code so that the need to re-return the value is made more apparent.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
