### PR TITLE
refactor(server): simplify error creation from unknown causes

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/error/TRPCError.ts
+++ b/packages/server/src/unstable-core-do-not-import/error/TRPCError.ts
@@ -22,11 +22,7 @@ export function getCauseFromUnknown(cause: unknown): Error | undefined {
 
   // If it's an object, we'll create a synthetic error
   if (isObject(cause)) {
-    const err = new UnknownCauseError();
-    for (const key in cause) {
-      err[key] = cause[key];
-    }
-    return err;
+    return Object.assign(new UnknownCauseError(), cause);
   }
 
   return undefined;


### PR DESCRIPTION
Updated the `getCauseFromUnknown` function to use `Object.assign` for creating a synthetic `UnknownCauseError` from an object, improving code readability.

Closes #

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

Minor refactor

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.