### PR TITLE
chore: loosen some generic types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -74,7 +74,7 @@ const config = {
         format: ['PascalCase'],
         leadingUnderscore: 'allow',
         custom: {
-          regex: '^(T|\\$)[A-Z][a-zA-Z]+[0-9]*$',
+          regex: '^(T|\\$)([A-Z]([a-zA-Z]+))?[0-9]*$',
           match: true,
         },
       },


### PR DESCRIPTION
Closes #

## 🎯 Changes

- Allows `T` / `$`  as a valid generic argument without a suffix
- Also allows e.g. `T1` / `T2` / `T3`