### PR TITLE
chore: support next15 in actions

### DIFF
--- a/.github/workflows/release-tmp.yml
+++ b/.github/workflows/release-tmp.yml
@@ -5,7 +5,7 @@ on:
     branches:
       # Replace this with the branch you want to release from
       # 👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇
-      - '04-26-resolveResponse-and-multi'
+      - 'rethrow-next-errors'
       # 👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆
     paths:
       - '.github/workflows/release-tmp.yml'

--- a/packages/server/src/adapters/next-app-dir/nextAppDirCaller.ts
+++ b/packages/server/src/adapters/next-app-dir/nextAppDirCaller.ts
@@ -46,6 +46,7 @@ export function nextAppDirCaller<TContext, TMeta>(
   const createContext = async (): Promise<TContext> => {
     return config?.createContext?.() ?? ({} as TContext);
   };
+
   return async (opts) => {
     const path =
       config.pathExtractor?.({ meta: opts._def.meta as TMeta }) ?? '';

--- a/packages/server/src/adapters/next-app-dir/rethrowNextErrors.ts
+++ b/packages/server/src/adapters/next-app-dir/rethrowNextErrors.ts
@@ -5,6 +5,7 @@ import { TRPCRedirectError } from './redirect';
 /**
  * @remarks The helpers from `next/dist/client/components/*` has been removed in Next.js 15.
  * Inlining them here instead...
+ * @see https://github.com/vercel/next.js/blob/5ae286ffd664e5c76841ed64f6e2da85a0835922/packages/next/src/client/components/redirect.ts#L97-L123
  */
 const REDIRECT_ERROR_CODE = 'NEXT_REDIRECT';
 function isRedirectError(error: unknown) {
@@ -26,6 +27,11 @@ function isRedirectError(error: unknown) {
   );
 }
 
+/**
+ * @remarks The helpers from `next/dist/client/components/*` has been removed in Next.js 15.
+ * Inlining them here instead...
+ * @see https://github.com/vercel/next.js/blob/5ae286ffd664e5c76841ed64f6e2da85a0835922/packages/next/src/client/components/not-found.ts#L33-L39
+ */
 const NOT_FOUND_ERROR_CODE = 'NEXT_NOT_FOUND';
 function isNotFoundError(error: unknown) {
   if (typeof error !== 'object' || error === null || !('digest' in error)) {

--- a/packages/server/src/adapters/next-app-dir/rethrowNextErrors.ts
+++ b/packages/server/src/adapters/next-app-dir/rethrowNextErrors.ts
@@ -1,4 +1,4 @@
-import * as nextNavigation from 'next/navigation';
+import * as nextNavigation from 'next/navigation.js';
 import type { TRPCError } from '../../@trpc/server';
 import { TRPCRedirectError } from './redirect';
 

--- a/packages/server/src/adapters/next-app-dir/rethrowNextErrors.ts
+++ b/packages/server/src/adapters/next-app-dir/rethrowNextErrors.ts
@@ -1,24 +1,60 @@
-import { isNotFoundError } from 'next/dist/client/components/not-found';
-import { isRedirectError } from 'next/dist/client/components/redirect';
-import {
-  notFound as __notFound,
-  redirect as __redirect,
-} from 'next/navigation';
+import * as nextNavigation from 'next/navigation';
 import type { TRPCError } from '../../@trpc/server';
 import { TRPCRedirectError } from './redirect';
 
 /**
+ * @remarks The helpers from `next/dist/client/components/*` has been removed in Next.js 15.
+ * Inlining them here instead...
+ */
+const REDIRECT_ERROR_CODE = 'NEXT_REDIRECT';
+function isRedirectError(error: unknown) {
+  if (
+    typeof error !== 'object' ||
+    error === null ||
+    !('digest' in error) ||
+    typeof error.digest !== 'string'
+  ) {
+    return false;
+  }
+  const [errorCode, type, destination, status] = error.digest.split(';', 4);
+  const statusCode = Number(status);
+  return (
+    errorCode === REDIRECT_ERROR_CODE &&
+    (type === 'replace' || type === 'push') &&
+    typeof destination === 'string' &&
+    !isNaN(statusCode)
+  );
+}
+
+const NOT_FOUND_ERROR_CODE = 'NEXT_NOT_FOUND';
+function isNotFoundError(error: unknown) {
+  if (typeof error !== 'object' || error === null || !('digest' in error)) {
+    return false;
+  }
+  return error.digest === NOT_FOUND_ERROR_CODE;
+}
+
+/**
  * Rethrow errors that should be handled by Next.js
  */
-
 export const rethrowNextErrors = (error: TRPCError) => {
   if (error.code === 'NOT_FOUND') {
-    __notFound();
+    nextNavigation.notFound();
   }
   if (error instanceof TRPCRedirectError) {
-    __redirect(...error.args);
+    nextNavigation.redirect(...error.args);
   }
   const { cause } = error;
+
+  // Next.js 15 has `unstable_rethrow`. Use that if it exists.
+  if (
+    'unstable_rethrow' in nextNavigation &&
+    typeof nextNavigation.unstable_rethrow === 'function'
+  ) {
+    nextNavigation.unstable_rethrow(cause);
+  }
+
+  // Before Next.js 15, we have to check and rethrow the error manually.
   if (isRedirectError(cause) || isNotFoundError(cause)) {
     throw error.cause;
   }


### PR DESCRIPTION
The helpers we imported from the internal dist path are removed in Next.js 15 RC making the current action stuff incompatible.

This little workaround should fix this. We can clean it up once 15 goes stable and we can use that as a peer dependency for these new stuff I think