### PR TITLE
fix(server): handle runtimes where `req.socket` isn't available

### DIFF
--- a/packages/server/src/adapters/fastify/fastifyRequestHandler.ts
+++ b/packages/server/src/adapters/fastify/fastifyRequestHandler.ts
@@ -19,8 +19,8 @@ import {
 // @trpc/server/node-http
 import {
   incomingMessageToRequest,
-  type IncomingMessageWithBody,
   type NodeHTTPCreateContextOption,
+  type UniversalIncomingMessage,
 } from '../node-http';
 
 export type FastifyHandlerOptions<
@@ -54,7 +54,7 @@ export async function fastifyRequestHandler<
     });
   };
 
-  const incomingMessage = opts.req.raw as IncomingMessageWithBody;
+  const incomingMessage: UniversalIncomingMessage = opts.req.raw;
 
   // monkey-path body to the IncomingMessage
   if ('body' in opts.req) {

--- a/packages/server/src/adapters/node-http/incomingMessageToRequest.ts
+++ b/packages/server/src/adapters/node-http/incomingMessageToRequest.ts
@@ -1,15 +1,21 @@
 import type * as http from 'http';
 import { TRPCError } from '../../@trpc/server';
 
-export interface IncomingMessageWithBody extends http.IncomingMessage {
+export interface UniversalIncomingMessage
+  extends Omit<http.IncomingMessage, 'socket'> {
   /**
    * Many adapters will add a `body` property to the incoming message and pre-parse the body
    */
   body?: unknown;
+  /**
+   * Socket is not always available in all deployments, so we need to make it optional
+   * @see https://github.com/trpc/trpc/issues/6341
+   */
+  socket?: http.IncomingMessage['socket'];
 }
 
 function createBody(
-  req: http.IncomingMessage,
+  req: UniversalIncomingMessage,
   opts: {
     /**
      * Max body size in bytes. If the body is larger than this, the request will be aborted
@@ -71,7 +77,7 @@ function createBody(
     },
   });
 }
-export function createURL(req: http.IncomingMessage): URL {
+export function createURL(req: UniversalIncomingMessage): URL {
   try {
     const protocol =
       req.socket && 'encrypted' in req.socket && req.socket.encrypted
@@ -117,7 +123,7 @@ function createHeaders(incoming: http.IncomingHttpHeaders): Headers {
  * Convert an [`IncomingMessage`](https://nodejs.org/api/http.html#class-httpincomingmessage) to a [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request)
  */
 export function incomingMessageToRequest(
-  req: http.IncomingMessage,
+  req: UniversalIncomingMessage,
   res: http.ServerResponse,
   opts: {
     /**
@@ -130,14 +136,14 @@ export function incomingMessageToRequest(
 
   const onAbort = () => {
     res.off('close', onAbort);
-    req.socket.off('end', onAbort);
+    req.socket?.off('end', onAbort);
 
     // abort the request
     ac.abort();
   };
 
   res.once('close', onAbort);
-  req.socket.once('end', onAbort);
+  req.socket?.once('end', onAbort);
 
   // Get host from either regular header or HTTP/2 pseudo-header
   const url = createURL(req);


### PR DESCRIPTION
Closes #6341

## 🎯 Changes


> It seems like `req` object in AWS/Netlify environment is an instance of `ComputeJsIncomingMessage` class, which doesn't have `socket` property.



## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
