### PR TITLE
fix(client): Websocket not reconnecting when lazy is enabled 

### DIFF
--- a/packages/client/src/links/wsLink/wsClient/wsClient.ts
+++ b/packages/client/src/links/wsLink/wsClient/wsClient.ts
@@ -330,14 +330,12 @@ export class WsClient {
       handleCloseOrError(event);
       this.callbacks.onClose?.(event);
 
-      if (!this.lazyMode) {
-        this.reconnect(
-          new TRPCWebSocketClosedError({
-            message: 'WebSocket closed',
-            cause: event,
-          }),
-        );
-      }
+      this.reconnect(
+        new TRPCWebSocketClosedError({
+          message: 'WebSocket closed',
+          cause: event,
+        }),
+      );
     });
 
     ws.addEventListener('error', (event) => {


### PR DESCRIPTION
## 🎯 Changes

- Fixes issue where websocket won't reconnect when it is closed unexpectedly when lazy mode is enabled

## Reasoning 💭 

If your tRPC server goes down and you have a client that uses lazy mode, it won't attempt to reconnect. Clients that use lazy mode should be able to gracefully reconnect.

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
