### PR TITLE
chore: use repository variable instead of secret

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ concurrency:
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
 jobs:
   autofix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 10
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
     runs-on: ubuntu-latest
 
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 10
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
     runs-on: ubuntu-latest
 
@@ -65,7 +65,7 @@ jobs:
           - 5432:5432
     env:
       NEXTAUTH_SECRET: supersecret
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -122,7 +122,7 @@ jobs:
     env:
       NEXTAUTH_SECRET: supersecret
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       # TURBO_REMOTE_ONLY: true
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -157,7 +157,7 @@ jobs:
     env:
       NEXTAUTH_SECRET: supersecret
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       # TURBO_REMOTE_ONLY: true
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
@@ -200,7 +200,7 @@ jobs:
     env:
       NEXTAUTH_SECRET: supersecret
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     continue-on-error: true
@@ -243,7 +243,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 10
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release-tmp.yml
+++ b/.github/workflows/release-tmp.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 10
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 10
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
so that trpc isn't redacted in workflow logs:

![CleanShot 2025-02-24 at 14 39 13](https://github.com/user-attachments/assets/f6819767-a943-457d-bc3f-6fa289b0ce24)

vs 

![image](https://github.com/user-attachments/assets/677cb5ab-43af-43b0-b878-bd48d0702385)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Revised the CI/CD configuration to source the team configuration from a standardized variable. This update enhances consistency across various automation jobs such as build, test, and release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->