### PR TITLE
docs(contribute): Update trpc-redis for the library adapters

### DIFF
--- a/www/docs/community/awesome-trpc.mdx
+++ b/www/docs/community/awesome-trpc.mdx
@@ -71,6 +71,7 @@ A collection of resources on tRPC.
 | trpc-bun-adapter - tRPC adapter for Bun runtime environment                                         | https://github.com/cah4a/trpc-bun-adapter                             |
 | trpc-rabbitmq - tRPC adapter using RabbitMQ as a transport layer                                    | https://github.com/imxeno/trpc-rabbitmq                               |
 | trpc-mqtt - tRPC adapter using MQTT as a transport layer                                            | https://github.com/edorgeville/trpc-mqtt                              |
+| trpc-redis - tRPC adapter using Redis as a transport layer                                          | https://github.com/cobeo2004/trpc-redis                               |
 | NestJS-tRPC - An opinionated approach to building end-to-end typesafe APIs with tRPC within NestJS. | https://www.nestjs-trpc.io/                                           |
 
 ## 🍀 Starting points, example projects, etc


### PR DESCRIPTION
G'day KATT and tRPC team,

I hope you all are doing well ! 

I've written an adapter in order to use `redis` with `trpc` as an transport layout. I have been using it for quite a time as the main transport layer for my microservice tRPC API, and it performs quite well. So I wanted to give it a shot by sharing it to the community.

This project is written based on the codebase of [trpc-rabbitmq](https://github.com/imxeno/trpc-rabbitmq) and [trpc-mqtt](https://github.com/edorgeville/trpc-mqtt). Shout out to @edorgeville and @imxeno for their great works !!!

Thank you for considering your time and looking forward for any feedbacks, comments !

Best regards,
cobeo2004

## 🎯 Changes

add trpc-redis to the awesome-trpc list

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the community resource page by adding a new entry that highlights a tRPC adapter integrating Redis.
	- The entry includes a brief description and a link for users to learn more about this integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->