### PR TITLE
docs: (procedures.md) use query instead of mutation for whoami

### DIFF
--- a/www/docs/server/procedures.md
+++ b/www/docs/server/procedures.md
@@ -118,7 +118,7 @@ export const organizationProcedure = authedProcedure
   });
 
 export const appRouter = t.router({
-  whoami: authedProcedure.mutation(async (opts) => {
+  whoami: authedProcedure.query(async (opts) => {
     // user is non-nullable here
     const { ctx } = opts;
     //      ^?


### PR DESCRIPTION
just fixed copy pasta in docs. who am i shuold be query not a mutatoin.