### PR TITLE
chore(`client`): change `ClientContext` from `type` to `interface`

### DIFF
--- a/packages/client/src/internals/types.ts
+++ b/packages/client/src/internals/types.ts
@@ -87,6 +87,9 @@ export interface ResponseEsque {
  */
 export type NonEmptyArray<TItem> = [TItem, ...TItem[]];
 
+/**
+ * @internal
+ */
 export interface ClientContext extends Record<string, unknown> {}
 
 /**

--- a/packages/client/src/internals/types.ts
+++ b/packages/client/src/internals/types.ts
@@ -87,7 +87,7 @@ export interface ResponseEsque {
  */
 export type NonEmptyArray<TItem> = [TItem, ...TItem[]];
 
-type ClientContext = Record<string, unknown>;
+export interface ClientContext extends Record<string, unknown> {}
 
 /**
  * @public


### PR DESCRIPTION
Closes #4876 

## 🎯 Changes

Allows extending `ClientContext` to a custom type, to get more convenient type completion in the client. e.g.

```ts
interface MyContext {
  retries: number;
  [key: string]: unknown;
}

declare module '@trpc/server/unstable-core-do-not-import' {
  interface ClientContext extends MyContext {}  // Override the default tRPC ClientContext
}

await client.users.getProfile.query({ id: '1' }, {
  context: {
    retries: 3,  // Type-safe retry configuration
  },
});
```

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: tRPC v11 Update

- **Type Changes**
  - Introduced new `TRPCProcedureOptions` type from `@trpc/client`
  - Removed `ProcedureOptions` type from server exports

- **Breaking Changes**
  - Requires TypeScript 5.7.2+
  - Requires React 18.2.0+
  - Updated TanStack Query to version 5.0.0

- **Deprecations**
  - Several server-side types and exports marked as deprecated
  - Removed `@trpc/client` export from `@trpc/react-query`

- **New Features**
  - Added `retryLink`
  - Improved `useSubscription`
  - Support for Server-Sent Events (SSE)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->