### PR TITLE
chore(server): fix exports of `callProcedure`

### DIFF
--- a/packages/server/src/@trpc/server/index.ts
+++ b/packages/server/src/@trpc/server/index.ts
@@ -44,6 +44,7 @@ export {
   type TrackedEnvelope,
   isTrackedEnvelope,
   lazy as experimental_lazy,
+  callProcedure as callTRPCProcedure,
 } from '../../unstable-core-do-not-import';
 
 export type {
@@ -97,11 +98,6 @@ export {
    * @deprecated use `getTRPCErrorShape` instead
    */
   getErrorShape,
-
-  /**
-   * @deprecated use `callTRPCProcedure` instead
-   */
-  callProcedure,
 } from '../../unstable-core-do-not-import';
 
 /**

--- a/packages/server/src/adapters/ws.ts
+++ b/packages/server/src/adapters/ws.ts
@@ -6,7 +6,7 @@ import type {
   inferRouterContext,
 } from '../@trpc/server';
 import {
-  callProcedure,
+  callTRPCProcedure,
   getErrorShape,
   getTRPCErrorFromUnknown,
   transformTRPCResponse,
@@ -218,7 +218,7 @@ export function getWSConnectionHandler<TRouter extends AnyRouter>(
         await ctxPromise; // asserts context has been set
 
         const abortController = new AbortController();
-        const result = await callProcedure({
+        const result = await callTRPCProcedure({
           router,
           path,
           getRawInput: async () => input,


### PR DESCRIPTION
Closes #

## 🎯 Changes

Fix exports of `callProcedure()`