### PR TITLE
feat/fix(server): pass the request's `AbortSignal` to procedures

### DIFF
--- a/packages/client/src/internals/types.ts
+++ b/packages/client/src/internals/types.ts
@@ -49,7 +49,7 @@ export interface RequestInitEsque {
   /**
    * Sets the request's signal.
    */
-  signal?: AbortSignal | null;
+  signal?: AbortSignal | undefined;
 }
 
 /**

--- a/packages/next/src/app-dir/links/nextCache.ts
+++ b/packages/next/src/app-dir/links/nextCache.ts
@@ -55,6 +55,7 @@ export function experimental_nextCacheLink<TRouter extends AnyRouter>(
                 getRawInput: async () => input,
                 ctx: ctx,
                 type,
+                signal: undefined,
               });
 
               // We need to serialize cause the cache only accepts JSON

--- a/packages/next/src/app-dir/server.ts
+++ b/packages/next/src/app-dir/server.ts
@@ -158,6 +158,8 @@ export function experimental_createServerActionHandler<
               path: '',
               getRawInput: async () => rawInput,
               type: proc._def.type,
+              // is it possible to get the AbortSignal from the request?
+              signal: undefined,
             });
 
         const transformedJSON = transformTRPCResponse(config, {

--- a/packages/react-query/src/server/ssgProxy.ts
+++ b/packages/react-query/src/server/ssgProxy.ts
@@ -154,6 +154,7 @@ export function createServerSideHelpers<TRouter extends AnyRouter>(
             getRawInput: async () => queryOpts.input,
             ctx,
             type: 'query',
+            signal: undefined,
           });
         },
       };

--- a/packages/server/src/adapters/next-app-dir/nextAppDirCaller.ts
+++ b/packages/server/src/adapters/next-app-dir/nextAppDirCaller.ts
@@ -96,6 +96,7 @@ export function nextAppDirCaller<TContext, TMeta>(
             getRawInput: async () => input,
             path,
             input,
+            signal: undefined,
           })
           .then((data) => {
             if (data instanceof TRPCRedirectError) throw data;
@@ -112,6 +113,7 @@ export function nextAppDirCaller<TContext, TMeta>(
             getRawInput: async () => input,
             path,
             input,
+            signal: undefined,
           })
           .then((data) => {
             if (data instanceof TRPCRedirectError) throw data;

--- a/packages/server/src/adapters/ws.ts
+++ b/packages/server/src/adapters/ws.ts
@@ -203,12 +203,14 @@ export function getWSConnectionHandler<TRouter extends AnyRouter>(
         }
         await ctxPromise; // asserts context has been set
 
+        const abortController = new AbortController();
         const result = await callProcedure({
           procedures: router._def.procedures,
           path,
           getRawInput: async () => input,
           ctx,
           type,
+          signal: abortController.signal,
         });
 
         const isIterableResult =
@@ -264,7 +266,6 @@ export function getWSConnectionHandler<TRouter extends AnyRouter>(
 
         const iterator: AsyncIterator<unknown> =
           iterable[Symbol.asyncIterator]();
-        const abortController = new AbortController();
 
         const abortPromise = new Promise<'abort'>((resolve) => {
           abortController.signal.onabort = () => resolve('abort');

--- a/packages/server/src/unstable-core-do-not-import/http/resolveResponse.ts
+++ b/packages/server/src/unstable-core-do-not-import/http/resolveResponse.ts
@@ -291,6 +291,7 @@ export async function resolveResponse<TRouter extends AnyRouter>(
           getRawInput: call.getRawInput,
           ctx,
           type: proc._def.type,
+          signal: opts.req.signal,
         });
         return [data];
       } catch (cause) {

--- a/packages/server/src/unstable-core-do-not-import/middleware.ts
+++ b/packages/server/src/unstable-core-do-not-import/middleware.ts
@@ -100,6 +100,7 @@ export type MiddlewareFunction<
     input: TInputOut;
     getRawInput: GetRawInputFn;
     meta: TMeta | undefined;
+    signal: AbortSignal | undefined;
     next: {
       (): Promise<MiddlewareResult<TContextOverridesIn>>;
       <$ContextOverride>(opts: {

--- a/packages/server/src/unstable-core-do-not-import/procedure.ts
+++ b/packages/server/src/unstable-core-do-not-import/procedure.ts
@@ -66,10 +66,25 @@ export interface MutationProcedure<TDef extends BuiltProcedureDef>
 export interface SubscriptionProcedure<TDef extends BuiltProcedureDef>
   extends Procedure<'subscription', TDef> {}
 
+/**
+ * @deprecated
+ */
+export interface LegacyObservableSubscriptionProcedure<
+  TDef extends BuiltProcedureDef,
+> extends SubscriptionProcedure<TDef> {
+  _observable: true;
+}
+
 export type AnyQueryProcedure = QueryProcedure<any>;
 export type AnyMutationProcedure = MutationProcedure<any>;
