### PR TITLE
useSubscription should abort when input changes

### DIFF
--- a/packages/tanstack-react-query/test/__helpers.tsx
+++ b/packages/tanstack-react-query/test/__helpers.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/vitest';
 import type { TestServerAndClientResourceOpts } from '@trpc/client/__tests__/testClientResource';
 import { testServerAndClientResource } from '@trpc/client/__tests__/testClientResource';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render } from '@testing-library/react';
+import { render, RenderResult } from '@testing-library/react';
 import { getUntypedClient } from '@trpc/client';
 import type { AnyTRPCRouter } from '@trpc/server';
 import * as React from 'react';
@@ -40,11 +40,22 @@ export function testReactResource<TRouter extends AnyTRPCRouter>(
     );
   }
 
+  function rerenderApp(render: RenderResult, ui: React.ReactNode) {
+    return render.rerender(
+      <QueryClientProvider client={queryClient}>
+        <TRPCProvider trpcClient={ctx.client} queryClient={queryClient}>
+          {ui}
+        </TRPCProvider>
+      </QueryClientProvider>,
+    );
+  }
+
   return {
     ...ctx,
     opts: ctx,
     queryClient,
     renderApp,
+    rerenderApp,
     useTRPC,
     useTRPCClient,
     optionsProxyClient,

--- a/packages/tanstack-react-query/test/useSubscription.test.tsx
+++ b/packages/tanstack-react-query/test/useSubscription.test.tsx
@@ -1,7 +1,6 @@
 import { EventEmitter, on } from 'node:events';
 import { testReactResource } from './__helpers';
 import { fireEvent } from '@testing-library/react';
-import { input } from '@testing-library/user-event/dist/types/event';
 import { httpSubscriptionLink, wsLink } from '@trpc/client';
 import { initTRPC } from '@trpc/server';
 import { observable } from '@trpc/server/observable';

--- a/packages/tanstack-react-query/test/useSubscription.test.tsx
+++ b/packages/tanstack-react-query/test/useSubscription.test.tsx
@@ -419,8 +419,36 @@ describe('http', () => {
     }
 
     const utils = ctx.renderApp(<MyComponent input={1} />);
+    await vi.waitFor(() => {
+      expect(utils.container).toHaveTextContent(`status:pending`);
+    });
+    // emit
+    ctx.ee.emit('data', 10);
+
+    await vi.waitFor(
+      () => {
+        expect(utils.container).toHaveTextContent('data:11');
+      },
+      {
+        timeout: 5_000,
+      },
+    );
 
     ctx.rerenderApp(utils, <MyComponent input={2} />);
+    await vi.waitFor(() => {
+      expect(utils.container).toHaveTextContent(`status:pending`);
+    });
+    // emit
+    ctx.ee.emit('data', 10);
+
+    await vi.waitFor(
+      () => {
+        expect(utils.container).toHaveTextContent('data:12');
+      },
+      {
+        timeout: 5_000,
+      },
+    );
 
     await vi.waitFor(() => {
       expect(ctx.abortState).toEqual({


### PR DESCRIPTION
Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a new test to verify that subscriptions are properly aborted when restarted or unmounted.
  - Introduced a helper to facilitate rerendering components with consistent context during testing.
  - Improved test utilities to track and assert subscription abort states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->