### PR TITLE
fix(react-query): type of `result.data` on subscriptions

### DIFF
--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -472,7 +472,7 @@ export function createRootHooks<
                   };
 
                 case 'pending':
-                  // handled when data is received
+                  // handled when data is / onStarted
                   return prev;
               }
             });

--- a/packages/react-query/src/shared/hooks/types.ts
+++ b/packages/react-query/src/shared/hooks/types.ts
@@ -212,7 +212,7 @@ export interface TRPCSubscriptionConnectingResult<TOutput, TError>
 export interface TRPCSubscriptionPendingResult<TOutput>
   extends TRPCSubscriptionBaseResult<TOutput, undefined> {
   status: 'pending';
-  data: TOutput;
+  data: TOutput | undefined;
   error: null;
 }
 


### PR DESCRIPTION
Closes #

## 🎯 Changes

The the type of `result.data` can be `undefined`