### PR TITLE
`sse({id, data})` -> `tracked(id, data)`

### DIFF
--- a/examples/next-sse-chat/src/server/routers/post.ts
+++ b/examples/next-sse-chat/src/server/routers/post.ts
@@ -1,4 +1,4 @@
-import { sse } from '@trpc/server';
+import { sse, tracked } from '@trpc/server';
 import { streamToAsyncIterable } from '~/lib/stream-to-async-iterator';
 import { db } from '~/server/db/client';
 import { Post, type PostType } from '~/server/db/schema';
@@ -102,7 +102,7 @@ export const postRouter = router({
       };
 
       // We use a readable stream here to prevent the client from missing events
-      // created between the fetching & yield'ing of `newItemsSinceCursor` and the 
+      // created between the fetching & yield'ing of `newItemsSinceCursor` and the
       // subscription to the ee
       const stream = new ReadableStream<PostType>({
         async start(controller) {
@@ -137,11 +137,8 @@ export const postRouter = router({
       });
 
       for await (const post of streamToAsyncIterable(stream)) {
-        yield sse({
-          // yielding the post id ensures the client can reconnect at any time and get the latest events this id
-          id: post.id,
-          data: post,
-        });
+        // tracking the post id ensures the client can reconnect at any time and get the latest events this id
+        yield tracked(post.id, post);
       }
     }),
 });

--- a/packages/client/src/links/httpSubscriptionLink.ts
+++ b/packages/client/src/links/httpSubscriptionLink.ts
@@ -3,7 +3,6 @@ import type {
   AnyClientTypes,
   inferClientTypes,
   InferrableClientTypes,
-  TrackedMessage,
 } from '@trpc/server/unstable-core-do-not-import';
 import {
   run,
@@ -96,13 +95,18 @@ export function unstable_httpSubscriptionLink<
           };
           // console.log('starting', new Date());
           eventSource.addEventListener('open', onStarted);
