### PR TITLE
patch: use `globalThis.` over `global.`

### DIFF
--- a/examples/next-prisma-starter/src/server/prisma.ts
+++ b/examples/next-prisma-starter/src/server/prisma.ts
@@ -5,7 +5,7 @@
 import { env } from './env';
 import { PrismaClient } from '@prisma/client';
 
-const prismaGlobal = global as typeof global & {
+const prismaGlobal = globalThis as typeof globalThis & {
   prisma?: PrismaClient;
 };
 

--- a/examples/next-prisma-websockets-starter/src/server/prisma.ts
+++ b/examples/next-prisma-websockets-starter/src/server/prisma.ts
@@ -4,7 +4,7 @@
  */
 import { PrismaClient } from '@prisma/client';
 
-const prismaGlobal = global as typeof global & {
+const prismaGlobal = globalThis as typeof globalThis & {
   prisma?: PrismaClient;
 };
 

--- a/packages/server/src/adapters/ws.ts
+++ b/packages/server/src/adapters/ws.ts
@@ -148,7 +148,7 @@ export function getWSConnectionHandler<TRouter extends AnyRouter>(
         });
 
         // close in next tick
-        (global.setImmediate ?? global.setTimeout)(() => {
+        (globalThis.setImmediate ?? globalThis.setTimeout)(() => {
           client.close();
         });
 

--- a/packages/tests/server/createClient.test.ts
+++ b/packages/tests/server/createClient.test.ts
@@ -1,6 +1,6 @@
 import { createTRPCClient, httpBatchLink } from '@trpc/client';
 
-global.fetch = vi.fn() as any;
+globalThis.fetch = vi.fn() as any;
 
 describe('typedefs on createClient', () => {
   test('ok to pass only links', () => {

--- a/packages/tests/server/react/regression/issue-1645-setErrorStatusSSR.test.tsx
+++ b/packages/tests/server/react/regression/issue-1645-setErrorStatusSSR.test.tsx
@@ -22,7 +22,7 @@ test('regression: SSR with error sets `status`=`error`', async () => {
 
   let queryState: any;
   // @ts-ignore
-  delete global.window;
+  delete globalThis.window;
   const { trpc, trpcClientOptions } = factory;
   const App: AppType = () => {
     // @ts-ignore
@@ -54,7 +54,7 @@ test('regression: SSR with error sets `status`=`error`', async () => {
   } as any);
 
   // @ts-ignore
-  global.window = window;
+  globalThis.window = window;
   expect(queryState.query1.error).toMatchInlineSnapshot(
     `[TRPCClientError: No procedure found on path "bad_useQuery"]`,
   );

--- a/packages/tests/server/react/withTRPC.test.tsx
+++ b/packages/tests/server/react/withTRPC.test.tsx
@@ -20,7 +20,7 @@ describe('withTRPC()', () => {
     const { window } = global;
 
     // @ts-ignore
-    delete global.window;
+    delete globalThis.window;
     const { trpc, trpcClientOptions } = ctx;
     const App: AppType = () => {
       const query = trpc.allPosts.useQuery();
@@ -39,7 +39,7 @@ describe('withTRPC()', () => {
     } as any);
 
     // @ts-ignore
-    global.window = window;
+    globalThis.window = window;
     const utils = render(<Wrapped {...props} />);
     expect(utils.container).toHaveTextContent('first post');
   });
@@ -49,7 +49,7 @@ describe('withTRPC()', () => {
       // @ts-ignore
       const { window } = global;
       // @ts-ignore
-      delete global.window;
+      delete globalThis.window;
       const { trpc, trpcClientOptions } = ctx;
       const App: AppType = () => {
         const query = trpc.allPosts.useQuery();
@@ -74,7 +74,7 @@ describe('withTRPC()', () => {
         ctx: mockContext,
       } as any);
       // @ts-ignore
-      global.window = window;
+      globalThis.window = window;
       const utils = render(<Wrapped {...props} />);
       expect(utils.container).toHaveTextContent('first post');
     });
@@ -83,7 +83,7 @@ describe('withTRPC()', () => {
       // @ts-ignore
       const { window } = global;
       // @ts-ignore
-      delete global.window;
+      delete globalThis.window;
       const { trpc, trpcClientOptions } = ctx;
       const App: AppType = () => {
         const query = trpc.allPosts.useQuery();
@@ -108,7 +108,7 @@ describe('withTRPC()', () => {
         ctx: mockContext,
       } as any);
       // @ts-ignore
-      global.window = window;
+      globalThis.window = window;
       const utils = render(<Wrapped {...props} />);
       expect(utils.container).not.toHaveTextContent('first post');
     });
@@ -117,7 +117,7 @@ describe('withTRPC()', () => {
       // @ts-ignore
       const { window } = global;
       // @ts-ignore
-      delete global.window;
+      delete globalThis.window;
       const { trpc, trpcClientOptions } = ctx;
       const App: AppType = () => {
         const query = trpc.allPosts.useQuery();
@@ -142,7 +142,7 @@ describe('withTRPC()', () => {
         ctx: mockContext,
       } as any);
       // @ts-ignore
-      global.window = window;
+      globalThis.window = window;
       const utils = render(<Wrapped {...props} />);
       expect(utils.container).not.toHaveTextContent('first post');
     });
@@ -151,7 +151,7 @@ describe('withTRPC()', () => {
       // @ts-ignore
       const { window } = global;
       // @ts-ignore
-      delete global.window;
+      delete globalThis.window;
       const { trpc, trpcClientOptions } = ctx;
       const App: AppType = () => {
         const query = trpc.allPosts.useQuery();
@@ -177,7 +177,7 @@ describe('withTRPC()', () => {
         ctx: mockContext,
       } as any);
       // @ts-ignore
-      global.window = window;
+      globalThis.window = window;
       const utils = render(<Wrapped {...props} />);
       expect(utils.container).toHaveTextContent('first post');
     }, 7000); // increase the timeout just for this test
@@ -213,7 +213,7 @@ describe('withTRPC()', () => {
       const { window } = global;
 
       // @ts-ignore
-      delete global.window;
+      delete globalThis.window;
       const { trpc, trpcClientOptions } = ctx;
 
       const App: AppType = () => {
@@ -248,7 +248,7 @@ describe('withTRPC()', () => {
         ctx: mockContext,
       } as any);
 
-      global.window = window;
+      globalThis.window = window;
 
       const utils = render(<Wrapped {...props} />);
       expect(utils.container).not.toHaveTextContent('first post');
@@ -293,7 +293,7 @@ describe('withTRPC()', () => {
     const { window } = global;
 
     // @ts-ignore
-    delete global.window;
+    delete globalThis.window;
     const { trpc, trpcClientOptions } = ctx;
     const App: AppType = () => {
       const results = trpc.useQueries((t) => {
@@ -352,7 +352,7 @@ describe('withTRPC()', () => {
     `);
 
     // @ts-ignore
-    global.window = window;
+    globalThis.window = window;
 
     const utils = render(<Wrapped {...props} />);
     expect(utils.container).toHaveTextContent('first post');
@@ -362,7 +362,7 @@ describe('withTRPC()', () => {
     const { window } = global;
 
     // @ts-ignore
-    delete global.window;
+    delete globalThis.window;
     const { trpc, trpcClientOptions } = ctx;
     const App: AppType = () => {
       const query = trpc.paginatedPosts.useInfiniteQuery(
@@ -387,7 +387,7 @@ describe('withTRPC()', () => {
       Component: <div />,
     } as any);
 
-    global.window = window;
+    globalThis.window = window;
 
     const utils = render(<Wrapped {...props} />);
     expect(utils.container).toHaveTextContent('first post');
@@ -423,7 +423,7 @@ describe('withTRPC()', () => {
       const { window } = global;
 
       // @ts-ignore
-      delete global.window;
+      delete globalThis.window;
       const { trpc, trpcClientOptions } = ctx;
       const App: AppType = () => {
         const query = trpc.allPosts.useQuery(undefined, {
@@ -443,7 +443,7 @@ describe('withTRPC()', () => {
         Component: <div />,
       } as any);
 
-      global.window = window;
+      globalThis.window = window;
 
       const utils = render(<Wrapped {...props} />);
       expect(utils.container).not.toHaveTextContent('first post');
@@ -458,7 +458,7 @@ describe('withTRPC()', () => {
       const { window } = global;
 
       // @ts-ignore
-      delete global.window;
+      delete globalThis.window;
       const { trpc, trpcClientOptions } = ctx;
       const App: AppType = () => {
         const query = trpc.paginatedPosts.useInfiniteQuery(
@@ -486,7 +486,7 @@ describe('withTRPC()', () => {
         Component: <div />,
       } as any);
 
-      global.window = window;
+      globalThis.window = window;
 
       const utils = render(<Wrapped {...props} />);
       expect(utils.container).not.toHaveTextContent('first post');
@@ -503,7 +503,7 @@ describe('withTRPC()', () => {
     const { window } = global;
 
     // @ts-ignore
-    delete global.window;
+    delete globalThis.window;
     const { trpc, trpcClientOptions, createContext } = ctx;
     const App: AppType = () => {
       const query1 = trpc.postById.useQuery('1');
@@ -524,7 +524,7 @@ describe('withTRPC()', () => {
     } as any);
 
     // @ts-ignore
-    global.window = window;
+    globalThis.window = window;
 
     const utils = render(<Wrapped {...props} />);
     expect(utils.container).toHaveTextContent('first post');
@@ -540,7 +540,7 @@ describe('withTRPC()', () => {
         const { window } = global;
 
         // @ts-ignore
-        delete global.window;
+        delete globalThis.window;
         const { trpc, trpcClientOptions } = ctx;
         const App: AppType = () => {
           const query1 = trpc.postById.useQuery('1');
@@ -567,7 +567,7 @@ describe('withTRPC()', () => {
           Component: <div />,
         } as any);
 
-        global.window = window;
+        globalThis.window = window;
 
         const utils = render(<Wrapped {...props} />);
 
@@ -584,7 +584,7 @@ describe('withTRPC()', () => {
         const { window } = global;
 
         // @ts-ignore
-        delete global.window;
+        delete globalThis.window;
         const { trpc, trpcClientOptions } = ctx;
         const App: AppType = () => {
           const query1 = trpc.postById.useQuery('1');
@@ -617,7 +617,7 @@ describe('withTRPC()', () => {
           };
         };
 
-        global.window = window;
+        globalThis.window = window;
 
         const utils = render(<Wrapped {...(props as any)} />);
 
@@ -633,7 +633,7 @@ describe('withTRPC()', () => {
         const { window } = global;
 
         // @ts-ignore
-        delete global.window;
+        delete globalThis.window;
         const { trpc, trpcClientOptions } = ctx;
         const App: AppType = () => {
           const query1 = trpc.postById.useQuery('1');
@@ -666,7 +666,7 @@ describe('withTRPC()', () => {
           Component: <div />,
         } as any);
 
-        global.window = window;
+        globalThis.window = window;
 
         const utils = render(<Wrapped {...props} />);
 
@@ -686,7 +686,7 @@ describe('withTRPC()', () => {
         const { window } = global;
 
         // @ts-ignore
-        delete global.window;
+        delete globalThis.window;
         const { trpc, trpcClientOptions } = ctx;
         const App: AppType = () => {
           const query1 = trpc.paginatedPosts.useInfiniteQuery(
@@ -722,7 +722,7 @@ describe('withTRPC()', () => {
           Component: <div />,
         } as any);
 
-        global.window = window;
+        globalThis.window = window;
 
         const utils = render(<Wrapped {...props} />);
 
@@ -740,7 +740,7 @@ describe('withTRPC()', () => {
         const { window } = global;
 
         // @ts-ignore
-        delete global.window;
+        delete globalThis.window;
         const { trpc, trpcClientOptions } = ctx;
         const App: AppType = () => {
           const query1 = trpc.paginatedPosts.useInfiniteQuery(
@@ -776,7 +776,7 @@ describe('withTRPC()', () => {
           Component: <div />,
         } as any);
 
-        global.window = window;
+        globalThis.window = window;
 
         const utils = render(<Wrapped {...props} />);
 
@@ -798,7 +798,7 @@ describe('withTRPC()', () => {
       const { window } = global;
 
       // @ts-ignore
-      delete global.window;
+      delete globalThis.window;
       const { trpc, trpcClientOptions } = ctx;
       const App = () => {
         const query = trpc.allPosts.useQuery();
@@ -810,7 +810,7 @@ describe('withTRPC()', () => {
       })(App);
 
       // @ts-ignore
-      global.window = window;
+      globalThis.window = window;
 
       const utils = render(<Wrapped />);
       expect(utils.container).not.toHaveTextContent('first post');
@@ -825,7 +825,7 @@ describe('withTRPC()', () => {
       const { window } = global;
 
       // @ts-ignore
-      delete global.window;
+      delete globalThis.window;
       const { trpc, trpcClientOptions } = ctx;
       const App = () => {
         const query = trpc.allPosts.useQuery();
@@ -839,7 +839,7 @@ describe('withTRPC()', () => {
       })(App);
 
       // @ts-ignore
-      global.window = window;
+      globalThis.window = window;
 
       // ssr should not work
 

--- a/packages/tests/server/regression/issue-4130-ssr-different-transformers.test.tsx
+++ b/packages/tests/server/regression/issue-4130-ssr-different-transformers.test.tsx
@@ -49,7 +49,7 @@ test('withTRPC - SSR', async () => {
   const { window } = global;
 
   // @ts-ignore
-  delete global.window;
+  delete globalThis.window;
 
   const trpc = createTRPCNext({
     config() {
@@ -98,5 +98,5 @@ test('withTRPC - SSR', async () => {
   `);
 
   // @ts-ignore
-  global.window = window;
+  globalThis.window = window;
 });

--- a/www/docs/client/links/httpSubscriptionLink.md
+++ b/www/docs/client/links/httpSubscriptionLink.md
@@ -203,10 +203,10 @@ import { ReadableStream, TransformStream } from 'web-streams-polyfill';
 declare global {
   interface EventSource extends RNEventSource {}
 }
-global.EventSource = global.EventSource || RNEventSource;
+globalThis.EventSource = globalThis.EventSource || RNEventSource;
 
-global.ReadableStream = global.ReadableStream || ReadableStream;
-global.TransformStream = global.TransformStream || TransformStream;
+globalThis.ReadableStream = globalThis.ReadableStream || ReadableStream;
+globalThis.TransformStream = globalThis.TransformStream || TransformStream;
 ```
 
 Once the polyfills are added, you can continue setting up the `httpSubscriptionLink` as described in the [setup](#setup) section.


### PR DESCRIPTION
Closes #5889

## 🎯 Changes

Use `globalThis` instead of `global`