### PR TITLE
fix(server+client): move client context from server to client

### DIFF
--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -128,7 +128,7 @@ export type CreateTRPCClient<TRouter extends AnyRouter> =
 /**
  * @internal
  */
-export function createTRPCClientProxy<TRouter extends AnyRouter>(
+function createTRPCClientProxy<TRouter extends AnyRouter>(
   client: TRPCUntypedClient<TRouter>,
 ): CreateTRPCClient<TRouter> {
   const proxy = createRecursiveProxy<CreateTRPCClient<TRouter>>(

--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -128,7 +128,7 @@ export type CreateTRPCClient<TRouter extends AnyRouter> =
 /**
  * @internal
  */
-function createTRPCClientProxy<TRouter extends AnyRouter>(
+export function createTRPCClientProxy<TRouter extends AnyRouter>(
   client: TRPCUntypedClient<TRouter>,
 ): CreateTRPCClient<TRouter> {
   const proxy = createRecursiveProxy<CreateTRPCClient<TRouter>>(

--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -7,7 +7,6 @@ import type {
   inferProcedureInput,
   inferTransformedProcedureOutput,
   IntersectionError,
-  ProcedureOptions,
   ProcedureType,
   RouterRecord,
 } from '@trpc/server/unstable-core-do-not-import';
@@ -21,6 +20,7 @@ import type {
   UntypedClientProperties,
 } from './internals/TRPCUntypedClient';
 import { TRPCUntypedClient } from './internals/TRPCUntypedClient';
+import type { TRPCProcedureOptions } from './internals/types';
 import type { TRPCClientError } from './TRPCClientError';
 
 /**
@@ -44,7 +44,7 @@ type coerceAsyncGeneratorToIterable<T> =
 /** @internal */
 export type Resolver<TDef extends ResolverDef> = (
   input: TDef['input'],
-  opts?: ProcedureOptions,
+  opts?: TRPCProcedureOptions,
 ) => Promise<coerceAsyncGeneratorToIterable<TDef['output']>>;
 
 type SubscriptionResolver<TDef extends ResolverDef> = (
@@ -52,7 +52,7 @@ type SubscriptionResolver<TDef extends ResolverDef> = (
   opts: Partial<
     TRPCSubscriptionObserver<TDef['output'], TRPCClientError<TDef>>
   > &
-    ProcedureOptions,
+    TRPCProcedureOptions,
 ) => Unsubscribable;
 
 type DecorateProcedure<

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -20,3 +20,5 @@ export {
    */
   type inferRouterClient as inferRouterProxyClient,
 } from './createTRPCClient';
+
+export { type TRPCProcedureOptions } from './internals/types';

--- a/packages/client/src/internals/types.ts
+++ b/packages/client/src/internals/types.ts
@@ -86,3 +86,16 @@ export interface ResponseEsque {
  * @internal
  */
 export type NonEmptyArray<TItem> = [TItem, ...TItem[]];
+
+type ClientContext = Record<string, unknown>;
+
+/**
+ * @public
+ */
+export interface TRPCProcedureOptions {
+  /**
+   * Client-side context
+   */
+  context?: ClientContext;
+  signal?: AbortSignal;
+}

--- a/packages/next/src/app-dir/create-action-hook.tsx
+++ b/packages/next/src/app-dir/create-action-hook.tsx
@@ -1,6 +1,7 @@
 import type {
   CreateTRPCClientOptions,
   TRPCLink,
+  TRPCProcedureOptions,
   TRPCRequestOptions,
 } from '@trpc/client';
 import { createTRPCUntypedClient, TRPCClientError } from '@trpc/client';
@@ -14,7 +15,6 @@ import type {
   inferClientTypes,
   InferrableClientTypes,
   MaybePromise,
-  ProcedureOptions,
   Simplify,
   TypeError,
 } from '@trpc/server/unstable-core-do-not-import';
@@ -25,8 +25,8 @@ import type { ActionHandlerDef } from './shared';
 import { isFormData } from './shared';
 
 type MutationArgs<TDef extends ActionHandlerDef> = TDef['input'] extends void
-  ? [input?: undefined | void, opts?: ProcedureOptions]
-  : [input: FormData | TDef['input'], opts?: ProcedureOptions];
+  ? [input?: undefined | void, opts?: TRPCProcedureOptions]
+  : [input: FormData | TDef['input'], opts?: TRPCProcedureOptions];
 
 interface UseTRPCActionBaseResult<TDef extends ActionHandlerDef> {
   mutate: (...args: MutationArgs<TDef>) => void;

--- a/packages/server/src/@trpc/server/index.ts
+++ b/packages/server/src/@trpc/server/index.ts
@@ -31,7 +31,6 @@ export {
   type AnyQueryProcedure as AnyTRPCQueryProcedure,
   type RouterRecord as TRPCRouterRecord,
   type AnySubscriptionProcedure as AnyTRPCSubscriptionProcedure,
-  type ProcedureOptions as TRPCProcedureOptions,
   type CreateContextCallback,
   type MutationProcedure as TRPCMutationProcedure,
   type QueryProcedure as TRPCQueryProcedure,

--- a/packages/server/src/unstable-core-do-not-import/procedure.ts
+++ b/packages/server/src/unstable-core-do-not-import/procedure.ts
@@ -7,19 +7,6 @@ export const procedureTypes = ['query', 'mutation', 'subscription'] as const;
  */
 export type ProcedureType = (typeof procedureTypes)[number];
 
-type ClientContext = Record<string, unknown>;
-
-/**
- * @internal
- */
-export interface ProcedureOptions {
-  /**
-   * Client-side context
-   */
-  context?: ClientContext;
-  signal?: AbortSignal;
-}
-
 interface BuiltProcedureDef {
   input: unknown;
   output: unknown;

--- a/www/docs/migration/migrate-from-v10-to-v11.mdx
+++ b/www/docs/migration/migrate-from-v10-to-v11.mdx
@@ -26,7 +26,7 @@ import { InstallSnippet } from '@site/src/components/InstallSnippet';
 
 ### Move `TRPCProcedureOptions` to `@trpc/client` (non-breaking for most)
 
-If you previously used `ProcedureOptions` from `@trpc/server`, you can now need to use `TRPCProcedureOptions` from `@trpc/client` instead.
+If you previously used `ProcedureOptions` from `@trpc/server`, you now need to use `TRPCProcedureOptions` from `@trpc/client` instead.
 
 ### Allow promises to be embedded in nested data (non-breaking)
 

--- a/www/docs/migration/migrate-from-v10-to-v11.mdx
+++ b/www/docs/migration/migrate-from-v10-to-v11.mdx
@@ -24,6 +24,10 @@ import { InstallSnippet } from '@site/src/components/InstallSnippet';
 > This is a draft document. It will be updated to a proper guide as we get closer to the v11 release.
 > The only major thing that will incur work for you is that you will need to do is to update TanStack Query to v5.0.0.
 
+### Move `TRPCProcedureOptions` to `@trpc/client` (non-breaking for most)
+
+If you previously used `ProcedureOptions` from `@trpc/server`, you can now need to use `TRPCProcedureOptions` from `@trpc/client` instead.
+
 ### Allow promises to be embedded in nested data (non-breaking)
 
 We now allow promises to be embedded in nested data when using the [`httpBatchStreamLink`](../client/links/httpBatchStreamLink.md), this means that you can now do things like this:


### PR DESCRIPTION
Closes #

## 🎯 Changes


Move client interfaces from server to client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced `TRPCProcedureOptions` type to enhance procedure configuration flexibility.
	- Added new method `useSuspenseQueries()` in `@trpc/react`.

- **Type Changes**
	- Replaced `ProcedureOptions` with `TRPCProcedureOptions` across multiple packages.
	- Updated type signatures in client and server modules.

- **Deprecations**
	- Marked several types and functions as deprecated, recommending newer alternatives.

- **Requirements**
	- Now requires TypeScript 5.7.2 or higher.
	- Supports NodeJS 18+ and modern browsers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->