### PR TITLE
DRAFT/STRAWMAN/not currently intended for merging: add trpc.foo.useQuery back?

### DIFF
--- a/examples/minimal-react/client/src/Greeting.tsx
+++ b/examples/minimal-react/client/src/Greeting.tsx
@@ -3,6 +3,15 @@ import { trpc } from './utils/trpc';
 
 export function Greeting() {
   const greeting = useQuery(trpc.greeting.queryOptions({ name: 'tRPC user' }));
+  const greeting2 = trpc.greeting.useQuery({name: 'tRPC user'});
+  const greeting3 = trpc.greeting.useQuery();
+  const greeting4 = trpc.greeting.useQuery({ name: 'tRPC user' }, {enabled: true});
+  const greeting5 = trpc.greeting.useQuery(undefined, {enabled: true});
 
-  return <div>{greeting.data?.text}</div>;
+  greeting2.data satisfies typeof greeting.data;
+  greeting3.data satisfies typeof greeting.data;
+  greeting4.data satisfies typeof greeting.data;
+  greeting5.data satisfies typeof greeting.data;
+
+  return <div>{greeting.data?.text} {greeting2.data?.text} {greeting3.data?.text} {greeting4.data?.text}</div>;
 }

--- a/packages/tanstack-react-query/src/internals/createOptionsProxy.ts
+++ b/packages/tanstack-react-query/src/internals/createOptionsProxy.ts
@@ -1,4 +1,4 @@
-import type { DataTag, QueryClient, QueryFilters } from '@tanstack/react-query';
+import { useQuery, type DataTag, type QueryClient, type QueryFilters } from '@tanstack/react-query';
 import type { TRPCClient, TRPCRequestOptions } from '@trpc/client';
 import { getUntypedClient, TRPCUntypedClient } from '@trpc/client';
 import type {
@@ -22,6 +22,7 @@ import {
   trpcMutationOptions,
   type TRPCMutationOptions,
 } from './mutationOptions';
+import type { TRPCUseQueryResult} from './queryOptions';
 import { trpcQueryOptions, type TRPCQueryOptions } from './queryOptions';
 import {
   trpcSubscriptionOptions,
@@ -86,6 +87,8 @@ export interface DecorateQueryProcedure<TDef extends ResolverDef> {
    * @see https://trpc.io/docs/client/tanstack-react-query/usage#queryOptions
    */
   queryOptions: TRPCQueryOptions<TDef>;
+
+  useQuery: TRPCUseQueryResult<TDef>;
 
   /**
    * Create a set of type-safe infinite query options that can be passed to `useInfiniteQuery`, `prefetchInfiniteQuery` etc.
@@ -318,6 +321,15 @@ export function createTRPCOptionsProxy<TRouter extends AnyTRPCRouter>(
           queryKey: getQueryKey(),
           query: callIt('query'),
         });
+      },
+      useQuery: () => {
+        return useQuery(trpcQueryOptions({
+          opts: arg2,
+          path,
+          queryClient: opts.queryClient,
+          queryKey: getQueryKey(),
+          query: callIt('query'),
+        }));
       },
       mutationOptions: () => {
         return trpcMutationOptions({

--- a/packages/tanstack-react-query/src/internals/queryOptions.ts
+++ b/packages/tanstack-react-query/src/internals/queryOptions.ts
@@ -6,6 +6,7 @@ import type {
   SkipToken,
   UndefinedInitialDataOptions,
   UnusedSkipTokenOptions,
+  UseQueryResult,
 } from '@tanstack/react-query';
 import { queryOptions, skipToken } from '@tanstack/react-query';
 import type { TRPCClientErrorLike, TRPCUntypedClient } from '@trpc/client';
@@ -153,6 +154,51 @@ export interface TRPCQueryOptions<TDef extends ResolverDef> {
       errorShape: TDef['errorShape'];
     }>
   >;
+}
+
+export interface TRPCUseQueryResult<TDef extends ResolverDef> {
+  <TQueryFnData extends TDef['output'], TData = TQueryFnData>(
+    input: TDef['input'] | SkipToken,
+    opts: DefinedTRPCQueryOptionsIn<
+      TQueryFnData,
+      TData,
+      TRPCClientErrorLike<{
+        transformer: TDef['transformer'];
+        errorShape: TDef['errorShape'];
+      }>
+    >,
+  ): UseQueryResult<TData, TRPCClientErrorLike<{
+    transformer: TDef['transformer'];
+    errorShape: TDef['errorShape'];
+  }>>;
+  <TQueryFnData extends TDef['output'], TData = TQueryFnData>(
+    input: TDef['input'],
+    opts?: UnusedSkipTokenTRPCQueryOptionsIn<
+      TQueryFnData,
+      TData,
+      TRPCClientErrorLike<{
+        transformer: TDef['transformer'];
+        errorShape: TDef['errorShape'];
+      }>
+    >,
+  ): UseQueryResult<TData, TRPCClientErrorLike<{
+    transformer: TDef['transformer'];
+    errorShape: TDef['errorShape'];
+  }>>;
+  <TQueryFnData extends TDef['output'], TData = TQueryFnData>(
+    input: TDef['input'] | SkipToken,
+    opts?: UseQueryResult<UndefinedTRPCQueryOptionsIn<
+      TQueryFnData,
+      TData,
+      TRPCClientErrorLike<{
+        transformer: TDef['transformer'];
+        errorShape: TDef['errorShape'];
+      }>
+    >>,
+  ): UseQueryResult<TData, TRPCClientErrorLike<{
+    transformer: TDef['transformer'];
+    errorShape: TDef['errorShape'];
+  }>>;
 }
 
 type AnyTRPCQueryOptionsIn =


### PR DESCRIPTION
Related to https://github.com/trpc/trpc/discussions/6240 - CC @juliusmarminge 

This PR isn't really a "pull" request - just as a place to allow discussion with commenting on code inline etc. if it's helpful.

Since @KATT suggested something to fill the gap between the old react-query API and the new one _might_ be welcome, I thought I'd just poke around and see what the dumbest possible implementation of it might look like.

I want to be clear though that I'm aware I _wasn't_ involved in the discussions around the new API and what the specific pitfalls of the old one were, so I am very sorry if this is just prompting people to repeat themselves!

## 🎯 Changes

For now, this just adds a `useQuery(...)` method to the `DecorateQueryProcedure` interface. Something similar would be needed for `useMutation` and `useSubscription` and `useInfiniteQuery`, but I didn't bother with those because I wanted to sanity check/find out pitfalls first.

DX for consumers wise, I think it brings back pretty much the usage pattern as before, along with all the shortcomings about new react-query features and so on.

Maintenance wise:

Code: it doesn't seem bad? I haven't been in the weeds in trpc for a while so I don't remember which helpers came into existence and when, but all I really did was copy-paste the `TRPCQueryOptions` interface into a `TRPCUseQueryResult` interface, with identical generics, but made the return types of each overload `UseQueryResult<TData, TRPCClientErrorLike...>`. The runtime implementation was trivial - just do what we're already doing for `queryOptions` and pass it to a `useQuery` imported from `@tanstack/react-query`

Of course even if this approach, there's more to consider than just the code. Test and docs would of course be needed, and decisions needed about the docs. trpc would now need to decide when it promotes which variant. My intuition says to promote `trpc.greeting.useQuery()` by default, and suggest `useQuery(trpc.greeting.queryOptions())` as an escape hatch, for when you need to override one of the options, use a new react-query feature, or use a different react-query version.

Also, it's hard to predict what'll happen in future. But, if react-query came out with a new version that renamed `queryFn` to `queryFunction` or something, I think it'd be simple for users to do something like `"react-query-v123": "npm:@tanstack/react-query@^123.0.0"` in their package.json, then something like this in their code:

```tsx
import {trpc} from '~/wherever'
import {useQuery} from 'react-query-v123'

export default function Foo() {
  const hello = trpc.hello.useQuery()
  
  const {queryFn, ...goodbyeOptions} = trpc.goodbye.queryOptions()
  const goodbye = useQuery({...goodbyeOptions, queryFunction: queryFn})

  return <>{hello.data} {goodbye.data}</>
}
```