### PR TITLE
feat: allow overriding of `mutationFn`

### DIFF
--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -316,9 +316,12 @@ export function createRootHooks<
       {
         ...opts,
         mutationKey: mutationKey,
-        mutationFn: (input) => {
-          return client.mutation(...getClientArgs([path, { input }], opts));
-        },
+        mutationFn:
+          opts?.mutationFn ??
+          defaultOpts?.mutationFn ??
+          ((input) => {
+            return client.mutation(...getClientArgs([path, { input }], opts));
+          }),
         onSuccess(...args) {
           const originalFn = () =>
             opts?.onSuccess?.(...args) ?? defaultOpts?.onSuccess?.(...args);


### PR DESCRIPTION
## 🎯 Changes

This PR enables users to override the `mutationFn` value via mutation options and default mutation options. 

This is very useful for offline-first apps when you want to conditionally mutate something locally without a network request. For example:

```ts
const utils = createTRPCQueryUtils({
  queryClient: opts.queryClient,
  client: opts.trpcClient,
});

utils.user.updatePhoto.setMutationDefaults(({ canonicalMutationFn }) => ({
  mutationFn: async (...params: Parameters<typeof canonicalMutationFn>) => {
    // The user could also be a guest user (generated locally without a connection)
    // For guest users, it doesn't make sense to perform the mutation online
    // because they would probably receive an "UNAUTHORIZED" error
    const user = utils.user.get.getData()!;
    if (!user.isGuest) {
      return canonicalMutationFn(...params);
    }
  },
  onMutate: async (input) => {
    // classic optimistic update
  }
}));
```


<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
