### PR TITLE
chore(server): fix flaky jsonl test

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/stream/jsonl.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/jsonl.test.ts
@@ -580,7 +580,7 @@ test('should work to throw after stream is closed', async () => {
 });
 
 test('e2e, withPing', async () => {
-  const deferred = createDeferred<void>();
+  const deferred = createDeferred();
   const data = {
     0: Promise.resolve({
       slow: run(async () => {

--- a/packages/server/src/unstable-core-do-not-import/stream/jsonl.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/jsonl.test.ts
@@ -614,7 +614,7 @@ test('e2e, withPing', async () => {
     let allData = '';
     for await (const chunk of text) {
       allData += chunk;
-      if (chunk.includes('  ')) break;
+      if (allData.includes('    ')) break;
     }
 
     deferred.resolve();

--- a/packages/server/src/unstable-core-do-not-import/stream/utils/createDeferred.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/utils/createDeferred.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-export function createDeferred<TValue>() {
+export function createDeferred<TValue = void>() {
   let resolve: (value: TValue) => void;
   let reject: (error: unknown) => void;
   const promise = new Promise<TValue>((res, rej) => {

--- a/packages/server/src/unstable-core-do-not-import/stream/utils/mergeAsyncIterables.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/utils/mergeAsyncIterables.test.ts
@@ -29,8 +29,8 @@ test('happy path', async () => {
 test('add iterable while iterating', async () => {
   const merged = mergeAsyncIterables<string>();
 
-  const startB = createDeferred<void>();
-  const continueA = createDeferred<void>();
+  const startB = createDeferred();
+  const continueA = createDeferred();
 
   merged.add(
     run(async function* () {

--- a/packages/server/src/unstable-core-do-not-import/stream/utils/mergeAsyncIterables.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/utils/mergeAsyncIterables.ts
@@ -73,7 +73,7 @@ interface MergedAsyncIterables<TYield>
  */
 export function mergeAsyncIterables<TYield>(): MergedAsyncIterables<TYield> {
   let state: 'idle' | 'pending' | 'done' = 'idle';
-  let flushSignal = createDeferred<void>();
+  let flushSignal = createDeferred();
 
   /**
    * used while {@link state} is `idle`

--- a/packages/tests/server/adapters/next.test.ts
+++ b/packages/tests/server/adapters/next.test.ts
@@ -18,7 +18,7 @@ function createHttpServer(opts: {
   handler: trpcNext.NextApiHandler;
   query: object;
 }) {
-  const deferred = createDeferred<void>();
+  const deferred = createDeferred();
   const httpServer = http.createServer((req, res) => {
     const _req = req as any;
     const _res = res as any;

--- a/packages/tests/server/httpSubscriptionLink.test.ts
+++ b/packages/tests/server/httpSubscriptionLink.test.ts
@@ -1051,7 +1051,7 @@ function createPuller(): PromiseLike<void> & {
   pull: () => void;
   reject: (err: unknown) => void;
 } {
-  let deferred = createDeferred<void>();
+  let deferred = createDeferred();
 
   return {
     pull: () => {

--- a/packages/tests/server/react/queryOptions.test.tsx
+++ b/packages/tests/server/react/queryOptions.test.tsx
@@ -21,7 +21,7 @@ const fixtureData = ['1', '2', '3', '4'];
 
 const ctx = konn()
   .beforeEach(() => {
-    let iterableDeferred = createDeferred<void>();
+    let iterableDeferred = createDeferred();
     const nextIterable = () => {
       iterableDeferred.resolve();
       iterableDeferred = createDeferred();

--- a/packages/tests/server/react/useQuery.test.tsx
+++ b/packages/tests/server/react/useQuery.test.tsx
@@ -4,22 +4,12 @@ import { skipToken, type InfiniteData } from '@tanstack/react-query';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { initTRPC } from '@trpc/server';
+import { createDeferred } from '@trpc/server/unstable-core-do-not-import';
 import { konn } from 'konn';
 import React, { useEffect } from 'react';
 import { z } from 'zod';
 
 const fixtureData = ['1', '2', '3', '4'];
-
-function createDeferred<TValue>() {
-  let resolve: (value: TValue) => void;
-  let reject: (error: unknown) => void;
-  const promise = new Promise<TValue>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-
-  return { promise, resolve: resolve!, reject: reject! };
-}
 
 const ctx = konn()
   .beforeEach(() => {

--- a/packages/tests/server/react/useQuery.test.tsx
+++ b/packages/tests/server/react/useQuery.test.tsx
@@ -23,7 +23,7 @@ function createDeferred<TValue>() {
 
 const ctx = konn()
   .beforeEach(() => {
-    let iterableDeferred = createDeferred<void>();
+    let iterableDeferred = createDeferred();
     const nextIterable = () => {
       iterableDeferred.resolve();
       iterableDeferred = createDeferred();

--- a/packages/tests/server/streaming.test.ts
+++ b/packages/tests/server/streaming.test.ts
@@ -35,7 +35,7 @@ describe('no transformer', () => {
 
       const manualRelease = new Map<number, () => void>();
 
-      let iterableDeferred = createDeferred<void>();
+      let iterableDeferred = createDeferred();
       const nextIterable = () => {
         iterableDeferred.resolve();
       };

--- a/packages/tests/server/websockets.test.ts
+++ b/packages/tests/server/websockets.test.ts
@@ -45,7 +45,7 @@ function factory(config?: {
 
   const t = initTRPC.create();
 
-  let iterableDeferred = createDeferred<void>();
+  let iterableDeferred = createDeferred();
   const nextIterable = () => {
     iterableDeferred.resolve();
     iterableDeferred = createDeferred();


### PR DESCRIPTION
- fix flaky e2e test
- add default value as `void` on `createDeferred`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified internal asynchronous handling by removing unnecessary type specifications, enhancing maintainability.

- **Tests**
  - Updated various test cases across streaming, query, and subscription scenarios to ensure more consistent and robust behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->