### PR TITLE
@trpc/upgrade: Fix error when running git check-ignore with 0 ignored files

### DIFF
--- a/packages/upgrade/README.md
+++ b/packages/upgrade/README.md
@@ -1,10 +1,10 @@
 run locally with source files
 
 ```sh
-DEV=1 pnpx tsx path/to/cli.ts
+DEV=1 pnpx tsx path/to/bin/index.ts
 
 # example
-cd examples/minimal-react/client && DEV=1 pnpx tsx ../../../packages/upgrade/src/bin/cli.ts --force --skipTanstackQuery --verbose
+cd examples/minimal-react/client && DEV=1 pnpx tsx ../../../packages/upgrade/src/bin/index.ts --force --skipTanstackQuery --verbose
 ```
 
 or compiled
@@ -25,4 +25,3 @@ A test is a composite of up to 4 files:
 - `myTest.snap.tsx` stores the output of the transform using standard vitest snapshot testing
 - `myTest.trpc.tsx` (Optional) stores your trpc appRouter config and test server
 - `myTest.spec.tsx` (Optional but recommended) a function which will test both the input and transformed components
--

--- a/packages/upgrade/src/lib/git.ts
+++ b/packages/upgrade/src/lib/git.ts
@@ -14,7 +14,17 @@ export async function assertCleanGitTree() {
 }
 
 export async function filterIgnored(files: readonly SourceFile[]) {
-  const { stdout } = await execa('git check-ignore **/*');
+  let stdout = '';
+  let stderr = '';
+  try {
+    const result = await execa('git check-ignore **/*');
+    stdout = result.stdout;
+    stderr = result.stderr;
+  } catch (error) {
+    log.error('Error executing git check-ignore:', error);
+    stdout = '';
+  }
+
   const ignores = stdout.split('\n');
 
   if (process.env['VERBOSE']) {


### PR DESCRIPTION

## 🎯 Changes

When running `git check-ignore **/*` in a folder with 0 ignored files the cli currently crashes with 

```js
┌  tRPC Upgrade CLI v11.0.1
│
◇  Select transforms to run
│  Migrate Hooks to xxxOptions API
node:internal/errors:983
  const err = new Error(message);
              ^

Error: Command failed: git check-ignore **/*

    at genericNodeError (node:internal/errors:983:15)
    at wrappedFn (node:internal/errors:537:14)
    at ChildProcess.exithandler (node:child_process:414:12)
    at ChildProcess.emit (node:events:507:28)
    at maybeClose (node:internal/child_process:1101:16)
    at ChildProcess._handle.onexit (node:internal/child_process:305:5) {
  code: 1,
  killed: false,
  signal: null,
  cmd: 'git check-ignore **/*',
  stdout: '',
  stderr: ''
  ```

This PR adds a try catch to the check-ignore and also fixes the path in the readme to the cli

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated local execution instructions to reflect the new command path.
  
- **Bug Fixes**
  - Enhanced error handling during underlying operations for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->