### PR TITLE
Correct example return type for pages

### DIFF
--- a/www/docs/client/react/suspense.md
+++ b/www/docs/client/react/suspense.md
@@ -103,7 +103,7 @@ import React from 'react';
 import { trpc } from '../utils/trpc';
 
 function PostView() {
-  const [pages, allPostsQuery] = trpc.post.all.useSuspenseInfiniteQuery(
+  const [{ pages }, allPostsQuery] = trpc.post.all.useSuspenseInfiniteQuery(
     {},
     {
       getNextPageParam(lastPage) {


### PR DESCRIPTION
`useSuspenseInfiniteQuery` returns an `InfiniteData` structure, which has the both the `pages` and `pageParams` attributes. This updates the example to suggest what a user likely expects `pages` to be.
