### PR TITLE
chore: bump prettier to v3

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -3,9 +3,7 @@
   "projectOwner": "trpc",
   "repoType": "github",
   "repoHost": "https://github.com",
-  "files": [
-    "README.md"
-  ],
+  "files": ["README.md"],
   "imageSize": 60,
   "contributorsPerLine": 8,
   "commit": false,
@@ -30,1100 +28,805 @@
       "name": "Colin McDonnell",
       "avatar_url": "https://avatars.githubusercontent.com/u/3084745?v=4",
       "profile": "https://colinhacks.com/",
-      "contributions": [
-        "ideas",
-        "code",
-        "test",
-        "doc"
-      ]
+      "contributions": ["ideas", "code", "test", "doc"]
     },
     {
       "login": "cyrus-za",
       "name": "Pieter Venter",
       "avatar_url": "https://avatars.githubusercontent.com/u/1845861?v=4",
       "profile": "https://pieter.venter.pro",
-      "contributions": [
-        "ideas",
-        "review"
-      ]
+      "contributions": ["ideas", "review"]
     },
     {
       "login": "Sendouc",
       "name": "Kalle",
       "avatar_url": "https://avatars.githubusercontent.com/u/38327916?v=4",
       "profile": "https://sendou.cc/",
-      "contributions": [
-        "bug"
-      ]
+      "contributions": ["bug"]
     },
     {
       "login": "mgranderath",
       "name": "Malte Granderath",
       "avatar_url": "https://avatars.githubusercontent.com/u/22001111?v=4",
       "profile": "http://granderath.tech",
-      "contributions": [
-        "bug"
-      ]
+      "contributions": ["bug"]
     },
     {
       "login": "kripod",
       "name": "Kristóf Poduszló",
       "avatar_url": "https://avatars.githubusercontent.com/u/14854048?v=4",
       "profile": "https://github.com/kripod",
-      "contributions": [
-        "ideas",
-        "bug"
-      ]
+      "contributions": ["ideas", "bug"]
     },
     {
       "login": "molebox",
       "name": "Rich Haines",
       "avatar_url": "https://avatars.githubusercontent.com/u/22930449?v=4",
       "profile": "https://www.richardhaines.dev",
-      "contributions": [
-        "example"
-      ]
+      "contributions": ["example"]
     },
     {
       "login": "simonedelmann",
       "name": "Simon Edelmann",
       "avatar_url": "https://avatars.githubusercontent.com/u/2821076?v=4",
       "profile": "https://github.com/simonedelmann",
-      "contributions": [
-        "code",
-        "ideas",
-        "test",
-        "doc",
-        "review"
-      ]
+      "contributions": ["code", "ideas", "test", "doc", "review"]
     },
     {
       "login": "anthonyshort",
       "name": "Anthony Short",
       "avatar_url": "https://avatars.githubusercontent.com/u/36125?v=4",
       "profile": "https://anthonyshort.me",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "pnfcre",
       "name": "Hampus Kraft",
       "avatar_url": "https://avatars.githubusercontent.com/u/24176136?v=4",
       "profile": "https://hampuskraft.com",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "hypnodron",
       "name": "hypnodron",
       "avatar_url": "https://avatars.githubusercontent.com/u/3454041?v=4",
       "profile": "https://github.com/hypnodron",
-      "contributions": [
-        "test",
-        "code",
-        "bug"
-      ]
+      "contributions": ["test", "code", "bug"]
     },
     {
       "login": "danielyogel",
       "name": "Daniel Yogel",
       "avatar_url": "https://avatars.githubusercontent.com/u/2037064?v=4",
       "profile": "http://www.appdome.com",
-      "contributions": [
-        "financial",
-        "review",
-        "bug"
-      ]
+      "contributions": ["financial", "review", "bug"]
     },
     {
       "login": "sam3d",
       "name": "Sam Holmes",
       "avatar_url": "https://avatars.githubusercontent.com/u/8385528?v=4",
       "profile": "https://samholmes.net",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "mmkal",
       "name": "Misha Kaletsky",
       "avatar_url": "https://avatars.githubusercontent.com/u/15040698?v=4",
       "profile": "https://github.com/mmkal",
-      "contributions": [
-        "ideas",
-        "test",
-        "code",
-        "review"
-      ]
+      "contributions": ["ideas", "test", "code", "review"]
     },
     {
       "login": "lostfictions",
       "name": "s",
       "avatar_url": "https://avatars.githubusercontent.com/u/567041?v=4",
       "profile": "https://github.com/lostfictions",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "jzimmek",
       "name": "Jan Zimmek",
       "avatar_url": "https://avatars.githubusercontent.com/u/40382?v=4",
       "profile": "https://github.com/jzimmek",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "alaister",
       "name": "Alaister Young",
       "avatar_url": "https://avatars.githubusercontent.com/u/10985857?v=4",
       "profile": "https://www.alaisteryoung.com",
-      "contributions": [
-        "code",
-        "test"
-      ]
+      "contributions": ["code", "test"]
     },
     {
       "login": "theobr",
       "name": "Theo Browne",
       "avatar_url": "https://avatars.githubusercontent.com/u/6751787?v=4",
       "profile": "http://t3.gg",
-      "contributions": [
-        "review",
-        "financial",
-        "video",
-        "talk",
-        "tutorial"
-      ]
+      "contributions": ["review", "financial", "video", "talk", "tutorial"]
     },
     {
       "login": "mgreenw",
       "name": "Max Greenwald",
       "avatar_url": "https://avatars.githubusercontent.com/u/2615374?v=4",
       "profile": "https://maxgreenwald.me",
-      "contributions": [
-        "financial",
-        "code",
-        "doc",
-        "test",
-        "bug"
-      ]
+      "contributions": ["financial", "code", "doc", "test", "bug"]
     },
     {
       "login": "stemount",
       "name": "Stephen Mount",
       "avatar_url": "https://avatars.githubusercontent.com/u/150512?v=4",
       "profile": "https://ste.london",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "infix",
       "name": "amr",
       "avatar_url": "https://avatars.githubusercontent.com/u/40860821?v=4",
       "profile": "https://github.com/infix",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "thomas-coldwell",
       "name": "Thomas Coldwell",
       "avatar_url": "https://avatars.githubusercontent.com/u/31568400?v=4",
       "profile": "http://thomascoldwell.dev",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "alexn-s",
       "name": "Alex Schumacher",
       "avatar_url": "https://avatars.githubusercontent.com/u/60710873?v=4",
       "profile": "https://github.com/alexn-s",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "ifiokjr",
       "name": "Ifiok Jr.",
       "avatar_url": "https://avatars.githubusercontent.com/u/1160934?v=4",
       "profile": "https://github.com/ifiokjr",
-      "contributions": [
-        "test",
-        "code",
-        "doc"
-      ]
+      "contributions": ["test", "code", "doc"]
     },
     {
       "login": "Memory-Lane-Games",
       "name": "Memory-Lane-Games",
       "avatar_url": "https://avatars.githubusercontent.com/u/63847783?v=4",
       "profile": "https://github.com/Memory-Lane-Games",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "bluebill1049",
       "name": "Bill",
       "avatar_url": "https://avatars.githubusercontent.com/u/10513364?v=4",
       "profile": "https://react-hook-form.com",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "keenahn",
       "name": "Keenahn Tiberius Jung",
       "avatar_url": "https://avatars.githubusercontent.com/u/283603?v=4",
       "profile": "http://about.me/keenahn",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "danielroe",
       "name": "Daniel Roe",
       "avatar_url": "https://avatars.githubusercontent.com/u/28706372?v=4",
       "profile": "https://roe.dev",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "sachinraja",
       "name": "Sachin Raja",
       "avatar_url": "https://avatars.githubusercontent.com/u/58836760?v=4",
       "profile": "https://github.com/sachinraja",
-      "contributions": [
-        "review",
-        "ideas",
-        "mentoring"
-      ]
+      "contributions": ["review", "ideas", "mentoring"]
     },
     {
       "login": "mkreuzmayr",
       "name": "Michael Kreuzmayr",
       "avatar_url": "https://avatars.githubusercontent.com/u/20108212?v=4",
       "profile": "https://github.com/mkreuzmayr",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "kimroen",
       "name": "Kim Røen",
       "avatar_url": "https://avatars.githubusercontent.com/u/520420?v=4",
       "profile": "https://github.com/kimroen",
-      "contributions": [
-        "ideas"
-      ]
+      "contributions": ["ideas"]
     },
     {
       "login": "chimon2000",
       "name": "Ryan",
       "avatar_url": "https://avatars.githubusercontent.com/u/6907797?v=4",
       "profile": "https://standardresume.co/r/ryan-edge",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "snaplet",
       "name": "Snaplet",
       "avatar_url": "https://avatars.githubusercontent.com/u/69029941?v=4",
       "profile": "https://www.snaplet.dev",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "merelinguist",
       "name": "Dylan Brookes",
       "avatar_url": "https://avatars.githubusercontent.com/u/24858006?v=4",
       "profile": "https://github.com/merelinguist",
-      "contributions": [
-        "example"
-      ]
+      "contributions": ["example"]
     },
     {
       "login": "MarcGuiselin",
       "name": "Marc Guiselin",
       "avatar_url": "https://avatars.githubusercontent.com/u/24906387?v=4",
       "profile": "http://guiselin.com",
-      "contributions": [
-        "doc",
-        "review"
-      ]
+      "contributions": ["doc", "review"]
     },
     {
       "login": "illarionvk",
       "name": "Illarion Koperski",
       "avatar_url": "https://avatars.githubusercontent.com/u/5012724?v=4",
       "profile": "https://www.illarionvk.com",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "albingroen",
       "name": "Albin Groen",
       "avatar_url": "https://avatars.githubusercontent.com/u/19674362?v=4",
       "profile": "http://abgn.me",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "esamattis",
       "name": "Esa-Matti Suuronen",
       "avatar_url": "https://avatars.githubusercontent.com/u/225712?v=4",
       "profile": "https://esamatti.fi/",
-      "contributions": [
-        "example"
-      ]
+      "contributions": ["example"]
     },
     {
       "login": "timcole",
       "name": "Timothy Cole",
       "avatar_url": "https://avatars.githubusercontent.com/u/6754577?v=4",
       "profile": "https://timcole.me",
-      "contributions": [
-        "financial",
-        "mentoring"
-      ]
+      "contributions": ["financial", "mentoring"]
     },
     {
       "login": "reggie3-braingu",
       "name": "reggie3-braingu",
       "avatar_url": "https://avatars.githubusercontent.com/u/90011823?v=4",
       "profile": "https://github.com/reggie3-braingu",
-      "contributions": [
-        "example",
-        "test",
-        "financial"
-      ]
+      "contributions": ["example", "test", "financial"]
     },
     {
       "login": "ShiftySlothe",
       "name": "ShiftySlothe",
       "avatar_url": "https://avatars.githubusercontent.com/u/59391676?v=4",
       "profile": "https://github.com/ShiftySlothe",
-      "contributions": [
-        "example"
-      ]
+      "contributions": ["example"]
     },
     {
       "login": "darioielardi",
       "name": "Dario Ielardi",
       "avatar_url": "https://avatars.githubusercontent.com/u/19256200?v=4",
       "profile": "https://github.com/darioielardi",
-      "contributions": [
-        "code",
-        "test"
-      ]
+      "contributions": ["code", "test"]
     },
     {
       "login": "utevo",
       "name": "Michał Kowieski",
       "avatar_url": "https://avatars.githubusercontent.com/u/29740731?v=4",
       "profile": "https://github.com/utevo",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "terose73",
       "name": "Theodore Rose",
       "avatar_url": "https://avatars.githubusercontent.com/u/34382127?v=4",
       "profile": "https://github.com/terose73",
-      "contributions": [
-        "example"
-      ]
+      "contributions": ["example"]
     },
     {
       "login": "icflorescu",
       "name": "Ionut-Cristian Florescu",
       "avatar_url": "https://avatars.githubusercontent.com/u/581999?v=4",
       "profile": "https://www.linkedin.com/in/icflorescu",
-      "contributions": [
-        "example"
-      ]
+      "contributions": ["example"]
     },
     {
       "login": "skarab42",
       "name": "skarab42",
       "avatar_url": "https://avatars.githubusercontent.com/u/62928763?v=4",
       "profile": "https://www.twitch.tv/skarab42/",
-      "contributions": [
-        "doc",
-        "code",
-        "example",
-        "test"
-      ]
+      "contributions": ["doc", "code", "example", "test"]
     },
     {
       "login": "SchlagerKhan",
       "name": "SchlagerKhan",
       "avatar_url": "https://avatars.githubusercontent.com/u/6490268?v=4",
       "profile": "https://iamkhan.io",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "BrockHerion",
       "name": "Brock Herion",
       "avatar_url": "https://avatars.githubusercontent.com/u/30359995?v=4",
       "profile": "https://www.brockherion.dev",
-      "contributions": [
-        "code",
-        "test",
-        "doc"
-      ]
+      "contributions": ["code", "test", "doc"]
     },
     {
       "login": "renderinc",
       "name": "Render",
       "avatar_url": "https://avatars.githubusercontent.com/u/36424661?v=4",
       "profile": "https://render.com",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "8balloon",
       "name": "Ethan Clark",
       "avatar_url": "https://avatars.githubusercontent.com/u/8572133?v=4",
       "profile": "https://yorick.sh",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "nihinihi01",
       "name": "nihinihi01",
       "avatar_url": "https://avatars.githubusercontent.com/u/57569287?v=4",
       "profile": "https://github.com/nihinihi01",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "CommanderRoot",
       "name": "CommanderRoot",
       "avatar_url": "https://avatars.githubusercontent.com/u/4395417?v=4",
       "profile": "https://github.com/CommanderRoot",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "JasonDocton",
       "name": "Jason Docton",
       "avatar_url": "https://avatars.githubusercontent.com/u/22589564?v=4",
       "profile": "http://Youarerad.org",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "pingdotgg",
       "name": "Ping Labs",
       "avatar_url": "https://avatars.githubusercontent.com/u/89191727?v=4",
       "profile": "https://ping.gg/",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "emilbryggare",
       "name": "Emil Bryggare",
       "avatar_url": "https://avatars.githubusercontent.com/u/1659740?v=4",
       "profile": "http://www.emilbryggare.com",
-      "contributions": [
-        "example",
-        "test"
-      ]
+      "contributions": ["example", "test"]
     },
     {
       "login": "ahhshm",
       "name": "ahhshm",
       "avatar_url": "https://avatars.githubusercontent.com/u/87268103?v=4",
       "profile": "https://github.com/ahhshm",
-      "contributions": [
-        "doc",
-        "example"
-      ]
+      "contributions": ["doc", "example"]
     },
     {
       "login": "jlalmes",
       "name": "James Berry",
       "avatar_url": "https://avatars.githubusercontent.com/u/69924001?v=4",
       "profile": "https://jamesbe.com",
-      "contributions": [
-        "bug",
-        "ideas",
-        "code",
-        "test"
-      ]
+      "contributions": ["bug", "ideas", "code", "test"]
     },
     {
       "login": "jwyce",
       "name": "Jared Wyce",
       "avatar_url": "https://avatars.githubusercontent.com/u/16946573?v=4",
       "profile": "https://jwyce.github.io/portfolio/",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "mechamobau",
       "name": "Lucas Viana",
       "avatar_url": "https://avatars.githubusercontent.com/u/13911440?v=4",
       "profile": "https://blog.lucasviana.dev",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "kevinlangleyjr",
       "name": "Kevin Langley Jr.",
       "avatar_url": "https://avatars.githubusercontent.com/u/877634?v=4",
       "profile": "https://kevinlangleyjr.dev",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "toyamarinyon",
       "name": "toyamarinyon",
       "avatar_url": "https://avatars.githubusercontent.com/u/535254?v=4",
       "profile": "https://github.com/toyamarinyon",
-      "contributions": [
-        "example",
-        "code"
-      ]
+      "contributions": ["example", "code"]
     },
     {
       "login": "FarazPatankar",
       "name": "Faraz Patankar",
       "avatar_url": "https://avatars.githubusercontent.com/u/10681116?v=4",
       "profile": "https://farazpatankar.com/",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "john-schmitz",
       "name": "John Schmitz",
       "avatar_url": "https://avatars.githubusercontent.com/u/25447051?v=4",
       "profile": "http://johnschmitz.me",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "okaforcj",
       "name": "okaforcj",
       "avatar_url": "https://avatars.githubusercontent.com/u/34102565?v=4",
       "profile": "https://github.com/okaforcj",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "LouisHaftmann",
       "name": "Louis Haftmann",
       "avatar_url": "https://avatars.githubusercontent.com/u/30736553?v=4",
       "profile": "https://github.com/LouisHaftmann",
-      "contributions": [
-        "code",
-        "test",
-        "doc"
-      ]
+      "contributions": ["code", "test", "doc"]
     },
     {
       "login": "Perfect7M",
       "name": "Perfect7M",
       "avatar_url": "https://avatars.githubusercontent.com/u/5896181?v=4",
       "profile": "https://marcin.page/",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "kindlyfire",
       "name": "Tijl Van den Brugghen",
       "avatar_url": "https://avatars.githubusercontent.com/u/10267586?v=4",
       "profile": "https://tijlvdb.me/",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "matthijscollabai",
       "name": "Matthijs Wolting",
       "avatar_url": "https://avatars.githubusercontent.com/u/89927222?v=4",
       "profile": "https://github.com/matthijscollabai",
-      "contributions": [
-        "bug"
-      ]
+      "contributions": ["bug"]
     },
     {
       "login": "lukahartwig",
       "name": "Luka Hartwig",
       "avatar_url": "https://avatars.githubusercontent.com/u/7414521?v=4",
       "profile": "https://lukahartwig.de",
-      "contributions": [
-        "code",
-        "maintenance"
-      ]
+      "contributions": ["code", "maintenance"]
     },
     {
       "login": "flylance-apps",
       "name": "Flylance",
       "avatar_url": "https://avatars.githubusercontent.com/u/67534310?v=4",
       "profile": "http://flylance.com",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "BWsix",
       "name": "VFLC",
       "avatar_url": "https://avatars.githubusercontent.com/u/57709309?v=4",
       "profile": "https://github.com/BWsix",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "wobsoriano",
       "name": "Robert Soriano",
       "avatar_url": "https://avatars.githubusercontent.com/u/13049130?v=4",
       "profile": "https://robsoriano.com",
-      "contributions": [
-        "example",
-        "tool"
-      ]
+      "contributions": ["example", "tool"]
     },
     {
       "login": "lukevella",
       "name": "Luke Vella",
       "avatar_url": "https://avatars.githubusercontent.com/u/676849?v=4",
       "profile": "https://lukevella.com",
-      "contributions": [
-        "example",
-        "tool"
-      ]
+      "contributions": ["example", "tool"]
     },
     {
       "login": "jld-adriano",
       "name": "João Adriano",
       "avatar_url": "https://avatars.githubusercontent.com/u/98129582?v=4",
       "profile": "https://github.com/jld-adriano",
-      "contributions": [
-        "bug"
-      ]
+      "contributions": ["bug"]
     },
     {
       "login": "nilskj",
       "name": "Nils Kjellman",
       "avatar_url": "https://avatars.githubusercontent.com/u/495782?v=4",
       "profile": "http://www.nisse.tech",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "luixo",
       "name": "Alexey Immoreev",
       "avatar_url": "https://avatars.githubusercontent.com/u/1051134?v=4",
       "profile": "https://github.com/luixo",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "bradennapier",
       "name": "Braden Napier",
       "avatar_url": "https://avatars.githubusercontent.com/u/15365418?v=4",
       "profile": "https://github.com/bradennapier",
-      "contributions": [
-        "code",
-        "test"
-      ]
+      "contributions": ["code", "test"]
     },
     {
       "login": "bautistaaa",
       "name": "bautistaaa",
       "avatar_url": "https://avatars.githubusercontent.com/u/3660667?v=4",
       "profile": "http://www.big-sir.com",
-      "contributions": [
-        "doc",
-        "example"
-      ]
+      "contributions": ["doc", "example"]
     },
     {
       "login": "blntrsz",
       "name": "Balint Orosz",
       "avatar_url": "https://avatars.githubusercontent.com/u/81449016?v=4",
       "profile": "https://github.com/blntrsz",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "skovhus",
       "name": "Kenneth Skovhus",
       "avatar_url": "https://avatars.githubusercontent.com/u/1260305?v=4",
       "profile": "https://skovhus.dev",
-      "contributions": [
-        "doc",
-        "code"
-      ]
+      "contributions": ["doc", "code"]
     },
     {
       "login": "lilja",
       "name": "Erik Lilja",
       "avatar_url": "https://avatars.githubusercontent.com/u/6134511?v=4",
       "profile": "https://github.com/Lilja",
-      "contributions": [
-        "doc",
-        "code",
-        "test"
-      ]
+      "contributions": ["doc", "code", "test"]
     },
     {
       "login": "ivanbuncic",
       "name": "Ivan Buncic",
       "avatar_url": "https://avatars.githubusercontent.com/u/29887111?v=4",
       "profile": "http://www.ivanbuncic.com",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "jokull",
       "name": "Jökull Sólberg Auðunsson",
       "avatar_url": "https://avatars.githubusercontent.com/u/701?v=4",
       "profile": "http://solberg.is",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "futpib",
       "name": "futpib",
       "avatar_url": "https://avatars.githubusercontent.com/u/4330357?v=4",
       "profile": "https://github.com/futpib",
-      "contributions": [
-        "bug"
-      ]
+      "contributions": ["bug"]
     },
     {
       "login": "lmatheus",
       "name": "Luis Matheus",
       "avatar_url": "https://avatars.githubusercontent.com/u/8514703?v=4",
       "profile": "https://github.com/lmatheus",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "makyfj",
       "name": "Franklin",
       "avatar_url": "https://avatars.githubusercontent.com/u/65879341?v=4",
       "profile": "http://franklinjara.dev",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "zomars",
       "name": "Omar López",
       "avatar_url": "https://avatars.githubusercontent.com/u/3504472?v=4",
       "profile": "https://www.linkedin.com/in/zomars/",
-      "contributions": [
-        "financial",
-        "bug"
-      ]
+      "contributions": ["financial", "bug"]
     },
     {
       "login": "webdiego",
       "name": "Diego Massarini",
       "avatar_url": "https://avatars.githubusercontent.com/u/63283003?v=4",
       "profile": "https://diego-slicecode.dev/",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "dmaykov",
       "name": "Dmitry Maykov",
       "avatar_url": "https://avatars.githubusercontent.com/u/6147048?v=4",
       "profile": "https://github.com/dmaykov",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "riccardogiorato",
       "name": "Riccardo Giorato",
       "avatar_url": "https://avatars.githubusercontent.com/u/4527364?v=4",
       "profile": "https://riccardogiorato.com/",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "carlbarrdahl",
       "name": "Carl Barrdahl",
       "avatar_url": "https://avatars.githubusercontent.com/u/2961337?v=4",
       "profile": "https://github.com/carlbarrdahl",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "PeerRich",
       "name": "Peer Richelsen",
       "avatar_url": "https://avatars.githubusercontent.com/u/8019099?v=4",
       "profile": "https://cal.com/peer",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "calcom",
       "name": "Cal.com, Inc.",
       "avatar_url": "https://avatars.githubusercontent.com/u/79145102?v=4",
       "profile": "https://cal.com",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "tomanagle",
       "name": "Tom",
       "avatar_url": "https://avatars.githubusercontent.com/u/8683577?v=4",
       "profile": "https://github.com/tomanagle",
-      "contributions": [
-        "video",
-        "talk",
-        "tutorial"
-      ]
+      "contributions": ["video", "talk", "tutorial"]
     },
     {
       "login": "3x071c",
       "name": "Victor Homic",
       "avatar_url": "https://avatars.githubusercontent.com/u/87198856?v=4",
       "profile": "https://github.com/3x071c",
-      "contributions": [
-        "code",
-        "test"
-      ]
+      "contributions": ["code", "test"]
     },
     {
       "login": "ixahmedxi",
       "name": "Ahmed Elsakaan",
       "avatar_url": "https://avatars.githubusercontent.com/u/20271968?v=4",
       "profile": "https://ixahmedxi.me",
-      "contributions": [
-        "doc",
-        "financial"
-      ]
+      "contributions": ["doc", "financial"]
     },
     {
       "login": "EnderSpirit",
       "name": "EnderSpirit",
       "avatar_url": "https://avatars.githubusercontent.com/u/28017013?v=4",
       "profile": "https://github.com/EnderSpirit",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "juliusmarminge",
       "name": "Julius Marminge",
       "avatar_url": "https://avatars.githubusercontent.com/u/51714798?v=4",
       "profile": "http://www.jumr.dev",
-      "contributions": [
-        "example",
-        "doc"
-      ]
+      "contributions": ["example", "doc"]
     },
     {
       "login": "system32uwu",
       "name": "Mateo Carriquí",
       "avatar_url": "https://avatars.githubusercontent.com/u/29718978?v=4",
       "profile": "https://tryhackme.com/p/zast99",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "OlegGulevskyy",
       "name": "Oleg Gulevskyy",
       "avatar_url": "https://avatars.githubusercontent.com/u/43781031?v=4",
       "profile": "https://github.com/OlegGulevskyy",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "joaosamouco",
       "name": "João Samouco",
       "avatar_url": "https://avatars.githubusercontent.com/u/6799006?v=4",
       "profile": "https://github.com/joaosamouco",
-      "contributions": [
-        "test"
-      ]
+      "contributions": ["test"]
     },
     {
       "login": "carstenlebek",
       "name": "Carsten Lebek",
       "avatar_url": "https://avatars.githubusercontent.com/u/59960385?v=4",
       "profile": "https://clebek.dev",
-      "contributions": [
-        "example"
-      ]
+      "contributions": ["example"]
     },
     {
       "login": "chrisbradleydev",
       "name": "Chris Bradley",
       "avatar_url": "https://avatars.githubusercontent.com/u/11767079?v=4",
       "profile": "https://chrisbradley.dev",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "Sven1106",
       "name": "Svend Aage Roperos Nielsen",
       "avatar_url": "https://avatars.githubusercontent.com/u/28002895?v=4",
       "profile": "https://github.com/Sven1106",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "iway1",
       "name": "iway1",
       "avatar_url": "https://avatars.githubusercontent.com/u/12774588?v=4",
       "profile": "https://github.com/iway1",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "prisma",
       "name": "Prisma",
       "avatar_url": "https://avatars.githubusercontent.com/u/17219288?v=4",
       "profile": "https://www.prisma.io",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "francisprovost",
       "name": "Francis Provost",
       "avatar_url": "https://avatars.githubusercontent.com/u/6840361?v=4",
       "profile": "http://francisprovost.com",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "dyaa",
       "name": "Dyaa",
       "avatar_url": "https://avatars.githubusercontent.com/u/4283185?v=4",
       "profile": "https://dyaa.me",
-      "contributions": [
-        "financial",
-        "code",
-        "test"
-      ]
+      "contributions": ["financial", "code", "test"]
     },
     {
       "login": "zzacong",
       "name": "Zac Ong",
       "avatar_url": "https://avatars.githubusercontent.com/u/61817066?v=4",
       "profile": "https://github.com/zzacong",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "LoriKarikari",
       "name": "Lori Karikari",
       "avatar_url": "https://avatars.githubusercontent.com/u/7902980?v=4",
       "profile": "https://github.com/LoriKarikari",
-      "contributions": [
-        "financial"
-      ]
+      "contributions": ["financial"]
     },
     {
       "login": "gioboa",
       "name": "Giorgio Boa",
       "avatar_url": "https://avatars.githubusercontent.com/u/35845425?v=4",
       "profile": "https://it.linkedin.com/in/giorgio-boa",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     },
     {
       "login": "relm923",
       "name": "Reagan Elm",
       "avatar_url": "https://avatars.githubusercontent.com/u/1347066?v=4",
       "profile": "https://github.com/relm923",
-      "contributions": [
-        "test"
-      ]
+      "contributions": ["test"]
     },
     {
       "login": "colelawrence",
       "name": "Cole Lawrence",
       "avatar_url": "https://avatars.githubusercontent.com/u/2925395?v=4",
       "profile": "https://colelawrence.com",
-      "contributions": [
-        "bug",
-        "code",
-        "test"
-      ]
+      "contributions": ["bug", "code", "test"]
     },
     {
       "login": "Grubba27",
       "name": "Gabriel Grubba",
       "avatar_url": "https://avatars.githubusercontent.com/u/70247653?v=4",
       "profile": "https://grubba.vercel.app/",
-      "contributions": [
-        "code"
-      ]
+      "contributions": ["code"]
     },
     {
       "login": "oscartbeaumont",
       "name": "Oscar Beaumont",
       "avatar_url": "https://avatars.githubusercontent.com/u/21004798?v=4",
       "profile": "https://otbeaumont.me",
-      "contributions": [
-        "question"
-      ]
+      "contributions": ["question"]
     },
     {
       "login": "anthonyshew",
       "name": "Anthony Shew",
       "avatar_url": "https://avatars.githubusercontent.com/u/35677084?v=4",
       "profile": "https://inthezone.dev",
-      "contributions": [
-        "doc"
-      ]
+      "contributions": ["doc"]
     }
   ],
   "skipCi": true

