### PR TITLE
Revert "fix(react-query): skip `export *` from `@trpc/client`"

### DIFF
--- a/packages/react-query/src/index.ts
+++ b/packages/react-query/src/index.ts
@@ -1,3 +1,5 @@
+export * from '@trpc/client';
+
 export { getQueryKey, getMutationKey } from './internals/getQueryKey';
 export {
   createTRPCReact,

--- a/www/docs/migration/migrate-from-v10-to-v11.mdx
+++ b/www/docs/migration/migrate-from-v10-to-v11.mdx
@@ -97,12 +97,6 @@ const router = router({
 });
 ```
 
-### Removed export of `@trpc/client` from `@trpc/react-query` (non-breaking)
-
-We have removed the re-exports of `@trpc/client` types and utilities from the `@trpc/react-query` package.
-
-This should not be a breaking change, but if you have missing imports after upgrading, you may need to update some import statements from `from '@trpc/react-query'` to `from '@trpc/client'`.
-
 ### Moved `reconnectAfterInactivityMs` to `sse.client` (non-breaking)
 
 Updated [HTTP Subscription Link improvements](#http-subscription-link-improvements)-section and related docs.


### PR DESCRIPTION
This partially reverts commit e5c0c1a8220fea9e49a6ba2fa1562abb86f4d6ee / #6382

## 🎯 Changes

It's just an annoying change for anyone upgrading and we're moving away from `@trpc/react-query` anyway
