### PR TITLE
fix: missing export from internal package

### DIFF
--- a/packages/server/src/@trpc/server/index.ts
+++ b/packages/server/src/@trpc/server/index.ts
@@ -56,6 +56,7 @@ export {
   type TRPC_ERROR_CODE_NUMBER,
   type DecorateCreateRouterOptions as TRPCDecorateCreateRouterOptions,
   type CreateRouterOptions as TRPCCreateRouterOptions,
+  type RouterCaller as TRPCRouterCaller,
   StandardSchemaV1Error,
   /**
    * @deprecated use `tracked(id, data)` instead


### PR DESCRIPTION
Closes #6834

## 🎯 Changes

Bug fix for `The inferred type of 'createCaller' cannot be named without a reference to '../../../node_modules/@trpc/server/dist/unstable-core-do-not-import.d-ptrxwuSa.mjs'. This is likely not portable. A type annotation is necessary.` Error

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new type export, `TRPCRouterCaller`, to improve type support for developers using the package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->