### PR TITLE
feat: add ts program scanner for import paths

### DIFF
--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trpc/upgrade",
-  "version": "0.0.0-alpha.26",
+  "version": "10.45.1",
   "description": "Upgrade scripts for tRPC",
   "author": "juliusmarminge",
   "license": "MIT",

--- a/packages/upgrade/src/lib/ast/scanners.ts
+++ b/packages/upgrade/src/lib/ast/scanners.ts
@@ -1,0 +1,106 @@
+import {
+  forEachChild,
+  isCallExpression,
+  isIdentifier,
+  isImportDeclaration,
+  isStringLiteral,
+  isVariableDeclaration,
+  isVariableStatement,
+  resolveModuleName,
+  sys,
+  type Program,
+} from 'typescript';
+
+export function findSourceAndImportName(program: Program) {
+  const files = program.getSourceFiles().filter((sourceFile) => {
+    if (sourceFile.isDeclarationFile) return false;
+    let found = false;
+    forEachChild(sourceFile, (node) => {
+      if (!found && isImportDeclaration(node)) {
+        const { moduleSpecifier } = node;
+        if (
+          isStringLiteral(moduleSpecifier) &&
+          moduleSpecifier.text.includes('@trpc/react-query')
+        ) {
+          found = true;
+        }
+      }
+    });
+    return found;
+  });
+
+  let importName = 'trpc';
+  files.forEach((sourceFile) => {
+    forEachChild(sourceFile, (node) => {
+      if (
+        isVariableStatement(node) &&
+        node.modifiers?.some((mod) => mod.getText(sourceFile) === 'export')
+      ) {
+        node.declarationList.declarations.forEach((declaration) => {
+          if (
+            isVariableDeclaration(declaration) &&
+            declaration.initializer &&
+            isCallExpression(declaration.initializer) &&
+            isIdentifier(declaration.initializer.expression) &&
+            declaration.initializer.expression.getText(sourceFile) ===
+              'createTRPCReact'
+          ) {
+            importName = declaration.name.getText(sourceFile);
+          }
+        });
+      }
+    });
+  });
+
+  return {
+    files: files.map((d) => d.fileName),
+    importName,
+  };
+}
+
+export function findTRPCImportReferences(program: Program) {
+  const { files: filesImportingTRPC, importName } =
+    findSourceAndImportName(program);
+  const trpcReferenceSpecifiers = new Map<string, string>();
+
+  program.getSourceFiles().forEach((sourceFile) => {
+    if (sourceFile.isDeclarationFile) return;
+    forEachChild(sourceFile, (node) => {
+      if (isImportDeclaration(node) && isStringLiteral(node.moduleSpecifier)) {
+        const resolved = resolveModuleName(
+          node.moduleSpecifier.text,
+          sourceFile.fileName,
+          program.getCompilerOptions(),
+          sys,
+        );
+        if (
+          resolved.resolvedModule &&
+          filesImportingTRPC.includes(resolved.resolvedModule.resolvedFileName)
+        ) {
+          trpcReferenceSpecifiers.set(
+            resolved.resolvedModule.resolvedFileName,
+            node.moduleSpecifier.text,
+          );
+        }
+      }
+    });
+  });
+
+  const counts: Record<string, number> = {};
+  let currentMax = 0;
+  const mostUsed = { file: '' };
+
+  [...trpcReferenceSpecifiers.values()].forEach((specifier) => {
+    counts[specifier] = (counts[specifier] || 0) + 1;
+    if (counts[specifier] > currentMax) {
+      currentMax = counts[specifier];
+      mostUsed.file = specifier;
+    }
+  });
+
+  return {
+    importName,
+    mostUsed,
+    all: Object.fromEntries(trpcReferenceSpecifiers.entries()),
+  };
+}

