### PR TITLE
fix(server): encode the SSE messages as bytes instead

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/stream/sse.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/sse.test.ts
@@ -51,7 +51,6 @@ test('e2e, server-sent events (SSE)', async () => {
       serialize: (v) => SuperJSON.serialize(v),
     })
       .pipeThrough(
-        // debug stream
         new TransformStream({
           transform: (chunk, controller) => {
             controller.enqueue(chunk);

--- a/packages/server/src/unstable-core-do-not-import/stream/sse.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/sse.test.ts
@@ -54,8 +54,6 @@ test('e2e, server-sent events (SSE)', async () => {
         // debug stream
         new TransformStream({
           transform: (chunk, controller) => {
-            // console.debug('debug', chunk);
-            written.push(chunk);
             controller.enqueue(chunk);
           },
         }),

--- a/packages/server/src/unstable-core-do-not-import/stream/sse.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/sse.test.ts
@@ -49,16 +49,24 @@ test('e2e, server-sent events (SSE)', async () => {
     const stream = sseStreamProducer({
       data: data(lastEventId ?? undefined),
       serialize: (v) => SuperJSON.serialize(v),
-    }).pipeThrough(
-      // debug stream
-      new TransformStream({
-        transform: (chunk, controller) => {
-          // console.debug('debug', chunk);
-          written.push(textDecoder.decode(chunk));
-          controller.enqueue(chunk);
-        },
-      }),
-    );
+    })
+      .pipeThrough(
+        // debug stream
+        new TransformStream({
+          transform: (chunk, controller) => {
+            controller.enqueue(chunk);
+          },
+        }),
+      )
+      .pipeThrough(new TextDecoderStream())
+      .pipeThrough(
+        new TransformStream({
+          transform(chunk, controller) {
+            written.push(chunk);
+            controller.enqueue(chunk);
+          },
+        }),
+      );
 
     return new Response(stream, {
       headers: sseHeaders,
@@ -199,14 +207,16 @@ test('SSE on serverless - emit and disconnect early', async () => {
       data: data(asNumber, reqAbortCtrl.signal),
       serialize: (v) => SuperJSON.serialize(v),
       emitAndEndImmediately: true,
-    }).pipeThrough(
-      new TransformStream({
-        transform(chunk, controller) {
-          requestTrace.written.push(textDecoder.decode(chunk));
-          controller.enqueue(chunk);
-        },
-      }),
-    );
+    })
+      .pipeThrough(new TextDecoderStream())
+      .pipeThrough(
+        new TransformStream({
+          transform(chunk, controller) {
+            requestTrace.written.push(chunk);
+            controller.enqueue(chunk);
+          },
+        }),
+      );
 
     return new Response(stream, {
       headers: sseHeaders,

--- a/packages/server/src/unstable-core-do-not-import/stream/sse.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/sse.test.ts
@@ -21,6 +21,9 @@ export const suppressLogs = () => {
     console.error = error;
   };
 };
+
+const textDecoder = new TextDecoder();
+
 test('e2e, server-sent events (SSE)', async () => {
   async function* data(lastEventId: string | undefined) {
     let i = lastEventId ? Number(lastEventId) : 0;
@@ -51,7 +54,7 @@ test('e2e, server-sent events (SSE)', async () => {
       new TransformStream({
         transform: (chunk, controller) => {
           // console.debug('debug', chunk);
-          written.push(chunk);
+          written.push(textDecoder.decode(chunk));
           controller.enqueue(chunk);
         },
       }),
@@ -199,7 +202,7 @@ test('SSE on serverless - emit and disconnect early', async () => {
     }).pipeThrough(
       new TransformStream({
         transform(chunk, controller) {
-          requestTrace.written.push(chunk);
+          requestTrace.written.push(textDecoder.decode(chunk));
           controller.enqueue(chunk);
         },
       }),

--- a/packages/server/src/unstable-core-do-not-import/stream/sse.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/sse.test.ts
@@ -54,6 +54,8 @@ test('e2e, server-sent events (SSE)', async () => {
         // debug stream
         new TransformStream({
           transform: (chunk, controller) => {
+            // console.debug('debug', chunk);
+            written.push(chunk);
             controller.enqueue(chunk);
           },
         }),

--- a/packages/server/src/unstable-core-do-not-import/stream/sse.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/sse.test.ts
@@ -50,15 +50,9 @@ test('e2e, server-sent events (SSE)', async () => {
       data: data(lastEventId ?? undefined),
       serialize: (v) => SuperJSON.serialize(v),
     })
-      .pipeThrough(
-        new TransformStream({
-          transform: (chunk, controller) => {
-            controller.enqueue(chunk);
-          },
-        }),
-      )
       .pipeThrough(new TextDecoderStream())
       .pipeThrough(
+        // debug stream
         new TransformStream({
           transform(chunk, controller) {
             written.push(chunk);

--- a/packages/server/src/unstable-core-do-not-import/stream/sse.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/sse.ts
@@ -15,6 +15,8 @@ import {
 } from './utils/timerResource';
 import { PING_SYM, withPing } from './utils/withPing';
 
+const textEncoder = new TextEncoder();
+
 type Serialize = (value: any) => any;
 type Deserialize = (value: any) => any;
 
@@ -176,24 +178,28 @@ export function sseStreamProducer<TValue = unknown>(
       };
     }
   }
+
   const stream = readableStreamFrom(generatorWithErrorHandling());
 
   return stream.pipeThrough(
     new TransformStream({
-      transform(chunk, controller: TransformStreamDefaultController<string>) {
+      transform(
+        chunk,
+        controller: TransformStreamDefaultController<Uint8Array>,
+      ) {
         if ('event' in chunk) {
-          controller.enqueue(`event: ${chunk.event}\n`);
+          controller.enqueue(textEncoder.encode(`event: ${chunk.event}\n`));
         }
         if ('data' in chunk) {
-          controller.enqueue(`data: ${chunk.data}\n`);
+          controller.enqueue(textEncoder.encode(`data: ${chunk.data}\n`));
         }
         if ('id' in chunk) {
-          controller.enqueue(`id: ${chunk.id}\n`);
+          controller.enqueue(textEncoder.encode(`id: ${chunk.id}\n`));
         }
         if ('comment' in chunk) {
-          controller.enqueue(`: ${chunk.comment}\n`);
+          controller.enqueue(textEncoder.encode(`: ${chunk.comment}\n`));
         }
-        controller.enqueue('\n\n');
+        controller.enqueue(textEncoder.encode('\n\n'));
       },
     }),
   );

--- a/packages/server/src/unstable-core-do-not-import/stream/sse.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/sse.ts
@@ -15,8 +15,6 @@ import {
 } from './utils/timerResource';
 import { PING_SYM, withPing } from './utils/withPing';
 
-const textEncoder = new TextEncoder();
-
 type Serialize = (value: any) => any;
 type Deserialize = (value: any) => any;
 
@@ -181,28 +179,27 @@ export function sseStreamProducer<TValue = unknown>(
 
   const stream = readableStreamFrom(generatorWithErrorHandling());
 
-  return stream.pipeThrough(
-    new TransformStream({
-      transform(
-        chunk,
-        controller: TransformStreamDefaultController<Uint8Array>,
-      ) {
-        if ('event' in chunk) {
-          controller.enqueue(textEncoder.encode(`event: ${chunk.event}\n`));
-        }
-        if ('data' in chunk) {
-          controller.enqueue(textEncoder.encode(`data: ${chunk.data}\n`));
-        }
-        if ('id' in chunk) {
-          controller.enqueue(textEncoder.encode(`id: ${chunk.id}\n`));
-        }
-        if ('comment' in chunk) {
-          controller.enqueue(textEncoder.encode(`: ${chunk.comment}\n`));
-        }
-        controller.enqueue(textEncoder.encode('\n\n'));
-      },
-    }),
-  );
+  return stream
+    .pipeThrough(
+      new TransformStream({
+        transform(chunk, controller: TransformStreamDefaultController<string>) {
+          if ('event' in chunk) {
+            controller.enqueue(`event: ${chunk.event}\n`);
+          }
+          if ('data' in chunk) {
+            controller.enqueue(`data: ${chunk.data}\n`);
+          }
+          if ('id' in chunk) {
+            controller.enqueue(`id: ${chunk.id}\n`);
+          }
+          if ('comment' in chunk) {
+            controller.enqueue(`: ${chunk.comment}\n`);
+          }
+          controller.enqueue('\n\n');
+        },
+      }),
+    )
+    .pipeThrough(new TextEncoderStream());
 }
 
 interface ConsumerStreamResultBase<TConfig extends ConsumerConfig> {


### PR DESCRIPTION
This makes it closer to the HTTP wire format and compatible with Cloudflare Workers.

Closes #6360

## 🎯 Changes

- Updated SSE to encode as bytes to play well with the Cloudflare Workerd runtime
- Updated SSE tests to handle binary chunks while maintaining human-readable output. Added TextDecoder to convert Uint8Array chunks to strings without changing existing test behavior or assertions.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.

I have tested also things continue to work as is outside of Cloudflare when running the server w/ `createHTTPServer` .