### PR TITLE
doc  typo  in  RSC section

### DIFF
--- a/www/docs/client/react/server-components.mdx
+++ b/www/docs/client/react/server-components.mdx
@@ -323,7 +323,7 @@ import { trpc } from '~/trpc/client';
 
 export function ClientGreeting() {
   const [data] = trpc.hello.useSuspenseQuery();
-  return <div>{greeting.data.greeting}</div>;
+  return <div>{data.greeting}</div>;
 }
 ```
 


### PR DESCRIPTION
In this section of doc https://trpc.io/docs/client/react/server-components#leveraging-suspense 

there is bug / typo


Closes #

## 🎯 Changes

Bug 

```

 const [data] = trpc.hello.useSuspenseQuery();
  return <div>{greeting.data.greeting}</div>; 
```

greeting   is not defined  in the file 

changed to  

 ```
const [data] = trpc.hello.useSuspenseQuery();
  return <div>{data.greeting}</div>; 
```

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
