### PR TITLE
style(src/css/custom.css): Adding display none property

### DIFF
--- a/www/src/css/custom.css
+++ b/www/src/css/custom.css
@@ -296,6 +296,10 @@ h5 {
   @apply border-zinc-700;
 }
 
+[data-theme='dark'] .shiki.min-light {
+  display: none;
+}
+
 [data-theme='light'] .shiki.min-light-with-diff .popover {
   @apply border-[1px] border-zinc-300 bg-zinc-100;
 }


### PR DESCRIPTION
Adding the display none property to the code block with the class .shiki.min-light when the dark theme is active

Closes #6342

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?
 
Fixing theme code block, custom.css:299 
Adding
``` css
[data-theme='dark'] .shiki.min-light {
  display: none;
}
```

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
