### PR TITLE
docs: fix reference to `retryDelay` in client docs

### DIFF
--- a/www/docs/client/links/retryLink.md
+++ b/www/docs/client/links/retryLink.md
@@ -38,7 +38,7 @@ const client = createTRPCClient<AppRouter>({
         return opts.attempts <= 3;
       },
       // Double every attempt, with max of 30 seconds (starting at 1 second)
-      retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+      retryDelayMs: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
     }),
     httpBatchLink({
       url: 'http://localhost:3000',
@@ -65,7 +65,7 @@ interface RetryLinkOptions<TInferrable extends InferrableClientTypes> {
   /**
    * The delay between retries in ms (defaults to 0)
    */
-  retryDelay?: (attempt: number) => number;
+  retryDelayMs?: (attempt: number) => number;
 }
 
 interface RetryFnOptions<TInferrable extends InferrableClientTypes> {


### PR DESCRIPTION
## 🎯 Changes

Corrects `retryDelay` to `retryDelayMs` in the web docs

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
