### PR TITLE
fix(server): forward `sseSubscription`-options to `sseStreamProducer`

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/http/resolveResponse.ts
+++ b/packages/server/src/unstable-core-do-not-import/http/resolveResponse.ts
@@ -380,6 +380,7 @@ export async function resolveResponse<TRouter extends AnyRouter>(
             ? observableToAsyncIterable(data)
             : data;
           const stream = sseStreamProducer({
+            ...router._def._config.experimental?.sseSubscriptions,
             data: dataAsIterable,
             serialize: (v) => config.transformer.output.serialize(v),
           });


### PR DESCRIPTION
Closes #

## 🎯 Changes


This currently makes it so that forwarding e.g. ping options don't work