### PR TITLE
Feat: Add default types to MutationLike

### DIFF
--- a/packages/react-query/src/shared/polymorphism/mutationLike.ts
+++ b/packages/react-query/src/shared/polymorphism/mutationLike.ts
@@ -13,8 +13,8 @@ import type {
  * Use to describe a mutation route which matches a given mutation procedure's interface
  */
 export type MutationLike<
-  TRoot extends AnyRootTypes,
-  TProcedure extends AnyProcedure,
+  TRoot extends AnyRootTypes = AnyRootTypes,
+  TProcedure extends AnyProcedure = AnyProcedure,
 > = {
   useMutation: (
     opts?: InferMutationOptions<TRoot, TProcedure>,


### PR DESCRIPTION
Closes #

## 🎯 Changes

```typescript
export type MutationLike<
  TRoot extends AnyRootTypes = AnyRootTypes, ////default types
  TProcedure extends AnyProcedure = AnyProcedure, //default types
> = {
  useMutation: (
    opts?: InferMutationOptions<TRoot, TProcedure>,
  ) => InferMutationResult<TRoot, TProcedure>;
};
```

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