--- a/packages/upgrade/src/transforms/hooksToOptions.ts
+++ b/packages/upgrade/src/transforms/hooksToOptions.ts
@@ -196,7 +196,17 @@ export default function transform(
         },
       })
       .forEach((path) => {
+        let isTRPCContextUtil = false;
+
         if (
+          j.MemberExpression.check(path.value.callee) &&
+          j.Identifier.check(path.value.callee.object)
+        ) {
+          isTRPCContextUtil = path.value.callee.object.name == trpcImportName;
+        }
+
+        if (
+          isTRPCContextUtil &&
           j.VariableDeclarator.check(path.parentPath.node) &&
           j.Identifier.check(path.parentPath.node.id)
         ) {

--- a/packages/upgrade/src/transforms/hooksToOptions.ts
+++ b/packages/upgrade/src/transforms/hooksToOptions.ts
@@ -196,14 +196,10 @@ export default function transform(
         },
       })
       .forEach((path) => {
-        let isTRPCContextUtil = false;
-
-        if (
+        const isTRPCContextUtil =
           j.MemberExpression.check(path.value.callee) &&
-          j.Identifier.check(path.value.callee.object)
-        ) {
-          isTRPCContextUtil = path.value.callee.object.name == trpcImportName;
-        }
+          j.Identifier.check(path.value.callee.object) &&
+          path.value.callee.object.name == trpcImportName;
 
         if (
           isTRPCContextUtil &&
@@ -262,7 +258,7 @@ export default function transform(
                 const replacedPath = replaceMemberExpressionRootIndentifier(
                   j,
                   memberExpr,
-                  j.identifier(trpcImportName!),
+                  j.identifier(trpcImportName),
                 );
                 if (!replacedPath) {
                   console.warn(

--- a/packages/upgrade/test/__fixtures__/hooks/react-context.ts
+++ b/packages/upgrade/test/__fixtures__/hooks/react-context.ts
@@ -1,0 +1,10 @@
+import React from 'react';
+import { trpc } from './trpc';
+
+export function Component() {
+  const y = trpc.useContext();
+}
+
+export function Component2() {
+  const x = React.useContext(React.createContext(2));
+}

--- a/packages/upgrade/test/__fixtures__/hooks/react-context.ts
+++ b/packages/upgrade/test/__fixtures__/hooks/react-context.ts
@@ -5,6 +5,8 @@ export function Component() {
   const y = trpc.useContext();
 }
 
+const DummyContext = React.createContext(2);
+
 export function Component2() {
-  const x = React.useContext(React.createContext(2));
+  const value = React.useContext(DummyContext);
 }

--- a/packages/upgrade/test/__snapshots__/transforms.test.ts.snap
+++ b/packages/upgrade/test/__snapshots__/transforms.test.ts.snap
@@ -59,6 +59,21 @@ export function Component2() {
 "
 `;
 
+exports[`hooks react-context.ts 1`] = `
+"import { useQueryClient } from '@tanstack/react-query';
+import React from 'react';
+import { useTRPC } from './trpc';
+
+export function Component() {
+  const queryClient = useQueryClient();
+}
+
+export function Component2() {
+  const x = React.useContext(React.createContext(2));
+}
+"
+`;
+
 exports[`hooks suspense-destructuring.ts 1`] = `
 "import {
   useSuspenseInfiniteQuery,

--- a/packages/upgrade/test/__snapshots__/transforms.test.ts.snap
+++ b/packages/upgrade/test/__snapshots__/transforms.test.ts.snap
@@ -68,8 +68,10 @@ export function Component() {
   const queryClient = useQueryClient();
 }
 
+const DummyContext = React.createContext(2);
+
 export function Component2() {
-  const x = React.useContext(React.createContext(2));
+  const value = React.useContext(DummyContext);
 }
 "
 `;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28900,7 +28900,7 @@ snapshots:
       '@typescript-eslint/parser': 7.16.1(eslint@9.13.0(jiti@2.3.3))(typescript@5.7.2)
       eslint: 9.13.0(jiti@2.3.3)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.5.2(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.16.1(eslint@9.13.0(jiti@2.3.3))(typescript@5.7.2))(eslint@9.13.0(jiti@2.3.3)))(eslint@9.13.0(jiti@2.3.3))
+      eslint-import-resolver-typescript: 3.5.2(eslint-plugin-import@2.31.0)(eslint@9.13.0(jiti@2.3.3))
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.16.1(eslint@9.13.0(jiti@2.3.3))(typescript@5.7.2))(eslint-import-resolver-typescript@3.5.2)(eslint@9.13.0(jiti@2.3.3))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.13.0(jiti@2.3.3))
       eslint-plugin-react: 7.37.2(eslint@9.13.0(jiti@2.3.3))
@@ -28923,7 +28923,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.5.2(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.16.1(eslint@9.13.0(jiti@2.3.3))(typescript@5.7.2))(eslint@9.13.0(jiti@2.3.3)))(eslint@9.13.0(jiti@2.3.3)):
+  eslint-import-resolver-typescript@3.5.2(eslint-plugin-import@2.31.0)(eslint@9.13.0(jiti@2.3.3)):
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
@@ -28937,14 +28937,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.16.1(eslint@9.13.0(jiti@2.3.3))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.2(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.16.1(eslint@9.13.0(jiti@2.3.3))(typescript@5.7.2))(eslint@9.13.0(jiti@2.3.3)))(eslint@9.13.0(jiti@2.3.3)))(eslint@9.13.0(jiti@2.3.3)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.16.1(eslint@9.13.0(jiti@2.3.3))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.2)(eslint@9.13.0(jiti@2.3.3)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.16.1(eslint@9.13.0(jiti@2.3.3))(typescript@5.7.2)
       eslint: 9.13.0(jiti@2.3.3)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.5.2(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.16.1(eslint@9.13.0(jiti@2.3.3))(typescript@5.7.2))(eslint@9.13.0(jiti@2.3.3)))(eslint@9.13.0(jiti@2.3.3))
+      eslint-import-resolver-typescript: 3.5.2(eslint-plugin-import@2.31.0)(eslint@9.13.0(jiti@2.3.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -28959,7 +28959,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.13.0(jiti@2.3.3)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.16.1(eslint@9.13.0(jiti@2.3.3))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.2(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.16.1(eslint@9.13.0(jiti@2.3.3))(typescript@5.7.2))(eslint@9.13.0(jiti@2.3.3)))(eslint@9.13.0(jiti@2.3.3)))(eslint@9.13.0(jiti@2.3.3))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.16.1(eslint@9.13.0(jiti@2.3.3))(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.5.2)(eslint@9.13.0(jiti@2.3.3))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3


### PR DESCRIPTION
Closes #

## 🎯 Changes

- Removes the need for manually adding the `importName` and `importFile`
- Fixes the bug from here https://x.com/ccccjjjjeeee/status/1891775072269934947

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The CLI upgrade tool now integrates TRPC import references into the transformation process for more context-aware operations.
  - New functions added to analyze TypeScript source files for TRPC module imports and their usage.
  - New React components demonstrate the integration of TRPC context within the application.
  - Updated the package version from `0.0.0-alpha.26` to `10.45.1`, marking a transition to a stable release.

- **Bug Fixes**
  - Enhanced specificity in the migration process for TRPC context utilities, improving control flow and accuracy in transformations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->