### PR TITLE
Alexdb/better structural sharing

### DIFF
--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -94,5 +94,8 @@
   },
   "funding": [
     "https://trpc.io/sponsor"
-  ]
+  ],
+  "dependencies": {
+    "fast-deep-equal": "^3.1.3"
+  }
 }

--- a/packages/react-query/src/index.ts
+++ b/packages/react-query/src/index.ts
@@ -7,4 +7,5 @@ export {
   type CreateTRPCReactBase,
 } from './createTRPCReact';
 export type { inferReactQueryProcedureOptions } from './utils/inferReactQueryProcedure';
+export { replaceEqualDeep } from './utils/structuralSharing';
 export { createTRPCQueryUtils } from './createTRPCQueryUtils';

--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -13,6 +13,7 @@ import {
 } from '@tanstack/react-query';
 import type { TRPCClientErrorLike } from '@trpc/client';
 import { createTRPCUntypedClient } from '@trpc/client';
+import { replaceEqualDeep } from '@trpc/react-query/utils/structuralSharing';
 import type { AnyRouter } from '@trpc/server/unstable-core-do-not-import';
 import { isAsyncIterable } from '@trpc/server/unstable-core-do-not-import';
 import * as React from 'react';
@@ -182,6 +183,7 @@ export function createRootHooks<
       void prefetchQuery(queryKey, opts as any);
     }
     const ssrOpts = useSSRQueryOptionsIfNeeded(queryKey, {
+      structuralSharing: replaceEqualDeep,
       ...defaultOpts,
       ...opts,
     });

--- a/packages/react-query/src/utils/structuralSharing.ts
+++ b/packages/react-query/src/utils/structuralSharing.ts
@@ -1,0 +1,83 @@
+import equal from 'fast-deep-equal/es6';
+
+/**
+ * Taken from @tanstack/query-core utils.ts
+ * Modified to support Date, Map, Set and NaN comparisons
+ *
+ * This function returns `a` if `b` is deeply equal.
+ * If not, it will replace any deeply equal children of `b` with those of `a`.
+ */
+export function replaceEqualDeep(a: any, b: any): any {
+  if (equal(a, b)) {
+    return a;
+  }
+
+  const array = isPlainArray(a) && isPlainArray(b);
+
+  if (array || (isPlainObject(a) && isPlainObject(b))) {
+    const aItems = array ? a : Object.keys(a);
+    const aSize = aItems.length;
+    const bItems = array ? b : Object.keys(b);
+    const bSize = bItems.length;
+    const copy: any = array ? [] : {};
+
+    let equalItems = 0;
+
+    for (let i = 0; i < bSize; i++) {
+      const key = array ? i : bItems[i];
+      if (
+        !array &&
+        a[key] === undefined &&
+        b[key] === undefined &&
+        aItems.includes(key)
+      ) {
+        copy[key] = undefined;
+        equalItems++;
+      } else {
+        copy[key] = replaceEqualDeep(a[key], b[key]);
+        if (copy[key] === a[key] && a[key] !== undefined) {
+          equalItems++;
+        }
+      }
+    }
+
+    return aSize === bSize && equalItems === aSize ? a : copy;
+  }
+
+  return b;
+}
+
+function isPlainArray(value: unknown) {
+  return Array.isArray(value) && value.length === Object.keys(value).length;
+}
+
+// Copied from: https://github.com/jonschlinkert/is-plain-object
+function isPlainObject(o: any): o is object {
+  if (!hasObjectPrototype(o)) {
+    return false;
+  }
+
+  // If has no constructor
+  const ctor = o.constructor;
+  if (ctor === undefined) {
+    return true;
+  }
+
+  // If has modified prototype
+  const prot = ctor.prototype;
+  if (!hasObjectPrototype(prot)) {
+    return false;
+  }
+
+  // If constructor does not have an Object-specific method
+  if (!prot.hasOwnProperty('isPrototypeOf')) {
+    return false;
+  }
+
+  // Most likely a plain Object
+  return true;
+}
+
+function hasObjectPrototype(o: any): boolean {
+  return Object.prototype.toString.call(o) === '[object Object]';
+}

