### PR TITLE
Fix missing import in example of authorization.md

### DIFF
--- a/www/docs/server/authorization.md
+++ b/www/docs/server/authorization.md
@@ -68,6 +68,7 @@ const appRouter = t.router({
 
 ```ts title='server/routers/_app.ts'
 import { initTRPC, TRPCError } from '@trpc/server';
+import type { Context } from '../context';
 
 export const t = initTRPC.context<Context>().create();
 


### PR DESCRIPTION
## 🎯 Changes

Fix `Cannot find name 'Context'.ts(2304)` in the provided example at `Option 2: Authorize using middleware`, which makes use of `Context` but does not import it.

