### PR TITLE
Always show an error message even if a non-error object with no message is thrown

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/error/TRPCError.ts
+++ b/packages/server/src/unstable-core-do-not-import/error/TRPCError.ts
@@ -25,6 +25,10 @@ export function getCauseFromUnknown(cause: unknown): Error | undefined {
     for (const key in cause) {
       err[key] = cause[key];
     }
+    // last ditch effort - if no discernable message, at least show something to the user
+    if (!err.message) {
+      err.message = JSON.stringify(cause);
+    }
     return err;
   }
 

--- a/packages/server/src/unstable-core-do-not-import/error/TRPCError.ts
+++ b/packages/server/src/unstable-core-do-not-import/error/TRPCError.ts
@@ -26,7 +26,8 @@ export function getCauseFromUnknown(cause: unknown): Error | undefined {
       err[key] = cause[key];
     }
     // last ditch effort - if no discernable message, at least show something to the user
-    if (!err.message) {
+    // eslint-disable-next-line @typescript-eslint/dot-notation
+    if (globalThis.process?.env['NODE_ENV'] !== 'production' && !err.message) {
       err.message = JSON.stringify(cause);
     }
     return err;


### PR DESCRIPTION
## 🎯 Changes

Currently, there's an edge case where if a non-error object with no `message` property is thrown, no message is shown at all. 

In my case this came up with this line in the package `@instantdb/admin`: `Promise.reject({ status: res.status, body: json });`

In an effort to show *something* to the user to help with debugging, this PR adds a last resort of stringifying the entire error object as a message.

I restricted this to dev because of similar logic for hiding `err.stack`, it's not feasible to access `config.isDev` from an error constructor though so hoping that process.env.NODE_ENV is good enough.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