-export type AnySubscriptionProcedure = SubscriptionProcedure<any>;
-export type AnyProcedure = Procedure<ProcedureType, any>;
+export type AnySubscriptionProcedure =
+  | SubscriptionProcedure<any>
+  | LegacyObservableSubscriptionProcedure<any>;
+
+export type AnyProcedure =
+  | AnyQueryProcedure
+  | AnyMutationProcedure
+  | AnySubscriptionProcedure;
 
 export type inferProcedureInput<TProcedure extends AnyProcedure> =
   undefined extends inferProcedureParams<TProcedure>['$types']['input']

--- a/packages/server/src/unstable-core-do-not-import/procedureBuilder.ts
+++ b/packages/server/src/unstable-core-do-not-import/procedureBuilder.ts
@@ -560,11 +560,7 @@ function createProcedureCaller(_def: AnyProcedureBuilderDef): AnyProcedure {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const middleware = _def.middlewares[index]!;
         const result = await middleware({
-          ctx: opts.ctx,
-          signal: opts.signal,
-          type: opts.type,
-          path: opts.path,
-          getRawInput: opts.getRawInput ?? opts.getRawInput,
+          ...opts,
           meta: _def.meta,
           input: opts.input,
           next(_nextOpts?: any) {

--- a/packages/server/src/unstable-core-do-not-import/router.ts
+++ b/packages/server/src/unstable-core-do-not-import/router.ts
@@ -272,8 +272,9 @@ export function createCallerFactory<TRoot extends AnyRootTypes>() {
 
     return function createCaller(
       ctxOrCallback,
-      options?: {
+      opts?: {
         onError?: RouterCallerErrorHandler<Context>;
+        signal?: AbortSignal;
       },
     ) {
       return createRecursiveProxy<ReturnType<RouterCaller<any, any>>>(
@@ -297,9 +298,10 @@ export function createCallerFactory<TRoot extends AnyRootTypes>() {
               getRawInput: async () => args[0],
               ctx,
               type: procedure._def.type,
+              signal: opts?.signal,
             });
           } catch (cause) {
-            options?.onError?.({
+            opts?.onError?.({
               ctx,
               error: getTRPCErrorFromUnknown(cause),
               input: args[0],

--- a/packages/tests/server/callRouter.test.ts
+++ b/packages/tests/server/callRouter.test.ts
@@ -14,6 +14,7 @@ test('call proc directly', async () => {
     path: 'asd',
     type: 'query',
     getRawInput: async () => ({}),
+    signal: undefined,
   });
 
   expect(result).toBe('hello');

--- a/packages/tests/server/caller.test.ts
+++ b/packages/tests/server/caller.test.ts
@@ -29,6 +29,7 @@ test('experimental caller', async () => {
             getRawInput: async () => input,
             path: '',
             input,
+            signal: undefined,
           });
         }
         case 'query': {
@@ -39,6 +40,7 @@ test('experimental caller', async () => {
             getRawInput: async () => input,
             path: '',
             input,
+            signal: undefined,
           });
         }
         default: {

--- a/packages/tests/server/getRawInput.test.ts
+++ b/packages/tests/server/getRawInput.test.ts
@@ -46,6 +46,7 @@ test('untyped caller', async () => {
     path: 'test',
     type: 'query',
     input: 'foo',
+    signal: undefined,
   });
   expect(result).toBe('foo');
 });
@@ -70,6 +71,7 @@ test('getRawInput fails', async () => {
       path: 'test',
       type: 'query',
       input: 'foo',
+      signal: undefined,
     }),
   );
 

--- a/packages/tests/server/httpSubscriptionLink.test.ts
+++ b/packages/tests/server/httpSubscriptionLink.test.ts
@@ -497,3 +497,5 @@ describe('transformers / different serialize-deserialize', async () => {
     });
   });
 });
+
+test;

--- a/packages/tests/server/httpSubscriptionLink.test.ts
+++ b/packages/tests/server/httpSubscriptionLink.test.ts
@@ -37,8 +37,10 @@ const ctx = konn()
 
     const router = t.router({
       sub: {
-        iterableEvent: t.procedure.subscription(async function* () {
-          for await (const data of on(ee, 'data')) {
+        iterableEvent: t.procedure.subscription(async function* (opts) {
+          for await (const data of on(ee, 'data', {
+            signal: opts.signal,
+          })) {
             const thing = data[0] as number | Error;
 
             if (thing instanceof Error) {
@@ -158,9 +160,6 @@ test('iterable event', async () => {
   await waitFor(() => {
     expect(ctx.onReqAborted).toHaveBeenCalledTimes(1);
   });
-
-  ctx.eeEmit(4);
-  ctx.eeEmit(5);
 
   await waitFor(() => {
     expect(ctx.ee.listenerCount('data')).toBe(0);
@@ -311,7 +310,9 @@ describe('auth / connectionParams', async () => {
 
       const appRouter = t.router({
         iterableEvent: t.procedure.subscription(async function* (opts) {
-          for await (const data of on(ee, 'data')) {
+          for await (const data of on(ee, 'data', {
+            signal: opts.signal,
+          })) {
             const num = data[0] as number;
             yield {
               user: opts.ctx.user,
@@ -440,8 +441,10 @@ describe('transformers / different serialize-deserialize', async () => {
       };
 
       const appRouter = t.router({
-        iterableEvent: t.procedure.subscription(async function* () {
-          for await (const data of on(ee, 'data')) {
+        iterableEvent: t.procedure.subscription(async function* (opts) {
+          for await (const data of on(ee, 'data', {
+            signal: opts.signal,
+          })) {
             const num = data[0] as number;
             yield tracked(String(num), { num });
           }

--- a/packages/tests/server/react/useSubscription.test.tsx
+++ b/packages/tests/server/react/useSubscription.test.tsx
@@ -31,10 +31,12 @@ describe.each([
       const appRouter = t.router({
         onEventIterable: t.procedure
           .input(z.number())
-          .subscription(async function* ({ input }) {
-            for await (const event of on(ee, 'data')) {
+          .subscription(async function* (opts) {
+            for await (const event of on(ee, 'data', {
+              signal: opts.signal,
+            })) {
               const data = event[0] as number;
-              yield data + input;
+              yield data + opts.input;
             }
           }),
         onEventObservable: t.procedure

--- a/packages/tests/server/websockets.test.ts
+++ b/packages/tests/server/websockets.test.ts
@@ -1380,8 +1380,8 @@ describe('keep alive', () => {
     });
   }
   test('pong message should be received', async () => {
-    const pingMs = 2000;
-    const pongWaitMs = 5000;
+    const pingMs = 2_000;
+    const pongWaitMs = 5_000;
     const ctx = factory({
       wssServer: {
         keepAlive: {

--- a/packages/tests/server/websockets.test.ts
+++ b/packages/tests/server/websockets.test.ts
@@ -104,7 +104,7 @@ function factory(config?: {
 
     onMessageObservable: t.procedure
       .input(z.string().nullish())
-      .subscription((opts) => {
+      .subscription(() => {
         const sub = observable<Message>((emit) => {
           subRef.current = emit;
           const onMessage = (data: Message) => {

--- a/packages/tests/server/websockets.test.ts
+++ b/packages/tests/server/websockets.test.ts
@@ -1365,10 +1365,10 @@ describe('lastEventId', () => {
 });
 
 describe('keep alive', () => {
-  beforeEach(() => {
+  beforeAll(() => {
     vi.useFakeTimers();
   });
-  afterEach(() => {
+  afterAll(() => {
     vi.useRealTimers();
   });
   function attachPongMock(wss: WebSocket.Server, pongMock: () => void) {
@@ -1407,7 +1407,7 @@ describe('keep alive', () => {
     const { wsClient, wss } = ctx;
     await attachPongMock(wss, pongMock);
     {
-      await vi.advanceTimersByTimeAsync(60000);
+      await vi.advanceTimersByTimeAsync(60_000);
       expect(wsClient.connection).not.toBe(null);
       expect(pongMock).not.toHaveBeenCalled();
     }

--- a/www/docs/client/links/httpSubscriptionLink.md
+++ b/www/docs/client/links/httpSubscriptionLink.md
@@ -69,12 +69,9 @@ const ee = new EventEmitter();
 
 export const subRouter = router({
   onPostAdd: publicProcedure.subscription(async function* (opts) {
-    // Abort signal of the request
-    const { signal } = opts;
-
     // listen for new events
     for await (const [data] of on(ee, 'add', {
-      // Passing the AbortSignal of the request makes the event emitter is cancelled
+      // Passing the AbortSignal from the request automatically cancels the event emitter when the request is aborted
       signal: opts.signal,
     })) {
       const post = data as Post;

--- a/www/docs/client/links/httpSubscriptionLink.md
+++ b/www/docs/client/links/httpSubscriptionLink.md
@@ -69,8 +69,14 @@ const ee = new EventEmitter();
 
 export const subRouter = router({
   onPostAdd: publicProcedure.subscription(async function* (opts) {
+    // Abort signal of the request
+    const { signal } = opts;
+
     // listen for new events
-    for await (const [data] of on(ee, 'add')) {
+    for await (const [data] of on(ee, 'add', {
+      // Passing the AbortSignal of the request makes the event emitter is cancelled
+      signal: opts.signal,
+    })) {
       const post = data as Post;
       yield post;
     }
@@ -114,7 +120,9 @@ export const subRouter = router({
         // [...] get the posts since the last event id and yield them
       }
       // listen for new events
-      for await (const [data] of on(ee, 'add')) {
+      for await (const [data] of on(ee, 'add'), {
+        signal: opts.signal,
+      }) {
         const post = data as Post;
         // tracking the post id ensures the client can reconnect at any time and get the latest events this id
         yield tracked(post.id, post);
@@ -139,7 +147,9 @@ export const subRouter = router({
   onPostAdd: publicProcedure.subscription(async function* (opts) {
     let timeout;
     try {
-      for await (const [data] of on(ee, 'add')) {
+      for await (const [data] of on(ee, 'add'), {
+        signal: opts.signal,
+      }) {
         timeout = setTimeout(() => console.log('Pretend like this is useful'));
         const post = data as Post;
         yield post;

--- a/www/docs/further/websockets.md
+++ b/www/docs/further/websockets.md
@@ -210,6 +210,7 @@ export const subRouter = router({
       }
       // listen for new events
       for await (const [data] of on(ee, 'add'), {
+        // Passing the AbortSignal from the request automatically cancels the event emitter when the subscription is aborted
         signal: opts.signal,
       }) {
         const post = data as Post;

--- a/www/docs/further/websockets.md
+++ b/www/docs/further/websockets.md
@@ -209,7 +209,9 @@ export const subRouter = router({
         // [...] get the posts since the last event id and yield them
       }
       // listen for new events
-      for await (const [data] of on(ee, 'add')) {
+      for await (const [data] of on(ee, 'add'), {
+        signal: opts.signal,
+      }) {
         const post = data as Post;
         // tracking the post id ensures the client can reconnect at any time and get the latest events this id
         yield tracked(post.id, post);


### PR DESCRIPTION
Closes #

## 🎯 Changes

### Fixes so that async generators can be canceled by passing `{ signal: opts.signal}`

Example: 
https://github.com/trpc/trpc/blob/ddfcac1ebf345ebab289e34909e3a2fb12386745/www/docs/client/links/httpSubscriptionLink.md?plain=1#L71-L80

### Fixes so that `createCaller()` returns the right type

easier to test subscriptions

https://github.com/trpc/trpc/blob/2c044414468e145684a93fbf3f479d371dff65b8/packages/tests/server/websockets.test.ts#L1517-L1570