### PR TITLE
fix(server): fix concat

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/middleware.ts
+++ b/packages/server/src/unstable-core-do-not-import/middleware.ts
@@ -159,7 +159,7 @@ export function createMiddlewareFactory<
 /**
  * Create a standalone middleware
  * @see https://trpc.io/docs/v11/server/middlewares#experimental-standalone-middlewares
- * @deprecated use `.unstable_concat()` instead
+ * @deprecated use `.concat()` instead
  */
 export const experimental_standaloneMiddleware = <
   TCtx extends {

--- a/packages/server/src/unstable-core-do-not-import/procedureBuilder.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/procedureBuilder.test.ts
@@ -484,4 +484,31 @@ describe('concat()', () => {
     result.ctx.__fromLib2;
     result.input;
   });
+
+  test('concat with default values', async () => {
+    const t = initTRPC.context().create();
+
+    const proc1 = t.procedure.input(z.number().default(1));
+
+    proc1.query((opts) => {
+      expectTypeOf(opts.input).toEqualTypeOf<number>();
+    });
+
+    const proc2 = t.procedure;
+
+    const concatProc = proc1.unstable_concat(proc2).query((opts) => {
+      // This type assertion verifies that num is strictly a number, not number | undefined
+      expectTypeOf(opts.input).toEqualTypeOf<number>();
+      return opts.input;
+    });
+
+    const router = t.router({
+      concat: concatProc,
+    });
+    const caller = router.createCaller({});
+
+    const result = await caller.concat(1);
+    expectTypeOf(result).toEqualTypeOf<number>();
+    expect(result).toEqual(1);
+  });
 });

--- a/packages/server/src/unstable-core-do-not-import/procedureBuilder.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/procedureBuilder.test.ts
@@ -496,7 +496,7 @@ describe('concat()', () => {
 
     const proc2 = t.procedure;
 
-    const concatProc = proc1.unstable_concat(proc2).query((opts) => {
+    const concatProc = proc1.concat(proc2).query((opts) => {
       // This type assertion verifies that num is strictly a number, not number | undefined
       expectTypeOf(opts.input).toEqualTypeOf<number>();
       return opts.input;

--- a/packages/server/src/unstable-core-do-not-import/procedureBuilder.ts
+++ b/packages/server/src/unstable-core-do-not-import/procedureBuilder.ts
@@ -304,7 +304,7 @@ export interface ProcedureBuilder<
     TMeta,
     Overwrite<TContextOverrides, $ContextOverrides>,
     IntersectIfDefined<TInputIn, $InputIn>,
-    IntersectIfDefined<TInputIn, $InputOut>,
+    IntersectIfDefined<TInputOut, $InputOut>,
     IntersectIfDefined<TOutputIn, $OutputIn>,
     IntersectIfDefined<TOutputOut, $OutputOut>,
     TCaller

--- a/packages/server/src/unstable-core-do-not-import/procedureBuilder.ts
+++ b/packages/server/src/unstable-core-do-not-import/procedureBuilder.ts
@@ -274,9 +274,46 @@ export interface ProcedureBuilder<
   >;
 
   /**
-   * Combine two procedure builders
+   * @deprecated use {@link concat} instead
    */
   unstable_concat<
+    $Context,
+    $Meta,
+    $ContextOverrides,
+    $InputIn,
+    $InputOut,
+    $OutputIn,
+    $OutputOut,
+  >(
+    builder: Overwrite<TContext, TContextOverrides> extends $Context
+      ? TMeta extends $Meta
+        ? ProcedureBuilder<
+            $Context,
+            $Meta,
+            $ContextOverrides,
+            $InputIn,
+            $InputOut,
+            $OutputIn,
+            $OutputOut,
+            TCaller
+          >
+        : TypeError<'Meta mismatch'>
+      : TypeError<'Context mismatch'>,
+  ): ProcedureBuilder<
+    TContext,
+    TMeta,
+    Overwrite<TContextOverrides, $ContextOverrides>,
+    IntersectIfDefined<TInputIn, $InputIn>,
+    IntersectIfDefined<TInputOut, $InputOut>,
+    IntersectIfDefined<TOutputIn, $OutputIn>,
+    IntersectIfDefined<TOutputOut, $OutputOut>,
+    TCaller
+  >;
+
+  /**
+   * Combine two procedure builders
+   */
+  concat<
     $Context,
     $Meta,
     $ContextOverrides,
@@ -485,6 +522,9 @@ export function createBuilder<TContext, TMeta>(
       });
     },
     unstable_concat(builder) {
+      return createNewBuilder(_def, (builder as AnyProcedureBuilder)._def);
+    },
+    concat(builder) {
       return createNewBuilder(_def, (builder as AnyProcedureBuilder)._def);
     },
     query(resolver) {

--- a/www/docs/server/middlewares.md
+++ b/www/docs/server/middlewares.md
@@ -158,10 +158,6 @@ protectedProcedure.query(({ ctx }) => ctx.user);
 
 ## Using `.concat()` to create reusable middlewares and plugins {#concat}
 
-:::info
-We have prefixed this as `unstable_` as it's a new API, but you're safe to use it! [Read more](/docs/faq#unstable).
-:::
-
 :::tip
 
 - Creating middlewares using `t.middleware` has the limitation that the `Context` type is tied to the `Context` type of the tRPC instance.
@@ -229,7 +225,7 @@ const plugin = createMyPlugin();
 
 // create a base procedure using the plugin
 const procedureWithPlugin = publicProcedure
-  .unstable_concat(
+  .concat(
     plugin.pluginProc,
   )
   .use(opts => {
@@ -337,7 +333,7 @@ barMiddleware.unstable_pipe(fooMiddleware);
 ## Experimental: standalone middlewares
 
 :::info
-This has been deprecated in favor of `.unstable_concat()`
+This has been deprecated in favor of `.concat()`
 :::
 
 tRPC has an experimental API called `experimental_standaloneMiddleware` which allows you to independently define a middleware that can be used with any tRPC instance. Creating middlewares using `t.middleware` has the limitation that


### PR DESCRIPTION
Closes #6110

## 🎯 Changes

- Fixes so we use the right generic when concating
- Remove `unstable_`-prefix
