### PR TITLE
fix(next): reusing same instance of ssg helpers across pages

### DIFF
--- a/packages/react-query/src/server/ssgProxy.ts
+++ b/packages/react-query/src/server/ssgProxy.ts
@@ -137,10 +137,8 @@ export function createServerSideHelpers<TRouter extends AnyRouter>(
         ...dehydrated,
         queries: dehydrated.queries.map((query) => {
           if (query.promise) {
-            return {
-              ...query,
-              promise: undefined,
-            };
+            const { promise: _, ...rest } = query;
+            return rest;
           }
           return query;
         }),

--- a/packages/react-query/src/server/ssgProxy.ts
+++ b/packages/react-query/src/server/ssgProxy.ts
@@ -25,6 +25,7 @@ import {
   callProcedure,
   createFlatProxy,
   createRecursiveProxy,
+  run,
 } from '@trpc/server/unstable-core-do-not-import';
 import { getQueryKeyInternal } from '../internals/getQueryKey';
 import type {
@@ -120,13 +121,31 @@ export function createServerSideHelpers<TRouter extends AnyRouter>(
 
   function _dehydrate(
     opts: DehydrateOptions = {
-      shouldDehydrateQuery() {
+      shouldDehydrateQuery(query) {
+        if (query.state.status === 'pending') {
+          return false;
+        }
         // makes sure to serialize errors
         return true;
       },
     },
   ): DehydratedState {
-    const before = dehydrate(queryClient, opts);
+    const before = run(() => {
+      const dehydrated = dehydrate(queryClient, opts);
+
+      return {
+        ...dehydrated,
+        queries: dehydrated.queries.map((query) => {
+          if (query.promise) {
+            return {
+              ...query,
+              promise: undefined,
+            };
+          }
+          return query;
+        }),
+      };
+    });
     const after = resolvedOpts.serialize(before);
     return after;
   }

--- a/packages/react-query/test/dehydrate.test.tsx
+++ b/packages/react-query/test/dehydrate.test.tsx
@@ -1,5 +1,6 @@
 import { createAppRouter } from './__testHelpers';
 import { createServerSideHelpers } from '@trpc/react-query/server';
+import { initTRPC } from '@trpc/server';
 
 let factory: ReturnType<typeof createAppRouter>;
 beforeEach(() => {
@@ -41,4 +42,57 @@ test('dehydrate', async () => {
       "title": "first post",
     }
   `);
+});
+
+// https://github.com/trpc/trpc/issues/6558
+test('reuse the same instance of ssg', async () => {
+  // using timers = fakeTimersResource();
+  const t = initTRPC.create({});
+  const router = t.router({
+    hello1: t.procedure.query(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      return '1';
+    }),
+    hello2: t.procedure.query(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      return '2';
+    }),
+  });
+
+  const ssg = createServerSideHelpers({ router, ctx: {} });
+
+  const page1GetStaticProps = async () => {
+    await ssg.hello1.fetch();
+
+    return {
+      props: {
+        trpcState: ssg.dehydrate(),
+      },
+    };
+  };
+
+  // Reusing the same ssg instance
+  const page2GetStaticProps = async () => {
+    await Promise.all([ssg.hello1.fetch(), ssg.hello2.fetch()]);
+
+    return {
+      props: {
+        trpcState: ssg.dehydrate(),
+      },
+    };
+  };
+
+  const page1 = page1GetStaticProps();
+  const page2 = page2GetStaticProps();
+
+  const page1Data = await page1;
+
+  expect(
+    page1Data.props.trpcState.queries.filter((it) => it.promise).length,
+  ).toBe(0);
+
+  const page2Data = await page2;
+  expect(
+    page2Data.props.trpcState.queries.filter((it) => it.promise).length,
+  ).toBe(0);
 });


### PR DESCRIPTION
Closes #6558

## 🎯 Changes

> The problem seems to be that you're creating the SSG helpers outside of the `getStaticProps()` so they will reshare the same `QueryClient` which means it will contain a pending `promise` which cannot be hydrated.
> 
> `promise` wasn't a property in TanStack Query v4
> 
> I will make it be omitted 

 _Originally posted by @KATT in [#6558](https://github.com/trpc/trpc/issues/6558#issuecomment-2690625804)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced server-side data handling to ensure that only complete data is processed during static page generation, resulting in more reliable content display.

- **Tests**
  - Expanded testing to verify that server-rendered pages consistently receive fully processed data, even when reusing the same rendering instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->