### PR TITLE
Fix createTRPCQueryUtils.md documentation

### DIFF
--- a/www/docs/client/react/createTRPCQueryUtils.md
+++ b/www/docs/client/react/createTRPCQueryUtils.md
@@ -57,10 +57,11 @@ import { useLoaderData } from 'react-router-dom';
 import type { AppRouter } from './server';
 
 const trpc = createTRPCReact<AppRouter>();
+const trpcClient = trpc.createClient({ links: [] );
 
 const queryClient = new QueryClient();
 
-const clientUtils = createTRPCQueryUtils({ queryClient, client: trpc });
+const clientUtils = createTRPCQueryUtils({ queryClient, client: trpcClient });
 
 // This is a react-router loader
 export async function loader() {


### PR DESCRIPTION
## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

The documentation around `createTRPCQueryUtils` is wrong. You need to pass a client created from `createClient`. If you try to pass the `CreateTRPCReactBase`, you'll get type errors.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
