### PR TITLE
Add dedicated non-json inputs page

### DIFF
--- a/www/docs/server/non-json-content-types.md
+++ b/www/docs/server/non-json-content-types.md
@@ -9,7 +9,7 @@ In addition to JSON-serializable data, tRPC can use FormData, File, and other Bi
 
 ## Client Setup
 
-:::warning
+:::info
 While tRPC natively supports several non-json serializable types, your client may need a little link configuration to support them depending on your setup.
 :::
 

--- a/www/docs/server/non-json-content-types.md
+++ b/www/docs/server/non-json-content-types.md
@@ -1,0 +1,104 @@
+---
+id: non-json-content-types
+title: Non-JSON Content Types
+sidebar_label: Non-JSON Inputs (FormData, File, Blob)
+slug: /server/non-json-content-types
+---
+
+In addition to JSON-serializable data, tRPC can use FormData, File, and other Binary types as procedure inputs
+
+## Client Setup
+
+:::warning
+While tRPC natively supports several non-json serializable types, your client may need a little link configuration to support them depending on your setup.
+:::
+
+`httpLink` supports non-json content types out the box, if you're only using this then your existing setup should work immediately
+
+```ts
+import { httpLink } from '@trpc/client';
+
+trpc.createClient({
+  links: [
+    httpLink({
+      url: 'http://localhost:2022',
+    }),
+  ],
+})
+```
+
+However, not all links support these new content types, if you're using `httpBatchLink` or `httpBatchStreamLink` you will need to include a splitLink and check which link to use depending on the content
+
+```ts
+import {
+  httpBatchLink,
+  httpLink,
+  isNonJsonSerializable,
+  splitLink,
+} from '@trpc/client';
+
+trpc.createClient({
+  links: [
+    splitLink({
+      condition: (op) => isNonJsonSerializable(op.input),
+      true: httpLink({
+        url,
+      }),
+      false: httpBatchLink({
+        url,
+      }),
+    })
+  ],
+})
+```
+
+## `FormData` Input
+
+FormData is natively supported, and for more advanced usage you could also combine this with a library like [zod-form-data](https://www.npmjs.com/package/zod-form-data) to validate inputs in a type-safe way.
+
+```ts twoslash
+// @target: esnext
+import { initTRPC } from '@trpc/server';
+// ---cut---
+
+// Our examples use Zod by default, but usage with other libraries is identical
+import { z } from 'zod';
+
+export const t = initTRPC.create();
+const publicProcedure = t.procedure;
+
+export const appRouter = t.router({
+  hello: publicProcedure.input(z.instanceof(FormData)).query((opts) => {
+    const data = opts.input;
+    //    ^?
+    return {
+      greeting: `Hello ${data.get('name')}`,
+    };
+  }),
+});
+```
+
+## `File` and other Binary Type Inputs
+
+tRPC converts many octet content types to a `ReadableStream` which can be consumed in a procedure. Currently these are `Blob` `Uint8Array` and `File`.
+
+```ts twoslash
+// @target: esnext
+import { initTRPC } from '@trpc/server';
+// ---cut---
+
+import { octetInputParser } from '@trpc/server/http';
+
+export const t = initTRPC.create();
+const publicProcedure = t.procedure;
+
+export const appRouter = t.router({
+  upload: publicProcedure.input(octetInputParser).query((opts) => {
+    const data = opts.input;
+    //    ^?
+    return {
+      valid: true,
+    };
+  }),
+});
+```

--- a/www/docs/server/non-json-content-types.md
+++ b/www/docs/server/non-json-content-types.md
@@ -24,7 +24,7 @@ trpc.createClient({
       url: 'http://localhost:2022',
     }),
   ],
-})
+});
 ```
 
 However, not all links support these new content types, if you're using `httpBatchLink` or `httpBatchStreamLink` you will need to include a splitLink and check which link to use depending on the content
@@ -47,9 +47,9 @@ trpc.createClient({
       false: httpBatchLink({
         url,
       }),
-    })
+    }),
   ],
-})
+});
 ```
 
 ## `FormData` Input

--- a/www/docs/server/non-json-content-types.md
+++ b/www/docs/server/non-json-content-types.md
@@ -77,6 +77,8 @@ export const appRouter = t.router({
 });
 ```
 
+For a more advanced code sample you can see our [example project here](https://github.com/juliusmarminge/trpc-interop/blob/66aa760141030ffc421cae1a3bda9b5f1ab340b6/src/server.ts#L28-L43)
+
 ## `File` and other Binary Type Inputs
 
 tRPC converts many octet content types to a `ReadableStream` which can be consumed in a procedure. Currently these are `Blob` `Uint8Array` and `File`.

--- a/www/docs/server/non-json-content-types.md
+++ b/www/docs/server/non-json-content-types.md
@@ -61,7 +61,6 @@ FormData is natively supported, and for more advanced usage you could also combi
 import { initTRPC } from '@trpc/server';
 // ---cut---
 
-// Our examples use Zod by default, but usage with other libraries is identical
 import { z } from 'zod';
 
 export const t = initTRPC.create();

--- a/www/docs/server/validators.md
+++ b/www/docs/server/validators.md
@@ -126,61 +126,6 @@ Since subscriptions are async iterators, you can use the same validation techniq
 
 Have a look at the [subscriptions guide](subscriptions.md#output-validation) for more information.
 
-## Non-JSON Content Types
-
-In addition to JSON-serializable data, tRPC can be used with FormData, File, and other Binary types
-
-### `FormData` Input
-
-FormData is natively supported, and for more advanced usage you could also combine this with a library like [zod-form-data](https://www.npmjs.com/package/zod-form-data) to validate inputs in a type-safe way.
-
-```ts twoslash
-// @target: esnext
-import { initTRPC } from '@trpc/server';
-// ---cut---
-
-// Our examples use Zod by default, but usage with other libraries is identical
-import { z } from 'zod';
-
-export const t = initTRPC.create();
-const publicProcedure = t.procedure;
-
-export const appRouter = t.router({
-  hello: publicProcedure.input(z.instanceof(FormData)).query((opts) => {
-    const data = opts.input;
-    //    ^?
-    return {
-      greeting: `Hello ${data.get('name')}`,
-    };
-  }),
-});
-```
-
-### `File` and other Binary Type Inputs
-
-tRPC converts many octet content types to a `ReadableStream` which can be consumed in a procedure. Currently these are `Blob` `Uint8Array` and `File` but more can be added easily.
-
-```ts twoslash
-// @target: esnext
-import { initTRPC } from '@trpc/server';
-// ---cut---
-
-import { octetInputParser } from '@trpc/server/http';
-
-export const t = initTRPC.create();
-const publicProcedure = t.procedure;
-
-export const appRouter = t.router({
-  upload: publicProcedure.input(octetInputParser).query((opts) => {
-    const data = opts.input;
-    //    ^?
-    return {
-      valid: true,
-    };
-  }),
-});
-```
-
 ## The most basic validator: a function
 
 You can define a validator without any 3rd party dependencies, with a function.

--- a/www/sidebars.ts
+++ b/www/sidebars.ts
@@ -34,6 +34,7 @@ const config: SidebarsConfig = {
         'server/routers',
         'server/procedures',
         'server/validators',
+        'server/non-json-content-types',
         'server/merging-routers',
         'server/context',
         'server/middlewares',


### PR DESCRIPTION
Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Introduced a new guide detailing the handling of non-JSON content types such as FormData, File, and binary inputs.
  - Removed redundant information regarding non-JSON content types from existing documentation.
  - Updated the site navigation to include a link to the new documentation section on non-JSON content types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->