### PR TITLE
fix: `useSuspenseQuery` for queryoptoins api

### DIFF
--- a/packages/react-query/src/internals/context.tsx
+++ b/packages/react-query/src/internals/context.tsx
@@ -154,7 +154,7 @@ export interface TRPCQueryUtils<TRouter extends AnyRouter> {
   queryOptions(
     path: readonly string[], // <-- look into if needed
     queryKey: TRPCQueryKey,
-    opts?: DefinedTRPCQueryOptionsIn<
+    opts: DefinedTRPCQueryOptionsIn<
       unknown,
       unknown,
       TRPCClientError<AnyClientTypes>

--- a/packages/react-query/src/shared/proxy/utilsProxy.ts
+++ b/packages/react-query/src/shared/proxy/utilsProxy.ts
@@ -56,6 +56,8 @@ import type {
   UndefinedTRPCQueryOptionsOut,
   UnusedSkipTokenTRPCInfiniteQueryOptionsIn,
   UnusedSkipTokenTRPCInfiniteQueryOptionsOut,
+  UnusedSkipTokenTRPCQueryOptionsIn,
+  UnusedSkipTokenTRPCQueryOptionsOut,
 } from '../types';
 
 export type DecorateQueryProcedure<
@@ -76,6 +78,24 @@ export type DecorateQueryProcedure<
       TRPCClientError<TRoot>
     >,
   ): DefinedTRPCQueryOptionsOut<TQueryFnData, TData, TRPCClientError<TRoot>>;
+  /**
+   * @see https://tanstack.com/query/latest/docs/framework/react/reference/queryOptions#queryoptions
+   */
+  queryOptions<
+    TQueryFnData extends inferTransformedProcedureOutput<TRoot, TProcedure>,
+    TData = TQueryFnData,
+  >(
+    input: inferProcedureInput<TProcedure> | SkipToken,
+    opts?: UnusedSkipTokenTRPCQueryOptionsIn<
+      TQueryFnData,
+      TData,
+      TRPCClientError<TRoot>
+    >,
+  ): UnusedSkipTokenTRPCQueryOptionsOut<
+    TQueryFnData,
+    TData,
+    TRPCClientError<TRoot>
+  >;
   /**
    * @see https://tanstack.com/query/latest/docs/framework/react/reference/queryOptions#queryoptions
    */

--- a/packages/react-query/src/shared/types.ts
+++ b/packages/react-query/src/shared/types.ts
@@ -7,6 +7,7 @@ import type {
   UndefinedInitialDataInfiniteOptions,
   UndefinedInitialDataOptions,
   UnusedSkipTokenInfiniteOptions,
+  UnusedSkipTokenOptions,
 } from '@tanstack/react-query';
 import type {
   AnyRouter,
@@ -83,6 +84,32 @@ export interface DefinedTRPCQueryOptionsOut<TQueryFnData, TData, TError>
     >,
     TRPCQueryOptionsResult {
   queryKey: DataTag<TRPCQueryKey, coerceAsyncIterableToArray<TData>>;
+}
+
+export interface UnusedSkipTokenTRPCQueryOptionsIn<TQueryFnData, TData, TError>
+  extends DistributiveOmit<
+      UnusedSkipTokenOptions<
+        coerceAsyncIterableToArray<TQueryFnData>,
+        TError,
+        coerceAsyncIterableToArray<TData>,
+        TRPCQueryKey
+      >,
+      TRPCOptionOverrides
+    >,
+    TRPCQueryBaseOptions {}
+
+export interface UnusedSkipTokenTRPCQueryOptionsOut<
+  TQueryFnData,
+  TOutput,
+  TError,
+> extends UnusedSkipTokenOptions<
+      coerceAsyncIterableToArray<TQueryFnData>,
+      TError,
+      coerceAsyncIterableToArray<TOutput>,
+      TRPCQueryKey
+    >,
+    TRPCQueryOptionsResult {
+  queryKey: DataTag<TRPCQueryKey, coerceAsyncIterableToArray<TOutput>>;
 }
 
 /**

--- a/packages/tests/server/react/queryOptions.test.tsx
+++ b/packages/tests/server/react/queryOptions.test.tsx
@@ -6,6 +6,7 @@ import {
   useInfiniteQuery,
   useQuery,
   useQueryClient,
+  useSuspenseQuery,
   type InfiniteData,
 } from '@tanstack/react-query';
 import { render, waitFor } from '@testing-library/react';
@@ -13,7 +14,7 @@ import userEvent from '@testing-library/user-event';
 import { initTRPC } from '@trpc/server';
 import { createDeferred } from '@trpc/server/unstable-core-do-not-import/stream/utils/createDeferred';
 import { konn } from 'konn';
-import React, { useEffect } from 'react';
+import React, { Suspense, useEffect } from 'react';
 import { z } from 'zod';
 
 const fixtureData = ['1', '2', '3', '4'];
@@ -347,6 +348,29 @@ describe('queryOptions', () => {
           },
         ]
       `);
+  });
+
+  test('useSuspenseQuery', async () => {
+    const { App, useTRPC } = ctx;
+    function MyComponent() {
+      const trpc = useTRPC();
+      const { data } = useSuspenseQuery(
+        trpc.post.byId.queryOptions({ id: '1' }),
+      );
+
+      expectTypeOf(data).toMatchTypeOf<'__result'>();
+
+      return <pre>{JSON.stringify(data ?? 'n/a', null, 4)}</pre>;
+    }
+
+    const utils = render(
+      <App>
+        <MyComponent />
+      </App>,
+    );
+    await waitFor(() => {
+      expect(utils.container).toHaveTextContent(`__result`);
+    });
   });
 });
 


### PR DESCRIPTION
Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
