### PR TITLE
docs: fix syntax error in example websocket documentation page

### DIFF
--- a/www/docs/server/websockets.md
+++ b/www/docs/server/websockets.md
@@ -156,7 +156,7 @@ export const subRouter = router({
         // [...] get the posts since the last event id and yield them
       }
       // listen for new events
-      for await (const [data] of on(ee, 'add',  {
+      for await (const [data] of on(ee, 'add', {
         // Passing the AbortSignal from the request automatically cancels the event emitter when the subscription is aborted
         signal: opts.signal,
       })) {

--- a/www/docs/server/websockets.md
+++ b/www/docs/server/websockets.md
@@ -156,10 +156,10 @@ export const subRouter = router({
         // [...] get the posts since the last event id and yield them
       }
       // listen for new events
-      for await (const [data] of on(ee, 'add'), {
+      for await (const [data] of on(ee, 'add',  {
         // Passing the AbortSignal from the request automatically cancels the event emitter when the subscription is aborted
         signal: opts.signal,
-      }) {
+      })) {
         const post = data as Post;
         // tracking the post id ensures the client can reconnect at any time and get the latest events this id
         yield tracked(post.id, post);


### PR DESCRIPTION
## 🎯 Changes

The [WebSockets](https://trpc.io/docs/server/websockets) documentation page for v11.x includes a malformed example. Specifically, the [`tracked()`](https://trpc.io/docs/server/websockets#automatic-tracking-of-id-using-tracked-recommended) part places the `StaticEventEmitterIteratorOptions` object in the `for of` statement instead of the `on` call expression, which obviously causes a syntax error.


## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
