### PR TITLE
Bug fix: Incorrect typings for the predicate function in invalidate() in react-query utils proxy

### DIFF
--- a/packages/react-query/src/shared/proxy/utilsProxy.ts
+++ b/packages/react-query/src/shared/proxy/utilsProxy.ts
@@ -103,7 +103,7 @@ type DecorateProcedure<TProcedure extends AnyQueryProcedure> = {
         query: Query<
           inferProcedureInput<TProcedure>,
           TRPCClientError<TProcedure>,
-          inferProcedureInput<TProcedure>,
+          inferTransformedProcedureOutput<TRoot, TProcedure>,
           QueryKeyKnown<
             inferProcedureInput<TProcedure>,
             inferProcedureInput<TProcedure> extends { cursor?: any } | void


### PR DESCRIPTION
## 🎯 Changes

Currently the query parameter of the predicate function inside the invalidate function of the react-query utils is typed in the following way:
```ts
Query<
  inferProcedureInput<TProcedure>,
  TRPCClientError<TRoot>,
  inferProcedureInput<TProcedure>,
  ...
>
```

That's incorrect, because the Query type requires the result data type in the third parameter:
```ts
declare class Query<TQueryFnData = unknown, TError = DefaultError, TData = TQueryFnData, TQueryKey extends QueryKey = QueryKey> extends
```

That's why we have to update the typing to use the output as a third parameter:
```ts
Query<
  inferProcedureInput<TProcedure>,
  TRPCClientError<TRoot>,
  inferTransformedProcedureOutput<TRoot, TProcedure>
  ...
>
```


## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made. ➡️ Is there a useful way to test this?
