### PR TITLE
fix(tanstack-react-query): falsy cursors

### DIFF
--- a/packages/tanstack-react-query/src/internals/infiniteQueryOptions.ts
+++ b/packages/tanstack-react-query/src/internals/infiniteQueryOptions.ts
@@ -252,7 +252,7 @@ export function trpcInfiniteQueryOptions(args: {
       ...opts,
       queryKey,
       queryFn: inputIsSkipToken ? skipToken : queryFn,
-      initialPageParam: opts?.initialCursor ?? null,
+      initialPageParam: opts?.initialCursor ?? (input as any)?.cursor,
     }),
     { trpc: createTRPCOptionsResult({ path }) },
   );

--- a/packages/tanstack-react-query/src/internals/utils.ts
+++ b/packages/tanstack-react-query/src/internals/utils.ts
@@ -36,7 +36,9 @@ export function getClientArgs<TOptions>(
   if (infiniteParams) {
     input = {
       ...(input ?? {}),
-      ...(infiniteParams.pageParam ? { cursor: infiniteParams.pageParam } : {}),
+      ...(infiniteParams.pageParam !== undefined
+        ? { cursor: infiniteParams.pageParam }
+        : {}),
       direction: infiniteParams.direction,
     };
   }


### PR DESCRIPTION
Closes #6599

## 🎯 Changes

Fix handling of falsiness + add regression test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced pagination behavior by improving the fallback mechanism for page parameters.
  - Refined conditional logic to accurately handle valid paging values, even when they appear falsy.
- **Tests**
  - Added a new test to confirm that pagination works correctly with the updated cursor handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->