### PR TITLE
feat(client): allow `eventSourceOptions` to be a callback

### DIFF
--- a/packages/client/src/links/httpSubscriptionLink.ts
+++ b/packages/client/src/links/httpSubscriptionLink.ts
@@ -12,6 +12,7 @@ import {
 import { TRPCClientError } from '../TRPCClientError';
 import { getTransformer, type TransformerOptions } from '../unstable-internals';
 import { getUrl } from './internals/httpUtils';
+import type { CallbackOrValue } from './internals/urlWithConnectionParams';
 import {
   resultOf,
   type UrlOptionsWithConnectionParams,
@@ -37,7 +38,7 @@ type HTTPSubscriptionLinkOptions<TRoot extends AnyClientTypes> = {
   /**
    * EventSource options
    */
-  eventSourceOptions?: EventSourceInit;
+  eventSourceOptions?: CallbackOrValue<EventSourceInit>;
 } & TransformerOptions<TRoot> &
   UrlOptionsWithConnectionParams;
 
@@ -72,12 +73,13 @@ export function unstable_httpSubscriptionLink<
             signal: null,
           });
 
+          const eventSourceOptions = await resultOf(opts.eventSourceOptions);
           /* istanbul ignore if -- @preserve */
           if (unsubscribed) {
             // already unsubscribed - rare race condition
             return;
           }
-          eventSource = new EventSource(url, opts.eventSourceOptions);
+          eventSource = new EventSource(url, eventSourceOptions);
           const onStarted = () => {
             observer.next({
               result: {

--- a/packages/client/src/links/httpSubscriptionLink.ts
+++ b/packages/client/src/links/httpSubscriptionLink.ts
@@ -51,7 +51,7 @@ export function unstable_httpSubscriptionLink<
   opts: HTTPSubscriptionLinkOptions<inferClientTypes<TInferrable>>,
 ): TRPCLink<TInferrable> {
   const transformer = getTransformer(opts.transformer);
-  const ES = opts.EventSource ?? EventSource;
+
   return () => {
     return ({ op }) => {
       return observable((observer) => {
@@ -80,7 +80,7 @@ export function unstable_httpSubscriptionLink<
             // already unsubscribed - rare race condition
             return;
           }
-          eventSource = new ES(url, eventSourceOptions);
+          eventSource = new EventSource(url, eventSourceOptions);
           const onStarted = () => {
             observer.next({
               result: {

--- a/packages/client/src/links/httpSubscriptionLink.ts
+++ b/packages/client/src/links/httpSubscriptionLink.ts
@@ -55,6 +55,7 @@ export function unstable_httpSubscriptionLink<
   opts: HTTPSubscriptionLinkOptions<inferClientTypes<TInferrable>>,
 ): TRPCLink<TInferrable> {
   const transformer = getTransformer(opts.transformer);
+  const ES = opts.EventSource ?? EventSource;
   return () => {
     return ({ op }) => {
       return observable((observer) => {
@@ -83,7 +84,7 @@ export function unstable_httpSubscriptionLink<
             // already unsubscribed - rare race condition
             return;
           }
-          eventSource = new EventSource(url, eventSourceOptions);
+          eventSource = new ES(url, eventSourceOptions);
           const onStarted = () => {
             observer.next({
               result: {

--- a/packages/client/src/links/httpSubscriptionLink.ts
+++ b/packages/client/src/links/httpSubscriptionLink.ts
@@ -36,13 +36,9 @@ async function urlWithConnectionParams(
 
 type HTTPSubscriptionLinkOptions<TRoot extends AnyClientTypes> = {
   /**
-   * EventSource options
+   * EventSource options or a callback that returns them
    */
   eventSourceOptions?: CallbackOrValue<EventSourceInit>;
-  /**
-   * A ponyfill for EventSource
-   */
-  EventSource: typeof EventSource;
 } & TransformerOptions<TRoot> &
   UrlOptionsWithConnectionParams;
 

--- a/packages/client/src/links/httpSubscriptionLink.ts
+++ b/packages/client/src/links/httpSubscriptionLink.ts
@@ -39,6 +39,10 @@ type HTTPSubscriptionLinkOptions<TRoot extends AnyClientTypes> = {
    * EventSource options
    */
   eventSourceOptions?: CallbackOrValue<EventSourceInit>;
+  /**
+   * A ponyfill for EventSource
+   */
+  EventSource: typeof EventSource;
 } & TransformerOptions<TRoot> &
   UrlOptionsWithConnectionParams;
 

--- a/packages/client/src/links/internals/urlWithConnectionParams.ts
+++ b/packages/client/src/links/internals/urlWithConnectionParams.ts
@@ -10,7 +10,7 @@ export const resultOf = <T>(value: T | (() => T)): T => {
 /**
  * A value that can be wrapped in callback
  */
-type CallbackOrValue<T> = T | (() => T | Promise<T>);
+export type CallbackOrValue<T> = T | (() => T | Promise<T>);
 
 export interface UrlOptionsWithConnectionParams {
   /**

--- a/www/docs/client/links/httpSubscriptionLink.md
+++ b/www/docs/client/links/httpSubscriptionLink.md
@@ -228,5 +228,9 @@ type HTTPSubscriptionLinkOptions<TRoot extends AnyClientTypes> = {
    * @link https://trpc.io/docs/v11/data-transformers
    **/
   transformer?: DataTransformerOptions;
+  /**
+   * A ponyfill for EventSource
+   */
+  EventSource?: Constructor<EventSource>;
 };
 ```

--- a/www/docs/client/links/httpSubscriptionLink.md
+++ b/www/docs/client/links/httpSubscriptionLink.md
@@ -184,7 +184,7 @@ const trpc = createTRPCClient<AppRouter>({
 
 ## Authorization by polyfilling `EventSource` and passing `eventSourceOptions` {#authorization-by-polyfilling-eventsource}
 
-You can also force polyfill `EventSource` and use the `options` -callback instead of `connectionParams`.
+You can also polyfill `EventSource` and use the `options` -callback instead of `connectionParams`.
 
 ```tsx
 import {

--- a/www/docs/client/links/httpSubscriptionLink.md
+++ b/www/docs/client/links/httpSubscriptionLink.md
@@ -212,7 +212,7 @@ const trpc = createTRPCClient<AppRouter>({
             headers: {
               'authorization': 'Bearer supersecret'
             }
-          } as any;
+          }; // you either need to typecast to `EventSourceInit` or use `as any` or override the types by a `declare global` statement
         }
       }),
       false: httpBatchLink({

--- a/www/docs/client/links/httpSubscriptionLink.md
+++ b/www/docs/client/links/httpSubscriptionLink.md
@@ -182,7 +182,7 @@ const trpc = createTRPCClient<AppRouter>({
 });
 ```
 
-### Don't like passing `connectionParams` as part of the URL?
+## Authorization by polyfilling `EventSource` and passing `eventSourceOptions` {#authorization-by-polyfilling-eventsource}
 
 You can also force polyfill `EventSource` and use the `options` -callback instead of `connectionParams`.
 


### PR DESCRIPTION
Closes #

## 🎯 Changes

Add ability for `eventSourceOptions` to be a callback

Useful when polyfilling `EventSource` with a more "rich" version

**📚  Docs:** https://www-git-07-17-eventsource-options-trpc.vercel.app/docs/client/links/httpSubscriptionLink#authorization-by-polyfilling-eventsourc