### PR TITLE
docs(suspense): fix 'preformance' typo

### DIFF
--- a/www/docs/client/react/suspense.md
+++ b/www/docs/client/react/suspense.md
@@ -135,7 +135,7 @@ const Component = (props: { postIds: string[] }) => {
 
 ## Prefetching
 
-The preformance of suspense queries can be improved by prefetching the query data before the Suspense component is rendered (this is sometimes called ["render-as-you-fetch"](https://tanstack.com/query/v5/docs/framework/react/guides/suspense#fetch-on-render-vs-render-as-you-fetch)).
+The performance of suspense queries can be improved by prefetching the query data before the Suspense component is rendered (this is sometimes called ["render-as-you-fetch"](https://tanstack.com/query/v5/docs/framework/react/guides/suspense#fetch-on-render-vs-render-as-you-fetch)).
 
 :::note
 


### PR DESCRIPTION
I just found something I believe is a typo and did a quick correction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Fixed a typographical error in the Suspense query performance documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->