### PR TITLE
feat(client): supply operation to the `httpSubscriptionLink`'s `eventSourceOptions`

### DIFF
--- a/packages/client/src/links/internals/urlWithConnectionParams.ts
+++ b/packages/client/src/links/internals/urlWithConnectionParams.ts
@@ -2,9 +2,15 @@ import { type TRPCRequestInfo } from '@trpc/server/http';
 
 /**
  * Get the result of a value or function that returns a value
+ * It also optionally accepts typesafe arguments for the function
  */
-export const resultOf = <T>(value: T | (() => T)): T => {
-  return typeof value === 'function' ? (value as () => T)() : value;
+export const resultOf = <T, TArgs extends any[]>(
+  value: T | ((...args: TArgs) => T),
+  ...args: TArgs
+): T => {
+  return typeof value === 'function'
+    ? (value as (...args: TArgs) => T)(...args)
+    : value;
 };
 
 /**


### PR DESCRIPTION
Closes #6148

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?
A new feature to supply the operation that initialises an EventSource in httpSubscriptionLink.

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [X] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
