### PR TITLE
fix(server): unsubscribe from `req.socket.once('close')`

### DIFF
--- a/packages/server/src/adapters/node-http/incomingMessageToRequest.ts
+++ b/packages/server/src/adapters/node-http/incomingMessageToRequest.ts
@@ -127,7 +127,7 @@ export function incomingMessageToRequest(
 
   const onAbort = () => {
     res.off('close', onAbort);
-    req.socket?.off?.('end', onAbort);
+    req.socket?.off?.('close', onAbort);
 
     // abort the request
     ac.abort();


### PR DESCRIPTION
Closes #6455

## 🎯 Changes


Fixes

```
(node:1489236) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 close listeners added to [Socket]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved interruption handling for network requests. This update refines the cancellation process during connection terminations to ensure that aborted requests are managed accurately and reliably. End-users should experience improved stability during unexpected network interruptions, leading to smoother and more predictable behavior under variable connectivity conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->