### PR TITLE
Update httpBatchStreamLink.md - react native polyfills 

### DIFF
--- a/www/docs/client/links/httpBatchStreamLink.md
+++ b/www/docs/client/links/httpBatchStreamLink.md
@@ -147,9 +147,8 @@ unstable_httpBatchStreamLink({
       ...opts,
       reactNative: { textStreaming: true },
     }),
-  ...restOfConfig
-  }
-)
+  ...restOfConfig,
+});
 ```
 
 ## Compatibility (server-side)

--- a/www/docs/client/links/httpBatchStreamLink.md
+++ b/www/docs/client/links/httpBatchStreamLink.md
@@ -138,6 +138,20 @@ This includes support for `undici`, `node-fetch`, native Node.js fetch implement
 
 Receiving the stream relies on the `TextDecoder` and `TextDecoderStream` APIs, which is not available in React Native. It's important to note that if your `TextDecoderStream` polyfill does not automatically polyfill `ReadableStream` and `WritableStream` those will also need to be polyfilled. If you still want to enable streaming, you need to polyfill those.
 
+You will also need to overide the default fetch in the `httpBatchStreamLink` configuration options. In the below example we will be using the [Expo fetch](https://docs.expo.dev/versions/latest/sdk/expo/) package for the fetch implementation.
+
+```typescript
+unstable_httpBatchStreamLink({
+  fetch: (url, opts) =>
+    fetch(url, {
+      ...opts,
+      reactNative: { textStreaming: true },
+    }),
+  ...restOfConfig
+  }
+)
+```
+
 ## Compatibility (server-side)
 
 > ⚠️ for **aws lambda**, `unstable_httpBatchStreamLink` is not supported (will simply behave like a regular `httpBatchLink`). It should not break anything if enabled, but will not have any effect.

--- a/www/docs/client/links/httpBatchStreamLink.md
+++ b/www/docs/client/links/httpBatchStreamLink.md
@@ -136,7 +136,7 @@ This includes support for `undici`, `node-fetch`, native Node.js fetch implement
 
 ### React Native
 
-Receiving the stream relies on the `TextDecoder` and `TextDecoderStream` APIs, which is not available in React Native. If you still want to enable streaming, you need to polyfill those.
+Receiving the stream relies on the `TextDecoder` and `TextDecoderStream` APIs, which is not available in React Native. It's important to note that if your `TextDecoderStream` polyfill does not automatically polyfill `ReadableStream` and `WritableStream` those will also need to be polyfilled. If you still want to enable streaming, you need to polyfill those.
 
 ## Compatibility (server-side)
 


### PR DESCRIPTION
## 🎯 Changes
I was struggling to get `httpBatchStreamLink` to work in react native/expo as I was not getting any errors about WritableStream not being defined and rather just the error `TRPCClientError: Invalid response or stream interrupted` or something really cryptic when I tried to use a debugger. Since there are not any popular `TextDecoderStream` polyfills out there having this addition to the documentation would of saved me time. Although the `TextDecoderStream` usage in trpc streaming does not use the writable functionality `WritableStream` gets used [here](https://github.com/trpc/trpc/blob/next/packages/server/src/unstable-core-do-not-import/stream/jsonl.ts#L597) making it actually needed.

I also made an example of how I got this to work on [stackoverflow](https://stackoverflow.com/a/79428194/17990405]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the documentation to provide clearer guidance on streaming functionality in React Native, highlighting that additional polyfills may be needed for complete streaming support.
  - Added instructions for overriding the default fetch in `httpBatchStreamLink` configuration, including an example using the Expo fetch package.
  - Retained and emphasized compatibility notes for server-side usage in specific cloud environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->