### PR TITLE
feat: implement output parsers for subscriptions

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/procedureBuilder.ts
+++ b/packages/server/src/unstable-core-do-not-import/procedureBuilder.ts
@@ -1,4 +1,4 @@
-import type { inferObservableValue } from '../observable';
+import type { inferObservableValue, Observable } from '../observable';
 import { getTRPCErrorFromUnknown, TRPCError } from './error/TRPCError';
 import type {
   AnyMiddlewareFunction,
@@ -356,18 +356,18 @@ export interface ProcedureBuilder<
    * Subscription procedure
    * @see https://trpc.io/docs/v11/concepts#vocabulary
    */
-  subscription<$Output>(
-    resolver: ProcedureResolver<
-      TContext,
-      TMeta,
-      TContextOverrides,
-      TInputOut,
-      TOutputIn,
-      $Output
-    >,
+  subscription<$Output, TResolver extends ProcedureResolver<
+    TContext,
+    TMeta,
+    TContextOverrides,
+    TInputOut,
+    TOutputIn extends UnsetMarker ? UnsetMarker : Observable<TOutputIn, unknown> | AsyncIterable<TOutputIn>,
+    $Output
+  >>(
+    resolver: TResolver,
   ): TCaller extends true
     ? TypeError<'Not implemented'>
-    : inferSubscriptionProcedure<TInputIn, TOutputOut, $Output>;
+    : inferSubscriptionProcedure<TInputIn, TOutputOut, ReturnType<TResolver>>;
 
   /**
    * Overrides the way a procedure is invoked

--- a/packages/tests/server/regression/issue-6062-subscription-output-parser.test.ts
+++ b/packages/tests/server/regression/issue-6062-subscription-output-parser.test.ts
@@ -1,0 +1,111 @@
+import type { TRPCError } from '@trpc/server';
+import { initTRPC } from '@trpc/server';
+import type { Observable} from '@trpc/server/observable';
+import { observable } from '@trpc/server/observable';
+import { z } from 'zod';
+
+async function consumeObservable<T>(observable: Observable<T, TRPCError>) {
+  const values: T[] = [];
+
+  await new Promise((resolve, reject) => {
+    observable.subscribe({
+      next(value) {
+        values.push(value);
+      },
+      complete() {
+        resolve(values);
+      },
+      error(error) {
+        reject(error);
+      },
+    });
+  });
+
+  return values;
+}
+
+async function consumeAsyncIterable<T>(iterable: AsyncIterable<T>) {
+  const values: T[] = [];
+
+  for await (const value of iterable) {
+    values.push(value);
+  }
+
+  return values;
+}
+
+describe('subscription output parser', () => {
+  const t = initTRPC.create();
+
+  describe('Observable', () => {
+    test('without output parser', async () => {
+      const appRouter = t.router({
+        hello: t.procedure
+          .subscription(() => observable<string>((emit) => {
+            emit.next('hello');
+            emit.next('world');
+            emit.complete();
+          })),
+      });
+
+      const caller = t.createCallerFactory(appRouter)({});
+      const result = await caller.hello();
+
+      expectTypeOf(result).toEqualTypeOf<Observable<string, TRPCError>>();
+      expect(await consumeObservable(result)).toEqual(['hello', 'world']);
+    });
+
+    test('with output parser', async () => {
+      const appRouter = t.router({
+        hello: t.procedure
+          .output(z.string().transform((value) => value.toUpperCase()))
+          .subscription(() => observable((emit) => {
+            emit.next('hello');
+            emit.next('world');
+            emit.complete();
+          })),
+      });
+
+      const caller = t.createCallerFactory(appRouter)({});
+      const result = await caller.hello();
+
+      expectTypeOf(result).toEqualTypeOf<Observable<string, TRPCError>>();
+      expect(await consumeObservable(result)).toEqual(['HELLO', 'WORLD']);
+    });
+  });
+
+  describe('AsyncGenerator', () => {
+    test('without output parser', async () => {
+      const appRouter = t.router({
+        hello: t.procedure
+          .subscription(async function* () {
+            yield 'hello';
+            yield 'world';
+          }),
+      });
+
+      const caller = t.createCallerFactory(appRouter)({});
+      const result = await caller.hello();
+
+      expectTypeOf(result).toEqualTypeOf<AsyncIterable<"hello" | "world">>();
+      expect(await consumeAsyncIterable(result)).toEqual(['hello', 'world']);
+    });
+
+    test('with output parser', async () => {
+      const appRouter = t.router({
+        hello: t.procedure
+          .output(z.string().transform((value) => value.toUpperCase()))
+          .subscription(async function* () {
+            yield 'hello';
+            yield 'world';
+          }),
+      });
+
+      const caller = t.createCallerFactory(appRouter)({});
+      const result = await caller.hello();
+
+      expectTypeOf(result).toEqualTypeOf<AsyncIterable<string>>();
+      expect(await consumeAsyncIterable(result)).toEqual(['HELLO', 'WORLD']);
+    });
+  });
+});


### PR DESCRIPTION
Closes #6062

## 🎯 Changes

This PR allow us to specify output parsers on subscription procedures. It will work with legacy style observers and also with async generators. Types are correctly generated and values are checked (parsed) at runtime.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
