### PR TITLE
fix(tanstack-react-query): skip inferring `initialData`

### DIFF
--- a/packages/tanstack-react-query/src/internals/queryOptions.ts
+++ b/packages/tanstack-react-query/src/internals/queryOptions.ts
@@ -55,7 +55,7 @@ interface UndefinedTRPCQueryOptionsOut<TQueryFnData, TOutput, TError>
 interface DefinedTRPCQueryOptionsIn<TQueryFnData, TData, TError>
   extends DistributiveOmit<
       DefinedInitialDataOptions<
-        coerceAsyncIterableToArray<TQueryFnData>,
+        coerceAsyncIterableToArray<NoInfer<TQueryFnData>>,
         TError,
         coerceAsyncIterableToArray<TData>,
         TRPCQueryKey

--- a/packages/tanstack-react-query/test/queryOptions.test.tsx
+++ b/packages/tanstack-react-query/test/queryOptions.test.tsx
@@ -352,7 +352,7 @@ describe('queryOptions', () => {
     function MyComponent() {
       const trpc = useTRPC();
       const queryOptions = trpc.post.list.queryOptions(undefined, {
-        // initialData: [],
+        initialData: [],
       });
       expect(queryOptions.trpc.path).toBe('post.list');
       const query1 = useQuery(queryOptions);


### PR DESCRIPTION
Closes #6792
Closes #6791

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added a new test to verify correct type inference and behavior when using initial data with queries that return an array of posts.
- **Bug Fixes**
  - Improved type inference for queries using initial data, ensuring more accurate data handling in query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->