### PR TITLE
[docs] correct a mistake in the migration description

### DIFF
--- a/www/docs/migration/migrate-from-v10-to-v11.mdx
+++ b/www/docs/migration/migrate-from-v10-to-v11.mdx
@@ -30,7 +30,7 @@ Updated [HTTP Subscription Link improvements](#http-subscription-link-improvemen
 
 ### TypeScript version >=5.7.2 is now required (non-breaking)
 
-tRPC now requires TypeScript version 5.6.2 or higher. This change was made in response to [a bug report](https://github.com/trpc/trpc/issues/6243) where we decided to take a forward-looking approach.
+tRPC now requires TypeScript version 5.7.2 or higher. This change was made in response to [a bug report](https://github.com/trpc/trpc/issues/6243) where we decided to take a forward-looking approach.
 
 If you try to install tRPC with an unsupported TypeScript version, you'll receive a peer dependency error during installation.
 


### PR DESCRIPTION
## 🎯 Changes

I fixed a misdescription in the section about bumping the TypeScript version. 
The version was miswritten as "5.6.2" in the description.

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
