### PR TITLE
fix(server/util): dangling event listener in `AbortSignal.any` ponyfill

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/utils.ts
+++ b/packages/server/src/unstable-core-do-not-import/utils.ts
@@ -102,9 +102,9 @@ export function abortSignalsAnyPonyfill(signals: AbortSignal[]): AbortSignal {
   for (const signal of signals) {
     if (signal.aborted) {
       trigger();
-    } else if (!ac.signal.aborted) {
-      signal.addEventListener('abort', trigger, { once: true });
+      break;
     }
+    signal.addEventListener('abort', trigger, { once: true });
   }
 
   return ac.signal;


### PR DESCRIPTION
Simple improvement as proposed by @KATT https://github.com/trpc/trpc/pull/6128#pullrequestreview-2379887271