### PR TITLE
Add trpc-cli to awesome-trpc

### DIFF
--- a/www/docs/community/awesome-trpc.mdx
+++ b/www/docs/community/awesome-trpc.mdx
@@ -26,6 +26,9 @@ A collection of resources on tRPC.
 | tRPC-Chrome - Web extensions messaging support for tRPC                        | https://github.com/jlalmes/trpc-chrome               |
 | Step CI - Automated API Testing and Quality Assurance                          | https://github.com/stepci/stepci                     |
 | msw-trpc - tRPC support for MSW                                                | https://github.com/maloguertin/msw-trpc              |
+| trpc-cli - Turn a tRPC router into a type-safe, fully documented CLI           | https://github.com/mmkal/trpc-cli                    |
+
+
 
 ### Frontend frameworks
 

--- a/www/docs/community/awesome-trpc.mdx
+++ b/www/docs/community/awesome-trpc.mdx
@@ -28,8 +28,6 @@ A collection of resources on tRPC.
 | msw-trpc - tRPC support for MSW                                                | https://github.com/maloguertin/msw-trpc              |
 | trpc-cli - Turn a tRPC router into a type-safe, fully documented CLI           | https://github.com/mmkal/trpc-cli                    |
 
-
-
 ### Frontend frameworks
 
 | Description                                             | Link                                            |


### PR DESCRIPTION
This is partly an awesome-trpc PR, partly a request for feedback on a new library I just published (/evaluation of whether it is indeed "awesome"). It takes an tRPC router and turns it into a CLI:

- procedures are mapped to commands
- inputs like `z.object({foo: z.string()})` are mapped to `--foo bar` type flags
- flags are parsed according to their target type (supporting numbers, string, booleans etc.)
- `t.procedure.meta({description: 'Add two numbers'})` is used to add to command help text
- `z.whatever().describe('...')` is used to add to flag help text

More docs and usage examples on https://github.com/mmkal/trpc-cli

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