-          const iterable = sseStreamConsumer<Partial<TrackedMessage>>({
+          const iterable = sseStreamConsumer<
+            Partial<{
+              id?: string;
+              data: unknown;
+            }>
+          >({
             from: eventSource,
             deserialize: transformer.output.deserialize,
           });
 
           for await (const chunk of iterable) {
-            // if the `sse({})`-helper is used, we always have an `id` field
+            // if the `tracked()`-helper is used, we always have an `id` field
             const data = 'id' in chunk ? chunk : chunk.data;
             observer.next({
               result: {

--- a/packages/client/src/links/httpSubscriptionLink.ts
+++ b/packages/client/src/links/httpSubscriptionLink.ts
@@ -3,7 +3,7 @@ import type {
   AnyClientTypes,
   inferClientTypes,
   InferrableClientTypes,
-  SSEMessage,
+  TrackedMessage,
 } from '@trpc/server/unstable-core-do-not-import';
 import {
   run,
@@ -96,7 +96,7 @@ export function unstable_httpSubscriptionLink<
           };
           // console.log('starting', new Date());
           eventSource.addEventListener('open', onStarted);
-          const iterable = sseStreamConsumer<Partial<SSEMessage>>({
+          const iterable = sseStreamConsumer<Partial<TrackedMessage>>({
             from: eventSource,
             deserialize: transformer.output.deserialize,
           });

--- a/packages/server/src/@trpc/server/index.ts
+++ b/packages/server/src/@trpc/server/index.ts
@@ -37,7 +37,11 @@ export {
   type QueryProcedure as TRPCQueryProcedure,
   type SubscriptionProcedure as TRPCSubscriptionProcedure,
   type TRPCBuilder,
+  /**
+   * @deprecated use `tracked(id, data)` instead
+   */
   sse,
+  tracked,
 } from '../../unstable-core-do-not-import';
 
 export type {

--- a/packages/server/src/adapters/ws.ts
+++ b/packages/server/src/adapters/ws.ts
@@ -310,7 +310,10 @@ export function getWSConnectionHandler<TRouter extends AnyRouter>(
             if (isTrackedEnvelope(next.value)) {
               const [id, data] = next.value;
               result.id = id;
-              result.data = data;
+              result.data = {
+                id,
+                data,
+              };
             }
 
             respond({

--- a/packages/server/src/adapters/ws.ts
+++ b/packages/server/src/adapters/ws.ts
@@ -27,12 +27,10 @@ import { parseConnectionParamsFromUnknown } from '../http';
 import { isObservable } from '../observable';
 import { observableToAsyncIterable } from '../observable/observable';
 // eslint-disable-next-line no-restricted-imports
-
-// eslint-disable-next-line no-restricted-imports
 import {
   isAsyncIterable,
   isObject,
-  isSSEMessageEnvelope,
+  isTrackedEnvelope,
   run,
   type MaybePromise,
 } from '../unstable-core-do-not-import';
@@ -309,10 +307,10 @@ export function getWSConnectionHandler<TRouter extends AnyRouter>(
               data: next.value,
             };
 
-            if (isSSEMessageEnvelope(next.value)) {
-              const message = next.value[1];
-              result.id = message.id;
-              result.data = message;
+            if (isTrackedEnvelope(next.value)) {
+              const [id, data] = next.value;
+              result.id = id;
+              result.data = data;
             }
 
             respond({

--- a/packages/server/src/unstable-core-do-not-import.ts
+++ b/packages/server/src/unstable-core-do-not-import.ts
@@ -34,6 +34,7 @@ export * from './unstable-core-do-not-import/router';
 export * from './unstable-core-do-not-import/rpc';
 export * from './unstable-core-do-not-import/stream/jsonl';
 export * from './unstable-core-do-not-import/stream/sse';
+export * from './unstable-core-do-not-import/stream/tracked';
 export * from './unstable-core-do-not-import/stream/utils/createDeferred';
 export * from './unstable-core-do-not-import/transformer';
 export * from './unstable-core-do-not-import/types';

--- a/packages/server/src/unstable-core-do-not-import/procedureBuilder.ts
+++ b/packages/server/src/unstable-core-do-not-import/procedureBuilder.ts
@@ -23,7 +23,7 @@ import type {
   QueryProcedure,
   SubscriptionProcedure,
 } from './procedure';
-import type { inferSSEOutput } from './stream/sse';
+import type { inferTrackedOutput } from './stream/tracked';
 import type {
   GetRawInputFn,
   MaybePromise,
@@ -47,7 +47,7 @@ type DefaultValue<TValue, TFallback> = TValue extends UnsetMarker
 type inferSubscriptionOutput<TOutput> = TOutput extends AsyncIterable<
   infer $Output
 >
-  ? inferSSEOutput<$Output>
+  ? inferTrackedOutput<$Output>
   : inferObservableValue<TOutput>;
 
 export type CallerOverride<TContext> = (opts: {

--- a/packages/server/src/unstable-core-do-not-import/stream/sse.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/sse.test.ts
@@ -1,13 +1,8 @@
 import { EventSourcePolyfill, NativeEventSource } from 'event-source-polyfill';
 import SuperJSON from 'superjson';
 import type { Maybe } from '../types';
-import {
-  isSSEMessageEnvelope,
-  sse,
-  sseHeaders,
-  sseStreamConsumer,
-  sseStreamProducer,
-} from './sse';
+import { sseHeaders, sseStreamConsumer, sseStreamProducer } from './sse';
+import { isTrackedEnvelope, sse, tracked } from './tracked';
 import { createServer } from './utils/createServer';
 
 (global as any).EventSource = NativeEventSource || EventSourcePolyfill;
@@ -29,10 +24,7 @@ test('e2e, server-sent events (SSE)', async () => {
     let i = lastEventId ?? 0;
     while (true) {
       i++;
-      yield sse({
-        id: String(i),
-        data: i,
-      });
+      yield tracked(String(i), i);
 
       await new Promise((resolve) => setTimeout(resolve, 5));
     }
@@ -153,10 +145,7 @@ test('SSE on serverless - emit and disconnect early', async () => {
 
     function* yieldEvent() {
       i++;
-      yield sse({
-        id: String(i),
-        data: i,
-      });
+      yield tracked(String(i), i);
     }
     while (true) {
       // yield 2 events at a time to test if the client will get both without reconnecting in between
@@ -315,7 +304,7 @@ test('sse()', () => {
     id: String(1),
     data: { json: 1 },
   });
-  expect(isSSEMessageEnvelope(event)).toBe(true);
+  expect(isTrackedEnvelope(event)).toBe(true);
 
   // no properties
   sse({

--- a/packages/server/src/unstable-core-do-not-import/stream/sse.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/sse.ts
@@ -1,7 +1,7 @@
 import { getTRPCErrorFromUnknown } from '../error/TRPCError';
 import { run } from '../utils';
 import type { ConsumerOnError } from './jsonl';
-import type { inferTrackedOutput, TrackedEnvelope } from './tracked';
+import type { inferTrackedOutput } from './tracked';
 import { isTrackedEnvelope } from './tracked';
 import { createTimeoutPromise } from './utils/createDeferred';
 import { createReadableStream } from './utils/createReadableStream';

--- a/packages/server/src/unstable-core-do-not-import/stream/sse.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/sse.ts
@@ -1,58 +1,13 @@
 import { getTRPCErrorFromUnknown } from '../error/TRPCError';
-import type { ValidateShape } from '../types';
 import { run } from '../utils';
 import type { ConsumerOnError } from './jsonl';
+import type { inferTrackedOutput, TrackedEnvelope } from './tracked';
+import { isTrackedEnvelope } from './tracked';
 import { createTimeoutPromise } from './utils/createDeferred';
 import { createReadableStream } from './utils/createReadableStream';
 
 type Serialize = (value: any) => any;
 type Deserialize = (value: any) => any;
-
-/**
- * Server-sent Event Message
- * @see https://html.spec.whatwg.org/multipage/server-sent-events.html
- * @public
- */
-export interface SSEMessage {
-  /**
-   * The data field of the message - this can be anything
-   */
-  data: unknown;
-  /**
-   * The id for this message
-   * Passing this id will allow the client to resume the connection from this point if the connection is lost
-   * @see https://html.spec.whatwg.org/multipage/server-sent-events.html#the-last-event-id-header
-   */
-  id: string;
-}
-
-const sseSymbol = Symbol('SSEMessageEnvelope');
-export type SSEMessageEnvelope<TData> = [typeof sseSymbol, TData];
-
-/**
- * Produce a typed server-sent event message
- */
-export function sse<TData extends SSEMessage>(
-  event: ValidateShape<TData, SSEMessage>,
-): SSEMessageEnvelope<TData> {
-  if (event.id === '') {
-    // This could be removed by using different event names for `yield sse(x)`-emitted events and `yield y`-emitted events
-    throw new Error(
-      '`id` must not be an empty string as empty string is the same as not setting the id at all',
-    );
-  }
-  return [sseSymbol, event as TData];
-}
-
-export function isSSEMessageEnvelope<TData extends SSEMessage>(
-  value: unknown,
-): value is SSEMessageEnvelope<TData> {
-  return Array.isArray(value) && value[0] === sseSymbol;
-}
-
-export type SerializedSSEvent = Omit<SSEMessage, 'data'> & {
-  data?: string;
-};
 
 /**
  * @internal
@@ -89,12 +44,12 @@ export interface SSEStreamProducerOptions {
   emitAndEndImmediately?: boolean;
 }
 
-type SSEvent = Partial<
-  SSEMessage & {
-    comment: string;
-    event: string;
-  }
->;
+type SSEvent = Partial<{
+  id: string;
+  data: unknown;
+  comment: string;
+  event: string;
+}>;
 /**
  *
  * @see https://html.spec.whatwg.org/multipage/server-sent-events.html
@@ -160,8 +115,11 @@ export function sseStreamProducer(opts: SSEStreamProducerOptions) {
 
       const value = next.value;
 
-      const chunk: SSEvent = isSSEMessageEnvelope(value)
-        ? { ...value[1] }
+      const chunk: SSEvent = isTrackedEnvelope(value)
+        ? {
+            id: value[0],
+            data: value[1],
+          }
         : {
             data: value,
           };
@@ -207,11 +165,6 @@ export function sseStreamProducer(opts: SSEStreamProducerOptions) {
     }),
   );
 }
-export type inferSSEOutput<TData> = TData extends SSEMessageEnvelope<
-  infer $Data
->
-  ? $Data
-  : TData;
 /**
  * @see https://html.spec.whatwg.org/multipage/server-sent-events.html
  */
@@ -220,22 +173,25 @@ export function sseStreamConsumer<TData>(opts: {
   from: EventSource;
   onError?: ConsumerOnError;
   deserialize?: Deserialize;
-}): AsyncIterable<inferSSEOutput<TData>> {
+}): AsyncIterable<inferTrackedOutput<TData>> {
   const { deserialize = (v) => v } = opts;
   const eventSource = opts.from;
 
   const stream = createReadableStream<MessageEvent>();
 
-  const transform = new TransformStream<MessageEvent, inferSSEOutput<TData>>({
+  const transform = new TransformStream<
+    MessageEvent,
+    inferTrackedOutput<TData>
+  >({
     async transform(chunk, controller) {
-      const def: Partial<SSEMessage> = {
+      const def: SSEvent = {
         data: deserialize(JSON.parse(chunk.data)),
       };
 
       if (chunk.lastEventId) {
         def.id = chunk.lastEventId;
       }
-      controller.enqueue(def as inferSSEOutput<TData>);
+      controller.enqueue(def as inferTrackedOutput<TData>);
     },
   });
 
@@ -253,7 +209,7 @@ export function sseStreamConsumer<TData>(opts: {
     [Symbol.asyncIterator]() {
       const reader = readable.getReader();
 
-      const iterator: AsyncIterator<inferSSEOutput<TData>> = {
+      const iterator: AsyncIterator<inferTrackedOutput<TData>> = {
         async next() {
           const value = await reader.read();
           if (value.done) {

--- a/packages/server/src/unstable-core-do-not-import/stream/tracked.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/tracked.ts
@@ -1,0 +1,61 @@
+const trackedSymbol = Symbol('TrackedEnvelope');
+
+type TrackedId = string & {
+  __brand: 'TrackedId';
+};
+export type TrackedEnvelope<TData> = [TrackedId, TData, typeof trackedSymbol];
+
+type Tracked<TData> = {
+  /**
+   * The id of the message to keep track of in case the connection gets lost
+   */
+  id: string;
+  /**
+   * The data field of the message - this can be anything
+   */
+  data: TData;
+};
+/**
+ * Produce a typed server-sent event message
+ * @deprecated use `tracked(id, data)` instead
+ */
+export function sse<TData>(event: {
+  id: string;
+  data: TData;
+}): TrackedEnvelope<TData> {
+  if (event.id === '') {
+    // This could be removed by using different event names for `yield sse(x)`-emitted events and `yield y`-emitted events
+    throw new Error(
+      '`id` must not be an empty string as empty string is the same as not setting the id at all',
+    );
+  }
+  return [event.id as TrackedId, event.data, trackedSymbol];
+}
+
+export function isTrackedEnvelope<TData>(
+  value: unknown,
+): value is TrackedEnvelope<TData> {
+  return Array.isArray(value) && value[2] === trackedSymbol;
+}
+
+/**
+ * Automatically track an event so that it can be resumed from a given id if the connection is lost
+ */
+export function tracked<TData>(
+  id: string,
+  data: TData,
+): TrackedEnvelope<TData> {
+  if (id === '') {
+    // This limitation could be removed by using different SSE event names / channels for tracked event and non-tracked event
+    throw new Error(
+      '`id` must not be an empty string as empty string is the same as not setting the id at all',
+    );
+  }
+  return [id as TrackedId, data, trackedSymbol];
+}
+
+export type inferTrackedOutput<TData> = TData extends TrackedEnvelope<
+  infer $Data
+>
+  ? Tracked<$Data>
+  : TData;

--- a/packages/server/src/unstable-core-do-not-import/stream/tracked.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/tracked.ts
@@ -23,13 +23,7 @@ export function sse<TData>(event: {
   id: string;
   data: TData;
 }): TrackedEnvelope<TData> {
-  if (event.id === '') {
-    // This could be removed by using different event names for `yield sse(x)`-emitted events and `yield y`-emitted events
-    throw new Error(
-      '`id` must not be an empty string as empty string is the same as not setting the id at all',
-    );
-  }
-  return [event.id as TrackedId, event.data, trackedSymbol];
+  return tracked(event.id, event.data);
 }
 
 export function isTrackedEnvelope<TData>(

--- a/packages/tests/server/httpSubscriptionLink.test.ts
+++ b/packages/tests/server/httpSubscriptionLink.test.ts
@@ -9,7 +9,7 @@ import {
   unstable_httpSubscriptionLink,
 } from '@trpc/client';
 import type { TRPCCombinedDataTransformer } from '@trpc/server';
-import { initTRPC, sse } from '@trpc/server';
+import { initTRPC, sse, tracked } from '@trpc/server';
 import { observable } from '@trpc/server/observable';
 import { uneval } from 'devalue';
 import { konn } from 'konn';
@@ -62,10 +62,7 @@ const ctx = konn()
             });
             let idx = opts.input.lastEventId ?? 0;
             while (true) {
-              yield sse({
-                id: String(idx),
-                data: idx,
-              });
+              yield tracked(String(idx), idx);
               idx++;
               await sleep();
               infiniteYields();

--- a/packages/tests/server/httpSubscriptionLink.test.ts
+++ b/packages/tests/server/httpSubscriptionLink.test.ts
@@ -9,7 +9,7 @@ import {
   unstable_httpSubscriptionLink,
 } from '@trpc/client';
 import type { TRPCCombinedDataTransformer } from '@trpc/server';
-import { initTRPC, sse, tracked } from '@trpc/server';
+import { initTRPC, tracked } from '@trpc/server';
 import { observable } from '@trpc/server/observable';
 import { uneval } from 'devalue';
 import { konn } from 'konn';
@@ -398,10 +398,7 @@ describe('transformers / different serialize-deserialize', async () => {
         iterableEvent: t.procedure.subscription(async function* () {
           for await (const data of on(ee, 'data')) {
             const num = data[0] as number;
-            yield sse({
-              id: num.toString(),
-              data: { num },
-            });
+            yield tracked(String(num), { num });
           }
         }),
       });

--- a/packages/tests/server/websockets.test.ts
+++ b/packages/tests/server/websockets.test.ts
@@ -4,7 +4,7 @@ import { waitFor } from '@testing-library/react';
 import type { TRPCClientError, WebSocketClientOptions } from '@trpc/client';
 import { createTRPCClient, createWSClient, wsLink } from '@trpc/client';
 import type { AnyRouter } from '@trpc/server';
-import { initTRPC, sse, TRPCError } from '@trpc/server';
+import { initTRPC, sse, tracked, TRPCError } from '@trpc/server';
 import type { WSSHandlerOptions } from '@trpc/server/adapters/ws';
 import { applyWSSHandler } from '@trpc/server/adapters/ws';
 import type { Observer } from '@trpc/server/observable';
@@ -75,10 +75,7 @@ function factory(config?: {
             title: 'hello ' + from,
           };
 
-          yield sse({
-            id: String(from),
-            data: msg,
-          });
+          yield tracked(String(from), msg);
         }
       }),
 

--- a/packages/tests/server/websockets.test.ts
+++ b/packages/tests/server/websockets.test.ts
@@ -1353,6 +1353,7 @@ describe('lastEventId', () => {
       });
     }
 
+    sub.unsubscribe();
     await ctx.close();
   });
 });

--- a/www/docs/client/links/httpSubscriptionLink.md
+++ b/www/docs/client/links/httpSubscriptionLink.md
@@ -78,9 +78,9 @@ export const subRouter = router({
 });
 ```
 
-### Automatic tracking of id using `sse()` (recommended)
+### Automatic tracking of id using `tracked()` (recommended)
 
-If you `yield` an event using our `sse()`-helper and include an `id`, the browser will automatically reconnect when it gets disconnected and send the last known ID - this is part of the [`EventSource`-spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#the-last-event-id-header) and will be propagated through `lastEventId` in your `.input()`.
+If you `yield` an event using our `tracked()`-helper and include an `id`, the browser will automatically reconnect when it gets disconnected and send the last known ID - this is part of the [`EventSource`-spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#the-last-event-id-header) and will be propagated through `lastEventId` in your `.input()`.
 
 You can send an initial `lastEventId` when initializing the subscription and it will be automatically updated as the browser receives data.
 
@@ -114,11 +114,8 @@ export const subRouter = router({
       // listen for new events
       for await (const [data] of on(ee, 'add')) {
         const post = data as Post;
-        yield sse({
-          // yielding the post id ensures the client can reconnect at any time and get the latest events this id
-          id: post.id,
-          data: post,
-        });
+        // tracking the post id ensures the client can reconnect at any time and get the latest events this id
+        yield tracked(post.id, post);
       }
     }),
 });

--- a/www/docs/client/links/httpSubscriptionLink.md
+++ b/www/docs/client/links/httpSubscriptionLink.md
@@ -100,12 +100,14 @@ const ee = new EventEmitter();
 export const subRouter = router({
   onPostAdd: publicProcedure
     .input(
-      z.object({
-        // lastEventId is the last event id that the client has received
-        // On the first call, it will be whatever was passed in the initial setup
-        // If the client reconnects, it will be the last event id that the client received
-        lastEventId: z.string().nullish(),
-      }),
+      z
+        .object({
+          // lastEventId is the last event id that the client has received
+          // On the first call, it will be whatever was passed in the initial setup
+          // If the client reconnects, it will be the last event id that the client received
+          lastEventId: z.string().nullish(),
+        })
+        .optional(),
     )
     .subscription(async function* (opts) {
       if (opts.input.lastEventId) {

--- a/www/docs/further/websockets.md
+++ b/www/docs/further/websockets.md
@@ -195,12 +195,14 @@ const ee = new EventEmitter();
 export const subRouter = router({
   onPostAdd: publicProcedure
     .input(
-      z.object({
-        // lastEventId is the last event id that the client has received
-        // On the first call, it will be whatever was passed in the initial setup
-        // If the client reconnects, it will be the last event id that the client received
-        lastEventId: z.string().nullish(),
-      }),
+      z
+        .object({
+          // lastEventId is the last event id that the client has received
+          // On the first call, it will be whatever was passed in the initial setup
+          // If the client reconnects, it will be the last event id that the client received
+          lastEventId: z.string().nullish(),
+        })
+        .optional(),
     )
     .subscription(async function* (opts) {
       if (opts.input.lastEventId) {

--- a/www/docs/further/websockets.md
+++ b/www/docs/further/websockets.md
@@ -173,6 +173,49 @@ export const trpc = createTRPCClient<AppRouter>({
 });
 ```
 
+### Automatic tracking of id using `tracked()` (recommended)
+
+If you `yield` an event using our `tracked()`-helper and include an `id`, the client will automatically reconnect when it gets disconnected and send the last known ID when reconnecting as part of the `lastEventId`-input.
+
+You can send an initial `lastEventId` when initializing the subscription and it will be automatically updated as the browser receives data.
+
+:::info
+If you're fetching data based on the `lastEventId`, and capturing all events is critical, you may want to use `ReadableStream`'s or a similar pattern as an intermediary as is done in [our full-stack SSE example](https://github.com/trpc/examples-next-sse-chat) to prevent newly emitted events being ignored while yield'ing the original batch based on `lastEventId`.
+:::
+
+```ts
+import EventEmitter, { on } from 'events';
+import type { Post } from '@prisma/client';
+import { sse } from '@trpc/server';
+import { z } from 'zod';
+import { publicProcedure, router } from '../trpc';
+
+const ee = new EventEmitter();
+
+export const subRouter = router({
+  onPostAdd: publicProcedure
+    .input(
+      z.object({
+        // lastEventId is the last event id that the client has received
+        // On the first call, it will be whatever was passed in the initial setup
+        // If the client reconnects, it will be the last event id that the client received
+        lastEventId: z.string().nullish(),
+      }),
+    )
+    .subscription(async function* (opts) {
+      if (opts.input.lastEventId) {
+        // [...] get the posts since the last event id and yield them
+      }
+      // listen for new events
+      for await (const [data] of on(ee, 'add')) {
+        const post = data as Post;
+        // tracking the post id ensures the client can reconnect at any time and get the latest events this id
+        yield tracked(post.id, post);
+      }
+    }),
+});
+```
+
 ## Using React
 
 See [/examples/next-prisma-starter-websockets](https://github.com/trpc/examples-next-prisma-starter-websockets).


### PR DESCRIPTION
fork of #5875