### PR TITLE
Fix quickstart docs import statements

### DIFF
--- a/www/docs/main/quickstart.mdx
+++ b/www/docs/main/quickstart.mdx
@@ -457,7 +457,7 @@ You now have access to your API procedures on the `trpc` object. Try it out!
 // @include: server
 // @filename: client.ts
 import { createTRPCClient, httpBatchLink } from '@trpc/client';
-import type { AppRouter } from './server';
+import type { AppRouter } from '../server';
 
 const trpc = createTRPCClient<AppRouter>({
   links: [
@@ -490,7 +490,7 @@ You can open up your Intellisense to explore your API on your frontend. You'll f
 // @include: server
 // @filename: client.ts
 import { createTRPCClient, httpBatchLink } from '@trpc/client';
-import type { AppRouter } from './server';
+import type { AppRouter } from '../server';
 
 const trpc = createTRPCClient<AppRouter>({
   links: [

--- a/www/docs/main/quickstart.mdx
+++ b/www/docs/main/quickstart.mdx
@@ -427,7 +427,7 @@ Let's now move to the client-side code and embrace the power of end-to-end types
 // @filename: client.ts
 // ---cut---
 import { createTRPCClient, httpBatchLink } from '@trpc/client';
-import type { AppRouter } from './server';
+import type { AppRouter } from '../server';
 //     👆 **type-only** import
 
 // Pass AppRouter as generic here. 👇 This lets the `trpc` object know


### PR DESCRIPTION
Closes #

## 🎯 Changes

Fix import statements in quickstart documentation to import the AppRouter type from the server correctly 