### PR TITLE
fix(server): do not abort when reading http2 req.body

### DIFF
--- a/packages/server/src/adapters/node-http/incomingMessageToRequest.ts
+++ b/packages/server/src/adapters/node-http/incomingMessageToRequest.ts
@@ -145,7 +145,7 @@ export function incomingMessageToRequest(
   };
 
   res.once('close', onAbort);
-  req.socket?.once?.('end', onAbort);
+  req.socket?.once?.('close', onAbort);
 
   // Get host from either regular header or HTTP/2 pseudo-header
   const url = createURL(req);


### PR DESCRIPTION
Closes #6432

## 🎯 Changes

Listen to the request `close` event instead of the `end` event to handle aborted requests.

This is actually how it was prior to PR #6206. There was no specific explanation as to why the change was made there so I'm not sure if there is a reason it was needed. I'm working under the assumption that this change was a mistake because it seems like `close` was the correct event to listen for.

The specific problem I am fixing here is that when the request is a POST, it reads the body stream. Once the stream has been fully read, the `end` event will be fired which then triggers the abort signal. I ran into this problem with HTTP2 requests specifically, but I could see how this could be problematic elsewhere as well.

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated request abort mechanism to improve socket handling and request termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->