--- a/packages/tests/server/react/structuralSharing.test.ts
+++ b/packages/tests/server/react/structuralSharing.test.ts
@@ -1,0 +1,136 @@
+import { replaceEqualDeep } from '@trpc/react-query';
+import { parse, stringify } from 'superjson';
+
+test('identical plain object', async () => {
+  const data = { a: 1, b: 2 };
+  const oldResult = parse(stringify(data));
+  const newResult = parse(stringify(data));
+
+  expect(replaceEqualDeep(oldResult, newResult)).toBe(oldResult);
+});
+
+test('different plain objects', async () => {
+  const oldResult = parse(stringify({ a: 1, b: 2 }));
+  const newResult = parse(stringify({ a: 1, b: 'a' }));
+
+  expect(replaceEqualDeep(oldResult, newResult)).not.toBe(oldResult);
+});
+
+test('nested plain objects - fully identical', async () => {
+  const oldResult = parse(stringify({ a: 1, b: { c: 2 } }));
+  const newResult = parse(stringify({ a: 1, b: { c: 2 } }));
+
+  expect(replaceEqualDeep(oldResult, newResult)).toBe(oldResult);
+});
+
+test('nested plain objects - same nested object', async () => {
+  const oldResult = parse(stringify({ a: 1, b: { c: 3 } }));
+  const newResult = parse(stringify({ a: 2, b: { c: 3 } }));
+
+  expect(replaceEqualDeep(oldResult, newResult)).not.toBe(oldResult);
+  expect(replaceEqualDeep(oldResult, newResult).b).toBe(oldResult.b);
+});
+
+test('stable for dates - identical', async () => {
+  const date = new Date('2024-04-01');
+  const oldResult = parse(stringify({ a: date }));
+  const newResult = parse(stringify({ a: date }));
+
+  expect(replaceEqualDeep(oldResult, newResult)).toBe(oldResult);
+});
+
+test('stable for dates - different', async () => {
+  const unchangedObj = { nested: { value: 42 } };
+  const oldResult = parse(
+    stringify({ a: new Date('2024-04-01'), b: unchangedObj }),
+  );
+  const newResult = parse(
+    stringify({ a: new Date('2024-04-02'), b: unchangedObj }),
+  );
+
+  expect(replaceEqualDeep(oldResult, newResult)).not.toBe(oldResult);
+  expect(replaceEqualDeep(oldResult, newResult).b).toBe(oldResult.b);
+});
+
+test('stable for maps - identical', async () => {
+  const map = new Map<unknown, unknown>([
+    ['a', 1],
+    [3, 'foo'],
+  ]);
+  const oldResult = parse(stringify({ a: map }));
+  const newResult = parse(stringify({ a: map }));
+
+  expect(replaceEqualDeep(oldResult, newResult)).toBe(oldResult);
+});
+
+test('stable for maps - different order is still equal', async () => {
+  const map = new Map<unknown, unknown>([
+    ['a', 1],
+    [3, 'foo'],
+  ]);
+  const oldResult = parse(stringify({ a: map }));
+  const newResult = parse(
+    stringify({
+      a: new Map<unknown, unknown>([
+        [3, 'foo'],
+        ['a', 1],
+      ]),
+    }),
+  );
+
+  expect(replaceEqualDeep(oldResult, newResult)).toBe(oldResult);
+});
+
+test('stable for maps - different keys are not equal', async () => {
+  const unchangedObj = { nested: { value: 42 } };
+  const oldResult = parse(
+    stringify({ a: new Map([['a', 1]]), b: unchangedObj }),
+  );
+  const newResult = parse(
+    stringify({ a: new Map([['b', 1]]), b: unchangedObj }),
+  );
+
+  expect(replaceEqualDeep(oldResult, newResult)).not.toBe(oldResult);
+  expect(replaceEqualDeep(oldResult, newResult).b).toBe(oldResult.b);
+});
+
+test('stable for sets - identical', async () => {
+  const set = new Set([1, 2, 3]);
+  const oldResult = parse(stringify({ a: set }));
+  const newResult = parse(stringify({ a: set }));
+
+  expect(replaceEqualDeep(oldResult, newResult)).toBe(oldResult);
+});
+
+test('stable for sets - different order is still equal', async () => {
+  const set = new Set([1, 2, 3]);
+  const oldResult = parse(stringify({ a: set }));
+  const newResult = parse(stringify({ a: new Set([3, 2, 1]) }));
+
+  expect(replaceEqualDeep(oldResult, newResult)).toBe(oldResult);
+});
+
+test('stable for sets - different values are not equal', async () => {
+  const unchangedObj = { nested: { value: 42 } };
+  const oldResult = parse(stringify({ a: new Set([1]), b: unchangedObj }));
+  const newResult = parse(stringify({ a: new Set([2]), b: unchangedObj }));
+
+  expect(replaceEqualDeep(oldResult, newResult)).not.toBe(oldResult);
+  expect(replaceEqualDeep(oldResult, newResult).b).toBe(oldResult.b);
+});
+
+test('stable for BigInts - identical', async () => {
+  const oldResult = parse(stringify({ a: BigInt(1) }));
+  const newResult = parse(stringify({ a: BigInt(1) }));
+
+  expect(replaceEqualDeep(oldResult, newResult)).toBe(oldResult);
+});
+
+test('stable for BigInts - different values are not equal', async () => {
+  const unchangedObj = { nested: { value: 42 } };
+  const oldResult = parse(stringify({ a: BigInt(1), b: unchangedObj }));
+  const newResult = parse(stringify({ a: BigInt(2), b: unchangedObj }));
+
+  expect(replaceEqualDeep(oldResult, newResult)).not.toBe(oldResult);
+  expect(replaceEqualDeep(oldResult, newResult).b).toBe(oldResult.b);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1723,6 +1723,10 @@ importers:
         version: 3.23.8
 
   packages/react-query:
+    dependencies:
+      fast-deep-equal:
+        specifier: ^3.1.3
+        version: 3.1.3
     devDependencies:
       '@tanstack/react-query':
         specifier: ^5.59.15


### PR DESCRIPTION
Closes #6306

## 🎯 Changes

This PR introduces a new function to handle structural sharing of non-JSON-serializable results in tanstack-query.
With this feature, API endpoints that returns `Date`s, `Set`s and `Map`s should now have more stable data object identity between renders.

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
