### PR TITLE
fix(server): reproduce fastify MaxListenersExceededWarning

### DIFF
--- a/examples/fastify-server/package.json
+++ b/examples/fastify-server/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "esbuild src/server/index.ts src/client/index.ts --bundle --packages=external --platform=node --format=esm --outdir=dist --sourcemap",
-    "dev:server": "tsx watch src/server",
+    "dev:server": "NODE_OPTIONS=--trace-warnings tsx watch src/server",
     "dev:client": "wait-port 2022 && tsx watch src/client",
     "dev": "run-p dev:* --print-label",
     "lint": "eslint --cache src",


### PR DESCRIPTION


link issue #6837

## 🎯 Changes

Reproduce fastify MaxListenersExceededWarning by forcing enable nodejs trace-warnings

## ✅ Checklist

- [✅] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [✅] If necessary, I have added documentation related to the changes made.
- [✅] I have added or updated the tests related to the changes made.
