### PR TITLE
fix(server): ensure order of observable subscription errors

### DIFF
--- a/packages/server/src/observable/observable.ts
+++ b/packages/server/src/observable/observable.ts
@@ -1,3 +1,4 @@
+import type { Result } from '../unstable-core-do-not-import';
 import type {
   Observable,
   Observer,
@@ -9,9 +10,9 @@ import type {
 
 /** @public */
 export type inferObservableValue<TObservable> = TObservable extends Observable<
-  infer TValue,
-  unknown
->
+    infer TValue,
+    unknown
+  >
   ? TValue
   : never;
 
@@ -130,16 +131,17 @@ export function observableToPromise<TValue>(
  */
 function observableToReadableStream<TValue>(
   observable: Observable<TValue, unknown>,
-): ReadableStream<TValue> {
+): ReadableStream<Result<TValue>> {
   let unsub: Unsubscribable | null = null;
-  return new ReadableStream<TValue>({
+  return new ReadableStream<Result<TValue>>({
     start(controller) {
       unsub = observable.subscribe({
         next(data) {
-          controller.enqueue(data);
+          controller.enqueue({ isOk: true, value: data });
         },
-        error(err) {
-          controller.error(err);
+        error(error) {
+          controller.enqueue({ isOk: false, error });
+          controller.close();
         },
         complete() {
           controller.close();
@@ -167,8 +169,12 @@ export function observableToAsyncIterable<TValue>(
           done: true,
         };
       }
+      const { value: result } = value;
+      if (!result.isOk) {
+        throw result.error;
+      }
       return {
-        value: value.value,
+        value: result.value,
         done: false,
       };
     },

--- a/packages/server/src/observable/observable.ts
+++ b/packages/server/src/observable/observable.ts
@@ -10,9 +10,9 @@ import type {
 
 /** @public */
 export type inferObservableValue<TObservable> = TObservable extends Observable<
-    infer TValue,
-    unknown
-  >
+  infer TValue,
+  unknown
+>
   ? TValue
   : never;
 
@@ -137,10 +137,10 @@ function observableToReadableStream<TValue>(
     start(controller) {
       unsub = observable.subscribe({
         next(data) {
-          controller.enqueue({ isOk: true, value: data });
+          controller.enqueue({ ok: true, value: data });
         },
         error(error) {
-          controller.enqueue({ isOk: false, error });
+          controller.enqueue({ ok: false, error });
           controller.close();
         },
         complete() {
@@ -170,7 +170,7 @@ export function observableToAsyncIterable<TValue>(
         };
       }
       const { value: result } = value;
-      if (!result.isOk) {
+      if (!result.ok) {
         throw result.error;
       }
       return {

--- a/packages/server/src/unstable-core-do-not-import/types.ts
+++ b/packages/server/src/unstable-core-do-not-import/types.ts
@@ -34,9 +34,9 @@ export type FilterKeys<TObj extends object, TFilter> = {
 /**
  * @internal
  */
-export type Result<TType, ErrType = unknown> =
+export type Result<TType, TErr = unknown> =
   | { isOk: true; value: TType }
-  | { isOk: false; error: ErrType };
+  | { isOk: false; error: TErr };
 
 /**
  * @internal

--- a/packages/server/src/unstable-core-do-not-import/types.ts
+++ b/packages/server/src/unstable-core-do-not-import/types.ts
@@ -34,6 +34,13 @@ export type FilterKeys<TObj extends object, TFilter> = {
 /**
  * @internal
  */
+export type Result<TType, ErrType = unknown> =
+  | { isOk: true; value: TType }
+  | { isOk: false; error: ErrType };
+
+/**
+ * @internal
+ */
 export type Filter<TObj extends object, TFilter> = Pick<
   TObj,
   FilterKeys<TObj, TFilter>

--- a/packages/server/src/unstable-core-do-not-import/types.ts
+++ b/packages/server/src/unstable-core-do-not-import/types.ts
@@ -35,8 +35,8 @@ export type FilterKeys<TObj extends object, TFilter> = {
  * @internal
  */
 export type Result<TType, TErr = unknown> =
-  | { isOk: true; value: TType }
-  | { isOk: false; error: TErr };
+  | { ok: true; value: TType }
+  | { ok: false; error: TErr };
 
 /**
  * @internal

--- a/packages/tests/server/websockets.test.ts
+++ b/packages/tests/server/websockets.test.ts
@@ -110,9 +110,14 @@ function factory(config?: {
             emit.next(data);
           };
           ee.on('server:msg', onMessage);
+          const onError = (error: unknown) => {
+            emit.error(error)
+          }
+          ee.on('observable:error', onError)
           return () => {
             subscriptionEnded();
             ee.off('server:msg', onMessage);
+            ee.off('observable:error', onError);
           };
         });
         ee.emit('subscription:created');
@@ -258,6 +263,74 @@ test('basic subscription test (observable)', async () => {
       Array [
         Object {
           "id": "2",
+        },
+      ],
+    ]
+  `);
+
+  subscription.unsubscribe();
+
+  await waitFor(() => {
+    expect(ee.listenerCount('server:msg')).toBe(0);
+    expect(ee.listenerCount('server:error')).toBe(0);
+  });
+  await close();
+});
+
+test('subscription observable with error', async () => {
+  const { client, close, ee } = factory();
+  ee.once('subscription:created', () => {
+    setTimeout(() => {
+      // two emits to be sure an error is triggered in order 
+      ee.emit('server:msg', {
+        id: '1',
+      });
+      ee.emit('server:msg', {
+        id: '2',
+      });
+      ee.emit('observable:error', new Error("MyError"));
+    });
+  });
+  const onStartedMock = vi.fn();
+  const onDataOrErrorMock = vi.fn();
+  const subscription = client.onMessageObservable.subscribe(undefined, {
+    onStarted() {
+      onStartedMock();
+    },
+    onData(data) {
+      expectTypeOf(data).not.toBeAny();
+      expectTypeOf(data).toMatchTypeOf<Message>();
+      onDataOrErrorMock({ data });
+    },
+    onError(error) {
+      onDataOrErrorMock({ error });
+    },
+  });
+
+  await waitFor(() => {
+    expect(onStartedMock).toHaveBeenCalledTimes(1);
+    expect(onDataOrErrorMock).toHaveBeenCalledTimes(3);
+  });
+
+  expect(onDataOrErrorMock.mock.calls).toMatchInlineSnapshot(`
+    Array [
+      Array [
+        Object {
+          "data": Object {
+            "id": "1",
+          },
+        },
+      ],
+      Array [
+        Object {
+          "data": Object {
+            "id": "2",
+          },
+        },
+      ],
+      Array [
+        Object {
+          "error": [TRPCClientError: MyError],
         },
       ],
     ]


### PR DESCRIPTION
## 🎯 Changes

The `ReadableStreamDefaultController.error()` causes **any** future interactions with the associated stream to error.
Thus, if the underlying observable receives an error, it would have caused any `.next()` call on the iterator to throw instantly. In case of multiple emits, this would cause the error to propagate out of order.

In addition, this would have caused the `stopped` package in the ws adapter not to be sent. `await iterator.return?.()` would have thrown.

I'm not sure when this was introduced, but it seems to have been a somewhat recent regression.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] ~If necessary, I have added documentation related to the changes made.~
- [x] I have added or updated the tests related to the changes made.
