### PR TITLE
Update types.ts

### DIFF
--- a/packages/react-query/src/shared/hooks/types.ts
+++ b/packages/react-query/src/shared/hooks/types.ts
@@ -280,7 +280,7 @@ export type UseTRPCSuspenseQueryResult<TData, TError> = [
  */
 export type UseTRPCInfiniteQueryResult<TData, TError, TInput> = TRPCHookResult &
   UseInfiniteQueryResult<
-    InfiniteData<TData, NonNullable<ExtractCursorType<TInput>> | null>,
+    InfiniteData<TData, NonNullable<ExtractCursorType<TInput>> | null | undefined>,
     TError
   >;
 


### PR DESCRIPTION
# Add `undefined` to possible cursor types in UseTRPCInfiniteQueryResult

The type definition of `UseTRPCInfiniteQueryResult` currently doesn't account for `undefined` as a possible cursor type, which can cause type inference issues when working with routes that can be used with both `useQuery` and `useInfiniteQuery`.

This PR adds `undefined` as a possible type for the cursor in the `InfiniteData` generic type parameter.

Closes #

## 🎯 Changes

- Updates the type definition of `UseTRPCInfiniteQueryResult` to include `undefined` as a possible cursor type
- This is a bug fix that improves type inference when working with dual-purpose routes (routes that can be used with both `useQuery` and `useInfiniteQuery`)

Before:
```typescript
export type UseTRPCInfiniteQueryResult<TData, TError, TInput> = TRPCHookResult &
  UseInfiniteQueryResult
    InfiniteData<TData, NonNullable<ExtractCursorType<TInput>> | null>,
    TError
  >;
  ```
  
  After:
  ```typescript
export type UseTRPCInfiniteQueryResult<TData, TError, TInput> = TRPCHookResult &
  UseInfiniteQueryResult
    InfiniteData<TData, NonNullable<ExtractCursorType<TInput>> | null | undefined>,
    TError
  >;
  ```