### PR TITLE
doc(awesome-trpc): add Start UI [web] in bootstrappers section

### DIFF
--- a/www/docs/community/awesome-trpc.mdx
+++ b/www/docs/community/awesome-trpc.mdx
@@ -48,6 +48,7 @@ A collection of resources on tRPC.
 | Create JD App - Scaffold a starter project using the JD Stack (SolidStart, tRPC, Tailwind, Prisma)  | https://github.com/OrJDev/create-jd-app         |
 | Create tRPC App - Create tRPC-powered apps with one command                                         | https://github.com/omar-dulaimi/create-trpc-app |
 | viteRPC - Monorepo template powered by Vite (Vite, tRPC, Tailwind CSS)                              | https://github.com/mnik01/viteRPC               |
+| Start UI [web] - Opinionated frontend starter (tRPC, Prisma, Next.js, Chakra UI)                    | https://github.com/bearstudio/start-ui-web      |
 
 ### Library adapters
 


### PR DESCRIPTION
Add Start UI [web] to the list of Bootstrapers in awesome-trpc

Start UI [web] repository: https://github.com/bearstudio/start-ui-web
Start UI [web] documentation: https://docs.web.start-ui.com/ (for our tRPC usage, you can check it out [here](https://docs.web.start-ui.com/technologies#trpc) and [here](https://docs.web.start-ui.com/tutorials/create-your-first-crud#step-2-create-the-backend-router))
Start UI [web] demo: https://demo.start-ui.com/app

I'm not sure what I need to say to make this bootstrapper part of the awesome tRPC list, I'll be really happy to talk about it if there's anything missing 🙂

## 🎯 Changes

These PR add a new bootstraper (Start UI [web]) in the boostrapers section in Awesome TRPC.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- ~[ ] If necessary, I have added documentation related to the changes made.~
- ~[ ] I have added or updated the tests related to the changes made.~
