### PR TITLE
fix(server): handle missing socket.off and socket.once methods

### DIFF
--- a/packages/server/src/adapters/node-http/incomingMessageToRequest.ts
+++ b/packages/server/src/adapters/node-http/incomingMessageToRequest.ts
@@ -136,14 +136,14 @@ export function incomingMessageToRequest(
 
   const onAbort = () => {
     res.off('close', onAbort);
-    req.socket?.off('end', onAbort);
+    req.socket?.off?.('end', onAbort);
 
     // abort the request
     ac.abort();
   };
 
   res.once('close', onAbort);
-  req.socket?.once('end', onAbort);
+  req.socket?.once?.('end', onAbort);
 
   // Get host from either regular header or HTTP/2 pseudo-header
   const url = createURL(req);

--- a/packages/server/src/adapters/node-http/incomingMessageToRequest.ts
+++ b/packages/server/src/adapters/node-http/incomingMessageToRequest.ts
@@ -10,8 +10,10 @@ export interface UniversalIncomingMessage
   /**
    * Socket is not always available in all deployments, so we need to make it optional
    * @see https://github.com/trpc/trpc/issues/6341
+   * The socket object provided in the request does not fully implement the expected Node.js Socket interface.
+   * @see https://github.com/trpc/trpc/pull/6358
    */
-  socket?: http.IncomingMessage['socket'];
+  socket?: Partial<http.IncomingMessage['socket']>;
 }
 
 function createBody(


### PR DESCRIPTION
## 🎯 Changes

PR https://github.com/trpc/trpc/pull/6343 didn't account for when the socket object exists but lacks the `once` and `off` methods. 

This behavior has been observed in certain runtime environments, such as AWS Lambda, where the socket object provided in the request does not fully implement the expected Node.js Socket interface.

This is the object that gets returned where socket is defined but `off` and `once` properties are not:
```ts
    socket: {
      encrypted: true,
      readable: true,
      remoteAddress: '...',
      address: [ ... ],
      end: {},
      destroy: {}
    },
```

Verified now working using `pkg-pr-new` node package

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
