### PR TITLE
feat(client): add trisect link

### DIFF
--- a/packages/client/src/links/trisectLink.test.ts
+++ b/packages/client/src/links/trisectLink.test.ts
@@ -1,0 +1,90 @@
+import { observable } from '@trpc/server/observable';
+import type { AnyRouter } from '@trpc/server/unstable-core-do-not-import';
+import { createChain } from './internals/createChain';
+import { trisectLink } from './trisectLink';
+import { isNonJsonSerializable, type OperationLink, type TRPCLink } from './types';
+
+test('trisectLink', () => {
+  const wsLinkSpy = vi.fn();
+  const wsLink: TRPCLink<any> = () => () =>
+    observable(() => {
+      wsLinkSpy();
+    });
+  const httpLinkSpy = vi.fn();
+  const httpLink: TRPCLink<any> = () => () =>
+    observable(() => {
+      httpLinkSpy();
+    });
+  const httpLinkFormDataSpy = vi.fn();
+  const httpLinkFormData: TRPCLink<any> = () => () =>
+    observable(() => {
+      httpLinkFormDataSpy();
+    });
+  const links: OperationLink<AnyRouter, any, any>[] = [
+    // "dedupe link"
+    trisectLink({
+      condition(op) {
+        if (op.type === "subscription") {
+          return 0;
+        }
+
+        if (isNonJsonSerializable(op.input)) {
+          return 1;
+        }
+
+        return 2;
+      },
+      0: wsLink,
+      1: [httpLinkFormData],
+      2: [httpLink]
+    })(null as any),
+  ];
+
+  createChain({
+    links,
+    op: {
+      type: 'query',
+      input: null,
+      path: '.',
+      id: 0,
+      context: {},
+      signal: null,
+    },
+  }).subscribe({});
+  expect(httpLinkFormDataSpy).toHaveBeenCalledTimes(0);
+  expect(httpLinkSpy).toHaveBeenCalledTimes(1);
+  expect(wsLinkSpy).toHaveBeenCalledTimes(0);
+  vi.resetAllMocks();
+
+  createChain({
+    links,
+    op: {
+      type: 'subscription',
+      input: null,
+      path: '.',
+      id: 0,
+      context: {},
+      signal: null,
+    },
+  }).subscribe({});
+  expect(httpLinkFormDataSpy).toHaveBeenCalledTimes(0);
+  expect(httpLinkSpy).toHaveBeenCalledTimes(0);
+  expect(wsLinkSpy).toHaveBeenCalledTimes(1);
+  vi.resetAllMocks();
+
+  createChain({
+    links,
+    op: {
+      type: 'query',
+      input: new FormData(),
+      path: '.',
+      id: 0,
+      context: {},
+      signal: null,
+    },
+  }).subscribe({});
+  expect(httpLinkFormDataSpy).toHaveBeenCalledTimes(1);
+  expect(httpLinkSpy).toHaveBeenCalledTimes(0);
+  expect(wsLinkSpy).toHaveBeenCalledTimes(0);
+});
+

--- a/packages/client/src/links/trisectLink.test.ts
+++ b/packages/client/src/links/trisectLink.test.ts
@@ -2,7 +2,11 @@ import { observable } from '@trpc/server/observable';
 import type { AnyRouter } from '@trpc/server/unstable-core-do-not-import';
 import { createChain } from './internals/createChain';
 import { trisectLink } from './trisectLink';
