### PR TITLE
feat(client): add `retryDelayMs`-option to `retryLink`

### DIFF
--- a/packages/client/src/links/retryLink.ts
+++ b/packages/client/src/links/retryLink.ts
@@ -12,6 +12,10 @@ interface RetryLinkOptions<TInferrable extends InferrableClientTypes> {
    * The retry function
    */
   retry: (opts: RetryFnOptions<TInferrable>) => boolean;
+  /**
+   * The delay between retries in ms (defaults to 0)
+   */
+  retryDelay?: (attempt: number) => number;
 }
 
 interface RetryFnOptions<TInferrable extends InferrableClientTypes> {
@@ -70,7 +74,14 @@ export function retryLink<TInferrable extends InferrableClientTypes>(
                 error,
               });
               if (shouldRetry) {
-                attempt(attempts + 1);
+                const delay = opts.retryDelay?.(attempts) ?? 0;
+                if (delay) {
+                  setTimeout(() => {
+                    attempt(attempts + 1);
+                  }, delay);
+                } else {
+                  attempt(attempts + 1);
+                }
               } else {
                 observer.error(error);
               }

--- a/packages/server/src/__tests__/fakeTimersResource.ts
+++ b/packages/server/src/__tests__/fakeTimersResource.ts
@@ -7,6 +7,7 @@ export function fakeTimersResource() {
     {
       advanceTimersByTimeAsync: vi.advanceTimersByTimeAsync,
       runAllTimersAsync: vi.runAllTimersAsync,
+      runAllTimers: vi.runAllTimers,
     },
     () => {
       vi.useRealTimers();

--- a/www/docs/client/links/retryLink.md
+++ b/www/docs/client/links/retryLink.md
@@ -37,6 +37,8 @@ const client = createTRPCClient<AppRouter>({
         // Retry up to 3 times
         return opts.attempts <= 3;
       },
+      // Double every attempt, with max of 30 seconds
+      retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000)
     }),
     httpBatchLink({
       url: 'http://localhost:3000',
@@ -60,6 +62,10 @@ interface RetryLinkOptions<TInferrable extends InferrableClientTypes> {
    * The retry function
    */
   retry: (opts: RetryFnOptions<TInferrable>) => boolean;
+  /**
+   * The delay between retries in ms (defaults to 0)
+   */
+  retryDelay?: (attempt: number) => number;
 }
 
 interface RetryFnOptions<TInferrable extends InferrableClientTypes> {

--- a/www/docs/client/links/retryLink.md
+++ b/www/docs/client/links/retryLink.md
@@ -37,7 +37,7 @@ const client = createTRPCClient<AppRouter>({
         // Retry up to 3 times
         return opts.attempts <= 3;
       },
-      // Double every attempt, with max of 30 seconds
+      // Double every attempt, with max of 30 seconds (starting at 1 second)
       retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000)
     }),
     httpBatchLink({

--- a/www/docs/client/links/retryLink.md
+++ b/www/docs/client/links/retryLink.md
@@ -38,7 +38,7 @@ const client = createTRPCClient<AppRouter>({
         return opts.attempts <= 3;
       },
       // Double every attempt, with max of 30 seconds (starting at 1 second)
-      retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000)
+      retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
     }),
     httpBatchLink({
       url: 'http://localhost:3000',


### PR DESCRIPTION
Addresses https://github.com/trpc/trpc/discussions/6425

## 🎯 Changes

Add a `retryDelay` option to RetryLink.  Right now it defaults to immediately retrying on failure, this allows introducing a delay.

IMO this should have a reasonable default (what i provided in the docs is the tanstack query default).  Since that would be a breaking change, I think it makes sense to do it in a follow up pr.

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled customizable retry delays between attempts, allowing users to define specific wait times based on the retry iteration.
  - Introduced a new function for simulating operation links that can fail a specified number of times before succeeding.

- **Bug Fixes**
  - Enhanced testing capabilities for the retry mechanism with additional test cases covering various scenarios.

- **Documentation**
  - Updated help materials to guide users on configuring the new customizable retry delay option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->