### PR TITLE
docs: improve link contrast in note blocks for dark mode

### DIFF
--- a/www/src/css/custom.css
+++ b/www/src/css/custom.css
@@ -262,6 +262,10 @@ h5 {
   @apply font-semibold;
 }
 
+.theme-admonition-note a {
+  @apply dark:text-sky-300 dark:hover:text-sky-400;
+}
+
 /**
  * Disable underline for some links
  **/


### PR DESCRIPTION
- Adjust link colors in .theme-admonition-note for better visibility
- Fix accessibility issue with link contrast

Fixes #6224
Closes #6224

## 🎯 Changes

This PR improves the visibility of links within note blocks (`.theme-admonition-note`) in dark mode by adjusting their color contrast to meet WCAG accessibility standards.

**Before:**
![Xnip2025-02-02_12-44-28](https://github.com/user-attachments/assets/23ffce7a-14ca-48a4-8ff0-4c95e1fd31de)
![Xnip2025-02-02_12-44-37](https://github.com/user-attachments/assets/1fdc7636-b9ba-42e2-b9a2-5e56f009efcb)

**After:** 
![Xnip2025-02-02_12-42-33](https://github.com/user-attachments/assets/d63f7b86-dc06-4f51-8963-78ff06055490)
![Xnip2025-02-02_12-43-49](https://github.com/user-attachments/assets/ed0a9d0b-97eb-4963-aec6-df64b17ce353)



Changed files:
- `www/src/css/custom.css`: Updated link colors in note blocks for dark mode

## ✅ Checklist

- [X] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md)
- [X] If necessary, I have added documentation related to the changes made
- [ ] I have added or updated the tests related to the changes made
  - N/A - This is a purely visual documentation change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced dark mode presentation by updating the appearance of links in note sections. The new styling applies a clearer sky-blue color and a subtle hover effect, leading to improved readability and a more consistent visual experience for users in dark mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->