### PR TITLE
feat(server): websocket keep alive for fastify

### DIFF
--- a/packages/server/src/adapters/ws.ts
+++ b/packages/server/src/adapters/ws.ts
@@ -461,7 +461,7 @@ export function getWSConnectionHandler<TRouter extends AnyRouter>(
 /**
  * Handle WebSocket keep-alive messages
  */
-function handleKeepAlive(
+export function handleKeepAlive(
   client: ws.WebSocket,
   pingMs = 30000,
   pongWaitMs = 5000,

--- a/www/docs/server/adapters/fastify.md
+++ b/www/docs/server/adapters/fastify.md
@@ -214,6 +214,14 @@ export const appRouter = t.router({
 ```ts title='server.ts'
 server.register(fastifyTRPCPlugin, {
   useWSS: true,
+  // Enable heartbeat messages to keep connection open (disabled by default)
+  keepAlive: {
+    enabled: true,
+    // server ping message interval in milliseconds
+    pingMs: 30000,
+    // connection is terminated if pong message is not received in this many milliseconds
+    pongWaitMs: 5000,
+  },
   // ...
 });
 ```


### PR DESCRIPTION
Follow-up of #5715.

## 🎯 Changes

Changes in #5715 added heartbeat logic to the basic websocket handler. This PR enables that same option in the Fastify plugin.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
