### PR TITLE
docs: add note explaining potential SSE incompatibility

### DIFF
--- a/www/docs/client/links/httpSubscriptionLink.md
+++ b/www/docs/client/links/httpSubscriptionLink.md
@@ -336,3 +336,12 @@ type HTTPSubscriptionLinkOptions<TRoot extends AnyClientTypes> = {
   transformer?: DataTransformerOptions;
 };
 ```
+
+## Framework Compatibility
+
+Before implementing `httpSubscriptionLink`, it's important to ensure that your framework supports the EventSource protocol. Some frameworks may have limitations or require additional configuration.
+
+:::caution
+**Next.js Compatibility:** Users of Next.js, particularly those using the Pages Router, should be aware of potential issues with Server-Sent Events (SSE) implementation. The Next.js Pages Router has known limitations in supporting SSE out of the box.
+
+For more information, refer to [this GitHub discussion](https://github.com/vercel/next.js/discussions/48427).


### PR DESCRIPTION
## 🎯 Changes

- Adds a snippet explaining that some react frameworks might not support SSE/EventSource protocol, specifically the NextJS pages router

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
