### PR TITLE
Use git lfs for hosting docs images from server-side-calls.md

### DIFF
--- a/www/docs/server/server-side-calls.md
+++ b/www/docs/server/server-side-calls.md
@@ -12,8 +12,8 @@ You may need to call your procedure(s) directly from the same server they're hos
 `createCaller` should not be used to call procedures from within other procedures. This creates overhead by (potentially) creating context again, executing all middlewares, and validating the input - all of which were already done by the current procedure. Instead, you should extract the shared logic into a separate function and call that from within the procedures, like so:
 
 <div className="flex gap-2 w-full justify-between pt-2">
-  <img src="https://user-images.githubusercontent.com/51714798/212568342-0a8440cb-68ed-48ae-9849-8c7bc417633e.png" className="w-[49.5%]" />
-  <img src="https://user-images.githubusercontent.com/51714798/212568254-06cc56d0-35f6-4bb5-bff9-d25caf092c2c.png" className="w-[49.5%]" />
+  <img src="www/static/img/212568342-0a8440cb-68ed-48ae-9849-8c7bc417633e.png" className="w-[49.5%]" />
+  <img src="www/static/img/212568254-06cc56d0-35f6-4bb5-bff9-d25caf092c2c.png" className="w-[49.5%]" />
 </div>
 
 :::


### PR DESCRIPTION
When running documentation locally and offline, images from server-side-calls.md are not available/shown.

## 🎯 Changes
- Changed img links to relative path in repository.
- Added `.gitattributes` file with `*.png`.
- Unsuccessfully tried to add images with LFS, [link](https://github.com/trpc/trpc/issues/5986) to more info.

Related issue: https://github.com/trpc/trpc/issues/5986
<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
