### PR TITLE
refactor(server/sse): split async iterable utils from `sseStreamProducer` 

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/stream/utils/asyncIterable.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/utils/asyncIterable.ts
@@ -1,0 +1,62 @@
+import { noop } from '../../utils';
+import { createPromiseTimer } from './promiseTimer';
+
+/**
+ * Derives a new {@link AsyncGenerator} based of {@link iterable}, that automatically stops with the
+ * passed {@link cancel} promise.
+ */
+export async function* withCancel<T>(
+  iterable: AsyncIterable<T>,
+  cancel: Promise<unknown>,
+): AsyncGenerator<T> {
+  const cancelPromise = cancel.then(noop);
+  const iterator = iterable[Symbol.asyncIterator]();
+  while (true) {
+    const result = await Promise.race([iterator.next(), cancelPromise]);
+    if (result == null) {
+      await iterator.return?.();
+      break;
+    }
+    if (result.done) {
+      break;
+    }
+    yield result.value;
+  }
+}
+
+interface TakeWithGraceOptions {
+  count: number;
+  gracePeriodMs: number;
+}
+
+/**
+ * Derives a new {@link AsyncGenerator} based of {@link iterable}, that yields its first
+ * {@link count} values. Then, a grace period of {@link gracePeriodMs} is started in which further
+ * values may still come through. After this period, the generator stops.
+ */
+export async function* takeWithGrace<T>(
+  iterable: AsyncIterable<T>,
+  { count, gracePeriodMs }: TakeWithGraceOptions,
+): AsyncGenerator<T> {
+  const iterator = iterable[Symbol.asyncIterator]();
+  const timer = createPromiseTimer(gracePeriodMs);
+  try {
+    while (true) {
+      const result = await Promise.race([iterator.next(), timer.promise]);
+      if (result == null) {
+        // cancelled
+        await iterator.return?.();
+        break;
+      }
+      if (result.done) {
+        break;
+      }
+      yield result.value;
+      if (--count === 0) {
+        timer.start();
+      }
+    }
+  } finally {
+    timer.clear();
+  }
+}

--- a/packages/server/src/unstable-core-do-not-import/stream/utils/createDeferred.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/utils/createDeferred.ts
@@ -10,39 +10,3 @@ export function createDeferred<TValue>() {
   return { promise, resolve: resolve!, reject: reject! };
 }
 export type Deferred<TValue> = ReturnType<typeof createDeferred<TValue>>;
-
-export const createTimeoutPromise = <TValue>(
-  timeoutMs: number,
-  value: TValue,
-) => {
-  let deferred = createDeferred<TValue>();
-  deferred = deferred as typeof deferred & { clear: () => void };
-
-  let timeout: ReturnType<typeof setTimeout> | null = null;
-  const clear = () => {
-    if (timeout) {
-      clearTimeout(timeout);
-      timeout = null;
-    }
-  };
-  const resolve = () => {
-    deferred.resolve(value);
-    clear();
-  };
-  if (timeoutMs !== Infinity) {
-    timeout = setTimeout(resolve, timeoutMs);
-    timeout.unref?.();
-  }
-
-  return {
-    promise: deferred.promise,
-    /**
-     * Clear the timeout without resolving the promise
-     */
-    clear,
-    /**
-     * Resolve the promise with the value
-     */
-    resolve,
-  };
-};

--- a/packages/server/src/unstable-core-do-not-import/stream/utils/promiseTimer.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/utils/promiseTimer.ts
@@ -1,0 +1,40 @@
+import { createDeferred } from './createDeferred';
+
+export function createPromiseTimer(ms: number) {
+  let deferred = createDeferred<void>();
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+
+  const timer = {
+    get promise() {
+      return deferred.promise;
+    },
+
+    start,
+    reset,
+    clear,
+  };
+  return timer;
+
+  function start(): PromiseTimer {
+    if (timeout != null) {
+      throw new Error("PromiseTimer already started.");
+    }
+    timeout = setTimeout(deferred.resolve, ms);
+    return timer;
+  }
+
+  function reset(): PromiseTimer {
+    clear();
+    deferred = createDeferred();
+    return timer;
+  }
+
+  function clear(): PromiseTimer {
+    if (timeout != null) {
+      clearTimeout(timeout);
+      timeout = null;
+    }
+    return timer;
+  }
+}
+export type PromiseTimer = ReturnType<typeof createPromiseTimer>;

--- a/packages/server/src/unstable-core-do-not-import/stream/utils/withPing.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/utils/withPing.ts
@@ -1,0 +1,30 @@
+export const PING_SYM = Symbol('ping');
+
+const PING_RESULT: IteratorResult<typeof PING_SYM> = {
+  value: PING_SYM,
+  done: false,
+};
+
+export async function* withPing<TValue>(
+  iterable: AsyncIterable<TValue>,
+  pingInterval: number,
+): AsyncGenerator<TValue | typeof PING_SYM> {
+  let timer!: ReturnType<typeof setTimeout>;
+  const iterator = iterable[Symbol.asyncIterator]();
+  while (true) {
+    const nextPromise = iterator.next();
+    const ping = new Promise<IteratorResult<typeof PING_SYM>>((resolve) => {
+      timer = setTimeout(resolve.bind(null, PING_RESULT), pingInterval);
+    });
+    let result: IteratorResult<TValue | typeof PING_SYM>;
+    try {
+      result = await Promise.race([ping, nextPromise]);
+    } finally {
+      clearTimeout(timer);
+    }
+    if (result.done) {
+      return result.value;
+    }
+    yield result.value;
+  }
+}

--- a/packages/server/src/unstable-core-do-not-import/utils.ts
+++ b/packages/server/src/unstable-core-do-not-import/utils.ts
@@ -61,3 +61,10 @@ export function isAsyncIterable<TValue>(
  * Run an IIFE
  */
 export const run = <TValue>(fn: () => TValue): TValue => fn();
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+export function noop(): void {}
+
+export function identity<T>(it: T): T {
+  return it;
+}


### PR DESCRIPTION
## 🎯 Changes

Some code refactoring to improve quality.

The `sseStreamProducer` is simplified and improved for readability. Used patterns are extracted into more general-purpose utils.

**However…** I do believe we have to move those patterns towards `resolveResponse()`, as we ought to merge the cancel conditions with the signal for `proc({..., signal})`. Otherwise (as it is right now), there will be dangling listeners on the user code (until the next `yield`). I just noticed this after making the changes o.O @KATT 

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
