### PR TITLE
docs: enchance `docs/server/non-json-content-types` page

### DIFF
--- a/www/docs/server/non-json-content-types.md
+++ b/www/docs/server/non-json-content-types.md
@@ -52,7 +52,30 @@ trpc.createClient({
 });
 ```
 
-## `FormData` Input
+## Server Usage
+
+:::info
+When a request is handled by tRPC, tRPC handles body parsing (based on request header `Content-Type`).  
+If you encounter weird errors like `Failed to parse body as XXX` check that your server (express, next.js...) that mounts tRPC isn't parsing the request body before tRPC.  
+If yes, exclude the body parsing in routes handled by tRPC.  
+```ts
+// Example in express
+
+// incorrect
+const app = express();
+app.use(express.json()); // this try to parse body before tRPC. 
+app.post('/express/hello', (req,res) => {/* ... */ }); // normal express route handler
+app.use('/trpc', trpcExpress.createExpressMiddleware({ /* ... */}))// tRPC fails to parse body
+
+// correct
+const app = express();
+app.use('/express', express.json()); // do it only in "/express/*" path 
+app.post('/express/hello', (req,res) => {/* ... */ });
+app.use('/trpc', trpcExpress.createExpressMiddleware({ /* ... */}))// tRPC can parse body
+```
+:::
+
+### `FormData` Input
 
 FormData is natively supported, and for more advanced usage you could also combine this with a library like [zod-form-data](https://www.npmjs.com/package/zod-form-data) to validate inputs in a type-safe way.
 
@@ -81,7 +104,7 @@ export const appRouter = t.router({
 
 For a more advanced code sample you can see our [example project here](https://github.com/juliusmarminge/trpc-interop/blob/66aa760141030ffc421cae1a3bda9b5f1ab340b6/src/server.ts#L28-L43)
 
-## `File` and other Binary Type Inputs
+### `File` and other Binary Type Inputs
 
 tRPC converts many octet content types to a `ReadableStream` which can be consumed in a procedure. Currently these are `Blob` `Uint8Array` and `File`.
 

--- a/www/docs/server/non-json-content-types.md
+++ b/www/docs/server/non-json-content-types.md
@@ -67,13 +67,15 @@ export const t = initTRPC.create();
 const publicProcedure = t.procedure;
 
 export const appRouter = t.router({
-  hello: publicProcedure.input(z.instanceof(FormData)).query((opts) => {
-    const data = opts.input;
-    //    ^?
-    return {
-      greeting: `Hello ${data.get('name')}`,
-    };
-  }),
+  hello: publicProcedure
+    .input(z.instanceof(FormData))
+    .query((opts) => {
+      const data = opts.input;
+      //    ^?
+      return {
+        greeting: `Hello ${data.get('name')}`,
+      };
+    }),
 });
 ```
 
@@ -94,12 +96,14 @@ export const t = initTRPC.create();
 const publicProcedure = t.procedure;
 
 export const appRouter = t.router({
-  upload: publicProcedure.input(octetInputParser).query((opts) => {
-    const data = opts.input;
-    //    ^?
-    return {
-      valid: true,
-    };
-  }),
+  upload: publicProcedure
+    .input(octetInputParser)
+    .query((opts) => {
+      const data = opts.input;
+      //    ^?
+      return {
+        valid: true,
+      };
+    }),
 });
 ```

--- a/www/docs/server/non-json-content-types.md
+++ b/www/docs/server/non-json-content-types.md
@@ -69,7 +69,7 @@ const publicProcedure = t.procedure;
 export const appRouter = t.router({
   hello: publicProcedure
     .input(z.instanceof(FormData))
-    .query((opts) => {
+    .mutation((opts) => {
       const data = opts.input;
       //    ^?
       return {
@@ -98,7 +98,7 @@ const publicProcedure = t.procedure;
 export const appRouter = t.router({
   upload: publicProcedure
     .input(octetInputParser)
-    .query((opts) => {
+    .mutation((opts) => {
       const data = opts.input;
       //    ^?
       return {


### PR DESCRIPTION
## 🎯 Changes

- add a tip for helping user fix potential body parsing errors
- add server section title as ##/h2, and changed sub sections to ###/h3
- fix server procedure examples that was using `query`, now they use `mutation`
- better indentation for readability

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
