### PR TITLE
fix(react-query): `useSuspenseQuery` does not forward trpc options

### DIFF
--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -253,6 +253,7 @@ export function createRootHooks<
         : (queryFunctionContext) => {
             const actualOpts = {
               trpc: {
+                ...opts?.trpc,
                 ...(shouldAbortOnUnmount
                   ? { signal: queryFunctionContext.signal }
                   : {}),
@@ -283,7 +284,9 @@ export function createRootHooks<
         queryKey: queryKey as any,
         queryFn: (queryFunctionContext) => {
           const actualOpts = {
+            ...opts,
             trpc: {
+              ...opts?.trpc,
               ...(shouldAbortOnUnmount
                 ? { signal: queryFunctionContext.signal }
                 : { signal: null }),

--- a/packages/tests/server/react/useSuspenseQuery.test.tsx
+++ b/packages/tests/server/react/useSuspenseQuery.test.tsx
@@ -31,9 +31,18 @@ const ctx = konn()
 test('useSuspenseQuery()', async () => {
   const { client, App } = ctx;
   function MyComponent() {
-    const [data, query1] = client.post.byId.useSuspenseQuery({
-      id: '1',
-    });
+    const [data, query1] = client.post.byId.useSuspenseQuery(
+      {
+        id: '1',
+      },
+      {
+        trpc: {
+          context: {
+            test: true,
+          },
+        },
+      },
+    );
     expectTypeOf(data).toEqualTypeOf<'__result'>();
 
     type TData = typeof data;
@@ -52,31 +61,9 @@ test('useSuspenseQuery()', async () => {
   await waitFor(() => {
     expect(utils.container).toHaveTextContent(`__result`);
   });
-});
 
-test('useSuspenseQuery()', async () => {
-  const { client, App } = ctx;
-  function MyComponent() {
-    const [data, query1] = client.post.byId.useSuspenseQuery({
-      id: '1',
-    });
-    expectTypeOf(data).toEqualTypeOf<'__result'>();
-
-    type TData = typeof data;
-    expectTypeOf<TData>().toMatchTypeOf<'__result'>();
-    expect(data).toBe('__result');
-    expect(query1.data).toBe('__result');
-
-    return <>{query1.data}</>;
-  }
-
-  const utils = render(
-    <App>
-      <MyComponent />
-    </App>,
-  );
-  await waitFor(() => {
-    expect(utils.container).toHaveTextContent(`__result`);
+  expect(ctx.spyLink.mock.calls[0]?.[0].context).toMatchObject({
+    test: true,
   });
 });
 


### PR DESCRIPTION
Closes #6133

## 🎯 Changes

Fix

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
