### PR TITLE
docs/www: Renamed the tRPC caller for Server Components to server.tsx

### DIFF
--- a/www/docs/client/react/server-components.mdx
+++ b/www/docs/client/react/server-components.mdx
@@ -233,7 +233,7 @@ Mount the provider in the root of your application (e.g. `app/layout.tsx` when u
 To prefetch queries from server components, we use a tRPC caller. The `@trpc/react-query/rsc` module exports a thin wrapper around
 [`createCaller`](https://trpc.io/docs/server/server-side-calls) that integrates with your React Query client.
 
-```tsx title='trpc/client.tsx'
+```tsx title='trpc/server.tsx'
 import 'server-only'; // <-- ensure this file cannot be imported from the client
 
 import { createHydrationHelpers } from '@trpc/react-query/rsc';


### PR DESCRIPTION


Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

Renamed the tRPC caller for Server Components to server.tsx to avoid having two client.tsx files in the tRPC folder. This helps keep the folder structure cleaner and reduces confusion for anyone reading the documentation.


## ✅ Checklist

- [✅ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
