### PR TITLE
chore: fix stackblitz output types

### DIFF
--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@trpc/client": "npm:@trpc/client@next",
     "@trpc/server": "npm:@trpc/server@next",
+    "superjson": "^1.12.4",
     "zod": "^3.0.0"
   },
   "devDependencies": {

--- a/examples/minimal/src/client/index.ts
+++ b/examples/minimal/src/client/index.ts
@@ -11,6 +11,7 @@ import {
  * We only import the `AppRouter` type from the server - this is not available at runtime
  */
 import type { AppRouter } from '../server/index.js';
+import { transformer } from '../shared/transformer.js';
 
 // Initialize the tRPC client
 const trpc = createTRPCClient<AppRouter>({
@@ -19,9 +20,11 @@ const trpc = createTRPCClient<AppRouter>({
       condition: (op) => op.type === 'subscription',
       true: unstable_httpSubscriptionLink({
         url: 'http://localhost:3000',
+        transformer,
       }),
       false: unstable_httpBatchStreamLink({
         url: 'http://localhost:3000',
+        transformer,
       }),
     }),
   ],

--- a/examples/minimal/src/server/trpc.ts
+++ b/examples/minimal/src/server/trpc.ts
@@ -1,10 +1,13 @@
 import { initTRPC } from '@trpc/server';
+import { transformer } from '../shared/transformer.js';
 
 /**
  * Initialization of tRPC backend
  * Should be done only once per backend!
  */
-const t = initTRPC.create();
+const t = initTRPC.create({
+  transformer,
+});
 
 /**
  * Export reusable router and procedure helpers

--- a/examples/minimal/src/shared/transformer.ts
+++ b/examples/minimal/src/shared/transformer.ts
@@ -1,0 +1,8 @@
+/**
+ * If you need to add transformers for special data types like `Temporal.Instant` or `Temporal.Date`, `Decimal.js`, etc you can do so here.
+ * Make sure to import this file rather than `superjson` directly.
+ * @see https://github.com/blitz-js/superjson#recipes
+ */
+import superjson from 'superjson';
+
+export const transformer = superjson;

--- a/examples/next-minimal-starter/package.json
+++ b/examples/next-minimal-starter/package.json
@@ -16,6 +16,7 @@
     "next": "^15.1.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "superjson": "^1.12.4",
     "zod": "^3.0.0"
   },
   "devDependencies": {

--- a/examples/next-minimal-starter/src/server/trpc.ts
+++ b/examples/next-minimal-starter/src/server/trpc.ts
@@ -8,8 +8,11 @@
  * @see https://trpc.io/docs/v11/procedures
  */
 import { initTRPC } from '@trpc/server';
+import { transformer } from '../utils/transformer';
 
-const t = initTRPC.create();
+const t = initTRPC.create({
+  transformer,
+});
 
 /**
  * Unprotected procedure

--- a/examples/next-minimal-starter/src/utils/transformer.ts
+++ b/examples/next-minimal-starter/src/utils/transformer.ts
@@ -1,0 +1,8 @@
+/**
+ * If you need to add transformers for special data types like `Temporal.Instant` or `Temporal.Date`, `Decimal.js`, etc you can do so here.
+ * Make sure to import this file rather than `superjson` directly.
+ * @see https://github.com/blitz-js/superjson#recipes
+ */
+import superjson from 'superjson';
+
+export const transformer = superjson;

--- a/examples/next-minimal-starter/src/utils/trpc.ts
+++ b/examples/next-minimal-starter/src/utils/trpc.ts
@@ -6,6 +6,7 @@ import {
 import { createTRPCNext } from '@trpc/next';
 import { ssrPrepass } from '@trpc/next/ssrPrepass';
 import type { AppRouter } from '../pages/api/trpc/[trpc]';
+import { transformer } from './transformer';
 
 function getBaseUrl() {
   if (typeof window !== 'undefined') {
@@ -32,9 +33,11 @@ export const trpc = createTRPCNext<AppRouter>({
           condition: (op) => op.type === 'subscription',
           true: unstable_httpSubscriptionLink({
             url,
+            transformer,
           }),
           false: httpBatchLink({
             url,
+            transformer,
           }),
         }),
       ],
@@ -42,4 +45,5 @@ export const trpc = createTRPCNext<AppRouter>({
   },
   ssr: true,
   ssrPrepass,
+  transformer,
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,7 @@ importers:
         version: 6.0.0(vitest@2.0.4)
       '@testing-library/react':
         specifier: ^16.1.0
-        version: 16.1.0(@testing-library/dom@10.0.0)(@types/react-dom@19.0.0)(@types/react@19.0.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 16.1.0(@testing-library/dom@10.0.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@testing-library/user-event':
         specifier: ^14.4.3
         version: 14.4.3(@testing-library/dom@10.0.0)
@@ -682,6 +682,9 @@ importers:
       '@trpc/server':
         specifier: npm:@trpc/server@next
         version: link:../../packages/server
+      superjson:
+        specifier: ^1.12.4
+        version: 1.12.4
       zod:
         specifier: ^3.0.0
         version: 3.23.8
@@ -1050,6 +1053,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
+      superjson:
+        specifier: ^1.12.4
+        version: 1.12.4
       zod:
         specifier: ^3.0.0
         version: 3.23.8
@@ -1894,7 +1900,7 @@ importers:
         version: 6.0.0(vitest@2.0.4)
       '@testing-library/react':
         specifier: ^16.1.0
-        version: 16.1.0(@testing-library/dom@10.0.0)(@types/react-dom@19.0.0)(@types/react@19.0.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 16.1.0(@testing-library/dom@10.0.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@testing-library/user-event':
         specifier: ^14.4.3
         version: 14.4.3(@testing-library/dom@10.0.0)
@@ -7550,8 +7556,8 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@testing-library/dom': ^10.0.0
-      '@types/react': ^18.0.0 || ^19.0.0
-      '@types/react-dom': ^18.0.0 || ^19.0.0
+      '@types/react': npm:types-react@rc
+      '@types/react-dom': npm:types-react-dom@rc
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
@@ -24320,15 +24326,12 @@ snapshots:
     optionalDependencies:
       vitest: 2.0.4(@edge-runtime/vm@2.0.2)(@types/node@20.17.10)(@vitest/ui@2.0.4)(jsdom@24.0.0)(lightningcss@1.28.2)(terser@5.34.0)
 
-  '@testing-library/react@16.1.0(@testing-library/dom@10.0.0)(@types/react-dom@19.0.0)(@types/react@19.0.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@testing-library/react@16.1.0(@testing-library/dom@10.0.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@babel/runtime': 7.24.7
       '@testing-library/dom': 10.0.0
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-    optionalDependencies:
-      '@types/react': 19.0.0
-      '@types/react-dom': 19.0.0
 
   '@testing-library/user-event@14.4.3(@testing-library/dom@10.0.0)':
     dependencies:
@@ -27798,7 +27801,7 @@ snapshots:
       eslint: 9.13.0(jiti@2.3.3)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.5.2(eslint-plugin-import@2.31.0)(eslint@9.13.0(jiti@2.3.3))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.16.1(eslint@9.13.0(jiti@2.3.3))(typescript@5.7.2))(eslint-import-resolver-typescript@3.5.2)(eslint@9.13.0(jiti@2.3.3))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.7.2))(eslint@9.13.0(jiti@2.3.3))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.13.0(jiti@2.3.3))
       eslint-plugin-react: 7.37.2(eslint@9.13.0(jiti@2.3.3))
       eslint-plugin-react-hooks: 5.1.0(eslint@9.13.0(jiti@2.3.3))
@@ -27825,7 +27828,7 @@ snapshots:
       debug: 4.3.7(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
       eslint: 9.13.0(jiti@2.3.3)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.16.1(eslint@9.13.0(jiti@2.3.3))(typescript@5.7.2))(eslint-import-resolver-typescript@3.5.2)(eslint@9.13.0(jiti@2.3.3))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.7.2))(eslint@9.13.0(jiti@2.3.3))
       get-tsconfig: 4.8.1
       globby: 13.1.3
       is-core-module: 2.13.1
@@ -27845,7 +27848,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.16.1(eslint@9.13.0(jiti@2.3.3))(typescript@5.7.2))(eslint-import-resolver-typescript@3.5.2)(eslint@9.13.0(jiti@2.3.3)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.7.2))(eslint@9.13.0(jiti@2.3.3)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -27868,7 +27871,7 @@ snapshots:
       string.prototype.trimend: 1.0.8
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 7.16.1(eslint@9.13.0(jiti@2.3.3))(typescript@5.7.2)
+      '@typescript-eslint/parser': 8.12.2(eslint@9.13.0(jiti@2.3.3))(typescript@5.7.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack


### PR DESCRIPTION

## 🎯 Changes

StackBlitz is currently showing `any` as types on all outputs since it doesn't support latest version of TypeScript

![CleanShot 2024-12-29 at 21 43 33@2x](https://github.com/user-attachments/assets/5173403f-ed38-4d5d-a8b6-b95be73bb3c6)



This issue exists as we're using the generic arguments of `AsyncIterable` that were added in 5.7: https://github.com/trpc/trpc/blob/3ca3dded131ec590dc373cb61c027561175473b1/packages/server/src/unstable-core-do-not-import/clientish/serialize.ts#L29

The fix adds a transformer as that ends up being a code path that isn't using this. Kinda a hack but 🤷 