### PR TITLE
fix: `httpSubscriptionLink` deserialization by using output deserializer

### DIFF
--- a/packages/client/src/links/httpSubscriptionLink.ts
+++ b/packages/client/src/links/httpSubscriptionLink.ts
@@ -95,7 +95,7 @@ export function unstable_httpSubscriptionLink<
           eventSource.addEventListener('open', onStarted);
           const iterable = sseStreamConsumer<Partial<SSEMessage>>({
             from: eventSource,
-            deserialize: transformer.input.deserialize,
+            deserialize: transformer.output.deserialize,
           });
 
           for await (const chunk of iterable) {


### PR DESCRIPTION
Closes #5900

## 🎯 Changes

Change de-serializer from `input` to `output`:
> https://github.com/trpc/trpc/blob/755f28799f40eb7fb56d065b6793af10271d407c/packages/client/src/links/httpSubscriptionLink.ts#L98

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
