### PR TITLE
Fix for subscription link always throw 500 ISE when encountering error

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/http/resolveResponse.ts
+++ b/packages/server/src/unstable-core-do-not-import/http/resolveResponse.ts
@@ -368,6 +368,8 @@ export async function resolveResponse<TRouter extends AnyRouter>(
             });
           }
 
+          if(error) throw error;
+
           if (!isObservable(data) && !isAsyncIterable(data)) {
             throw new TRPCError({
               message: `Subscription ${

--- a/packages/server/src/unstable-core-do-not-import/http/resolveResponse.ts
+++ b/packages/server/src/unstable-core-do-not-import/http/resolveResponse.ts
@@ -368,6 +368,12 @@ export async function resolveResponse<TRouter extends AnyRouter>(
             });
           }
 
+          /**
+           * Previously, any error throw in middleware before an SSE subscription would result in data having a value of `null`.
+           * This means it would fail the following "isObservable(data)" and "isAsyncIterable(data)" checks, and an INTERNAL_SERVER_ERROR would always be thrown.
+           * So, if you wanted to throw a custom error, that'd be impossible.
+           * Checking to see if the error variable is defined before checking if it is an observable or async iterable fixes this issue.
+           */
           if(error) throw error;
 
           if (!isObservable(data) && !isAsyncIterable(data)) {


### PR DESCRIPTION
Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

Fix for SSE links only throwing internal server errros.

## ✅ Checklist

- [yes] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [yes] If necessary, I have added documentation related to the changes made.
- [yes] I have added or updated the tests related to the changes made.
