### PR TITLE
fix(tanstack-react-quey): Ensure TRPC Tanstack React Query receives raw values from Vue ref inputs in Vue Query

### DIFF
--- a/packages/tanstack-react-query/src/internals/queryOptions.ts
+++ b/packages/tanstack-react-query/src/internals/queryOptions.ts
@@ -193,6 +193,7 @@ export function trpcQueryOptions(args: {
           : { signal: null }),
       },
     };
+    const queryKey = queryFnContext.queryKey;
 
     const result = await query(...getClientArgs(queryKey, actualOpts));
 


### PR DESCRIPTION
I successfully integrated Vue Query with TRPC Tanstack React Query, and reactive queries are now working as expected. 

Initially, I needed to make TRPC work with TanStack Vue Query. To do that, I started by building two wrappers:

1.  A wrapper to bridge the TRPC Tanstack React Router with Vue Query query:

```ts
export function useTrcpQuery<T extends { queryKey: DataTag<any, any, any> }>(
  options: T
): UseQueryReturnType<
  T['queryKey'][dataTagSymbol],
  T['queryKey'][dataTagErrorSymbol]
> {
  return useQuery(options);
}
```

2. A type-mapping wrapper to allow reactive `ref` inputs using Vue:

```ts
type MaybeRefDeep<T> = Extract<
  Extract<
    UseQueryOptions<any, any, any, any, [T]>,
    { queryKey: any }
  >['queryKey'],
  any[]
>[0];

type MapQueryOptions<F> = F extends (
  input: infer A,
  ...rest: infer B
) => infer R
  ? (input: MaybeRefDeep<A>, ...rest: B) => R
  : never;

type MapToVue<T> = {
  [K in keyof T]: K extends 'queryOptions'
    ? MapQueryOptions<T[K]>
    : T[K] extends object
    ? MapToVue<T[K]>
    : T[K];
};

type TRPCVue = MapToVue<typeof trpc>;

export const trpc = createTRPCOptionsProxy<Router>({
  client: trpcClient,
  queryClient
}) as TRPCVue;

```

While these wrappers allowed me to call TRPC queries reactively, I discovered that TRPC was receiving the raw `ref` instead of its unwrapped value. This caused TRPC to throw errors during query execution.


## 🎯 Changes

The solution is to use `queryKey` from `QueryFunctionContext`, which already contains the fully unwrapped input. By deriving the query input from this source instead of the original `queryKey` with refs, the query works correctly and maintains reactivity.

This change ensures that TRPC  Tanstack React Query receives clean, non-reactive input values. However, this PR does not yet include these two wrappers. It focuses solely on solving the core issue: ensuring that TRPC receives raw values (not refs) from Vue Query inputs.

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of query keys for better clarity and maintainability. No changes to user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->