### PR TITLE
fix(react-query): fix types of utility fns

### DIFF
--- a/packages/react-query/src/internals/context.tsx
+++ b/packages/react-query/src/internals/context.tsx
@@ -29,11 +29,17 @@ import * as React from 'react';
 import type { ExtractCursorType } from '../shared';
 import type { TRPCMutationKey, TRPCQueryKey } from './getQueryKey';
 
-export type TRPCFetchQueryOptions<TOutput, TError> = DistributiveOmit<
-  FetchQueryOptions<TOutput, TError>,
-  'queryKey'
-> &
-  TRPCRequestOptions;
+interface TRPCUseUtilsOptions {
+  /**
+   * tRPC-related options
+   */
+  trpc?: TRPCRequestOptions;
+}
+export interface TRPCFetchQueryOptions<TOutput, TError>
+  extends DistributiveOmit<FetchQueryOptions<TOutput, TError>, 'queryKey'>,
+    TRPCUseUtilsOptions {
+  //
+}
 
 export type TRPCFetchInfiniteQueryOptions<TInput, TOutput, TError> =
   DistributiveOmit<
@@ -46,7 +52,7 @@ export type TRPCFetchInfiniteQueryOptions<TInput, TOutput, TError> =
     >,
     'queryKey' | 'initialPageParam'
   > &
-    TRPCRequestOptions & {
+    TRPCUseUtilsOptions & {
       initialCursor?: ExtractCursorType<TInput>;
     };
 

--- a/packages/tests/server/react/useUtils.test.tsx
+++ b/packages/tests/server/react/useUtils.test.tsx
@@ -173,14 +173,23 @@ test('client mutation', async () => {
 test('fetch', async () => {
   const { client, App } = ctx;
 
+  const context = {
+    ___TEST___: true,
+  };
   function MyComponent() {
     const utils = client.useUtils();
     const [posts, setPosts] = useState<Post[]>([]);
 
     useEffect(() => {
-      utils.post.all.fetch().then((allPosts) => {
-        setPosts(allPosts);
-      });
+      utils.post.all
+        .fetch(undefined, {
+          trpc: {
+            context,
+          },
+        })
+        .then((allPosts) => {
+          setPosts(allPosts);
+        });
     }, []);
 
     return <p>{posts[0]?.text}</p>;
@@ -194,11 +203,17 @@ test('fetch', async () => {
   await waitFor(() => {
     expect(utils.container).toHaveTextContent('new post');
   });
+
+  expect(ctx.spyLink.mock.calls[0]![0]!.context).toMatchObject(context);
 });
 
 test('prefetch', async () => {
   const { client, App } = ctx;
   const renderclient = vi.fn();
+
+  const context = {
+    ___TEST___: true,
+  };
 
   function Posts() {
     const allPosts = client.post.all.useQuery();
@@ -216,9 +231,15 @@ test('prefetch', async () => {
     const utils = client.useUtils();
     const [hasPrefetched, setHasPrefetched] = useState(false);
     useEffect(() => {
-      utils.post.all.prefetch().then(() => {
-        setHasPrefetched(true);
-      });
+      utils.post.all
+        .prefetch(undefined, {
+          trpc: {
+            context,
+          },
+        })
+        .then(() => {
+          setHasPrefetched(true);
+        });
     }, [utils]);
 
     return hasPrefetched ? <Posts /> : null;
@@ -233,6 +254,8 @@ test('prefetch', async () => {
   await waitFor(() => {
     expect(renderclient).toHaveBeenNthCalledWith<[Post[]]>(1, [defaultPost]);
   });
+
+  expect(ctx.spyLink.mock.calls[0]![0]!.context).toMatchObject(context);
 });
 
 test('invalidate', async () => {


### PR DESCRIPTION
Closes #6028

## 🎯 Changes

Fixes types of `trpc`-prop in `.fetch()`