### PR TITLE
Export types SubscriptionResolver and ResolverDef

### DIFF
--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -65,7 +65,8 @@ export type Resolver<TDef extends ResolverDef> = (
   opts?: TRPCProcedureOptions,
 ) => Promise<coerceAsyncGeneratorToIterable<TDef['output']>>;
 
-type SubscriptionResolver<TDef extends ResolverDef> = (
+/** @internal */
+export type SubscriptionResolver<TDef extends ResolverDef> = (
   input: TDef['input'],
   opts: Partial<
     TRPCSubscriptionObserver<TDef['output'], TRPCClientError<TDef>>

--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -47,7 +47,8 @@ export type TRPCClient<TRouter extends AnyRouter> = DecoratedProcedureRecord<
   [untypedClientSymbol]: TRPCUntypedClient<TRouter>;
 };
 
-type ResolverDef = {
+/** @internal */
+export type ResolverDef = {
   input: any;
   output: any;
   transformer: boolean;


### PR DESCRIPTION
## 🎯 Changes

Export types `SubscriptionResolver` and `ResolverDef` (because of generic type argument `TDef extends ResolverDef`)

Both exported types are marked as `@internal`

Previously, only type `Resolver` was exported, but not `SubscriptionResolver`

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
