### PR TITLE
fix: update fastify dependency

### DIFF
--- a/examples/fastify-server/package.json
+++ b/examples/fastify-server/package.json
@@ -19,7 +19,7 @@
     "@fastify/websocket": "^10.0.1",
     "@trpc/client": "npm:@trpc/client@next",
     "@trpc/server": "npm:@trpc/server@next",
-    "fastify": "^4.16.0",
+    "fastify": "^4.26.0",
     "superjson": "^1.12.4",
     "tslib": "^2.5.0",
     "ws": "^8.0.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -128,7 +128,7 @@
     "devalue": "^5.0.0",
     "eslint": "^8.57.0",
     "express": "^4.17.1",
-    "fastify": "^4.16.0",
+    "fastify": "^4.26.0",
     "fastify-plugin": "^5.0.0",
     "hash-sum": "^2.0.0",
     "myzod": "^1.3.1",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -32,7 +32,7 @@
     "dataloader": "^2.2.2",
     "devalue": "^5.0.0",
     "eslint": "^8.57.0",
-    "fastify": "^4.16.0",
+    "fastify": "^4.26.0",
     "fastify-plugin": "^5.0.0",
     "jsdom": "^24.0.0",
     "konn": "^0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -591,7 +591,7 @@ importers:
         specifier: npm:@trpc/server@next
         version: link:../../packages/server
       fastify:
-        specifier: ^4.16.0
+        specifier: ^4.26.0
         version: 4.26.2
       superjson:
         specifier: ^1.12.4
@@ -1815,8 +1815,8 @@ importers:
         specifier: ^4.17.1
         version: 4.20.0
       fastify:
-        specifier: ^4.16.0
-        version: 4.26.2
+        specifier: ^4.26.0
+        version: 4.26.0
       fastify-plugin:
         specifier: ^5.0.0
         version: 5.0.0
@@ -1938,8 +1938,8 @@ importers:
         specifier: ^8.57.0
         version: 8.57.0
       fastify:
-        specifier: ^4.16.0
-        version: 4.26.2
+        specifier: ^4.26.0
+        version: 4.26.0
       fastify-plugin:
         specifier: ^5.0.0
         version: 5.0.0
@@ -17557,6 +17557,28 @@ packages:
   /fastify-plugin@5.0.0:
     resolution: {integrity: sha512-0725fmH/yYi8ugsjszLci+lLnGBK6cG+WSxM7edY2OXJEU7gr2JiGBoieL2h9mhTych1vFsEfXsAsGGDJ/Rd5w==}
 
+  /fastify@4.26.0:
+    resolution: {integrity: sha512-Fq/7ziWKc6pYLYLIlCRaqJqEVTIZ5tZYfcW/mDK2AQ9v/sqjGFpj0On0/7hU50kbPVjLO4de+larPA1WwPZSfw==}
+    dependencies:
+      '@fastify/ajv-compiler': 3.5.0
+      '@fastify/error': 3.4.1
+      '@fastify/fast-json-stringify-compiler': 4.3.0
+      abstract-logging: 2.0.1
+      avvio: 8.3.0
+      fast-content-type-parse: 1.1.0
+      fast-json-stringify: 5.13.0
+      find-my-way: 8.1.0
+      light-my-request: 5.12.0
+      pino: 8.19.0
+      process-warning: 3.0.0
+      proxy-addr: 2.0.7
+      rfdc: 1.3.0
+      secure-json-parse: 2.7.0
+      semver: 7.6.3
+      toad-cache: 3.7.0
+    transitivePeerDependencies:
+      - supports-color
+
   /fastify@4.26.2:
     resolution: {integrity: sha512-90pjTuPGrfVKtdpLeLzND5nyC4woXZN5VadiNQCicj/iJU4viNHKhsAnb7jmv1vu2IzkLXyBiCzdWuzeXgQ5Ug==}
     dependencies:
@@ -17574,10 +17596,11 @@ packages:
       proxy-addr: 2.0.7
       rfdc: 1.3.0
       secure-json-parse: 2.7.0
-      semver: 7.5.4
+      semver: 7.6.3
       toad-cache: 3.7.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
@@ -26047,6 +26070,7 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
+    dev: false
 
   /semver@7.6.2:
     resolution: {integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1816,7 +1816,7 @@ importers:
         version: 4.20.0
       fastify:
         specifier: ^4.26.0
-        version: 4.26.0
+        version: 4.26.2
       fastify-plugin:
         specifier: ^5.0.0
         version: 5.0.0
@@ -1939,7 +1939,7 @@ importers:
         version: 8.57.0
       fastify:
         specifier: ^4.26.0
-        version: 4.26.0
+        version: 4.26.2
       fastify-plugin:
         specifier: ^5.0.0
         version: 5.0.0
@@ -17557,28 +17557,6 @@ packages:
   /fastify-plugin@5.0.0:
     resolution: {integrity: sha512-0725fmH/yYi8ugsjszLci+lLnGBK6cG+WSxM7edY2OXJEU7gr2JiGBoieL2h9mhTych1vFsEfXsAsGGDJ/Rd5w==}
 
-  /fastify@4.26.0:
-    resolution: {integrity: sha512-Fq/7ziWKc6pYLYLIlCRaqJqEVTIZ5tZYfcW/mDK2AQ9v/sqjGFpj0On0/7hU50kbPVjLO4de+larPA1WwPZSfw==}
-    dependencies:
-      '@fastify/ajv-compiler': 3.5.0
-      '@fastify/error': 3.4.1
-      '@fastify/fast-json-stringify-compiler': 4.3.0
-      abstract-logging: 2.0.1
-      avvio: 8.3.0
-      fast-content-type-parse: 1.1.0
-      fast-json-stringify: 5.13.0
-      find-my-way: 8.1.0
-      light-my-request: 5.12.0
-      pino: 8.19.0
-      process-warning: 3.0.0
-      proxy-addr: 2.0.7
-      rfdc: 1.3.0
-      secure-json-parse: 2.7.0
-      semver: 7.6.3
-      toad-cache: 3.7.0
-    transitivePeerDependencies:
-      - supports-color
-
   /fastify@4.26.2:
     resolution: {integrity: sha512-90pjTuPGrfVKtdpLeLzND5nyC4woXZN5VadiNQCicj/iJU4viNHKhsAnb7jmv1vu2IzkLXyBiCzdWuzeXgQ5Ug==}
     dependencies:
@@ -17600,7 +17578,6 @@ packages:
       toad-cache: 3.7.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}


### PR DESCRIPTION
## 🎯 Changes

Update Fastify dependency to support passing Response object directly to Reply.send.
Earlier versions of fastify do not support passing a Response object directly. The capability was introduced here and is first available on version 4.26.0

https://github.com/fastify/fastify/commit/101ba57f894281421d902bf509adb4270473799d

Without this change, users who upgrade to v11 of tRPC who are using a prior version of fastify will receive an empty object `{}` for every response. No errors are emitted from the server, but tRPC clients will reject the response as invalid

 
## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
