### PR TITLE
chore: improve jsonl async code

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/stream/jsonl.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/jsonl.ts
@@ -2,7 +2,7 @@ import { isAsyncIterable, isFunction, isObject, run } from '../utils';
 import { iteratorResource } from './utils/asyncIterable';
 import type { Deferred } from './utils/createDeferred';
 import { createDeferred } from './utils/createDeferred';
-import { makeAsyncResource, makeResource } from './utils/disposable';
+import { makeResource } from './utils/disposable';
 import { raceAsyncIterables } from './utils/raceAsyncIterables';
 import { readableStreamFrom } from './utils/readableStreamFrom';
 
@@ -129,15 +129,6 @@ async function* createBatchStreamProducer(
   const placeholder = 0 as PlaceholderValue;
 
   const racer = raceAsyncIterables<ChunkData>();
-  await using queue = makeAsyncResource(
-    new Set<{
-      iterator: AsyncIterator<ChunkData, ChunkData>;
-      nextPromise: Promise<IteratorResult<ChunkData, ChunkData>>;
-    }>(),
-    async () => {
-      await Promise.all(Array.from(queue).map((it) => it.iterator.return?.()));
-    },
-  );
   function registerAsync(
     callback: (idx: ChunkIndex) => AsyncIterable<ChunkData, void>,
   ) {

--- a/packages/server/src/unstable-core-do-not-import/stream/jsonl.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/jsonl.ts
@@ -1,9 +1,9 @@
-import { Unpromise } from '../../vendor/unpromise';
 import { isAsyncIterable, isFunction, isObject, run } from '../utils';
 import { iteratorResource } from './utils/asyncIterable';
 import type { Deferred } from './utils/createDeferred';
 import { createDeferred } from './utils/createDeferred';
 import { makeAsyncResource, makeResource } from './utils/disposable';
+import { raceAsyncIterables } from './utils/raceAsyncIterables';
 import { readableStreamFrom } from './utils/readableStreamFrom';
 
 /**
@@ -128,6 +128,7 @@ async function* createBatchStreamProducer(
   let counter = 0 as ChunkIndex;
   const placeholder = 0 as PlaceholderValue;
 
+  const racer = raceAsyncIterables<ChunkData>();
   await using queue = makeAsyncResource(
     new Set<{
       iterator: AsyncIterator<ChunkData, ChunkData>;
@@ -138,21 +139,12 @@ async function* createBatchStreamProducer(
     },
   );
   function registerAsync(
-    callback: (idx: ChunkIndex) => AsyncIterable<ChunkData, ChunkData>,
+    callback: (idx: ChunkIndex) => AsyncIterable<ChunkData, void>,
   ) {
     const idx = counter++ as ChunkIndex;
 
-    const iterator = callback(idx)[Symbol.asyncIterator]();
-
-    const nextPromise = iterator.next();
-
-    nextPromise.catch(() => {
-      // prevent unhandled promise rejection
-    });
-    queue.add({
-      iterator,
-      nextPromise,
-    });
+    const iterable = callback(idx);
+    racer.add(iterable);
 
     return idx;
   }
@@ -170,10 +162,10 @@ async function* createBatchStreamProducer(
       }
       try {
         const next = await promise;
-        return [idx, PROMISE_STATUS_FULFILLED, encode(next, path)];
+        yield [idx, PROMISE_STATUS_FULFILLED, encode(next, path)];
       } catch (cause) {
         opts.onError?.({ error: cause, path });
-        return [
+        yield [
           idx,
           PROMISE_STATUS_REJECTED,
           opts.formatError?.({ error: cause, path }),
@@ -196,17 +188,15 @@ async function* createBatchStreamProducer(
         while (true) {
           const next = await iterator.next();
           if (next.done) {
-            return [
-              idx,
-              ASYNC_ITERABLE_STATUS_RETURN,
-              encode(next.value, path),
-            ];
+            yield [idx, ASYNC_ITERABLE_STATUS_RETURN, encode(next.value, path)];
+            return;
           }
           yield [idx, ASYNC_ITERABLE_STATUS_YIELD, encode(next.value, path)];
         }
       } catch (cause) {
         opts.onError?.({ error: cause, path });
-        return [
+
+        yield [
           idx,
           ASYNC_ITERABLE_STATUS_ERROR,
           opts.formatError?.({ error: cause, path }),
@@ -270,21 +260,8 @@ async function* createBatchStreamProducer(
 
   yield newHead;
 
-  // Process all async iterables in parallel by racing their next values
-  while (queue.size > 0) {
-    // Race all iterators to get the next value from any of them
-    const [entry, res] = await Unpromise.race(
-      Array.from(queue).map(async (it) => [it, await it.nextPromise] as const),
-    );
-
-    yield res.value;
-
-    // Remove current iterator and re-add if not done
-    queue.delete(entry);
-    if (!res.done) {
-      entry.nextPromise = entry.iterator.next();
-      queue.add(entry);
-    }
+  for await (const value of racer) {
+    yield value;
   }
 }
 /**

--- a/packages/server/src/unstable-core-do-not-import/stream/utils/raceAsyncIterables.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/utils/raceAsyncIterables.test.ts
@@ -1,0 +1,111 @@
+import { run } from '../../utils';
+import { createDeferred } from './createDeferred';
+import { raceAsyncIterables } from './raceAsyncIterables';
+
+test('happy path', async () => {
+  const racer = raceAsyncIterables<string>();
+
+  racer.add(
+    run(async function* () {
+      yield 'a:1';
+      yield 'a:2';
+    }),
+  );
+
+  racer.add(
+    run(async function* () {
+      yield 'b:1';
+    }),
+  );
+
+  const aggregate: string[] = [];
+  for await (const value of racer) {
+    aggregate.push(value);
+  }
+
+  expect(aggregate).toEqual(['a:1', 'b:1', 'a:2']);
+});
+
+test('add after iteration starts', async () => {
+  const racer = raceAsyncIterables<string>();
+
+  const yieldDeferred = createDeferred<void>();
+  const addDeferred = createDeferred<void>();
+
+  racer.add(
+    run(async function* () {
+      yield 'a:1';
+      await yieldDeferred.promise;
+      yield 'a:2';
+    }),
+  );
+
+  addDeferred.promise.then(() => {
+    racer.add(
+      run(async function* () {
+        yield 'b:1';
+        yieldDeferred.resolve();
+      }),
+    );
+  });
+
+  const aggregate: string[] = [];
+  for await (const value of racer) {
+    addDeferred.resolve();
+    aggregate.push(value);
+  }
+
+  expect(aggregate).toEqual(['a:1', 'b:1', 'a:2']);
+});
+
+test('iterators are returned() when disposed', async () => {
+  const racer = raceAsyncIterables<string>();
+
+  const disposeSpy = vi.fn();
+  const beforeFirst = vi.fn();
+  const afterFirst = vi.fn();
+  racer.add(
+    run(async function* () {
+      try {
+        beforeFirst();
+        yield 'a:1';
+        afterFirst();
+        yield 'a:2';
+      } finally {
+        disposeSpy();
+      }
+    }),
+  );
+
+  expect(beforeFirst).not.toHaveBeenCalled();
+
+  const aggregate: string[] = [];
+  for await (const value of racer) {
+    aggregate.push(value);
+    break;
+  }
+
+  expect(aggregate).toEqual(['a:1']);
+  expect(beforeFirst).toHaveBeenCalled();
+  expect(afterFirst).not.toHaveBeenCalled();
+  expect(disposeSpy).toHaveBeenCalled();
+});
+
+test('cannot iterate twice', async () => {
+  const racer = raceAsyncIterables<string>();
+
+  racer.add(
+    run(async function* () {
+      yield 'a:1';
+    }),
+  );
+
+  for await (const _ of racer) {
+    break;
+  }
+
+  await expect(async () => {
+    for await (const _ of racer) {
+    }
+  }).rejects.toMatchInlineSnapshot(`[Error: Cannot iterate twice]`);
+});

--- a/packages/server/src/unstable-core-do-not-import/stream/utils/raceAsyncIterables.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/utils/raceAsyncIterables.ts
@@ -57,7 +57,8 @@ type ManagedIterator<TYield, TReturn> = ReturnType<
   typeof createManagedIterator<TYield, TReturn>
 >;
 
-interface RaceAsyncIterables<TYield> extends AsyncIterable<TYield> {
+interface RaceAsyncIterables<TYield>
+  extends AsyncIterable<TYield, void, unknown> {
   add(iterable: AsyncIterable<TYield>): void;
 }
 

--- a/packages/server/src/unstable-core-do-not-import/stream/utils/raceAsyncIterables.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/utils/raceAsyncIterables.ts
@@ -13,21 +13,31 @@ type ResultTuple<T> = [status: 0, value: T] | [status: 1, cause: unknown];
 /**
  * Merges multiple async iterables into a single async iterable that yields values in the order they resolve
  */
-export function raceAsyncIterables<T>(): AsyncIterable<T, void, unknown> & {
-  add(iterable: AsyncIterable<T, void, unknown>): void;
+export function raceAsyncIterables<TYield>(): AsyncIterable<
+  TYield,
+  void,
+  unknown
+> & {
+  add(iterable: AsyncIterable<TYield, void, unknown>): void;
 } {
-  const pendingIterables: AsyncIterable<T, void, unknown>[] = [];
+  const pendingIterables: AsyncIterable<TYield, void, unknown>[] = [];
 
-  const activeIterators = new Map<AsyncIterator<T, void, unknown>, State>();
+  const activeIterators = new Map<
+    AsyncIterator<TYield, void, unknown>,
+    State
+  >();
   let running = false;
   let frozen = false;
   const buffer: Array<
-    [iterator: AsyncIterator<T, void, unknown>, result: ResultTuple<T>]
+    [
+      iterator: AsyncIterator<TYield, void, unknown>,
+      result: ResultTuple<TYield>,
+    ]
   > = [];
 
   let drain = createDeferred<void>();
 
-  function pull(iterator: AsyncIterator<T>) {
+  function pull(iterator: AsyncIterator<TYield>) {
     const next = iterator.next();
     activeIterators.set(iterator, ActiveStatePending);
 
@@ -50,7 +60,7 @@ export function raceAsyncIterables<T>(): AsyncIterable<T, void, unknown> & {
   }
 
   return {
-    add(iterable: AsyncIterable<T, void, unknown>) {
+    add(iterable: AsyncIterable<TYield, void, unknown>) {
       if (frozen) {
         throw new Error('Cannot add iterable after iteration ended');
       }

--- a/packages/server/src/unstable-core-do-not-import/stream/utils/raceAsyncIterables.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/utils/raceAsyncIterables.ts
@@ -149,10 +149,7 @@ export function raceAsyncIterables<TYield>(): RaceAsyncIterables<TYield> {
           .filter((r) => r.status === 'rejected')
           .map((r) => r.reason);
         if (errors.length > 0) {
-          throw new AggregateError(
-            errors,
-            'Errors during cleanup of iterators',
-          );
+          throw new AggregateError(errors);
         }
       });
 

--- a/packages/server/src/unstable-core-do-not-import/stream/utils/raceAsyncIterables.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/utils/raceAsyncIterables.ts
@@ -1,0 +1,107 @@
+import { createDeferred } from './createDeferred';
+import { makeAsyncResource } from './disposable';
+
+type ActiveStatePending = 0 & { _brand: 'Pending' };
+const ActiveStatePending = 0 as ActiveStatePending;
+type ActiveStateIdle = 1 & { _brand: 'Idle' };
+const ActiveStateIdle = 1 as ActiveStateIdle;
+type State = ActiveStatePending | ActiveStateIdle;
+
+/**
+ * Merges multiple async iterables into a single async iterable that yields values in the order they resolve
+ */
+export function raceAsyncIterables<T>(): AsyncIterable<T, void, unknown> & {
+  add(iterable: AsyncIterable<T, void, unknown>): void;
+} {
+  const pendingIterables: AsyncIterable<T, void, unknown>[] = [];
+
+  const activeIterators = new Map<AsyncIterator<T, void, unknown>, State>();
+  let running = false;
+  let frozen = false;
+  const buffer: Array<
+    | [AsyncIterator<T, void, unknown>, 0, T]
+    | [AsyncIterator<T, void, unknown>, 1, unknown]
+  > = [];
+
+  let drain = createDeferred<void>();
+
+  function iterate(iterator: AsyncIterator<T>) {
+    const next = iterator.next();
+    activeIterators.set(iterator, ActiveStatePending);
+
+    next
+      .then((result) => {
+        if (result.done) {
+          activeIterators.delete(iterator);
+        } else {
+          buffer.push([iterator, 0, result.value]);
+          activeIterators.set(iterator, ActiveStateIdle);
+        }
+      })
+      .catch((cause) => {
+        buffer.push([iterator, 1, cause]);
+        activeIterators.delete(iterator);
+      })
+      .finally(() => {
+        drain.resolve();
+      });
+  }
+
+  return {
+    add(iterable: AsyncIterable<T, void, unknown>) {
+      if (frozen) {
+        throw new Error('Cannot add iterable after iteration ended');
+      }
+      if (!running) {
+        pendingIterables.push(iterable);
+        return;
+      }
+      const iterator = iterable[Symbol.asyncIterator]();
+      iterate(iterator);
+    },
+
+    async *[Symbol.asyncIterator]() {
+      if (frozen || running) {
+        throw new Error('Cannot iterate twice');
+      }
+      running = true;
+
+      await using _finally = makeAsyncResource({}, async () => {
+        frozen = true;
+        await Promise.all(
+          Array.from(activeIterators.keys()).map((it) => it.return?.()),
+        );
+        activeIterators.clear();
+        buffer.length = 0;
+        running = false;
+      });
+
+      let iterable;
+      while ((iterable = pendingIterables.shift())) {
+        const iterator = iterable[Symbol.asyncIterator]();
+        iterate(iterator);
+      }
+
+      while (activeIterators.size > 0) {
+        await drain.promise;
+
+        let chunk;
+        while ((chunk = buffer.shift())) {
+          const [iterator, status, value] = chunk;
+
+          switch (status) {
+            case 0:
+              yield value;
+              if (activeIterators.get(iterator) === ActiveStateIdle) {
+                iterate(iterator);
+              }
+              break;
+            case 1:
+              throw value;
+          }
+        }
+        drain = createDeferred();
+      }
+    },
+  };
+}


### PR DESCRIPTION
Closes #

## 🎯 Changes

Adds a `raceAsyncIterables`-function that can race async iterables

No reason, was just fun