### PR TITLE
docs: use indirect eval for devalue example

### DIFF
--- a/www/versioned_docs/version-10.x/server/data-transformers.md
+++ b/www/versioned_docs/version-10.x/server/data-transformers.md
@@ -86,8 +86,8 @@ export const transformer = {
   input: superjson,
   output: {
     serialize: (object) => uneval(object),
-    // This `eval` only ever happens on the **client**
-    deserialize: (object) => eval(`(${object})`),
+    // This `eval` only ever happens on the **client**.
+    deserialize: (object) => (0, eval)(`(${object})`),
   },
 };
 ```


### PR DESCRIPTION
Direct eval can pollute the scope of the deserializer callback, indirect eval cant. See also https://github.com/Rich-Harris/devalue?tab=readme-ov-file#other-security-considerations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation comments for data transformers
  - Minor clarification in comment describing client-side `eval` usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->