### PR TITLE
Switch jlalmes/trpc-openapi reference to mcampa/trpc-to-openapi

### DIFF
--- a/www/docs/community/awesome-trpc.mdx
+++ b/www/docs/community/awesome-trpc.mdx
@@ -20,7 +20,7 @@ A collection of resources on tRPC.
 | Description                                                                   | Link                                                 |
 | ----------------------------------------------------------------------------- | ---------------------------------------------------- |
 | tRPC-ui - Automatically generates a UI for manually testing your tRPC backend | https://github.com/aidansunbury/trpc-ui              |
-| tRPC-OpenAPI - OpenAPI & REST support for your tRPC routers                   | https://github.com/mcampa/trpc-to-openapi            |
+| trpc-to-openapi - OpenAPI & REST support for your tRPC routers                | https://github.com/mcampa/trpc-to-openapi            |
 | tRPC Client Devtools browser extension                                        | https://github.com/rhenriquez28/trpc-client-devtools |
 | tRPC Playground - sandbox for testing tRPC queries in the browser             | https://github.com/sachinraja/trpc-playground        |
 | tRPC-Chrome - Web extensions messaging support for tRPC                       | https://github.com/jlalmes/trpc-chrome               |


### PR DESCRIPTION
No issue.

## 🎯 Changes

Update the trpc-openapi link to point to the maintained version.
https://github.com/trpc/trpc-openapi is archived and suggests https://github.com/mcampa/trpc-to-openapi as alternative.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the listing for the OpenAPI & REST support extension in the community resources, replacing the previous entry with a new name and link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->