-import { isNonJsonSerializable, type OperationLink, type TRPCLink } from './types';
+import {
+  isNonJsonSerializable,
+  type OperationLink,
+  type TRPCLink,
+} from './types';
 
 test('trisectLink', () => {
   const wsLinkSpy = vi.fn();
@@ -24,7 +28,7 @@ test('trisectLink', () => {
     // "dedupe link"
     trisectLink({
       condition(op) {
-        if (op.type === "subscription") {
+        if (op.type === 'subscription') {
           return 0;
         }
 
@@ -36,7 +40,7 @@ test('trisectLink', () => {
       },
       0: wsLink,
       1: [httpLinkFormData],
-      2: [httpLink]
+      2: [httpLink],
     })(null as any),
   ];
 
@@ -87,4 +91,3 @@ test('trisectLink', () => {
   expect(httpLinkSpy).toHaveBeenCalledTimes(0);
   expect(wsLinkSpy).toHaveBeenCalledTimes(0);
 });
-

--- a/packages/client/src/links/trisectLink.ts
+++ b/packages/client/src/links/trisectLink.ts
@@ -1,0 +1,37 @@
+import { observable } from '@trpc/server/observable';
+import type { AnyRouter } from '@trpc/server/unstable-core-do-not-import';
+import { createChain } from './internals/createChain';
+import type { Operation, TRPCLink } from './types';
+
+function asArray<TType>(value: TType | TType[]) {
+  return Array.isArray(value) ? value : [value];
+}
+export function trisectLink<TRouter extends AnyRouter = AnyRouter>(opts: {
+  condition: (op: Operation) => 0 | 1 | 2;
+  /**
+   * The link to execute next if the test function returns `0`.
+   */
+  0: TRPCLink<TRouter> | TRPCLink<TRouter>[];
+  /**
+   * The link to execute next if the test function returns `1`.
+   */
+  1: TRPCLink<TRouter> | TRPCLink<TRouter>[];
+  /**
+   * The link to execute next if the test function returns `2`.
+   */
+  2: TRPCLink<TRouter> | TRPCLink<TRouter>[];
+}): TRPCLink<TRouter> {
+  return (runtime) => {
+    const link0 = asArray(opts[0]).map((link) => link(runtime));
+    const link1 = asArray(opts[1]).map((link) => link(runtime));
+    const link2 = asArray(opts[2]).map((link) => link(runtime));
+    return (props) => {
+      return observable((observer) => {
+        const links = opts.condition(props.op) === 0 ? link0 : opts.condition(props.op) === 1 ? link1 : link2;
+
+        return createChain({ op: props.op, links }).subscribe(observer);
+      });
+    };
+  };
+}
+

--- a/packages/client/src/links/trisectLink.ts
+++ b/packages/client/src/links/trisectLink.ts
@@ -27,11 +27,15 @@ export function trisectLink<TRouter extends AnyRouter = AnyRouter>(opts: {
     const link2 = asArray(opts[2]).map((link) => link(runtime));
     return (props) => {
       return observable((observer) => {
-        const links = opts.condition(props.op) === 0 ? link0 : opts.condition(props.op) === 1 ? link1 : link2;
+        const links =
+          opts.condition(props.op) === 0
+            ? link0
+            : opts.condition(props.op) === 1
+              ? link1
+              : link2;
 
         return createChain({ op: props.op, links }).subscribe(observer);
       });
     };
   };
 }
-


### PR DESCRIPTION
## 🎯 Changes

This PR adds `trisectLink` to `@trpc/client`. trisectLink is the same as `splitLink` but accepts 3 condition branches (`0 | 1 | 2`) instead of 2 (`true | false`).

### Why?

While working on a project I needed to support SSE subscriptions (`unstable_httpSubscriptionLink`), batched+streamed HTTP requests (`unstable_httpBatchStreamLink`) and HTTP requests with FormData as input (`httpLink`). I've implemented `trisectLink` in my project but I figured it might be useful for others to reuse this functionality too. I guess we could support N branches even in a type-safe way but I didn't want to spend more time on that because a) it might not get approved by TRPC team and b) why would you need more than 3 links?

Example

```ts
const trpcClient = trpc.createClient({
  links: [
    trisectLink({
      condition: (op) => {
        if (op.type === "subscription") {
          return 0;
        }

        if (isNonJsonSerializable(op.input)) {
          return 1;
        }

        return 2;
      },
      0: unstable_httpSubscriptionLink({ url, transformer: SuperJSON }),
      1: httpLink({
        url,
        transformer: {
          serialize: (data) => data as FormData,
          deserialize: SuperJSON.deserialize,
        },
      }),
      2: unstable_httpBatchStreamLink({ url, transformer: SuperJSON }),
    }),
  ],
});
```

In an ideal world we would be able to change `transformer.serialize` based on the data, like 
```ts
unstable_httpBatchStreamLink({
  url,
  transformer: {
    serialize: (data) => {
      if (isNonJsonSerializable(data)) {
        return data;
      }

      return SuperJSON.serialize(data);
    },
    deserialize: SuperJSON.deserialize,
  },
})
```

but I was getting

```
"TRPCError: Cannot use 'in' operator to search for 'Symbol(Symbol.iterator)' in undefined
    at inputValidatorMiddleware (file:///Users/kacperochmanski/dev/[redacted]/node_modules/.pnpm/@trpc+server@11.0.0-rc.666_typescript@5.7.2/node_modules/@trpc/server/dist/unstable-core-do-not-import/middleware.mjs:46:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async callRecursive (file:///Users/kacperochmanski/dev/[redacted]/node_modules/.pnpm/@trpc+server@11.0.0-rc.666_typescript@5.7.2/node_modules/@trpc/server/dist/unstable-core-do-not-import/procedureBuilder.mjs:143:24)
    at async procedure (file:///Users/kacperochmanski/dev/[redacted]/node_modules/.pnpm/@trpc+server@11.0.0-rc.666_typescript@5.7.2/node_modules/@trpc/server/dist/unstable-core-do-not-import/procedureBuilder.mjs:176:24)
    at async /Users/kacperochmanski/[redacted]/node_modules/.pnpm/@trpc+server@11.0.0-rc.660_typescript@5.7.2/node_modules/@trpc/server/dist/unstable-core-do-not-import/http/resolveResponse.js:251:30
    at async /Users/kacperochmanski/dev/[redacted]/node_modules/.pnpm/@trpc+server@11.0.0-rc.660_typescript@5.7.2/node_modules/@trpc/server/dist/unstable-core-do-not-import/http/resolveResponse.js:425:45
    at async /Users/kacperochmanski/[redacted]/node_modules/.pnpm/@trpc+server@11.0.0-rc.660_typescript@5.7.2/node_modules/@trpc/server/dist/unstable-core-do-not-import/stream/jsonl.js:147:34"
```

It does work with `httpLink` though.

## 📚 Summary

Sending FormData with any batch link does not work (see above). I still needed to use it so to workaround this feature/bug I've added `trisectLink` which allows to have 3 specific links based on link condition. Adapting `splitLink` to use arbitrary number of branches might be a better approach but since I'm a new contributor I'm not sure if it's the best for TRPC project. I'm happy to work on it though.

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made. <-- I didn't add any documentation because I'm not sure if this change is aligned with TRPC maintainers but if it's approved I'm happy to add documentation.
- [x] I have added or updated the tests related to the changes made.
