### PR TITLE
fix(sse): no `onError`-calls on aborted requests

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/stream/sse.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/sse.ts
@@ -89,7 +89,7 @@ export function sseStreamProducer(opts: SSEStreamProducerOptions) {
       const next = await Promise.race([
         nextPromise.catch((err) => {
           if (err instanceof Error && err.name === 'AbortError') {
-            // Fixes so that aborting the request does not throw an error
+            // Ensures that aborting the request doesn't throw an error
             return 'aborted' as const;
           }
           return getTRPCErrorFromUnknown(err);

--- a/packages/tests/server/httpSubscriptionLink.test.ts
+++ b/packages/tests/server/httpSubscriptionLink.test.ts
@@ -170,6 +170,8 @@ test('iterable event', async () => {
     expect(ctx.onReqAborted).toHaveBeenCalledTimes(1);
   });
 
+  expect(ctx.onErrorSpy).not.toHaveBeenCalled();
+
   await waitFor(() => {
     expect(ctx.ee.listenerCount('data')).toBe(0);
   });


### PR DESCRIPTION
Closes #

## 🎯 Changes

Fixes so we don't do cancellation errors on aborted requests