### PR TITLE
fix(server): `unstable_httpBatchStreamLink` hiccups

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -73,7 +73,8 @@
     "package.json",
     "links",
     "unstable-internals",
-    "!**/*.test.*"
+    "!**/*.test.*",
+    "!**/__tests__"
   ],
   "dependencies": {},
   "peerDependencies": {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -69,7 +69,8 @@
     "package.json",
     "app-dir",
     "ssrPrepass",
-    "!**/*.test.*"
+    "!**/*.test.*",
+    "!**/__tests__"
   ],
   "dependencies": {},
   "peerDependencies": {

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -51,7 +51,8 @@
     "rsc",
     "server",
     "shared",
-    "!**/*.test.*"
+    "!**/*.test.*",
+    "!**/__tests__"
   ],
   "eslintConfig": {
     "rules": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -110,7 +110,8 @@
     "rpc",
     "shared",
     "unstable-core-do-not-import",
-    "!**/*.test.*"
+    "!**/*.test.*",
+    "!**/__tests__"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/server/src/unstable-core-do-not-import/http/resolveResponse.ts
+++ b/packages/server/src/unstable-core-do-not-import/http/resolveResponse.ts
@@ -466,7 +466,6 @@ export async function resolveResponse<TRouter extends AnyRouter>(
           const stream = sseStreamProducer({
             ...config.sse,
             data: iterable,
-            abortCtrl: result?.abortCtrl ?? new AbortController(),
             serialize: (v) => config.transformer.output.serialize(v),
             formatError(errorOpts) {
               const error = getTRPCErrorFromUnknown(errorOpts.error);

--- a/packages/server/src/unstable-core-do-not-import/stream/jsonl.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/jsonl.test.ts
@@ -5,7 +5,7 @@ import { run } from '../utils';
 import type { ConsumerOnError, ProducerOnError } from './jsonl';
 import { jsonlStreamConsumer, jsonlStreamProducer } from './jsonl';
 import { createDeferred } from './utils/createDeferred';
-import { createServer } from './utils/createServer';
+import { serverResource } from './utils/createServer';
 
 test('encode/decode with superjson', async () => {
   const data = {
@@ -227,12 +227,12 @@ test('decode - bad data', async () => {
   }
 });
 
-function createServerForStream(
+function serverResourceForStream(
   stream: ReadableStream,
   abortCtrl: AbortController,
   headers: Record<string, string> = {},
 ) {
-  return createServer(async (req, res) => {
+  return serverResource(async (req, res) => {
     req.once('aborted', () => {
       abortCtrl.abort();
     });
@@ -288,7 +288,7 @@ test('e2e, create server', async () => {
     serialize: (v) => SuperJSON.serialize(v),
   });
 
-  const server = createServerForStream(stream, new AbortController());
+  await using server = serverResourceForStream(stream, new AbortController());
 
   const res = await fetch(server.url);
 
@@ -329,8 +329,6 @@ test('e2e, create server', async () => {
   }
   // await meta.reader.closed;
   expect(meta.controllers.size).toBe(0);
-
-  await server.close();
 });
 
 test('e2e, client aborts request halfway through', async () => {
@@ -366,7 +364,7 @@ test('e2e, client aborts request halfway through', async () => {
     data,
     onError: onProducerErrorSpy,
   });
-  const server = createServerForStream(stream, serverAbort);
+  await using server = serverResourceForStream(stream, serverAbort);
 
   const res = await fetch(server.url, {
     signal: clientAbort.signal,
@@ -409,8 +407,6 @@ test('e2e, client aborts request halfway through', async () => {
   `);
   expect(onConsumerErrorSpy).toHaveBeenCalledTimes(1);
   expect(onProducerErrorSpy).toHaveBeenCalledTimes(0);
-
-  await server.close();
 });
 
 test('e2e, client aborts request halfway through - through breaking async iterable', async () => {
@@ -445,7 +441,7 @@ test('e2e, client aborts request halfway through - through breaking async iterab
     data,
     onError: onProducerErrorSpy,
   });
-  const server = createServerForStream(stream, serverAbort);
+  await using server = serverResourceForStream(stream, serverAbort);
 
   const res = await fetch(server.url, {
     signal: clientAbort.signal,
@@ -490,8 +486,6 @@ test('e2e, client aborts request halfway through - through breaking async iterab
 
   expect(onProducerErrorSpy).toHaveBeenCalledTimes(0);
   expect(onConsumerErrorSpy).toHaveBeenCalledTimes(1);
-
-  await server.close();
 });
 
 test('e2e, encode/decode - maxDepth', async () => {
@@ -509,7 +503,7 @@ test('e2e, encode/decode - maxDepth', async () => {
     maxDepth: 1,
   });
 
-  const server = createServerForStream(stream, new AbortController());
+  await using server = serverResourceForStream(stream, new AbortController());
 
   const ac = new AbortController();
   const res = await fetch(server.url, {
@@ -544,8 +538,6 @@ test('e2e, encode/decode - maxDepth', async () => {
       ],
     ]
   `);
-
-  await server.close();
 });
 
 test('should work to throw after stream is closed', async () => {
@@ -565,7 +557,7 @@ test('should work to throw after stream is closed', async () => {
     onError,
   });
 
-  const server = createServerForStream(stream, ac);
+  await using server = serverResourceForStream(stream, ac);
   const res = await fetch(server.url, {
     signal: ac.signal,
   });

--- a/packages/server/src/unstable-core-do-not-import/stream/jsonl.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/jsonl.test.ts
@@ -1,10 +1,10 @@
+import { serverResource } from './utils/__tests__/serverResource';
 import { waitFor } from '@testing-library/react';
 import SuperJSON from 'superjson';
 import { run } from '../utils';
 import type { ConsumerOnError, ProducerOnError } from './jsonl';
 import { jsonlStreamConsumer, jsonlStreamProducer } from './jsonl';
 import { createDeferred } from './utils/createDeferred';
-import { serverResource } from './utils/createServer';
 
 test('encode/decode with superjson', async () => {
   const data = {

--- a/packages/server/src/unstable-core-do-not-import/stream/jsonl.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/jsonl.test.ts
@@ -1,6 +1,5 @@
 import { waitFor } from '@testing-library/react';
 import SuperJSON from 'superjson';
-import { writeResponseBody } from '../../adapters/node-http/writeResponse';
 import { run } from '../utils';
 import type { ConsumerOnError, ProducerOnError } from './jsonl';
 import { jsonlStreamConsumer, jsonlStreamProducer } from './jsonl';

--- a/packages/server/src/unstable-core-do-not-import/stream/jsonl.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/jsonl.ts
@@ -425,6 +425,10 @@ export async function jsonlStreamConsumer<THead>(opts: {
 
   type ControllerChunk = ChunkData | StreamInterruptedError;
   type ChunkController = ReadableStreamDefaultController<ControllerChunk>;
+  /**
+   * This is needed as new values can come in before the controller has read the chunk
+   * Not pretty, could likely be refactored and omitted somehow
+   */
   const chunkDeferred = new Map<ChunkIndex, Deferred<ChunkController>>();
 
   const controllers = new Map<ChunkIndex, ChunkController>();

--- a/packages/server/src/unstable-core-do-not-import/stream/jsonl.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/jsonl.ts
@@ -501,6 +501,8 @@ export async function jsonlStreamConsumer<THead>(opts: {
             }
             if (done) {
               controllers.delete(chunkId);
+              maybeAbort();
+
               return {
                 done: true,
                 value: undefined,
@@ -517,8 +519,8 @@ export async function jsonlStreamConsumer<THead>(opts: {
                 };
               case ASYNC_ITERABLE_STATUS_RETURN:
                 controllers.delete(chunkId);
-
                 maybeAbort();
+
                 return {
                   done: true,
                   value: decode(data),
@@ -526,6 +528,7 @@ export async function jsonlStreamConsumer<THead>(opts: {
               case ASYNC_ITERABLE_STATUS_ERROR:
                 controllers.delete(chunkId);
                 maybeAbort();
+
                 throw (
                   opts.formatError?.({ error: data }) ?? new AsyncError(data)
                 );

--- a/packages/server/src/unstable-core-do-not-import/stream/jsonl.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/jsonl.ts
@@ -127,6 +127,7 @@ function createBatchStreamProducer(opts: ProducerOptions) {
     if (!stream.cancelled()) {
       stream.controller.close();
     }
+    return true;
   });
 
   const maybeEnqueue = (chunk: ChunkData) => {
@@ -425,13 +426,16 @@ export async function jsonlStreamConsumer<THead>(opts: {
 
   type ControllerChunk = ChunkData | StreamInterruptedError;
   type ChunkController = ReadableStreamDefaultController<ControllerChunk>;
+  const chunkDeferred = new Map<ChunkIndex, Deferred<ChunkController>>();
 
-  const controllers = withRefCount(
-    new Map<ChunkIndex, ChunkController>(),
-    () => {
+  const controllers = new Map<ChunkIndex, ChunkController>();
+
+  const maybeAbort = () => {
+    if (chunkDeferred.size === 0 && controllers.size === 0) {
+      // nothing is listening to the stream anymore
       opts.abortController?.abort();
-    },
-  );
+    }
+  };
 
   function decodeChunkDefinition(value: ChunkDefinition) {
     const [_path, type, chunkId] = value;
@@ -439,6 +443,13 @@ export async function jsonlStreamConsumer<THead>(opts: {
     const stream = createReadableStream<ChunkData>();
 
     controllers.set(chunkId, stream.controller);
+
+    // resolve chunk deferred if it exists
+    const deferred = chunkDeferred.get(chunkId);
+    if (deferred) {
+      deferred.resolve(stream.controller);
+      chunkDeferred.delete(chunkId);
+    }
 
     switch (type) {
       case CHUNK_VALUE_TYPE_PROMISE: {
@@ -518,6 +529,7 @@ export async function jsonlStreamConsumer<THead>(opts: {
               },
               return: async () => {
                 controllers.delete(chunkId);
+                maybeAbort();
                 return {
                   done: true,
                   value: undefined,
@@ -560,6 +572,12 @@ export async function jsonlStreamConsumer<THead>(opts: {
   source
     .pipeTo(
       new WritableStream({
+        start(writeController) {
+          if (opts.abortController.signal.aborted) {
+            writeController.error(new StreamInterruptedError());
+            return;
+          }
+        },
         async write(chunkOrHead) {
           if (headDeferred) {
             const head = chunkOrHead as Record<number | string, unknown>;
@@ -571,19 +589,29 @@ export async function jsonlStreamConsumer<THead>(opts: {
             headDeferred.resolve(head as THead);
             headDeferred = null;
 
-            controllers.activate();
             return;
           }
           const chunk = chunkOrHead as ChunkData;
           const [idx] = chunk;
 
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          const controller = controllers.get(idx)!;
-          controller.enqueue(chunk);
+          let readController = controllers.get(idx)!;
+          if (!readController) {
+            let deferred = chunkDeferred.get(idx);
+            if (!deferred) {
+              deferred = createDeferred();
+              chunkDeferred.set(idx, deferred);
+            }
+            readController = await deferred.promise;
+          }
+          readController.enqueue(chunk);
         },
         close: closeOrAbort,
         abort: closeOrAbort,
       }),
+      {
+        signal: opts.abortController.signal,
+      },
     )
     .catch((error) => {
       opts.onError?.({ error });

--- a/packages/server/src/unstable-core-do-not-import/stream/jsonl.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/jsonl.ts
@@ -577,12 +577,6 @@ export async function jsonlStreamConsumer<THead>(opts: {
   source
     .pipeTo(
       new WritableStream({
-        start(writeController) {
-          if (opts.abortController.signal.aborted) {
-            writeController.error(new StreamInterruptedError());
-            return;
-          }
-        },
         async write(chunkOrHead) {
           if (headDeferred) {
             const head = chunkOrHead as Record<number | string, unknown>;

--- a/packages/server/src/unstable-core-do-not-import/stream/sse.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/sse.test.ts
@@ -135,9 +135,9 @@ test('e2e, server-sent events (SSE)', async () => {
 
   expect(values).toEqual(range(1, ITERATIONS * 2 + 1));
 
-  expect(server.onRequestEnd).toHaveBeenCalledTimes(1);
+  expect(server.abortCount).toBe(1);
   // The break after double the ITERATIONS will trigger a second socket close
-  await vi.waitFor(() => expect(server.onRequestEnd).toHaveBeenCalledTimes(2), {
+  await vi.waitFor(() => expect(server.abortCount).toBe(2), {
     timeout: 1000,
   });
 

--- a/packages/server/src/unstable-core-do-not-import/stream/sse.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/sse.test.ts
@@ -1,11 +1,11 @@
 import { EventEmitter, on } from 'node:events';
+import { serverResource } from './utils/__tests__/serverResource';
 import { EventSourcePolyfill, NativeEventSource } from 'event-source-polyfill';
 import SuperJSON from 'superjson';
 import type { inferAsyncIterableYield, Maybe } from '../types';
 import { run, sleep } from '../utils';
 import { sseHeaders, sseStreamConsumer, sseStreamProducer } from './sse';
 import { isTrackedEnvelope, sse, tracked } from './tracked';
-import { serverResource } from './utils/createServer';
 
 (global as any).EventSource = NativeEventSource || EventSourcePolyfill;
 

--- a/packages/server/src/unstable-core-do-not-import/stream/sse.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/sse.ts
@@ -32,7 +32,7 @@ export interface PingOptions {
 export interface SSEStreamProducerOptions<TValue = unknown> {
   serialize?: Serialize;
   data: AsyncIterable<TValue>;
-  abortCtrl: AbortController;
+
   maxDepth?: number;
   ping?: PingOptions;
   /**
@@ -85,7 +85,6 @@ export function sseStreamProducer<TValue = unknown>(
       iterable = takeWithGrace(iterable, {
         count: 1,
         gracePeriodMs: 1,
-        abortCtrl: opts.abortCtrl,
       });
     }
 
@@ -96,7 +95,6 @@ export function sseStreamProducer<TValue = unknown>(
     ) {
       iterable = withMaxDuration(iterable, {
         maxDurationMs: opts.maxDurationMs,
-        abortCtrl: opts.abortCtrl,
       });
     }
 

--- a/packages/server/src/unstable-core-do-not-import/stream/utils/__tests__/serverResource.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/utils/__tests__/serverResource.ts
@@ -1,8 +1,9 @@
 import http from 'http';
 import type { Socket } from 'net';
-import { incomingMessageToRequest } from '../../../adapters/node-http/incomingMessageToRequest';
-import { writeResponse } from '../../../adapters/node-http/writeResponse';
-import { run } from '../../utils';
+import { vi } from 'vitest';
+import { incomingMessageToRequest } from '../../../../adapters/node-http/incomingMessageToRequest';
+import { writeResponse } from '../../../../adapters/node-http/writeResponse';
+import { run } from '../../../utils';
 
 type Handler = (request: Request) => Response | Promise<Response>;
 

--- a/packages/server/src/unstable-core-do-not-import/stream/utils/__tests__/serverResource.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/utils/__tests__/serverResource.ts
@@ -44,7 +44,10 @@ export function serverResource(handler: Handler) {
 
   const url = `http://localhost:${port}`;
 
-  async function close() {
+  async function forceClose() {
+    for (const conn of connections.values()) {
+      conn.destroy();
+    }
     await new Promise<void>((resolve, reject) => {
       server.close((err) => {
         if (err) {
@@ -62,18 +65,12 @@ export function serverResource(handler: Handler) {
       return abortCount;
     },
     restart: async () => {
-      for (const conn of connections.values()) {
-        conn.destroy();
-      }
-      await close();
+      await forceClose();
 
       server.listen(port);
     },
     [Symbol.asyncDispose]: async () => {
-      for (const conn of connections.values()) {
-        conn.destroy();
-      }
-      await close();
+      await forceClose();
     },
   };
 }

--- a/packages/server/src/unstable-core-do-not-import/stream/utils/asyncIterable.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/utils/asyncIterable.ts
@@ -6,7 +6,7 @@ import { disposablePromiseTimerResult, timerResource } from './timerResource';
  */
 export async function* withMaxDuration<T>(
   iterable: AsyncIterable<T>,
-  opts: { maxDurationMs: number; abortCtrl: AbortController },
+  opts: { maxDurationMs: number },
 ): AsyncGenerator<T> {
   const iterator = iterable[Symbol.asyncIterator]();
 
@@ -21,7 +21,7 @@ export async function* withMaxDuration<T>(
       result = await Unpromise.race([iterator.next(), timerPromise]);
       if (result === disposablePromiseTimerResult) {
         // cancelled due to timeout
-        opts.abortCtrl.abort();
+
         const res = await iterator.return?.();
         return res?.value;
       }
@@ -49,7 +49,6 @@ export async function* takeWithGrace<T>(
   opts: {
     count: number;
     gracePeriodMs: number;
-    abortCtrl: AbortController;
   },
 ): AsyncGenerator<T> {
   const iterator = iterable[Symbol.asyncIterator]();
@@ -78,8 +77,6 @@ export async function* takeWithGrace<T>(
       yield result.value;
       if (--count === 0) {
         timerPromise = timer.start();
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        timerPromise.then(() => opts.abortCtrl.abort());
       }
       // free up reference for garbage collection
       result = null;

--- a/packages/server/src/unstable-core-do-not-import/stream/utils/asyncIterable.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/utils/asyncIterable.ts
@@ -1,8 +1,5 @@
 import { Unpromise } from '../../../vendor/unpromise';
-import {
-  disposablePromiseTimer,
-  disposablePromiseTimerResult,
-} from './disposablePromiseTimer';
+import { disposablePromiseTimerResult, timerResource } from './timerResource';
 
 /**
  * Derives a new {@link AsyncGenerator} based on {@link iterable}, that automatically stops after the specified duration.
@@ -13,7 +10,7 @@ export async function* withMaxDuration<T>(
 ): AsyncGenerator<T> {
   const iterator = iterable[Symbol.asyncIterator]();
 
-  const timer = disposablePromiseTimer(opts.maxDurationMs);
+  const timer = timerResource(opts.maxDurationMs);
   try {
     const timerPromise = timer.start();
 
@@ -60,7 +57,7 @@ export async function* takeWithGrace<T>(
   // declaration outside the loop for garbage collection reasons
   let result: null | IteratorResult<T> | typeof disposablePromiseTimerResult;
 
-  const timer = disposablePromiseTimer(opts.gracePeriodMs);
+  const timer = timerResource(opts.gracePeriodMs);
   try {
     let count = opts.count;
 

--- a/packages/server/src/unstable-core-do-not-import/stream/utils/timerResource.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/utils/timerResource.ts
@@ -2,7 +2,7 @@
 Symbol.dispose ??= Symbol();
 
 export const disposablePromiseTimerResult = Symbol();
-export function disposablePromiseTimer(ms: number) {
+export function timerResource(ms: number) {
   let timer: ReturnType<typeof setTimeout> | null = null;
 
   return {

--- a/packages/server/src/unstable-core-do-not-import/stream/utils/withPing.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/utils/withPing.ts
@@ -1,8 +1,5 @@
 import { Unpromise } from '../../../vendor/unpromise';
-import {
-  disposablePromiseTimer,
-  disposablePromiseTimerResult,
-} from './disposablePromiseTimer';
+import { disposablePromiseTimerResult, timerResource } from './timerResource';
 
 export const PING_SYM = Symbol('ping');
 
@@ -23,7 +20,7 @@ export async function* withPing<TValue>(
 
   let nextPromise = iterator.next();
   while (true) {
-    const pingPromise = disposablePromiseTimer(pingIntervalMs);
+    const pingPromise = timerResource(pingIntervalMs);
 
     try {
       result = await Unpromise.race([nextPromise, pingPromise.start()]);

--- a/packages/server/src/unstable-core-do-not-import/stream/utils/withRefCount.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/utils/withRefCount.ts
@@ -1,5 +1,8 @@
-// Callback function type that is called when a collection is drained
-type OnDrain = () => void;
+/**
+ * Callback function that is called when a collection is drained.
+ * @returns {boolean} `true` if the collection should be locked, `false` otherwise
+ */
+type ShouldLockCallback = () => boolean;
 
 // Interface for objects that can be activated
 export interface RefCount {
@@ -21,15 +24,15 @@ export interface RefCountSet<TValue> extends Set<TValue>, RefCount {}
  */
 export function withRefCount<TKey, TValue>(
   map: Map<TKey, TValue>,
-  onDrain: OnDrain,
+  onDrain: ShouldLockCallback,
 ): RefCountMap<TKey, TValue>;
 export function withRefCount<TValue>(
   set: Set<TValue>,
-  onDrain: OnDrain,
+  onDrain: ShouldLockCallback,
 ): RefCountSet<TValue>;
 export function withRefCount(
   _obj: Set<any> | Map<any, any>,
-  onDrain: OnDrain,
+  onDrain: ShouldLockCallback,
 ): RefCountMap<any, any> & RefCountSet<any> {
   const obj = _obj as any;
 
@@ -41,8 +44,10 @@ export function withRefCount(
   // Check if collection should be drained (empty and active)
   const checkDrain = () => {
     if (!drained && active && obj.size === 0) {
-      onDrain();
-      drained = true;
+      const check = onDrain();
+      if (check) {
+        drained = true;
+      }
     }
   };
 

--- a/packages/server/src/unstable-core-do-not-import/stream/utils/withRefCount.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/utils/withRefCount.ts
@@ -1,8 +1,5 @@
-/**
- * Callback function that is called when a collection is drained.
- * @returns {boolean} `true` if the collection should be locked, `false` otherwise
- */
-type ShouldLockCallback = () => boolean;
+// Callback function type that is called when a collection is drained
+type OnDrain = () => void;
 
 // Interface for objects that can be activated
 export interface RefCount {
@@ -24,15 +21,15 @@ export interface RefCountSet<TValue> extends Set<TValue>, RefCount {}
  */
 export function withRefCount<TKey, TValue>(
   map: Map<TKey, TValue>,
-  onDrain: ShouldLockCallback,
+  onDrain: OnDrain,
 ): RefCountMap<TKey, TValue>;
 export function withRefCount<TValue>(
   set: Set<TValue>,
-  onDrain: ShouldLockCallback,
+  onDrain: OnDrain,
 ): RefCountSet<TValue>;
 export function withRefCount(
   _obj: Set<any> | Map<any, any>,
-  onDrain: ShouldLockCallback,
+  onDrain: OnDrain,
 ): RefCountMap<any, any> & RefCountSet<any> {
   const obj = _obj as any;
 
@@ -44,10 +41,8 @@ export function withRefCount(
   // Check if collection should be drained (empty and active)
   const checkDrain = () => {
     if (!drained && active && obj.size === 0) {
-      const check = onDrain();
-      if (check) {
-        drained = true;
-      }
+      onDrain();
+      drained = true;
     }
   };
 

--- a/scripts/entrypoints.ts
+++ b/scripts/entrypoints.ts
@@ -116,6 +116,7 @@ export async function generateEntrypoints(rawInputs: string[]) {
 
   // Exclude test files in builds
   pkgJson.files.push('!**/*.test.*');
+  pkgJson.files.push('!**/__tests__');
   // Add `funding` in all packages
   pkgJson.funding = ['https://trpc.io/sponsor'];
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -25,5 +25,5 @@
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitOverride": true
   },
-  "exclude": ["test", "**/*.test.ts", "**/*.test.tsx"]
+  "exclude": ["test", "**/*.test.ts", "**/*.test.tsx", "__tests__"]
 }


### PR DESCRIPTION
Closes #

## 🎯 Changes

Introduced bugs in some edge cases in #6206 that were show-cased when reducing timeout for iterations in the tests

## Summary

- Reintroduce deferreds in jsonl consumer
- Add `using` a bit more in tests, for fun

## Notes

Hide whitespace when reviewing

![CleanShot 2024-11-15 at 12 54 12@2x](https://github.com/user-attachments/assets/c4f4405a-1b34-484b-95a9-ed051acfef08)


## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
