### PR TITLE
fix(client) `throwIfAborted` usage for React Native

### DIFF
--- a/packages/client/src/links/internals/httpUtils.ts
+++ b/packages/client/src/links/internals/httpUtils.ts
@@ -161,7 +161,7 @@ export type HTTPRequestOptions = ContentOptions &
 
 export async function fetchHTTPResponse(opts: HTTPRequestOptions) {
   if (opts.signal?.aborted) {
-    throw new Error(opts.signal.reason || 'Aborted')
+    throw new Error('AbortError')
   }
 
   const url = opts.getUrl(opts);

--- a/packages/client/src/links/internals/httpUtils.ts
+++ b/packages/client/src/links/internals/httpUtils.ts
@@ -160,7 +160,10 @@ export type HTTPRequestOptions = ContentOptions &
   };
 
 export async function fetchHTTPResponse(opts: HTTPRequestOptions) {
-  opts.signal?.throwIfAborted();
+  if (opts.signal?.aborted) {
+    throw new Error(opts.signal.reason || 'Aborted')
+  }
+
   const url = opts.getUrl(opts);
   const body = opts.getBody(opts);
   const { type } = opts;

--- a/packages/client/src/links/internals/httpUtils.ts
+++ b/packages/client/src/links/internals/httpUtils.ts
@@ -154,6 +154,17 @@ export const jsonHttpRequester: Requester = (opts) => {
   });
 };
 
+/**
+ * Polyfill for DOMException with AbortError name
+ */
+class AbortError extends Error {
+  constructor(message = "aborted") {
+    super(message);
+    this.name = "AbortError";
+    this.message = message;
+  }
+}
+
 export type HTTPRequestOptions = ContentOptions &
   HTTPBaseRequestOptions & {
     headers: () => HTTPHeaders | Promise<HTTPHeaders>;
@@ -161,7 +172,7 @@ export type HTTPRequestOptions = ContentOptions &
 
 export async function fetchHTTPResponse(opts: HTTPRequestOptions) {
   if (opts.signal?.aborted) {
-    throw new Error('AbortError')
+    throw new AbortError()
   }
 
   const url = opts.getUrl(opts);

--- a/packages/client/src/links/internals/httpUtils.ts
+++ b/packages/client/src/links/internals/httpUtils.ts
@@ -172,7 +172,7 @@ export type HTTPRequestOptions = ContentOptions &
 
 export async function fetchHTTPResponse(opts: HTTPRequestOptions) {
   if (opts.signal?.aborted) {
-    throw new AbortError()
+    throw new AbortError();
   }
 
   const url = opts.getUrl(opts);


### PR DESCRIPTION
Closes #

## 🎯 Changes

`AbortSignal.throwIfAborted()` is NOT available on React Native and causes all tRPC procedures to fail on React Native. Since there is no good widely maintained polyfill for `AbortController / AbortSignal`, we could just use a straighforward implementation instead of using `throwIfAborted` directly (+ lightweight polyfill for `AbortError`)

This error was introduced with `11.0.0-rc.455` tag here:

https://github.com/trpc/trpc/pull/5865/files#diff-d2f09745539c905e09fb5b0eabdfddcca87cb2496a3bc9ddcd585c89e4620e8eR163

Alternative approach to this PR is bring back the deleted `AbortControllerInstanceEsque` polyfill and add our implementations there.

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
