### PR TITLE
feat(server): expose more http helpers

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/http/getHTTPStatusCode.ts
+++ b/packages/server/src/unstable-core-do-not-import/http/getHTTPStatusCode.ts
@@ -1,9 +1,10 @@
 import type { TRPCError } from '../error/TRPCError';
 import type { TRPC_ERROR_CODES_BY_KEY, TRPCResponse } from '../rpc';
 import { TRPC_ERROR_CODES_BY_NUMBER } from '../rpc';
+import type { InvertKeyValue, ValueOf } from '../types';
 import { isObject } from '../utils';
 
-const JSONRPC2_TO_HTTP_CODE: Record<
+export const JSONRPC2_TO_HTTP_CODE: Record<
   keyof typeof TRPC_ERROR_CODES_BY_KEY,
   number
 > = {
@@ -28,11 +29,42 @@ const JSONRPC2_TO_HTTP_CODE: Record<
   GATEWAY_TIMEOUT: 504,
 };
 
-function getStatusCodeFromKey(code: keyof typeof TRPC_ERROR_CODES_BY_KEY) {
+export const HTTP_CODE_TO_JSONRPC2: InvertKeyValue<
+  typeof JSONRPC2_TO_HTTP_CODE
+> = {
+  400: 'BAD_REQUEST',
+  401: 'UNAUTHORIZED',
+  403: 'FORBIDDEN',
+  404: 'NOT_FOUND',
+  405: 'METHOD_NOT_SUPPORTED',
+  408: 'TIMEOUT',
+  409: 'CONFLICT',
+  412: 'PRECONDITION_FAILED',
+  413: 'PAYLOAD_TOO_LARGE',
+  415: 'UNSUPPORTED_MEDIA_TYPE',
+  422: 'UNPROCESSABLE_CONTENT',
+  429: 'TOO_MANY_REQUESTS',
+  499: 'CLIENT_CLOSED_REQUEST',
+  500: 'INTERNAL_SERVER_ERROR',
+  501: 'NOT_IMPLEMENTED',
+  502: 'BAD_GATEWAY',
+  503: 'SERVICE_UNAVAILABLE',
+  504: 'GATEWAY_TIMEOUT',
+} as const;
+
+export function getStatusCodeFromKey(
+  code: keyof typeof TRPC_ERROR_CODES_BY_KEY,
+) {
   return JSONRPC2_TO_HTTP_CODE[code] ?? 500;
 }
 
-export function getHTTPStatusCode(json: TRPCResponse | TRPCResponse[]): number {
+export function getStatusKeyFromCode(
+  code: keyof typeof HTTP_CODE_TO_JSONRPC2,
+): ValueOf<typeof HTTP_CODE_TO_JSONRPC2> {
+  return HTTP_CODE_TO_JSONRPC2[code] ?? 'INTERNAL_SERVER_ERROR';
+}
+
+export function getHTTPStatusCode(json: TRPCResponse | TRPCResponse[]) {
   const arr = Array.isArray(json) ? json : [json];
   const httpStatuses = new Set<number>(
     arr.map((res) => {

--- a/packages/server/src/unstable-core-do-not-import/rpc/codes.ts
+++ b/packages/server/src/unstable-core-do-not-import/rpc/codes.ts
@@ -1,4 +1,4 @@
-import type { ValueOf } from '../types';
+import type { InvertKeyValue, ValueOf } from '../types';
 
 // reference: https://www.jsonrpc.org/specification
 
@@ -41,16 +41,8 @@ export const TRPC_ERROR_CODES_BY_KEY = {
   CLIENT_CLOSED_REQUEST: -32099, // 499
 } as const;
 
-type KeyFromValue<TValue, TType extends Record<PropertyKey, PropertyKey>> = {
-  [K in keyof TType]: TValue extends TType[K] ? K : never;
-}[keyof TType];
-
-type Invert<TType extends Record<PropertyKey, PropertyKey>> = {
-  [TValue in TType[keyof TType]]: KeyFromValue<TValue, TType>;
-};
-
 // pure
-export const TRPC_ERROR_CODES_BY_NUMBER: Invert<
+export const TRPC_ERROR_CODES_BY_NUMBER: InvertKeyValue<
   typeof TRPC_ERROR_CODES_BY_KEY
 > = {
   [-32700]: 'PARSE_ERROR',

--- a/packages/server/src/unstable-core-do-not-import/types.ts
+++ b/packages/server/src/unstable-core-do-not-import/types.ts
@@ -131,6 +131,17 @@ export type PickFirstDefined<TType, TPick> = undefined extends TType
     : TPick
   : TType;
 
+export type KeyFromValue<
+  TValue,
+  TType extends Record<PropertyKey, PropertyKey>,
+> = {
+  [K in keyof TType]: TValue extends TType[K] ? K : never;
+}[keyof TType];
+
+export type InvertKeyValue<TType extends Record<PropertyKey, PropertyKey>> = {
+  [TValue in TType[keyof TType]]: KeyFromValue<TValue, TType>;
+};
+
 /**
  * ================================
  * tRPC specific types


### PR DESCRIPTION
### Description

This PR target and will close #6137 

## 🎯 Changes

- Export `JSONRPC2_TO_HTTP_CODE`
- Add & export `HTTP_CODE_TO_JSONRPC2`
- Export `getStatusCodeFromKey`
- Add & export `getStatusKeyFromCode`
- Move the `Invert` type helper at `unstable-core-do-not-import/types.ts` and rename it to `InvertKeyValue`

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.

### Additional notes

I've not updated any documentation to my current changes, and I'm unsure if I should...
But we have a good documentation section about [error-handling](https://trpc.io/docs/server/error-handling) and it would make sense to mention it somewhere like there...

> PS: this is my first contribution to `[trpc](https://github.com/trpc/trpc)`, if I've missed something or did something wrong please let me know 🥹

