### PR TITLE
feat(www): allow multiple authors on articles

### DIFF
--- a/www/og-image/package.json
+++ b/www/og-image/package.json
@@ -2,7 +2,7 @@
   "name": "@www/og-image",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --port 3001",
     "build": "next build",
     "start": "next start"
   },

--- a/www/og-image/pages/api/blog.tsx
+++ b/www/og-image/pages/api/blog.tsx
@@ -6,6 +6,10 @@ export const config = {
   runtime: 'edge',
 };
 
+const classNames = (...classes: (string | undefined | null | false | 0)[]) => {
+  return classes.filter(Boolean).join(' ');
+};
+
 export default async (req: Request) => {
   const [inter900, inter700, inter400] = await Promise.all([
     fetchFont('Inter', 900),
@@ -50,21 +54,31 @@ export default async (req: Request) => {
             </p>
           </div>
           <div tw="flex items-center">
-            <img
-              src={props.authorImg}
-              alt="author profile"
-              width="75px"
-              height="75px"
-              tw="mr-6 rounded-xl"
-            />
-            <div tw="flex flex-col justify-center">
-              <p tw="text-2xl leading-[1px] font-semibold">
-                {props.authorName}
-              </p>
-              <p tw="text-xl leading-[1px] text-zinc-300">
-                {props.authorTitle}
-              </p>
-            </div>
+            {props.authors.map((author, idx) => {
+              const isLast = idx === props.authors.length - 1;
+              return (
+                <div
+                  key={idx}
+                  tw={classNames('flex items-center', !isLast && 'mr-8')}
+                >
+                  <img
+                    src={author.img}
+                    alt={`${author.name}'s profile`}
+                    width="75px"
+                    height="75px"
+                    tw="mr-6 rounded-xl"
+                  />
+                  <div tw="flex flex-col justify-center">
+                    <p tw="text-2xl leading-[1px] font-semibold">
+                      {author.name}
+                    </p>
+                    <p tw="text-xl leading-[1px] text-zinc-300">
+                      {author.title}
+                    </p>
+                  </div>
+                </div>
+              );
+            })}
           </div>
         </div>
       </div>

--- a/www/og-image/pages/index.tsx
+++ b/www/og-image/pages/index.tsx
@@ -36,9 +36,23 @@ export default function Page() {
           <h2>Blog</h2>
           <img
             src={`/api/blog?${blogParams.toSearchString({
-              authorImg: 'https://avatars.githubusercontent.com/u/459267',
-              authorName: 'Alex "KATT" Johansson',
-              authorTitle: 'Creator of tRPC',
+              authors: [
+                {
+                  name: 'Alex "KATT" Johansson',
+                  title: 'Creator of tRPC',
+                  img: 'https://github.com/KATT.png',
+                },
+                {
+                  name: 'Julius Marminge',
+                  title: 'tRPC Core Team',
+                  img: 'https://github.com/juliusmarminge.png',
+                },
+                {
+                  name: 'Julius Marminge',
+                  title: 'tRPC Core Team',
+                  img: 'https://github.com/juliusmarminge.png',
+                },
+              ],
               date: '2021-08-01',
               description:
                 'Eiusmod elit id dolor proident Lorem ut quis exercitation velit cupidatat sit occaecat. Fugiat do culpa exercitation quis anim tempor excepteur sit qui dolor ex aute in. Proident magna eiusmod mollit amet tempor aute in. Labore officia Lorem velit adipisicing reprehenderit. Incididunt aute aliqua Lorem qui consectetur eiusmod pariatur ut exercitation ea est mollit quis.',

--- a/www/og-image/utils/zodParams.ts
+++ b/www/og-image/utils/zodParams.ts
@@ -67,9 +67,13 @@ export const blogParams = zodParams(
         }).format(date),
       ),
     readingTimeInMinutes: z.number().positive(),
-    authorName: z.string(),
-    authorTitle: z.string(),
-    authorImg: z.string(),
+    authors: z.array(
+      z.object({
+        name: z.string(),
+        title: z.string(),
+        img: z.string(),
+      }),
+    ),
   }),
 );
 

--- a/www/package.json
+++ b/www/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "dev:og-image": "cd og-image && pnpm dev --port 3001",
+    "dev:og-image": "cd og-image && pnpm dev",
     "dev:docusaurus": "NODE_OPTIONS=--max_old_space_size=16384 docusaurus start",
     "dev": "run-p dev:* --print-label",
     "build": "docusaurus build",

--- a/www/src/theme/BlogPostPage/Metadata/index.tsx
+++ b/www/src/theme/BlogPostPage/Metadata/index.tsx
@@ -11,17 +11,18 @@ export default function BlogPostPageMetadata(): JSX.Element {
   const { keywords } = frontMatter;
 
   const env = useEnv();
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const author = authors[0]!;
 
   const ogImg = `${env.OG_URL}/api/blog?${blogParams.toSearchString({
     title: metadata.title,
     description: metadata.description,
-    /* eslint-disable @typescript-eslint/no-non-null-assertion */
-    authorName: author.name!,
-    authorTitle: author.title!,
-    authorImg: author.imageURL!,
-    /* eslint-enable @typescript-eslint/no-non-null-assertion */
+    authors: authors.map((author) => ({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      name: author.name!,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      title: author.title!,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      img: author.imageURL!,
+    })),
     date,
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     readingTimeInMinutes: metadata.readingTime!,


### PR DESCRIPTION
Closes #

## 🎯 Changes

see https://og-image-git-02-11-og-image-multi-author-trpc.vercel.app/

![CleanShot 2025-02-11 at 12 47 26](https://github.com/user-attachments/assets/a3220112-7a97-47e5-9330-61f0fc58fc86)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Blog posts now support multiple authors, with each contributor’s image, name, and title displayed for a richer reading experience.
  - Social sharing previews and metadata have been updated to accurately reflect the expanded author information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->