### PR TITLE
docs: add link to `@trpc/tanstack-react-query` as recommended react usage in quickstart page

### DIFF
--- a/www/docs/main/quickstart.mdx
+++ b/www/docs/main/quickstart.mdx
@@ -556,4 +556,7 @@ tRPC includes more sophisticated client-side tooling designed for React projects
 
 - [Usage with Next.js](../client/nextjs/introduction.mdx)
 - [Usage with Express (server-side)](/docs/server/adapters/express)
-- [Usage with React (client-side)](../client/react/introduction.mdx)
+- Usage with React (client-side)
+  - [React Integration (Recommended) -> `@trpc/tanstack-react-query`](../client/tanstack-react-query/setup.mdx)
+  - [React Integration (Classic) -> `@trpc/react-query`](../client/react/introduction.mdx)
+  - If you are unsure use `Recommended`


### PR DESCRIPTION
Prevent duplication of #6729 and confusion between the two react-query packages.

## 🎯 Changes

Added a link at the end of quickstart page

Before

<img width="980" alt="Schermata 2025-04-29 alle 14 37 16" src="https://github.com/user-attachments/assets/e35718c3-099f-4b76-bdab-9c427f6569a6" />


After

<img width="984" alt="Schermata 2025-04-29 alle 14 39 57" src="https://github.com/user-attachments/assets/30e3db45-025b-46c7-8f3e-efd4368ae338" />



<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
