### PR TITLE
Bugfix: Adjust invalidate typings of utils proxy of react-query

### DIFF
--- a/packages/react-query/src/shared/proxy/utilsProxy.ts
+++ b/packages/react-query/src/shared/proxy/utilsProxy.ts
@@ -22,6 +22,7 @@ import type {
   AnyRouter,
   DeepPartial,
   inferProcedureInput,
+  inferProcedureOutput,
   inferTransformedProcedureOutput,
   ProtectedIntersection,
   RouterRecord,
@@ -242,7 +243,7 @@ export type DecorateQueryProcedure<
     filters?: Omit<InvalidateQueryFilters, 'predicate'> & {
       predicate?: (
         query: Query<
-          inferProcedureInput<TProcedure>,
+          inferProcedureOutput<TProcedure>,
           TRPCClientError<TRoot>,
           inferTransformedProcedureOutput<TRoot, TProcedure>,
           QueryKeyKnown<

--- a/packages/react-query/src/shared/proxy/utilsProxy.ts
+++ b/packages/react-query/src/shared/proxy/utilsProxy.ts
@@ -244,7 +244,7 @@ export type DecorateQueryProcedure<
         query: Query<
           inferProcedureInput<TProcedure>,
           TRPCClientError<TRoot>,
-          inferProcedureInput<TProcedure>,
+          inferTransformedProcedureOutput<TRoot, TProcedure>,
           QueryKeyKnown<
             inferProcedureInput<TProcedure>,
             inferProcedureInput<TProcedure> extends { cursor?: any } | void


### PR DESCRIPTION
Sorry, the last PR was from the wrong base branch and targeted at the wrong upstream branch.

## 🎯 Changes

Currently the query parameter of the predicate function inside the invalidate function of the react-query utils is typed in the following way:
```ts
Query<
  inferProcedureInput<TProcedure>,
  TRPCClientError<TRoot>,
  inferProcedureInput<TProcedure>,
  ...
>
```

That's incorrect, because the Query type requires the result data type in the third parameter:
```ts
declare class Query<TQueryFnData = unknown, TError = DefaultError, TData = TQueryFnData, TQueryKey extends QueryKey = QueryKey> extends
```

That's why we have to update the typing to use the output as a third parameter:
```ts
Query<
  inferProcedureInput<TProcedure>,
  TRPCClientError<TRoot>,
  inferTransformedProcedureOutput<TRoot, TProcedure>
  ...
>
```


## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made. ➡️ Is there a useful way to test this?
<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->
