### PR TITLE
Make opts optional in trpcSubscriptionOptions.

### DIFF
--- a/packages/tanstack-react-query/src/internals/subscriptionOptions.ts
+++ b/packages/tanstack-react-query/src/internals/subscriptionOptions.ts
@@ -125,7 +125,7 @@ export const trpcSubscriptionOptions = (args: {
   subscribe: typeof TRPCUntypedClient.prototype.subscription;
   path: readonly string[];
   queryKey: TRPCQueryKey;
-  opts: AnyTRPCSubscriptionOptionsIn;
+  opts?: AnyTRPCSubscriptionOptionsIn;
 }): AnyTRPCSubscriptionOptionsOut => {
   const { subscribe, path, queryKey, opts = {} } = args;
   const input = queryKey[1]?.input;

--- a/packages/tanstack-react-query/src/internals/subscriptionOptions.ts
+++ b/packages/tanstack-react-query/src/internals/subscriptionOptions.ts
@@ -127,7 +127,7 @@ export const trpcSubscriptionOptions = (args: {
   queryKey: TRPCQueryKey;
   opts: AnyTRPCSubscriptionOptionsIn;
 }): AnyTRPCSubscriptionOptionsOut => {
-  const { subscribe, path, queryKey, opts } = args;
+  const { subscribe, path, queryKey, opts = {} } = args;
   const input = queryKey[1]?.input;
   const enabled = 'enabled' in opts ? !!opts.enabled : input !== skipToken;
 


### PR DESCRIPTION
Closes #6660

## 🎯 Changes

Make opts optional in trpcSubscriptionOptions.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced subscription flexibility by making options parameter optional, preventing potential runtime errors when options are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->