### PR TITLE
chore: easier call signature

### DIFF
--- a/packages/next/src/app-dir/server.ts
+++ b/packages/next/src/app-dir/server.ts
@@ -156,11 +156,8 @@ export function experimental_createServerActionHandler<
         const data = proc._def.experimental_caller
           ? await proc(rawInput as any)
           : await proc({
-              input: undefined,
               ctx,
-              path: '',
               getRawInput: async () => rawInput,
-              type: proc._def.type,
               // is it possible to get the AbortSignal from the request?
               signal: undefined,
             });

--- a/packages/server/src/adapters/next-app-dir/nextAppDirCaller.ts
+++ b/packages/server/src/adapters/next-app-dir/nextAppDirCaller.ts
@@ -91,7 +91,6 @@ export function nextAppDirCaller<TContext, TMeta>(
 
         return await opts
           .invoke({
-            type: opts._def.type,
             ctx,
             getRawInput: async () => input,
             path,
@@ -108,7 +107,6 @@ export function nextAppDirCaller<TContext, TMeta>(
         const input = opts.args[0];
         return await opts
           .invoke({
-            type: opts._def.type,
             ctx,
             getRawInput: async () => input,
             path,

--- a/packages/server/src/unstable-core-do-not-import/http/resolveResponse.ts
+++ b/packages/server/src/unstable-core-do-not-import/http/resolveResponse.ts
@@ -348,7 +348,6 @@ export async function resolveResponse<TRouter extends AnyRouter>(
           path: call.path,
           getRawInput: call.getRawInput,
           ctx: ctxManager.value(),
-          type: proc._def.type,
           signal: opts.req.signal,
         });
         return [undefined, { data }];

--- a/packages/server/src/unstable-core-do-not-import/middleware.ts
+++ b/packages/server/src/unstable-core-do-not-import/middleware.ts
@@ -96,11 +96,11 @@ export type MiddlewareFunction<
   (opts: {
     ctx: Simplify<Overwrite<TContext, TContextOverridesIn>>;
     type: ProcedureType;
-    path: string;
+    path?: string;
     input: TInputOut;
     getRawInput: GetRawInputFn;
     meta: TMeta | undefined;
-    signal: AbortSignal | undefined;
+    signal?: AbortSignal | undefined;
     next: {
       (): Promise<MiddlewareResult<TContextOverridesIn>>;
       <$ContextOverride>(opts: {

--- a/packages/server/src/unstable-core-do-not-import/procedure.ts
+++ b/packages/server/src/unstable-core-do-not-import/procedure.ts
@@ -90,7 +90,7 @@ export type inferProcedureOutput<TProcedure> =
 export interface ErrorHandlerOptions<TContext> {
   error: TRPCError;
   type: ProcedureType | 'unknown';
-  path: string | undefined;
+  path?: string | undefined;
   input: unknown;
   ctx: TContext | undefined;
 }

--- a/packages/server/src/unstable-core-do-not-import/procedureBuilder.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/procedureBuilder.test.ts
@@ -230,6 +230,44 @@ test('inferProcedureBuilderResolverOptions', async () => {
   }
 });
 
+describe('procedure calling', () => {
+  test('basic', async () => {
+    const t = initTRPC.create();
+
+    const proc = t.procedure
+      .input(
+        z.object({
+          foo: z.string(),
+        }),
+      )
+      .use((opts) => {
+        return opts.next({
+          ctx: { type: opts.type, path: opts.path },
+        });
+      })
+      .query((opts) => {
+        expect(opts.ctx.type).toBe('query');
+
+        return {
+          result: '__result' as const,
+          path: opts.ctx.path,
+        };
+      });
+
+    const result = await proc({
+      ctx: {},
+      getRawInput: async () => ({
+        foo: 'foo',
+      }),
+    });
+
+    expect(result).toEqual({
+      result: '__result',
+      path: undefined,
+    });
+  });
+});
+
 describe('concat()', () => {
   test('basic', async () => {
     const t = initTRPC.context().create();

--- a/packages/server/src/unstable-core-do-not-import/procedureBuilder.ts
+++ b/packages/server/src/unstable-core-do-not-import/procedureBuilder.ts
@@ -106,7 +106,7 @@ export interface ProcedureResolverOptions<
   /**
    * The AbortSignal of the request
    */
-  signal: AbortSignal | undefined;
+  signal?: AbortSignal | undefined;
 }
 
 /**
@@ -562,9 +562,8 @@ export interface ProcedureCallOptions<TContext> {
   ctx: TContext;
   getRawInput: GetRawInputFn;
   input?: unknown;
-  path: string;
-  type: ProcedureType;
-  signal: AbortSignal | undefined;
+  path?: string;
+  signal?: AbortSignal | undefined;
 }
 
 const codeblock = `
@@ -579,10 +578,14 @@ async function callRecursive(
   opts: ProcedureCallOptions<any>,
 ): Promise<MiddlewareResult<any>> {
   try {
+    if (!_def.type) {
+      throw new Error('Procedure type not set and can not be called yet.');
+    }
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const middleware = _def.middlewares[index]!;
     const result = await middleware({
       ...opts,
+      type: _def.type,
       meta: _def.meta,
       input: opts.input,
       next(_nextOpts?: any) {

--- a/packages/server/src/unstable-core-do-not-import/router.ts
+++ b/packages/server/src/unstable-core-do-not-import/router.ts
@@ -8,6 +8,7 @@ import type {
   inferProcedureInput,
   inferProcedureOutput,
   LegacyObservableSubscriptionProcedure,
+  ProcedureType,
 } from './procedure';
 import type { ProcedureCallOptions } from './procedureBuilder';
 import type { AnyRootTypes, RootConfig } from './rootConfig';
@@ -378,6 +379,8 @@ export async function getProcedureAtPath(
  */
 export async function callProcedure(
   opts: ProcedureCallOptions<unknown> & {
+    type: ProcedureType;
+    path: string;
     router: AnyRouter;
     allowMethodOverride?: boolean;
   },
@@ -444,7 +447,6 @@ export function createCallerFactory<TRoot extends AnyRootTypes>() {
               path: fullPath,
               getRawInput: async () => args[0],
               ctx,
-              type: procedure._def.type,
               signal: opts?.signal,
             });
           } catch (cause) {

--- a/packages/tanstack-react-query/src/internals/createOptionsProxy.ts
+++ b/packages/tanstack-react-query/src/internals/createOptionsProxy.ts
@@ -244,8 +244,8 @@ export function createTRPCOptionsProxy<TRouter extends AnyRouter>(
             path: path,
             getRawInput: async () => input,
             ctx: ctx,
-            type: type,
             signal: undefined,
+            type,
           }),
         );
       }


### PR DESCRIPTION
Always annoyed myself that you need to specify the type - also `path` should probably be optional as we want procedure to be more standalone and callable outside of routers?