### PR TITLE
fix(docs): Fix createContextInner in server/context.md

### DIFF
--- a/www/docs/server/context.md
+++ b/www/docs/server/context.md
@@ -195,7 +195,7 @@ export async function createContext(opts: CreateNextContextOptions) {
   };
 }
 
-export type Context = Awaited<ReturnType<typeof createContextInner>>;
+export type Context = Awaited<ReturnType<typeof createContext>>;
 
 // The usage in your router is the same as the example above.
 ```


### PR DESCRIPTION
Closes #

## 🎯 Changes

Docs change.

In my opinion, it seems appropriate for `createContext` to be used as the `Context` type instead of `createContextInner`, given that req and res can be inferred in the example below.



Below example:
```ts
export const apiProcedure = publicProcedure.use((opts) => {
  if (!opts.ctx.req || !opts.ctx.res) {
    throw new Error('You are missing `req` or `res` in your call.');
  }
  return opts.next({
    ctx: {
      // We overwrite the context with the truthy `req` & `res`, which will also overwrite the types used in your procedure.
      req: opts.ctx.req,
      res: opts.ctx.res,
    },
  });
});

```

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
