### PR TITLE
fix(server): strict `false`-check when calling `.write()`

### DIFF
--- a/packages/server/src/adapters/node-http/nodeHTTPRequestHandler.ts
+++ b/packages/server/src/adapters/node-http/nodeHTTPRequestHandler.ts
@@ -82,7 +82,7 @@ export async function nodeHTTPRequestHandler<
         if (!res.writable) {
           break;
         }
-        if (!res.write(value)) {
+        if (res.write(value) === false) {
           await new Promise<void>((resolve) => {
             res.once('drain', resolve);
           });


### PR DESCRIPTION
Closes #5857

## 🎯 Changes

Do strict false check since some libs don't implement `res.write()` correctly