--- a/examples/minimal-content-types/client/index.html
+++ b/examples/minimal-content-types/client/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/examples/minimal-react/client/index.html
+++ b/examples/minimal-react/client/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/examples/next-formdata/src/pages/react-hook-form.tsx
+++ b/examples/next-formdata/src/pages/react-hook-form.tsx
@@ -9,13 +9,8 @@ import type { z } from 'zod';
 /**
  * zod-form-data wraps zod in an effect where the original type is a `FormData`
  */
-type UnwrapZodEffect<TType extends z.ZodType> = TType extends z.ZodEffects<
-  infer U,
-  any,
-  any
->
-  ? U
-  : TType;
+type UnwrapZodEffect<TType extends z.ZodType> =
+  TType extends z.ZodEffects<infer U, any, any> ? U : TType;
 
 type GetInput<TType extends z.ZodType> = UnwrapZodEffect<TType>['_input'];
 

--- a/examples/next-prisma-starter/package.json
+++ b/examples/next-prisma-starter/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.14",
-    "prettier": "^2.8.8",
+    "prettier": "^3.3.2",
     "prisma": "^5.12.1",
     "start-server-and-test": "^1.12.0",
     "tailwindcss": "^3.3.0",

--- a/examples/next-prisma-starter/src/pages/index.tsx
+++ b/examples/next-prisma-starter/src/pages/index.tsx
@@ -72,8 +72,8 @@ const IndexPage: NextPageWithLayout = () => {
           {postsQuery.isFetchingNextPage
             ? 'Loading more...'
             : postsQuery.hasNextPage
-            ? 'Load More'
-            : 'Nothing more to load'}
+              ? 'Load More'
+              : 'Nothing more to load'}
         </button>
 
         {postsQuery.data?.pages.map((page, index) => (

--- a/examples/next-prisma-todomvc/src/pages/[filter].tsx
+++ b/examples/next-prisma-todomvc/src/pages/[filter].tsx
@@ -250,12 +250,10 @@ export default function TodosPage(props: PageProps) {
                 props.filter === 'completed'
                   ? completed
                   : props.filter === 'active'
-                  ? !completed
-                  : true,
+                    ? !completed
+                    : true,
               )
-              .map((task) => (
-                <ListItem key={task.id} task={task} />
-              ))}
+              .map((task) => <ListItem key={task.id} task={task} />)}
           </ul>
         </section>
 

--- a/examples/next-prisma-websockets-starter/package.json
+++ b/examples/next-prisma-websockets-starter/package.json
@@ -71,7 +71,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.14",
-    "prettier": "^2.8.8",
+    "prettier": "^3.3.2",
     "prisma": "^5.12.1",
     "start-server-and-test": "^1.12.0",
     "tailwindcss": "^3.3.0",

--- a/examples/next-prisma-websockets-starter/src/pages/index.tsx
+++ b/examples/next-prisma-websockets-starter/src/pages/index.tsx
@@ -255,8 +255,8 @@ export default function IndexPage() {
                 {isFetchingNextPage
                   ? 'Loading more...'
                   : hasNextPage
-                  ? 'Load More'
-                  : 'Nothing more to load'}
+                    ? 'Load More'
+                    : 'Nothing more to load'}
               </button>
               <div className="space-y-4">
                 {messages?.map((item) => (

--- a/examples/next-sse-chat/src/app/channels/[channelId]/chat.tsx
+++ b/examples/next-sse-chat/src/app/channels/[channelId]/chat.tsx
@@ -61,8 +61,8 @@ export function Chat(props: Readonly<{ channelId: string }>) {
                   {livePosts.query.isFetchingNextPage
                     ? 'Loading...'
                     : !livePosts.query.hasNextPage
-                    ? 'Fetched everything!'
-                    : 'Load more'}
+                      ? 'Fetched everything!'
+                      : 'Load more'}
                 </Button>
               </div>
 

--- a/examples/next-sse-chat/src/components/avatar.tsx
+++ b/examples/next-sse-chat/src/components/avatar.tsx
@@ -23,12 +23,12 @@ export function Avatar({
       className={cx(
         className,
         // Basic layout
-        'inline-grid shrink-0 align-middle [--avatar-radius:20%] [--ring-opacity:20%] *:col-start-1 *:row-start-1',
+        '*:col-start-1 *:row-start-1 inline-grid shrink-0 align-middle [--avatar-radius:20%] [--ring-opacity:20%]',
         'outline outline-1 -outline-offset-1 outline-black/[--ring-opacity] dark:outline-white/[--ring-opacity]',
         // Add the correct border radius
         square
-          ? 'rounded-[--avatar-radius] *:rounded-[--avatar-radius]'
-          : 'rounded-full *:rounded-full',
+          ? '*:rounded-[--avatar-radius] rounded-[--avatar-radius]'
+          : '*:rounded-full rounded-full',
       )}
     >
       {initials && (

--- a/examples/next-sse-chat/src/components/dialog.tsx
+++ b/examples/next-sse-chat/src/components/dialog.tsx
@@ -54,7 +54,7 @@ export function Dialog({
                 className={cx(
                   className,
                   sizes[size],
-                  'row-start-2 w-full min-w-0 rounded-t-3xl bg-white p-[--gutter] shadow-lg ring-1 ring-gray-950/10 [--gutter:theme(spacing.8)] dark:bg-gray-900 dark:ring-white/10 sm:mb-auto sm:rounded-2xl forced-colors:outline',
+                  'forced-colors:outline row-start-2 w-full min-w-0 rounded-t-3xl bg-white p-[--gutter] shadow-lg ring-1 ring-gray-950/10 [--gutter:theme(spacing.8)] dark:bg-gray-900 dark:ring-white/10 sm:mb-auto sm:rounded-2xl',
                 )}
               >
                 {children}
@@ -89,7 +89,7 @@ export function DialogDescription({
   return (
     <Headless.Description
       {...props}
-      className={cx(className, 'mt-2 text-pretty')}
+      className={cx(className, 'text-pretty mt-2')}
     />
   );
 }
@@ -110,7 +110,7 @@ export function DialogActions({
       {...props}
       className={cx(
         className,
-        'mt-8 flex flex-col-reverse items-center justify-end gap-3 *:w-full sm:flex-row sm:*:w-auto',
+        '*:w-full sm:*:w-auto mt-8 flex flex-col-reverse items-center justify-end gap-3 sm:flex-row',
       )}
     />
   );

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "hash-sum": "^2.0.0",
     "lerna": "^8.1.2",
     "npm-run-all2": "^6.0.0",
-    "prettier": "^2.8.8",
+    "prettier": "^3.3.2",
     "prettier-plugin-tailwindcss": "^0.4.0",
     "rollup": "^4.9.5",
     "rollup-plugin-analyzer": "^4.0.0",

--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -58,14 +58,14 @@ type DecorateProcedure<
       query: Resolver<TDef>;
     }
   : TType extends 'mutation'
-  ? {
-      mutate: Resolver<TDef>;
-    }
-  : TType extends 'subscription'
-  ? {
-      subscribe: SubscriptionResolver<TDef>;
-    }
-  : never;
+    ? {
+        mutate: Resolver<TDef>;
+      }
+    : TType extends 'subscription'
+      ? {
+          subscribe: SubscriptionResolver<TDef>;
+        }
+      : never;
 
 /**
  * @internal
@@ -78,19 +78,19 @@ type DecoratedProcedureRecord<
     ? $Value extends RouterRecord
       ? DecoratedProcedureRecord<TRouter, $Value>
       : $Value extends AnyProcedure
-      ? DecorateProcedure<
-          $Value['_def']['type'],
-          {
-            input: inferProcedureInput<$Value>;
-            output: inferTransformedProcedureOutput<
-              inferClientTypes<TRouter>,
-              $Value
-            >;
-            errorShape: inferClientTypes<TRouter>['errorShape'];
-            transformer: inferClientTypes<TRouter>['transformer'];
-          }
-        >
-      : never
+        ? DecorateProcedure<
+            $Value['_def']['type'],
+            {
+              input: inferProcedureInput<$Value>;
+              output: inferTransformedProcedureOutput<
+                inferClientTypes<TRouter>,
+                $Value
+              >;
+              errorShape: inferClientTypes<TRouter>['errorShape'];
+              transformer: inferClientTypes<TRouter>['transformer'];
+            }
+          >
+        : never
     : never;
 };
 

--- a/packages/next/src/app-dir/create-action-hook.tsx
+++ b/packages/next/src/app-dir/create-action-hook.tsx
@@ -81,16 +81,16 @@ export function experimental_serverActionLink<
         TypeError<'Generic parameter missing in `experimental_createActionHook<HERE>()` or experimental_serverActionLink<HERE>()'>,
       ]
     : inferClientTypes<TInferrable>['transformer'] extends true
-    ? [
-        opts: TransformerOptions<{
-          transformer: true;
-        }>,
-      ]
-    : [
-        opts?: TransformerOptions<{
-          transformer: false;
-        }>,
-      ]
+      ? [
+          opts: TransformerOptions<{
+            transformer: true;
+          }>,
+        ]
+      : [
+          opts?: TransformerOptions<{
+            transformer: false;
+          }>,
+        ]
 ): TRPCLink<TInferrable> {
   const [opts] = args as [CoercedTransformerParameters];
   const transformer = getTransformer(opts?.transformer);

--- a/packages/next/src/app-dir/shared.ts
+++ b/packages/next/src/app-dir/shared.ts
@@ -28,13 +28,13 @@ export type UseProcedureRecord<
     ? $Value extends RouterRecord
       ? UseProcedureRecord<TRoot, $Value>
       : $Value extends AnyQueryProcedure
-      ? Resolver<{
-          input: inferProcedureInput<$Value>;
-          output: inferTransformedProcedureOutput<TRoot, $Value>;
-          errorShape: TRoot['errorShape'];
-          transformer: TRoot['transformer'];
-        }>
-      : never
+        ? Resolver<{
+            input: inferProcedureInput<$Value>;
+            output: inferTransformedProcedureOutput<TRoot, $Value>;
+            errorShape: TRoot['errorShape'];
+            transformer: TRoot['transformer'];
+          }>
+        : never
     : never;
 };
 

--- a/packages/next/src/app-dir/types.ts
+++ b/packages/next/src/app-dir/types.ts
@@ -28,14 +28,14 @@ export type DecorateProcedureServer<
       >;
     }
   : TType extends 'mutation'
-  ? {
-      mutate: Resolver<TDef>;
-    }
-  : TType extends 'subscription'
-  ? {
-      subscribe: Resolver<TDef>;
-    }
-  : never;
+    ? {
+        mutate: Resolver<TDef>;
+      }
+    : TType extends 'subscription'
+      ? {
+          subscribe: Resolver<TDef>;
+        }
+      : never;
 
 export type NextAppDirDecorateRouterRecord<
   TRoot extends AnyRootTypes,
@@ -45,15 +45,15 @@ export type NextAppDirDecorateRouterRecord<
     ? $Value extends RouterRecord
       ? NextAppDirDecorateRouterRecord<TRoot, $Value>
       : $Value extends AnyProcedure
-      ? DecorateProcedureServer<
-          $Value['_def']['type'],
-          {
-            input: inferProcedureInput<$Value>;
-            output: inferTransformedProcedureOutput<TRoot, $Value>;
-            errorShape: TRoot['errorShape'];
-            transformer: TRoot['transformer'];
-          }
-        >
-      : never
+        ? DecorateProcedureServer<
+            $Value['_def']['type'],
+            {
+              input: inferProcedureInput<$Value>;
+              output: inferTransformedProcedureOutput<TRoot, $Value>;
+              errorShape: TRoot['errorShape'];
+              transformer: TRoot['transformer'];
+            }
+          >
+        : never
     : never;
 };

--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -200,15 +200,15 @@ export type DecorateProcedure<
 > = TType extends 'query'
   ? DecoratedQuery<TDef>
   : TType extends 'mutation'
-  ? DecoratedMutation<TDef>
-  : TType extends 'subscription'
-  ? {
-      /**
-       * @link https://trpc.io/docs/v11/subscriptions
-       */
-      useSubscription: ProcedureUseSubscription<TDef>;
-    }
-  : never;
+    ? DecoratedMutation<TDef>
+    : TType extends 'subscription'
+      ? {
+          /**
+           * @link https://trpc.io/docs/v11/subscriptions
+           */
+          useSubscription: ProcedureUseSubscription<TDef>;
+        }
+      : never;
 
 /**
  * @internal
@@ -221,16 +221,16 @@ export type DecorateRouterRecord<
     ? $Value extends RouterRecord
       ? DecorateRouterRecord<TRoot, $Value>
       : $Value extends AnyProcedure
-      ? DecorateProcedure<
-          $Value['_def']['type'],
-          {
-            input: inferProcedureInput<$Value>;
-            output: inferTransformedProcedureOutput<TRoot, $Value>;
-            transformer: TRoot['transformer'];
-            errorShape: TRoot['errorShape'];
-          }
-        >
-      : never
+        ? DecorateProcedure<
+            $Value['_def']['type'],
+            {
+              input: inferProcedureInput<$Value>;
+              output: inferTransformedProcedureOutput<TRoot, $Value>;
+              transformer: TRoot['transformer'];
+              errorShape: TRoot['errorShape'];
+            }
+          >
+        : never
     : never;
 };
 

--- a/packages/react-query/src/internals/useQueries.ts
+++ b/packages/react-query/src/internals/useQueries.ts
@@ -125,19 +125,24 @@ export type QueriesOptions<
 > = TQueriesOptions extends []
   ? []
   : TQueriesOptions extends [infer Head]
-  ? [...TResult, GetOptions<Head>]
-  : TQueriesOptions extends [infer Head, ...infer Tail]
-  ? QueriesOptions<Tail, [...TResult, GetOptions<Head>]>
-  : unknown[] extends TQueriesOptions
-  ? TQueriesOptions
-  : TQueriesOptions extends UseQueryOptionsForUseQueries<
-      infer TQueryFnData,
-      infer TError,
-      infer TData,
-      infer TQueryKey
-    >[]
-  ? UseQueryOptionsForUseQueries<TQueryFnData, TError, TData, TQueryKey>[]
-  : UseQueryOptionsForUseQueries[];
+    ? [...TResult, GetOptions<Head>]
+    : TQueriesOptions extends [infer Head, ...infer Tail]
+      ? QueriesOptions<Tail, [...TResult, GetOptions<Head>]>
+      : unknown[] extends TQueriesOptions
+        ? TQueriesOptions
+        : TQueriesOptions extends UseQueryOptionsForUseQueries<
+              infer TQueryFnData,
+              infer TError,
+              infer TData,
+              infer TQueryKey
+            >[]
+          ? UseQueryOptionsForUseQueries<
+              TQueryFnData,
+              TError,
+              TData,
+              TQueryKey
+            >[]
+          : UseQueryOptionsForUseQueries[];
 
 type GetSuspenseOptions<TQueryOptions> =
   TQueryOptions extends UseQueryOptionsForUseSuspenseQueries<any, any, any, any>
@@ -153,24 +158,24 @@ export type SuspenseQueriesOptions<
 > = TQueriesOptions extends []
   ? []
   : TQueriesOptions extends [infer Head]
-  ? [...TResult, GetSuspenseOptions<Head>]
-  : TQueriesOptions extends [infer Head, ...infer Tail]
-  ? QueriesOptions<Tail, [...TResult, GetSuspenseOptions<Head>]>
-  : unknown[] extends TQueriesOptions
-  ? TQueriesOptions
-  : TQueriesOptions extends UseQueryOptionsForUseSuspenseQueries<
-      infer TQueryFnData,
-      infer TError,
-      infer TData,
-      infer TQueryKey
-    >[]
-  ? UseQueryOptionsForUseSuspenseQueries<
-      TQueryFnData,
-      TError,
-      TData,
-      TQueryKey
-    >[]
-  : UseQueryOptionsForUseSuspenseQueries[];
+    ? [...TResult, GetSuspenseOptions<Head>]
+    : TQueriesOptions extends [infer Head, ...infer Tail]
+      ? QueriesOptions<Tail, [...TResult, GetSuspenseOptions<Head>]>
+      : unknown[] extends TQueriesOptions
+        ? TQueriesOptions
+        : TQueriesOptions extends UseQueryOptionsForUseSuspenseQueries<
+              infer TQueryFnData,
+              infer TError,
+              infer TData,
+              infer TQueryKey
+            >[]
+          ? UseQueryOptionsForUseSuspenseQueries<
+              TQueryFnData,
+              TError,
+              TData,
+              TQueryKey
+            >[]
+          : UseQueryOptionsForUseSuspenseQueries[];
 
 /**
  * @internal

--- a/packages/react-query/src/rsc.tsx
+++ b/packages/react-query/src/rsc.tsx
@@ -35,9 +35,9 @@ type DecorateProcedure<
   TRoot extends AnyRootTypes,
   TProcedure extends AnyProcedure,
 > = {
-  (input: inferProcedureInput<TProcedure>): Promise<
-    inferProcedureOutput<TProcedure>
-  >;
+  (
+    input: inferProcedureInput<TProcedure>,
+  ): Promise<inferProcedureOutput<TProcedure>>;
   prefetch: (
     input: inferProcedureInput<TProcedure>,
     opts?: TRPCFetchQueryOptions<
@@ -62,8 +62,8 @@ type DecorateRouterRecord<
   [TKey in keyof TRecord]: TRecord[TKey] extends AnyProcedure
     ? DecorateProcedure<TRoot, TRecord[TKey]>
     : TRecord[TKey] extends RouterRecord
-    ? DecorateRouterRecord<TRoot, TRecord[TKey]>
-    : never;
+      ? DecorateRouterRecord<TRoot, TRecord[TKey]>
+      : never;
 };
 
 type Caller<TRouter extends AnyRouter> = ReturnType<

--- a/packages/react-query/src/server/ssgProxy.ts
+++ b/packages/react-query/src/server/ssgProxy.ts
@@ -119,9 +119,9 @@ type DecoratedProcedureSSGRecord<
     ? $Value extends RouterRecord
       ? DecoratedProcedureSSGRecord<TRoot, $Value>
       : // utils only apply to queries
-      $Value extends AnyQueryProcedure
-      ? DecorateProcedure<TRoot, $Value>
-      : never
+        $Value extends AnyQueryProcedure
+        ? DecorateProcedure<TRoot, $Value>
+        : never
     : never;
 };
 

--- a/packages/react-query/src/shared/hooks/types.ts
+++ b/packages/react-query/src/shared/hooks/types.ts
@@ -160,11 +160,8 @@ export type CreateClient<TRouter extends AnyRouter> = (
   opts: CreateTRPCClientOptions<TRouter>,
 ) => TRPCUntypedClient<TRouter>;
 
-type coerceAsyncIterableToArray<TValue> = TValue extends AsyncIterable<
-  infer $Inferred
->
-  ? $Inferred[]
-  : TValue;
+type coerceAsyncIterableToArray<TValue> =
+  TValue extends AsyncIterable<infer $Inferred> ? $Inferred[] : TValue;
 
 /**
  * @internal

--- a/packages/react-query/src/shared/polymorphism/mutationLike.ts
+++ b/packages/react-query/src/shared/polymorphism/mutationLike.ts
@@ -26,15 +26,17 @@ export type MutationLike<
  */
 export type InferMutationLikeInput<
   TMutationLike extends MutationLike<any, any>,
-> = TMutationLike extends MutationLike<any, infer $Procedure>
-  ? inferProcedureInput<$Procedure>
-  : never;
+> =
+  TMutationLike extends MutationLike<any, infer $Procedure>
+    ? inferProcedureInput<$Procedure>
+    : never;
 
 /**
  * Use to unwrap a MutationLike's data output
  */
 export type InferMutationLikeData<
   TMutationLike extends MutationLike<any, any>,
-> = TMutationLike extends MutationLike<infer TRoot, infer TProcedure>
-  ? inferTransformedProcedureOutput<TRoot, TProcedure>
-  : never;
+> =
+  TMutationLike extends MutationLike<infer TRoot, infer TProcedure>
+    ? inferTransformedProcedureOutput<TRoot, TProcedure>
+    : never;

--- a/packages/react-query/src/shared/polymorphism/queryLike.ts
+++ b/packages/react-query/src/shared/polymorphism/queryLike.ts
@@ -37,21 +37,19 @@ export type QueryLike<
 /**
  * Use to unwrap a QueryLike's input
  */
-export type InferQueryLikeInput<TQueryLike> = TQueryLike extends DecoratedQuery<
-  infer $Def
->
-  ? $Def['input']
-  : TQueryLike extends QueryLike<any, infer TProcedure>
-  ? inferProcedureInput<TProcedure>
-  : never;
+export type InferQueryLikeInput<TQueryLike> =
+  TQueryLike extends DecoratedQuery<infer $Def>
+    ? $Def['input']
+    : TQueryLike extends QueryLike<any, infer TProcedure>
+      ? inferProcedureInput<TProcedure>
+      : never;
 
 /**
  * Use to unwrap a QueryLike's data output
  */
-export type InferQueryLikeData<TQueryLike> = TQueryLike extends DecoratedQuery<
-  infer $Def
->
-  ? $Def['output']
-  : TQueryLike extends QueryLike<infer TRoot, infer TProcedure>
-  ? inferTransformedProcedureOutput<TRoot, TProcedure>
-  : never;
+export type InferQueryLikeData<TQueryLike> =
+  TQueryLike extends DecoratedQuery<infer $Def>
+    ? $Def['output']
+    : TQueryLike extends QueryLike<infer TRoot, infer TProcedure>
+      ? inferTransformedProcedureOutput<TRoot, TProcedure>
+      : never;

--- a/packages/react-query/src/shared/polymorphism/routerLike.ts
+++ b/packages/react-query/src/shared/polymorphism/routerLike.ts
@@ -23,10 +23,10 @@ export type RouterLikeInner<
     ? $Value extends RouterRecord
       ? RouterLikeInner<TRoot, $Value>
       : $Value extends AnyQueryProcedure
-      ? QueryLike<TRoot, $Value>
-      : $Value extends AnyMutationProcedure
-      ? MutationLike<TRoot, $Value>
-      : never
+        ? QueryLike<TRoot, $Value>
+        : $Value extends AnyMutationProcedure
+          ? MutationLike<TRoot, $Value>
+          : never
     : never;
 };
 

--- a/packages/react-query/src/shared/proxy/useQueriesProxy.ts
+++ b/packages/react-query/src/shared/proxy/useQueriesProxy.ts
@@ -44,8 +44,8 @@ export type UseQueriesProcedureRecord<
     ? $Value extends RouterRecord
       ? UseQueriesProcedureRecord<TRoot, $Value>
       : $Value extends AnyQueryProcedure
-      ? GetQueryOptions<TRoot, $Value>
-      : never
+        ? GetQueryOptions<TRoot, $Value>
+        : never
     : never;
 };
 
@@ -76,8 +76,8 @@ export type UseSuspenseQueriesProcedureRecord<
     ? $Value extends RouterRecord
       ? UseSuspenseQueriesProcedureRecord<TRoot, $Value>
       : $Value extends AnyQueryProcedure
-      ? GetSuspenseQueryOptions<TRoot, $Value>
-      : never
+        ? GetSuspenseQueryOptions<TRoot, $Value>
+        : never
     : never;
 };
 

--- a/packages/react-query/src/shared/proxy/utilsProxy.ts
+++ b/packages/react-query/src/shared/proxy/utilsProxy.ts
@@ -253,9 +253,9 @@ export type DecoratedProcedureUtilsRecord<
     ? $Value extends RouterRecord
       ? DecoratedProcedureUtilsRecord<TRoot, $Value> & DecorateRouter
       : // utils only apply to queries
-      $Value extends AnyQueryProcedure
-      ? DecorateProcedure<TRoot, $Value>
-      : never
+        $Value extends AnyQueryProcedure
+        ? DecorateProcedure<TRoot, $Value>
+        : never
     : never;
 }; // Add functions that should be available at utils root
 

--- a/packages/react-query/src/utils/inferReactQueryProcedure.ts
+++ b/packages/react-query/src/utils/inferReactQueryProcedure.ts
@@ -78,10 +78,10 @@ type inferReactQueryProcedureOptionsInner<
     ? $Value extends RouterRecord
       ? inferReactQueryProcedureOptionsInner<TRoot, $Value>
       : $Value extends AnyMutationProcedure
-      ? InferMutationOptions<TRoot, $Value>
-      : $Value extends AnyQueryProcedure
-      ? InferQueryOptions<TRoot, $Value>
-      : never
+        ? InferMutationOptions<TRoot, $Value>
+        : $Value extends AnyQueryProcedure
+          ? InferQueryOptions<TRoot, $Value>
+          : never
     : never;
 };
 

--- a/packages/server/src/adapters/aws-lambda/getPlanner.ts
+++ b/packages/server/src/adapters/aws-lambda/getPlanner.ts
@@ -29,8 +29,8 @@ function determinePayloadFormat(event: LambdaEvent): string {
 export type inferAPIGWReturn<TEvent> = TEvent extends APIGatewayProxyEvent
   ? APIGatewayProxyResult
   : TEvent extends APIGatewayProxyEventV2
-  ? APIGatewayProxyStructuredResultV2
-  : never;
+    ? APIGatewayProxyStructuredResultV2
+    : never;
 
 interface Processor<TEvent extends LambdaEvent> {
   getTRPCPath: (event: TEvent) => string;

--- a/packages/server/src/adapters/aws-lambda/index.ts
+++ b/packages/server/src/adapters/aws-lambda/index.ts
@@ -33,12 +33,11 @@ export type CreateAWSLambdaContextOptions<TEvent extends LambdaEvent> = {
 export type AWSLambdaOptions<
   TRouter extends AnyRouter,
   TEvent extends LambdaEvent,
-> =
-  | HTTPBaseHandlerOptions<TRouter, TEvent> &
-      CreateContextCallback<
-        inferRouterContext<AnyRouter>,
-        AWSLambdaCreateContextFn<TRouter, TEvent>
-      >;
+> = HTTPBaseHandlerOptions<TRouter, TEvent> &
+  CreateContextCallback<
+    inferRouterContext<AnyRouter>,
+    AWSLambdaCreateContextFn<TRouter, TEvent>
+  >;
 
 export type AWSLambdaCreateContextFn<
   TRouter extends AnyRouter,

--- a/packages/server/src/observable/observable.ts
+++ b/packages/server/src/observable/observable.ts
@@ -8,12 +8,8 @@ import type {
 } from './types';
 
 /** @public */
-export type inferObservableValue<TObservable> = TObservable extends Observable<
-  infer TValue,
-  unknown
->
-  ? TValue
-  : never;
+export type inferObservableValue<TObservable> =
+  TObservable extends Observable<infer TValue, unknown> ? TValue : never;
 
 /** @public */
 export function isObservable(x: unknown): x is Observable<unknown, unknown> {

--- a/packages/server/src/unstable-core-do-not-import/clientish/inference.ts
+++ b/packages/server/src/unstable-core-do-not-import/clientish/inference.ts
@@ -40,10 +40,10 @@ export type GetInferenceHelpers<
     ? $Value extends RouterRecord
       ? GetInferenceHelpers<TType, TRoot, $Value>
       : $Value extends AnyProcedure
-      ? TType extends 'input'
-        ? inferProcedureInput<$Value>
-        : inferTransformedProcedureOutput<TRoot, $Value>
-      : never
+        ? TType extends 'input'
+          ? inferProcedureInput<$Value>
+          : inferTransformedProcedureOutput<TRoot, $Value>
+        : never
     : never;
 };
 

--- a/packages/server/src/unstable-core-do-not-import/clientish/inferrable.ts
+++ b/packages/server/src/unstable-core-do-not-import/clientish/inferrable.ts
@@ -41,9 +41,9 @@ export type inferClientTypes<TInferrable extends InferrableClientTypes> =
   TInferrable extends AnyClientTypes
     ? TInferrable
     : TInferrable extends RootConfigLike
-    ? TInferrable['$types']
-    : TInferrable extends InitLike
-    ? TInferrable['_config']['$types']
-    : TInferrable extends RouterLike
-    ? TInferrable['_def']['_config']['$types']
-    : never;
+      ? TInferrable['$types']
+      : TInferrable extends InitLike
+        ? TInferrable['_config']['$types']
+        : TInferrable extends RouterLike
+          ? TInferrable['_def']['_config']['$types']
+          : never;

--- a/packages/server/src/unstable-core-do-not-import/clientish/serialize.ts
+++ b/packages/server/src/unstable-core-do-not-import/clientish/serialize.ts
@@ -119,5 +119,5 @@ type UndefinedToOptional<T extends object> =
     (ExactOptionalPropertyTypes extends true
       ? HandleIndexSignature<T> & HandleUndefined<WithoutIndexSignature<T>>
       : HasIndexSignature<T> extends true
-      ? HandleIndexSignature<T>
-      : HandleUndefined<T>);
+        ? HandleIndexSignature<T>
+        : HandleUndefined<T>);

--- a/packages/server/src/unstable-core-do-not-import/createProxy.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/createProxy.test.ts
@@ -27,7 +27,9 @@ test('createRecursiveProxy() - prevent mutation of args', () => {
     return opts;
   });
 
-  expect(() => mutateArgs.foo.bar.query()).toThrowErrorMatchingInlineSnapshot(`[TypeError: Cannot add property 0, object is not extensible]`);
+  expect(() => mutateArgs.foo.bar.query()).toThrowErrorMatchingInlineSnapshot(
+    `[TypeError: Cannot add property 0, object is not extensible]`,
+  );
 
   const mutatePath: any = createRecursiveProxy((opts) => {
     // @ts-expect-error - mutate args
@@ -35,5 +37,7 @@ test('createRecursiveProxy() - prevent mutation of args', () => {
     return opts;
   });
 
-  expect(() => mutatePath.foo.bar.query()).toThrowErrorMatchingInlineSnapshot(`[TypeError: Cannot add property 3, object is not extensible]`);
+  expect(() => mutatePath.foo.bar.query()).toThrowErrorMatchingInlineSnapshot(
+    `[TypeError: Cannot add property 3, object is not extensible]`,
+  );
 });

--- a/packages/server/src/unstable-core-do-not-import/http/resolveResponse.ts
+++ b/packages/server/src/unstable-core-do-not-import/http/resolveResponse.ts
@@ -85,8 +85,8 @@ function initResponse<TRouter extends AnyRouter, TRequest>(initOpts: {
   const data = eagerGeneration
     ? []
     : Array.isArray(untransformedJSON)
-    ? untransformedJSON
-    : [untransformedJSON];
+      ? untransformedJSON
+      : [untransformedJSON];
 
   const meta =
     responseMeta?.({

--- a/packages/server/src/unstable-core-do-not-import/initTRPC.ts
+++ b/packages/server/src/unstable-core-do-not-import/initTRPC.ts
@@ -16,12 +16,8 @@ import type { DataTransformerOptions } from './transformer';
 import { defaultTransformer, getDataTransformer } from './transformer';
 import type { Unwrap, ValidateShape } from './types';
 
-type inferErrorFormatterShape<TType> = TType extends ErrorFormatter<
-  any,
-  infer TShape
->
-  ? TShape
-  : DefaultErrorShape;
+type inferErrorFormatterShape<TType> =
+  TType extends ErrorFormatter<any, infer TShape> ? TShape : DefaultErrorShape;
 interface RuntimeConfigOptions<TContext extends object, TMeta extends object>
   extends Partial<
     Omit<

--- a/packages/server/src/unstable-core-do-not-import/middleware.ts
+++ b/packages/server/src/unstable-core-do-not-import/middleware.ts
@@ -106,9 +106,9 @@ export type MiddlewareFunction<
         ctx?: $ContextOverride;
         input?: unknown;
       }): Promise<MiddlewareResult<$ContextOverride>>;
-      (opts: { getRawInput: GetRawInputFn }): Promise<
-        MiddlewareResult<TContextOverridesIn>
-      >;
+      (opts: {
+        getRawInput: GetRawInputFn;
+      }): Promise<MiddlewareResult<TContextOverridesIn>>;
     };
   }): Promise<MiddlewareResult<$ContextOverridesOut>>;
   _type?: string | undefined;

--- a/packages/server/src/unstable-core-do-not-import/parser.ts
+++ b/packages/server/src/unstable-core-do-not-import/parser.ts
@@ -53,11 +53,11 @@ export type inferParser<TParser extends Parser> =
         out: $TOut;
       }
     : TParser extends ParserWithoutInput<infer $InOut>
-    ? {
-        in: $InOut;
-        out: $InOut;
-      }
-    : never;
+      ? {
+          in: $InOut;
+          out: $InOut;
+        }
+      : never;
 
 export type ParseFn<TType> = (value: unknown) => Promise<TType> | TType;
 

--- a/packages/server/src/unstable-core-do-not-import/procedureBuilder.ts
+++ b/packages/server/src/unstable-core-do-not-import/procedureBuilder.ts
@@ -37,18 +37,17 @@ import { mergeWithoutOverrides } from './utils';
 type IntersectIfDefined<TType, TWith> = TType extends UnsetMarker
   ? TWith
   : TWith extends UnsetMarker
-  ? TType
-  : Simplify<TType & TWith>;
+    ? TType
+    : Simplify<TType & TWith>;
 ``;
 type DefaultValue<TValue, TFallback> = TValue extends UnsetMarker
   ? TFallback
   : TValue;
 
-type inferSubscriptionOutput<TOutput> = TOutput extends AsyncIterable<
-  infer $Output
->
-  ? inferSSEOutput<$Output>
-  : inferObservableValue<TOutput>;
+type inferSubscriptionOutput<TOutput> =
+  TOutput extends AsyncIterable<infer $Output>
+    ? inferSSEOutput<$Output>
+    : inferObservableValue<TOutput>;
 
 export type CallerOverride<TContext> = (opts: {
   args: unknown[];
@@ -129,35 +128,36 @@ export type AnyProcedureBuilder = ProcedureBuilder<
  */
 export type inferProcedureBuilderResolverOptions<
   TProcedureBuilder extends AnyProcedureBuilder,
-> = TProcedureBuilder extends ProcedureBuilder<
-  infer TContext,
-  infer TMeta,
-  infer TContextOverrides,
-  infer _TInputIn,
-  infer TInputOut,
-  infer _TOutputIn,
-  infer _TOutputOut,
-  infer _TCaller
->
-  ? ProcedureResolverOptions<
-      TContext,
-      TMeta,
-      TContextOverrides,
-      TInputOut extends UnsetMarker
-        ? // if input is not set, we don't want to infer it as `undefined` since a procedure further down the chain might have set an input
-          unknown
-        : TInputOut extends object
-        ? Simplify<
-            TInputOut & {
-              /**
-               * Extra input params might have been added by a `.input()` further down the chain
-               */
-              [keyAddedByInputCallFurtherDown: string]: unknown;
-            }
-          >
-        : TInputOut
-    >
-  : never;
+> =
+  TProcedureBuilder extends ProcedureBuilder<
+    infer TContext,
+    infer TMeta,
+    infer TContextOverrides,
+    infer _TInputIn,
+    infer TInputOut,
+    infer _TOutputIn,
+    infer _TOutputOut,
+    infer _TCaller
+  >
+    ? ProcedureResolverOptions<
+        TContext,
+        TMeta,
+        TContextOverrides,
+        TInputOut extends UnsetMarker
+          ? // if input is not set, we don't want to infer it as `undefined` since a procedure further down the chain might have set an input
+            unknown
+          : TInputOut extends object
+            ? Simplify<
+                TInputOut & {
+                  /**
+                   * Extra input params might have been added by a `.input()` further down the chain
+                   */
+                  [keyAddedByInputCallFurtherDown: string]: unknown;
+                }
+              >
+            : TInputOut
+      >
+    : never;
 
 export interface ProcedureBuilder<
   TContext,
@@ -177,14 +177,14 @@ export interface ProcedureBuilder<
     schema: TInputOut extends UnsetMarker
       ? $Parser
       : inferParser<$Parser>['out'] extends Record<string, unknown> | undefined
-      ? TInputOut extends Record<string, unknown> | undefined
-        ? undefined extends inferParser<$Parser>['out'] // if current is optional the previous must be too
-          ? undefined extends TInputOut
-            ? $Parser
-            : TypeError<'Cannot chain an optional parser to a required parser'>
-          : $Parser
-        : TypeError<'All input parsers did not resolve to an object'>
-      : TypeError<'All input parsers did not resolve to an object'>,
+        ? TInputOut extends Record<string, unknown> | undefined
+          ? undefined extends inferParser<$Parser>['out'] // if current is optional the previous must be too
+            ? undefined extends TInputOut
+              ? $Parser
+              : TypeError<'Cannot chain an optional parser to a required parser'>
+            : $Parser
+          : TypeError<'All input parsers did not resolve to an object'>
+        : TypeError<'All input parsers did not resolve to an object'>,
   ): ProcedureBuilder<
     TContext,
     TMeta,

--- a/packages/server/src/unstable-core-do-not-import/router.ts
+++ b/packages/server/src/unstable-core-do-not-import/router.ts
@@ -33,8 +33,8 @@ export type DecorateRouterRecord<TRecord extends RouterRecord> = {
   [TKey in keyof TRecord]: TRecord[TKey] extends AnyProcedure
     ? DecorateProcedure<TRecord[TKey]>
     : TRecord[TKey] extends RouterRecord
-    ? DecorateRouterRecord<TRecord[TKey]>
-    : never;
+      ? DecorateRouterRecord<TRecord[TKey]>
+      : never;
 };
 
 /**
@@ -142,10 +142,10 @@ export type DecorateCreateRouterOptions<
     ? $Value extends AnyProcedure
       ? $Value
       : $Value extends Router<any, infer TRecord>
-      ? TRecord
-      : $Value extends CreateRouterOptions
-      ? DecorateCreateRouterOptions<$Value>
-      : never
+        ? TRecord
+        : $Value extends CreateRouterOptions
+          ? DecorateCreateRouterOptions<$Value>
+          : never
     : never;
 };
 

--- a/packages/server/src/unstable-core-do-not-import/stream/sse.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/sse.ts
@@ -207,11 +207,8 @@ export function sseStreamProducer(opts: SSEStreamProducerOptions) {
     }),
   );
 }
-export type inferSSEOutput<TData> = TData extends SSEMessageEnvelope<
-  infer $Data
->
-  ? $Data
-  : TData;
+export type inferSSEOutput<TData> =
+  TData extends SSEMessageEnvelope<infer $Data> ? $Data : TData;
 /**
  * @see https://html.spec.whatwg.org/multipage/server-sent-events.html
  */

--- a/packages/server/src/unstable-core-do-not-import/types.ts
+++ b/packages/server/src/unstable-core-do-not-import/types.ts
@@ -76,8 +76,8 @@ export type WithoutIndexSignature<TObj> = {
   [K in keyof TObj as string extends K
     ? never
     : number extends K
-    ? never
-    : K]: TObj[K];
+      ? never
+      : K]: TObj[K];
 };
 
 /**
@@ -94,14 +94,14 @@ export type Overwrite<TType, TWith> = TWith extends any
           | keyof WithoutIndexSignature<TWith>]: K extends keyof TWith
           ? TWith[K]
           : K extends keyof TType
-          ? TType[K]
-          : never;
+            ? TType[K]
+            : never;
       } & (string extends keyof TWith // Handle cases with an index signature
         ? { [key: string]: TWith[string] }
         : number extends keyof TWith
-        ? { [key: number]: TWith[number] }
-        : // eslint-disable-next-line @typescript-eslint/ban-types
-          {})
+          ? { [key: number]: TWith[number] }
+          : // eslint-disable-next-line @typescript-eslint/ban-types
+            {})
     : TWith
   : never;
 

--- a/packages/tests/server/react/useInfiniteQuery.test.tsx
+++ b/packages/tests/server/react/useInfiniteQuery.test.tsx
@@ -56,8 +56,8 @@ test('useInfiniteQuery()', async () => {
             {q.isFetchingNextPage
               ? 'Loading more...'
               : q.hasNextPage
-              ? 'Load More'
-              : 'Nothing more to load'}
+                ? 'Load More'
+                : 'Nothing more to load'}
           </button>
         </div>
         <div>
@@ -143,8 +143,8 @@ test('useInfiniteQuery bi-directional', async () => {
             {q.isFetchingPreviousPage
               ? 'Loading previous...'
               : q.hasPreviousPage
-              ? 'Load Previous'
-              : 'Nothing previous to load'}
+                ? 'Load Previous'
+                : 'Nothing previous to load'}
           </button>
         </div>
         {q.data?.pages.map((group, i) => (
@@ -165,8 +165,8 @@ test('useInfiniteQuery bi-directional', async () => {
             {q.isFetchingNextPage
               ? 'Loading more...'
               : q.hasNextPage
-              ? 'Load More'
-              : 'Nothing more to load'}
+                ? 'Load More'
+                : 'Nothing more to load'}
           </button>
         </div>
         <div>
@@ -272,8 +272,8 @@ test('useInfiniteQuery and prefetchInfiniteQuery', async () => {
             {q.isFetchingNextPage
               ? 'Loading more...'
               : q.hasNextPage
-              ? 'Load More'
-              : 'Nothing more to load'}
+                ? 'Load More'
+                : 'Nothing more to load'}
           </button>
         </div>
         <div>
@@ -401,8 +401,8 @@ test('useInfiniteQuery and fetchInfiniteQuery', async () => {
             {q.isFetchingNextPage
               ? 'Loading more...'
               : q.hasNextPage
-              ? 'Load More'
-              : 'Nothing more to load'}
+                ? 'Load More'
+                : 'Nothing more to load'}
           </button>
         </div>
         <div>

--- a/packages/tests/server/streaming.test.ts
+++ b/packages/tests/server/streaming.test.ts
@@ -432,11 +432,14 @@ describe('with transformer', () => {
     const iterable = await client.iterableWithError.query();
 
     const aggregated: unknown[] = [];
-    const error = await waitError(async () => {
-      for await (const value of iterable) {
-        aggregated.push(value);
-      }
-    }, TRPCClientError<typeof router>);
+    const error = await waitError(
+      async () => {
+        for await (const value of iterable) {
+          aggregated.push(value);
+        }
+      },
+      TRPCClientError<typeof router>,
+    );
 
     error.data!.stack = '[redacted]';
     expect(error.data).toMatchInlineSnapshot(`

--- a/packages/tests/showcase/tinyrpc.ts
+++ b/packages/tests/showcase/tinyrpc.ts
@@ -58,18 +58,18 @@ type DecorateProcedure<TProcedure> = TProcedure extends AnyTRPCQueryProcedure
       query: Resolver<TProcedure>;
     }
   : TProcedure extends AnyTRPCMutationProcedure
-  ? {
-      mutate: Resolver<TProcedure>;
-    }
-  : never;
+    ? {
+        mutate: Resolver<TProcedure>;
+      }
+    : never;
 
 type DecorateRouterRecord<TRecord extends TRPCRouterRecord> = {
   [TKey in keyof TRecord]: TRecord[TKey] extends infer $Value
     ? $Value extends TRPCRouterRecord
       ? DecorateRouterRecord<$Value>
       : $Value extends AnyTRPCProcedure
-      ? DecorateProcedure<$Value>
-      : never
+        ? DecorateProcedure<$Value>
+        : never
     : never;
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 6.0.0
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^4.0.0
-        version: 4.0.0(prettier@2.8.8)
+        version: 4.0.0(prettier@3.3.2)
       '@manypkg/cli':
         specifier: ^0.21.2
         version: 0.21.2
@@ -102,11 +102,11 @@ importers:
         specifier: ^6.0.0
         version: 6.1.1
       prettier:
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^3.3.2
+        version: 3.3.2
       prettier-plugin-tailwindcss:
         specifier: ^0.4.0
-        version: 0.4.0(@ianvs/prettier-plugin-sort-imports@4.0.0)(prettier@2.8.8)
+        version: 0.4.0(@ianvs/prettier-plugin-sort-imports@4.0.0)(prettier@3.3.2)
       rollup:
         specifier: ^4.9.5
         version: 4.9.5
@@ -1146,8 +1146,8 @@ importers:
         specifier: ^8.4.14
         version: 8.4.31
       prettier:
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^3.3.2
+        version: 3.3.2
       prisma:
         specifier: ^5.12.1
         version: 5.12.1
@@ -1346,8 +1346,8 @@ importers:
         specifier: ^8.4.14
         version: 8.4.31
       prettier:
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^3.3.2
+        version: 3.3.2
       prisma:
         specifier: ^5.12.1
         version: 5.12.1
@@ -2043,8 +2043,8 @@ importers:
         specifier: ^8.4.14
         version: 8.4.31
       prettier:
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^3.3.2
+        version: 3.3.2
       runtypes:
         specifier: ^6.6.0
         version: 6.6.0
@@ -2068,7 +2068,7 @@ importers:
         version: 0.24.7(typescript@5.1.3)
       typedoc-plugin-markdown:
         specifier: ^4.0.0-next.13
-        version: 4.0.0-next.13(prettier@2.8.8)(typedoc@0.24.7)
+        version: 4.0.0-next.13(prettier@3.3.2)(typedoc@0.24.7)
       typescript:
         specifier: npm:typescript@~5.1.3
         version: 5.1.3
@@ -6475,7 +6475,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: false
 
-  /@ianvs/prettier-plugin-sort-imports@4.0.0(prettier@2.8.8):
+  /@ianvs/prettier-plugin-sort-imports@4.0.0(prettier@3.3.2):
     resolution: {integrity: sha512-56wYZhq/Ezt5o4Lzc+CEUV+sqTPEV2WcTFJSSLBOhe15yfIkrUheGeRvC3lg30VQ8K0J1kvWjXIY5lxeOlW2Tg==}
     peerDependencies:
       '@vue/compiler-sfc': '>=3.0.0'
@@ -6489,7 +6489,7 @@ packages:
       '@babel/parser': 7.21.8
       '@babel/traverse': 7.21.5
       '@babel/types': 7.21.5
-      prettier: 2.8.8
+      prettier: 3.3.2
       semver: 7.5.0
     transitivePeerDependencies:
       - supports-color
@@ -12639,7 +12639,7 @@ packages:
       typedoc-plugin-markdown: '>=4.0.0-next.13'
     dependencies:
       typedoc-plugin-frontmatter: 0.0.2
-      typedoc-plugin-markdown: 4.0.0-next.13(prettier@2.8.8)(typedoc@0.24.7)
+      typedoc-plugin-markdown: 4.0.0-next.13(prettier@3.3.2)(typedoc@0.24.7)
     dev: true
 
   /docusaurus-preset-shiki-twoslash@1.1.41:
@@ -19946,7 +19946,7 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /prettier-plugin-tailwindcss@0.4.0(@ianvs/prettier-plugin-sort-imports@4.0.0)(prettier@2.8.8):
+  /prettier-plugin-tailwindcss@0.4.0(@ianvs/prettier-plugin-sort-imports@4.0.0)(prettier@3.3.2):
     resolution: {integrity: sha512-Rna0sDPETA0KNhMHlN8wxKNgfSa8mTl2hPPAGxnbv6tUcHT6J4RQmQ8TLXyhB7Dm5Von4iHloBxTyClYM6wT0A==}
     engines: {node: '>=12.17.0'}
     peerDependencies:
@@ -19998,13 +19998,13 @@ packages:
       prettier-plugin-twig-melody:
         optional: true
     dependencies:
-      '@ianvs/prettier-plugin-sort-imports': 4.0.0(prettier@2.8.8)
-      prettier: 2.8.8
+      '@ianvs/prettier-plugin-sort-imports': 4.0.0(prettier@3.3.2)
+      prettier: 3.3.2
     dev: false
 
-  /prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
+  /prettier@3.3.2:
+    resolution: {integrity: sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==}
+    engines: {node: '>=14'}
     hasBin: true
 
   /pretty-bytes@5.6.0:
@@ -23312,13 +23312,13 @@ packages:
       yaml: 2.3.3
     dev: true
 
-  /typedoc-plugin-markdown@4.0.0-next.13(prettier@2.8.8)(typedoc@0.24.7):
+  /typedoc-plugin-markdown@4.0.0-next.13(prettier@3.3.2)(typedoc@0.24.7):
     resolution: {integrity: sha512-ZOcLsJoGN4QI5x1iS2M5lj6bA3MABf6hA183W1KebbxcBA+SFr+XIu73Uovv3SiwqPa+viBftLzkZlLyA6J9bg==}
     peerDependencies:
       prettier: '>=1.8.0'
       typedoc: '>=0.24.0'
     dependencies:
-      prettier: 2.8.8
+      prettier: 3.3.2
       typedoc: 0.24.7(typescript@5.1.3)
     dev: true
 

--- a/scripts/entrypoints.ts
+++ b/scripts/entrypoints.ts
@@ -120,7 +120,7 @@ export async function generateEntrypoints(rawInputs: string[]) {
   pkgJson.funding = ['https://trpc.io/sponsor'];
 
   // write package.json
-  const formattedPkgJson = prettier.format(JSON.stringify(pkgJson), {
+  const formattedPkgJson = await prettier.format(JSON.stringify(pkgJson), {
     parser: 'json-stringify',
     ...(await prettier.resolveConfig(pkgJsonPath)),
   });
@@ -129,7 +129,7 @@ export async function generateEntrypoints(rawInputs: string[]) {
   const turboPath = path.resolve('turbo.json');
   const turboJson = JSON.parse(fs.readFileSync(turboPath, 'utf8'));
   turboJson.tasks['codegen-entrypoints'].outputs = [...scriptOutputs];
-  const formattedTurboJson = prettier.format(JSON.stringify(turboJson), {
+  const formattedTurboJson = await prettier.format(JSON.stringify(turboJson), {
     parser: 'json',
     ...(await prettier.resolveConfig(turboPath)),
   });

--- a/www/blog/2023-01-14-typescript-performance-lessons.md
+++ b/www/blog/2023-01-14-typescript-performance-lessons.md
@@ -106,10 +106,10 @@ export type DecoratedProcedureUtilsRecord<TRouter extends AnyRouter> =
     [TKey in keyof TRouter['_def']['record']]: TRouter['_def']['record'][TKey] extends LegacyV9ProcedureTag
       ? never
       : TRouter['_def']['record'][TKey] extends AnyRouter
-      ? DecoratedProcedureUtilsRecord<TRouter['_def']['record'][TKey]>
-      : TRouter['_def']['record'][TKey] extends AnyQueryProcedure
-      ? DecorateProcedure<TRouter, TRouter['_def']['record'][TKey]>
-      : never;
+        ? DecoratedProcedureUtilsRecord<TRouter['_def']['record'][TKey]>
+        : TRouter['_def']['record'][TKey] extends AnyQueryProcedure
+          ? DecorateProcedure<TRouter, TRouter['_def']['record'][TKey]>
+          : never;
   }>;
 ```
 

--- a/www/docs/server/authorization.md
+++ b/www/docs/server/authorization.md
@@ -72,24 +72,24 @@ import { initTRPC, TRPCError } from '@trpc/server';
 export const t = initTRPC.context<Context>().create();
 
 // you can reuse this for any procedure
-export const protectedProcedure = t.procedure.use(async function isAuthed(
-  opts,
-) {
-  const { ctx } = opts;
-  // `ctx.user` is nullable
-  if (!ctx.user) {
-    //     ^?
-    throw new TRPCError({ code: 'UNAUTHORIZED' });
-  }
+export const protectedProcedure = t.procedure.use(
+  async function isAuthed(opts) {
+    const { ctx } = opts;
+    // `ctx.user` is nullable
+    if (!ctx.user) {
+      //     ^?
+      throw new TRPCError({ code: 'UNAUTHORIZED' });
+    }
 
-  return opts.next({
-    ctx: {
-      // ✅ user value is known to be non-null now
-      user: ctx.user,
-      // ^?
-    },
-  });
-});
+    return opts.next({
+      ctx: {
+        // ✅ user value is known to be non-null now
+        user: ctx.user,
+        // ^?
+      },
+    });
+  },
+);
 
 t.router({
   // this is accessible for everyone

--- a/www/docs/server/validators.md
+++ b/www/docs/server/validators.md
@@ -351,7 +351,9 @@ const publicProcedure = t.procedure;
 export const appRouter = t.router({
   hello: publicProcedure
     .input(Schema.decodeUnknownSync(Schema.Struct({ name: Schema.String })))
-    .output(Schema.decodeUnknownSync(Schema.Struct({ greeting: Schema.String })))
+    .output(
+      Schema.decodeUnknownSync(Schema.Struct({ greeting: Schema.String })),
+    )
     .query(({ input }) => {
       //      ^?
       return {

--- a/www/package.json
+++ b/www/package.json
@@ -82,7 +82,7 @@
     "npm-run-all2": "^6.0.0",
     "oauth": "^0.10.0",
     "postcss": "^8.4.14",
-    "prettier": "^2.8.8",
+    "prettier": "^3.3.2",
     "runtypes": "^6.6.0",
     "scale-codec": "^0.13.0",
     "superstruct": "^2.0.0",

--- a/www/src/components/sponsors/script.push.ts
+++ b/www/src/components/sponsors/script.push.ts
@@ -55,12 +55,12 @@ for (const sponsor of sponsors) {
   const section = sections.diamond.includes(login)
     ? 'diamond'
     : sections.gold.includes(login)
-    ? 'gold'
-    : sections.silver.includes(login)
-    ? 'silver'
-    : sections.bronze.includes(login)
-    ? 'bronze'
-    : 'other';
+      ? 'gold'
+      : sections.silver.includes(login)
+        ? 'silver'
+        : sections.bronze.includes(login)
+          ? 'bronze'
+          : 'other';
 
   buckets[section].push(sponsor);
 }

--- a/www/src/css/custom.css
+++ b/www/src/css/custom.css
@@ -71,13 +71,15 @@ div[class^='announcementBar_'] {
 }
 
 .homepage .main-wrapper {
-  background: linear-gradient(180deg, hsla(0, 0%, 100%, 0) 0, #fff 300px),
+  background:
+    linear-gradient(180deg, hsla(0, 0%, 100%, 0) 0, #fff 300px),
     fixed 0 0 /20px 20px radial-gradient(#d1d1d1 1px, transparent 0),
     fixed 10px 10px /20px 20px radial-gradient(#d1d1d1 1px, transparent 0);
 }
 
 [data-theme='dark'] .homepage .main-wrapper {
-  background: linear-gradient(180deg, transparent 0, #111 300px),
+  background:
+    linear-gradient(180deg, transparent 0, #111 300px),
     fixed 0 0 /20px 20px radial-gradient(#313131 1px, transparent 0),
     fixed 10px 10px /20px 20px radial-gradient(#313131 1px, transparent 0);
 }

--- a/www/unversioned/_love.mdx
+++ b/www/unversioned/_love.mdx
@@ -15,11 +15,13 @@ Do you love or hate tRPC? Feel free to ping [@alexdotjs on Twitter](https://twit
     very very fast.
     <br />
     <br />
-    Sort of wishing I had used this instead of graphql for my last project. <a href="https://t.co/xPPIJ5Zqa3">
-      https://t.co/xPPIJ5Zqa3
-    </a>
+    Sort of wishing I had used this instead of graphql for my last project.{' '}
+    <a href="https://t.co/xPPIJ5Zqa3">https://t.co/xPPIJ5Zqa3</a>
   </p>
-  &mdash; Matt Pocock (@mattpocockuk) <a href="https://twitter.com/mattpocockuk/status/1537761528962764802?ref_src=twsrc%5Etfw">June 17, 2022</a>
+  &mdash; Matt Pocock (@mattpocockuk){' '}
+  <a href="https://twitter.com/mattpocockuk/status/1537761528962764802?ref_src=twsrc%5Etfw">
+    June 17, 2022
+  </a>
 </blockquote> <script
   async
   src="https://platform.twitter.com/widgets.js"
@@ -37,7 +39,8 @@ Do you love or hate tRPC? Feel free to ping [@alexdotjs on Twitter](https://twit
     <br />
     Haven&#39;t thought about client state much but the former probably applies.
   </p>
-  &mdash; Dominik 🇺🇦 (@TkDodo) <a href="https://twitter.com/TkDodo/status/1573391189373751297?ref_src=twsrc%5Etfw">
+  &mdash; Dominik 🇺🇦 (@TkDodo){' '}
+  <a href="https://twitter.com/TkDodo/status/1573391189373751297?ref_src=twsrc%5Etfw">
     September 23, 2022
   </a>
 </blockquote> <script
@@ -54,7 +57,10 @@ Do you love or hate tRPC? Feel free to ping [@alexdotjs on Twitter](https://twit
     <br />I know I shill it a lot but seriously, please try{' '}
     <a href="https://twitter.com/trpcio?ref_src=twsrc%5Etfw">@trpcio</a>
   </p>
-  &mdash; Theo - t3.gg (@t3dotgg) <a href="https://twitter.com/t3dotgg/status/1571922456239284224?ref_src=twsrc%5Etfw">September 19, 2022</a>
+  &mdash; Theo - t3.gg (@t3dotgg){' '}
+  <a href="https://twitter.com/t3dotgg/status/1571922456239284224?ref_src=twsrc%5Etfw">
+    September 19, 2022
+  </a>
 </blockquote> <script
   async
   src="https://platform.twitter.com/widgets.js"
@@ -71,7 +77,8 @@ Do you love or hate tRPC? Feel free to ping [@alexdotjs on Twitter](https://twit
     Why? The &quot;t&quot; - TypeScript means you get end-to-end type safety
     PLUS auto-complete for your query keys everywhere, like `invalidateQueries`.
   </p>
-  &mdash; R. Alex Anderson 🚀 (@ralex1993) <a href="https://twitter.com/ralex1993/status/1556619478556876802?ref_src=twsrc%5Etfw">
+  &mdash; R. Alex Anderson 🚀 (@ralex1993){' '}
+  <a href="https://twitter.com/ralex1993/status/1556619478556876802?ref_src=twsrc%5Etfw">
     August 8, 2022
   </a>
 </blockquote> <script
@@ -87,11 +94,15 @@ Do you love or hate tRPC? Feel free to ping [@alexdotjs on Twitter](https://twit
     <br />I *LOVE* this project!
     <br />
     <br />
-    If you&#39;re building your client and server with TypeScript, tRPC allows you
-    to have static verification of your communication protocol with *zero* overhead
-    on the client.<a href="https://t.co/qsyjD9et3R">https://t.co/qsyjD9et3R</a>
+    If you&#39;re building your client and server with TypeScript, tRPC allows
+    you to have static verification of your communication protocol with *zero*
+    overhead on the client.
+    <a href="https://t.co/qsyjD9et3R">https://t.co/qsyjD9et3R</a>
   </p>
-  &mdash; Minko Gechev (@mgechev) <a href="https://twitter.com/mgechev/status/1549140656752234496?ref_src=twsrc%5Etfw">July 18, 2022</a>
+  &mdash; Minko Gechev (@mgechev){' '}
+  <a href="https://twitter.com/mgechev/status/1549140656752234496?ref_src=twsrc%5Etfw">
+    July 18, 2022
+  </a>
 </blockquote> <script
   async
   src="https://platform.twitter.com/widgets.js"
@@ -102,7 +113,10 @@ Do you love or hate tRPC? Feel free to ping [@alexdotjs on Twitter](https://twit
   <p lang="en" dir="ltr">
     tRPC is super cool. Mucho magic there and good magic at that.
   </p>
-  &mdash; Tanner Linsley (@tannerlinsley) <a href="https://twitter.com/tannerlinsley/status/1507753424187650048?ref_src=twsrc%5Etfw">March 26, 2022</a>
+  &mdash; Tanner Linsley (@tannerlinsley){' '}
+  <a href="https://twitter.com/tannerlinsley/status/1507753424187650048?ref_src=twsrc%5Etfw">
+    March 26, 2022
+  </a>
 </blockquote> <script
   async
   src="https://platform.twitter.com/widgets.js"
@@ -114,7 +128,10 @@ Do you love or hate tRPC? Feel free to ping [@alexdotjs on Twitter](https://twit
     Hah, we just did our first endpoint, returned some mock data from a resolver
     and got instant autocomplete in the client. Everyone&#39;s heads went 🤯🥳
   </p>
-  &mdash; Marcus Rådell 🦀 (@marcusradell) <a href="https://twitter.com/marcusradell/status/1402991694446952458?ref_src=twsrc%5Etfw">June 10, 2021</a>
+  &mdash; Marcus Rådell 🦀 (@marcusradell){' '}
+  <a href="https://twitter.com/marcusradell/status/1402991694446952458?ref_src=twsrc%5Etfw">
+    June 10, 2021
+  </a>
 </blockquote>
 
 <blockquote className="twitter-tweet">
@@ -127,7 +144,10 @@ Do you love or hate tRPC? Feel free to ping [@alexdotjs on Twitter](https://twit
     what are the other challengers?{' '}
     <a href="https://t.co/qFxfjzg0fa">https://t.co/qFxfjzg0fa</a>
   </p>
-  &mdash; Colin McDonnell (@colinhacks) <a href="https://twitter.com/colinhacks/status/1629950516242313216?ref_src=twsrc%5Etfw">February 26, 2023</a>
+  &mdash; Colin McDonnell (@colinhacks){' '}
+  <a href="https://twitter.com/colinhacks/status/1629950516242313216?ref_src=twsrc%5Etfw">
+    February 26, 2023
+  </a>
 </blockquote> <script
   async
   src="https://platform.twitter.com/widgets.js"
@@ -141,14 +161,20 @@ Do you love or hate tRPC? Feel free to ping [@alexdotjs on Twitter](https://twit
     We built a nextjs website with trpc and it has worked wonderful 🙌{' '}
     <em>[...]</em>
   </p>
-  &mdash; cNille <a href="https://github.com/trpc/trpc/issues/775#issue-966343527">Aug 11, 2021</a>
+  &mdash; cNille{' '}
+  <a href="https://github.com/trpc/trpc/issues/775#issue-966343527">
+    Aug 11, 2021
+  </a>
 </blockquote>
 
 <blockquote className="github-comment">
   <p lang="en" dir="ltr">
     Hi - have just started using trpc and it is 👌 <em>[...]</em>
   </p>
-  &mdash; mmkal <a href="https://github.com/trpc/trpc/issues/703#issue-950972268">July 22, 2021</a>
+  &mdash; mmkal{' '}
+  <a href="https://github.com/trpc/trpc/issues/703#issue-950972268">
+    July 22, 2021
+  </a>
 </blockquote>
 
 <blockquote className="github-comment">
@@ -157,7 +183,10 @@ Do you love or hate tRPC? Feel free to ping [@alexdotjs on Twitter](https://twit
     in Next.js projects is something I have been trying to achieve for a while
     and your solution here ticks all the boxes. <em>[...]</em>
   </p>
-  &mdash; dangreaves <a href="https://github.com/trpc/trpc/discussions/455#discussion-3392848">June 2, 2021</a>
+  &mdash; dangreaves{' '}
+  <a href="https://github.com/trpc/trpc/discussions/455#discussion-3392848">
+    June 2, 2021
+  </a>
 </blockquote>
 
 <blockquote className="github-comment">
@@ -166,7 +195,10 @@ Do you love or hate tRPC? Feel free to ping [@alexdotjs on Twitter](https://twit
     was already looking for a library like this for quite some time.{' '}
     <em>[...]</em>
   </p>
-  &mdash; simonedelmann <a href="https://github.com/trpc/trpc/issues/378#issue-893740950">May 17, 2021</a>
+  &mdash; simonedelmann{' '}
+  <a href="https://github.com/trpc/trpc/issues/378#issue-893740950">
+    May 17, 2021
+  </a>
 </blockquote>
 
 <blockquote className="github-comment">
@@ -175,12 +207,18 @@ Do you love or hate tRPC? Feel free to ping [@alexdotjs on Twitter](https://twit
     feels like a much more lightweight approach to my typical
     Prisma-Nexus-Apollo-GQL Codegen stack. <em>[...]</em>
   </p>
-  &mdash; lostfictions <a href="https://github.com/trpc/trpc/pull/712#issue-696293837">June 24, 2021</a>
+  &mdash; lostfictions{' '}
+  <a href="https://github.com/trpc/trpc/pull/712#issue-696293837">
+    June 24, 2021
+  </a>
 </blockquote>
 
 <blockquote className="github-comment">
   <p lang="en" dir="ltr">
     Thank you for the quick fix and the amazing project 💯
   </p>
-  &mdash; mgranderath <a href="https://github.com/trpc/trpc/issues/331#issuecomment-831263018">May 3, 2021</a>
+  &mdash; mgranderath{' '}
+  <a href="https://github.com/trpc/trpc/issues/331#issuecomment-831263018">
+    May 3, 2021
+  </a>
 </blockquote>

--- a/www/versioned_docs/version-10.x/server/authorization.md
+++ b/www/versioned_docs/version-10.x/server/authorization.md
@@ -72,24 +72,24 @@ import { initTRPC, TRPCError } from '@trpc/server';
 export const t = initTRPC.context<Context>().create();
 
 // you can reuse this for any procedure
-export const protectedProcedure = t.procedure.use(async function isAuthed(
-  opts,
-) {
-  const { ctx } = opts;
-  // `ctx.user` is nullable
-  if (!ctx.user) {
-    //     ^?
-    throw new TRPCError({ code: 'UNAUTHORIZED' });
-  }
+export const protectedProcedure = t.procedure.use(
+  async function isAuthed(opts) {
+    const { ctx } = opts;
+    // `ctx.user` is nullable
+    if (!ctx.user) {
+      //     ^?
+      throw new TRPCError({ code: 'UNAUTHORIZED' });
+    }
 
-  return opts.next({
-    ctx: {
-      // ✅ user value is known to be non-null now
-      user: ctx.user,
-      // ^?
-    },
-  });
-});
+    return opts.next({
+      ctx: {
+        // ✅ user value is known to be non-null now
+        user: ctx.user,
+        // ^?
+      },
+    });
+  },
+);
 
 t.router({
   // this is accessible for everyone

--- a/www/versioned_docs/version-10.x/server/validators.md
+++ b/www/versioned_docs/version-10.x/server/validators.md
@@ -351,7 +351,9 @@ const publicProcedure = t.procedure;
 export const appRouter = t.router({
   hello: publicProcedure
     .input(Schema.decodeUnknownSync(Schema.Struct({ name: Schema.String })))
-    .output(Schema.decodeUnknownSync(Schema.Struct({ greeting: Schema.String })))
+    .output(
+      Schema.decodeUnknownSync(Schema.Struct({ greeting: Schema.String })),
+    )
     .query(({ input }) => {
       //      ^?
       return {


### PR DESCRIPTION
Starts on #5867.

## 🎯 Changes

Bumps `prettier` to the latest version, in a new major version 3. Runs `pnpm format --write` to apply formatting updates.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
