### PR TITLE
fix(client): wrongly typing `AsyncGenerator` where it should be `AsyncIterable`

### DIFF
--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -36,11 +36,16 @@ type ResolverDef = {
   errorShape: any;
 };
 
+type coerceAsyncGeneratorToIterable<T> =
+  T extends AsyncGenerator<infer $T, infer $Return, infer $Next>
+    ? AsyncIterable<$T, $Return, $Next>
+    : T;
+
 /** @internal */
 export type Resolver<TDef extends ResolverDef> = (
   input: TDef['input'],
   opts?: ProcedureOptions,
-) => Promise<TDef['output']>;
+) => Promise<coerceAsyncGeneratorToIterable<TDef['output']>>;
 
 type SubscriptionResolver<TDef extends ResolverDef> = (
   input: TDef['input'],

--- a/packages/server/src/unstable-core-do-not-import/clientish/serialize.ts
+++ b/packages/server/src/unstable-core-do-not-import/clientish/serialize.ts
@@ -26,7 +26,7 @@ type IsRecord<T extends object> = keyof WithoutIndexSignature<T> extends never
 export type Serialize<T> =
   IsAny<T> extends true ? any :
   unknown extends T ? unknown :
-  T extends AsyncGenerator<infer $T, infer $Return, infer $Next> ? AsyncGenerator<Serialize<$T>, Serialize<$Return>, Serialize<$Next>> :
+  T extends AsyncIterable<infer $T, infer $Return, infer $Next> ? AsyncIterable<Serialize<$T>, Serialize<$Return>, Serialize<$Next>> :
   T extends JsonReturnable ? T :
   T extends Map<any, any> | Set<any> ? object :
   T extends NonJsonPrimitive ? never :

--- a/packages/server/src/unstable-core-do-not-import/procedureBuilder.ts
+++ b/packages/server/src/unstable-core-do-not-import/procedureBuilder.ts
@@ -44,21 +44,22 @@ type DefaultValue<TValue, TFallback> = TValue extends UnsetMarker
   ? TFallback
   : TValue;
 
-type inferAsyncIterator<TOutput> =
-  TOutput extends AsyncIterator<infer $Yield, infer $Return, infer $Next>
+type inferAsyncIterable<TOutput> =
+  TOutput extends AsyncIterable<infer $Yield, infer $Return, infer $Next>
     ? {
         yield: $Yield;
         return: $Return;
         next: $Next;
       }
     : never;
-type inferSubscriptionOutput<TOutput> = TOutput extends AsyncGenerator
-  ? AsyncGenerator<
-      inferTrackedOutput<inferAsyncIterator<TOutput>['yield']>,
-      inferAsyncIterator<TOutput>['return'],
-      inferAsyncIterator<TOutput>['next']
-    >
-  : TypeError<'Subscription output could not be inferred'>;
+type inferSubscriptionOutput<TOutput> =
+  TOutput extends AsyncIterable<any>
+    ? AsyncIterable<
+        inferTrackedOutput<inferAsyncIterable<TOutput>['yield']>,
+        inferAsyncIterable<TOutput>['return'],
+        inferAsyncIterable<TOutput>['next']
+      >
+    : TypeError<'Subscription output could not be inferred'>;
 
 export type CallerOverride<TContext> = (opts: {
   args: unknown[];

--- a/packages/tests/server/httpSubscriptionLink.test.ts
+++ b/packages/tests/server/httpSubscriptionLink.test.ts
@@ -26,7 +26,7 @@ import { uneval } from 'devalue';
 import { konn } from 'konn';
 import superjson from 'superjson';
 import { z } from 'zod';
-import { zAsyncGenerator } from './zAsyncGenerator';
+import { zAsyncIterable } from './zAsyncIterable';
 
 const sleep = (ms = 1) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -51,7 +51,7 @@ const ctx = konn()
       sub: {
         iterableEvent: t.procedure
           .output(
-            zAsyncGenerator({
+            zAsyncIterable({
               yield: z.number(),
               tracked: false,
             }),
@@ -75,7 +75,7 @@ const ctx = konn()
               lastEventId: z.coerce.number().min(0).optional(),
             }),
           )
-          .output(zAsyncGenerator({ yield: z.number(), tracked: true }))
+          .output(zAsyncIterable({ yield: z.number(), tracked: true }))
           .subscription(async function* (opts) {
             onIterableInfiniteSpy({
               input: opts.input,

--- a/packages/tests/server/streaming.test.ts
+++ b/packages/tests/server/streaming.test.ts
@@ -22,7 +22,7 @@ import {
 import { konn } from 'konn';
 import superjson from 'superjson';
 import { z } from 'zod';
-import { zAsyncGenerator } from './zAsyncGenerator';
+import { zAsyncIterable } from './zAsyncIterable';
 
 describe('no transformer', () => {
   const orderedResults: number[] = [];
@@ -37,7 +37,6 @@ describe('no transformer', () => {
       let iterableDeferred = createDeferred<void>();
       const nextIterable = () => {
         iterableDeferred.resolve();
-        iterableDeferred = createDeferred();
       };
       const yieldSpy = vi.fn((v: number) => v);
 
@@ -82,7 +81,7 @@ describe('no transformer', () => {
               .optional(),
           )
           .output(
-            zAsyncGenerator({
+            zAsyncIterable({
               yield: z.number(),
               return: z.string(),
             }),
@@ -90,7 +89,9 @@ describe('no transformer', () => {
           .query(async function* (opts) {
             for (let i = 0; i < 10; i++) {
               yield yieldSpy(i + 1);
+
               await iterableDeferred.promise;
+
               iterableDeferred = createDeferred();
             }
 
@@ -157,6 +158,21 @@ describe('no transformer', () => {
       await opts?.close?.();
     })
     .done();
+
+  test('server-side call', async () => {
+    const caller = ctx.router.createCaller({});
+    const iterable = await caller.iterable();
+    expectTypeOf(iterable).toEqualTypeOf<
+      AsyncIterable<number, string, unknown>
+    >();
+
+    const aggregated: number[] = [];
+    for await (const value of iterable) {
+      ctx.nextIterable();
+      aggregated.push(value);
+    }
+    expect(aggregated).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  });
 
   test('out-of-order streaming', async () => {
     const { client } = ctx;
@@ -245,7 +261,7 @@ describe('no transformer', () => {
     const iterable = await client.iterable.query();
 
     expectTypeOf(iterable).toEqualTypeOf<
-      AsyncGenerator<number, string, unknown>
+      AsyncIterable<number, string, unknown>
     >();
     const aggregated: unknown[] = [];
     for await (const value of iterable) {
@@ -319,6 +335,7 @@ describe('no transformer', () => {
           2,
           3,
           4,
+          5,
         ]
       `);
     expect(err).toMatchInlineSnapshot(
@@ -552,7 +569,7 @@ describe('with transformer', () => {
     const iterable = await client.iterable.query();
 
     expectTypeOf(iterable).toEqualTypeOf<
-      AsyncGenerator<number, string, unknown>
+      AsyncIterable<number, string, unknown>
     >();
 
     const aggregated: unknown[] = [];

--- a/packages/tests/server/zAsyncIterable.ts
+++ b/packages/tests/server/zAsyncIterable.ts
@@ -11,12 +11,12 @@ const trackedEnvelopeSchema =
   z.custom<TrackedEnvelope<unknown>>(isTrackedEnvelope);
 
 /**
- * A Zod schema helper designed specifically for validating async generators. This schema ensures that:
+ * A Zod schema helper designed specifically for validating async iterables. This schema ensures that:
  * 1. The value being validated is an async iterable.
  * 2. Each item yielded by the async iterable conforms to a specified type.
  * 3. The return value of the async iterable, if any, also conforms to a specified type.
  */
-export function zAsyncGenerator<
+export function zAsyncIterable<
   TYieldIn,
   TYieldOut,
   TReturnIn = void,
@@ -40,7 +40,7 @@ export function zAsyncGenerator<
 }) {
   return z
     .custom<
-      AsyncGenerator<
+      AsyncIterable<
         Tracked extends true ? TrackedEnvelope<TYieldIn> : TYieldIn,
         TReturnIn
       >
@@ -61,13 +61,13 @@ export function zAsyncGenerator<
       }
       return;
     }) as z.ZodType<
-    AsyncGenerator<
+    AsyncIterable<
       Tracked extends true ? TrackedEnvelope<TYieldIn> : TYieldIn,
       TReturnIn,
       unknown
     >,
     any,
-    AsyncGenerator<
+    AsyncIterable<
       Tracked extends true ? TrackedEnvelope<TYieldOut> : TYieldOut,
       TReturnOut,
       unknown

--- a/www/docs/server/subscriptions.md
+++ b/www/docs/server/subscriptions.md
@@ -157,7 +157,7 @@ Since subscriptions are async iterators, you have to go through the iterator to 
 
 ### Example with zod
 
-```ts title="zAsyncGenerator.ts"
+```ts title="zAsyncIterable.ts"
 import type { TrackedEnvelope } from '@trpc/server';
 import { isTrackedEnvelope, tracked } from '@trpc/server';
 import { z } from 'zod';
@@ -171,12 +171,12 @@ const trackedEnvelopeSchema =
   z.custom<TrackedEnvelope<unknown>>(isTrackedEnvelope);
 
 /**
- * A Zod schema helper designed specifically for validating async generators. This schema ensures that:
+ * A Zod schema helper designed specifically for validating async iterables. This schema ensures that:
  * 1. The value being validated is an async iterable.
  * 2. Each item yielded by the async iterable conforms to a specified type.
  * 3. The return value of the async iterable, if any, also conforms to a specified type.
  */
-export function zAsyncGenerator<
+export function zAsyncIterable<
   TYieldIn,
   TYieldOut,
   TReturnIn = void,
@@ -200,7 +200,7 @@ export function zAsyncGenerator<
 }) {
   return z
     .custom<
-      AsyncGenerator<
+      AsyncIterable<
         Tracked extends true ? TrackedEnvelope<TYieldIn> : TYieldIn,
         TReturnIn
       >
@@ -221,13 +221,13 @@ export function zAsyncGenerator<
       }
       return;
     }) as z.ZodType<
-    AsyncGenerator<
+    AsyncIterable<
       Tracked extends true ? TrackedEnvelope<TYieldIn> : TYieldIn,
       TReturnIn,
       unknown
     >,
     any,
-    AsyncGenerator<
+    AsyncIterable<
       Tracked extends true ? TrackedEnvelope<TYieldOut> : TYieldOut,
       TReturnOut,
       unknown
@@ -240,7 +240,7 @@ Now you can use this helper to validate the output of your subscription procedur
 
 ```ts title="_app.ts"
 import { publicProcedure, router } from '../trpc';
-import { zAsyncGenerator } from './zAsyncGenerator';
+import { zAsyncIterable } from './zAsyncIterable';
 
 export const appRouter = router({
   mySubscription: publicProcedure
@@ -250,7 +250,7 @@ export const appRouter = router({
       }),
     )
     .output(
-      zAsyncGenerator({
+      zAsyncIterable({
         yield: z.object({
           count: z.number(),
         }),


### PR DESCRIPTION
Closes #6226

## 🎯 Changes

Fixes bad typing where we say we return an `AsyncGenerator` where in fact we return `AsyncGenerator`