### PR TITLE
feat(server): add typed errors to procedure builder

### DIFF
--- a/examples/minimal-react-typesafe-errors/README.md
+++ b/examples/minimal-react-typesafe-errors/README.md
@@ -1,0 +1,19 @@
+# A minimal React tRPC example
+
+Requires node 18 (for global fetch).
+
+## Playing around
+
+```bash
+npm i
+npm run dev
+```
+
+Try editing the ts files to see the type checking in action :)
+
+## Building
+
+```bash
+npm run build
+npm run start
+```

--- a/examples/minimal-react-typesafe-errors/client/.gitignore
+++ b/examples/minimal-react-typesafe-errors/client/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/examples/minimal-react-typesafe-errors/client/index.html
+++ b/examples/minimal-react-typesafe-errors/client/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + React + TS</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/minimal-react-typesafe-errors/client/package.json
+++ b/examples/minimal-react-typesafe-errors/client/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "examples-minimal-react-typesafe-errors-client",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "lint": "eslint --cache src",
+    "start": "vite preview"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.80.3",
+    "@trpc/client": "npm:@trpc/client",
+    "@trpc/server": "npm:@trpc/server",
+    "@trpc/tanstack-react-query": "npm:@trpc/tanstack-react-query",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.0",
+    "@types/react-dom": "^19.1.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "eslint": "^9.26.0",
+    "typescript": "^5.8.2",
+    "vite": "^6.1.1"
+  },
+  "version": "11.4.3"
+}

--- a/examples/minimal-react-typesafe-errors/client/src/App.tsx
+++ b/examples/minimal-react-typesafe-errors/client/src/App.tsx
@@ -1,0 +1,11 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { Users } from './Users';
+import { queryClient } from './utils/trpc';
+
+export function App() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <Users />
+    </QueryClientProvider>
+  );
+}

--- a/examples/minimal-react-typesafe-errors/client/src/Users.tsx
+++ b/examples/minimal-react-typesafe-errors/client/src/Users.tsx
@@ -1,0 +1,111 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+import { trpc } from './utils/trpc';
+
+export function Users() {
+  const users = useQuery(trpc.user.list.queryOptions());
+
+  const [nameToCreate, setNameToCreate] = useState('');
+  const [idToUpdate, setIdToUpdate] = useState('');
+  const [nameToUpdate, setNameToUpdate] = useState('');
+
+  const { mutate: createUser } = useMutation(
+    trpc.user.create.mutationOptions({
+      onSuccess: () => {
+        setNameToCreate('');
+        void users.refetch();
+      },
+      onError: (error) => {
+        if (error.data?.customCode === 'NAME_ALREADY_TAKEN') {
+          window.alert(
+            `Name already taken by user with ID: ${error.data.customData.id}`,
+          );
+        } else {
+          window.alert(`Unexpected error: ${error.message}`);
+        }
+      },
+    }),
+  );
+
+  const { mutate: updateUser } = useMutation(
+    trpc.user.update.mutationOptions({
+      onSuccess: () => {
+        setIdToUpdate('');
+        setNameToUpdate('');
+        void users.refetch();
+      },
+      onError: (error) => {
+        if (error.data?.customCode === 'NAME_ALREADY_TAKEN') {
+          window.alert(
+            `Name already taken by user with ID: ${error.data.customData.id}`,
+          );
+        } else if (error.data?.customCode === 'USER_NOT_FOUND') {
+          window.alert(`User with ID "${idToUpdate}" not found`);
+        } else {
+          window.alert(`Unexpected error: ${error.message}`);
+        }
+      },
+    }),
+  );
+
+  return (
+    <div style={{ display: 'flex', gap: 20 }}>
+      <form
+        style={{ display: 'flex', flexDirection: 'column', gap: 4 }}
+        onSubmit={(e) => {
+          e.preventDefault();
+          createUser({ name: nameToCreate });
+        }}
+      >
+        <h2>Create User</h2>
+
+        <label htmlFor="nameToCreate">Name</label>
+        <input
+          id="nameToCreate"
+          type="text"
+          value={nameToCreate}
+          onChange={(e) => setNameToCreate(e.target.value)}
+        />
+        <button type="submit">Add</button>
+      </form>
+
+      <form
+        style={{ display: 'flex', flexDirection: 'column', gap: 4 }}
+        onSubmit={(e) => {
+          e.preventDefault();
+          updateUser({ id: idToUpdate, name: nameToUpdate });
+        }}
+      >
+        <h2>Update User</h2>
+
+        <label htmlFor="idToUpdate">ID</label>
+        <input
+          id="idToUpdate"
+          type="text"
+          value={idToUpdate}
+          onChange={(e) => setIdToUpdate(e.target.value)}
+        />
+
+        <label htmlFor="nameToUpdate">Name</label>
+        <input
+          id="nameToUpdate"
+          type="text"
+          value={nameToUpdate}
+          onChange={(e) => setNameToUpdate(e.target.value)}
+        />
+        <button type="submit">Update</button>
+      </form>
+
+      <div>
+        <h2>Users</h2>
+        <ul>
+          {users.data?.map((user) => (
+            <li key={user.id}>
+              {user.id}: {user.name}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/examples/minimal-react-typesafe-errors/client/src/main.tsx
+++ b/examples/minimal-react-typesafe-errors/client/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { App } from './App';
+
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/examples/minimal-react-typesafe-errors/client/src/utils/trpc.ts
+++ b/examples/minimal-react-typesafe-errors/client/src/utils/trpc.ts
@@ -1,0 +1,21 @@
+import { QueryClient } from '@tanstack/react-query';
+import { createTRPCClient, httpBatchLink } from '@trpc/client';
+import { createTRPCOptionsProxy } from '@trpc/tanstack-react-query';
+import type { AppRouter } from '../../../server';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // ...
+    },
+  },
+});
+
+const trpcClient = createTRPCClient<AppRouter>({
+  links: [httpBatchLink({ url: 'http://localhost:2022' })],
+});
+
+export const trpc = createTRPCOptionsProxy<AppRouter>({
+  client: trpcClient,
+  queryClient,
+});

--- a/examples/minimal-react-typesafe-errors/client/src/vite-env.d.ts
+++ b/examples/minimal-react-typesafe-errors/client/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/minimal-react-typesafe-errors/client/tsconfig.json
+++ b/examples/minimal-react-typesafe-errors/client/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/examples/minimal-react-typesafe-errors/client/vite.config.ts
+++ b/examples/minimal-react-typesafe-errors/client/vite.config.ts
@@ -1,0 +1,13 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  server: {
+    port: 3000,
+  },
+  preview: {
+    port: 3000,
+  },
+  plugins: [react()],
+});

--- a/examples/minimal-react-typesafe-errors/package.json
+++ b/examples/minimal-react-typesafe-errors/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "examples-minimal-react-typesafe-errors",
+  "private": true,
+  "workspaces": [
+    "client",
+    "server"
+  ],
+  "scripts": {
+    "build:client": "npm run build -w client",
+    "build:server": "npm run build -w server",
+    "build": "run-s build:server build:client",
+    "dev:client": "npm run dev -w client",
+    "dev:server": "npm run dev -w server",
+    "dev": "run-p dev:*",
+    "start:client": "npm run start -w client",
+    "start:server": "npm run start -w server",
+    "start": "run-p start:*"
+  },
+  "devDependencies": {
+    "npm-run-all": "^4.1.5"
+  },
+  "version": "11.4.3"
+}

--- a/examples/minimal-react-typesafe-errors/playwright.config.ts
+++ b/examples/minimal-react-typesafe-errors/playwright.config.ts
@@ -1,0 +1,21 @@
+import { devices, PlaywrightTestConfig } from '@playwright/test';
+
+const baseUrl = process.env.PLAYWRIGHT_TEST_BASE_URL || 'http://localhost:3000';
+console.log(`ℹ️ Using base URL "${baseUrl}"`);
+
+const opts = {
+  // launch headless on CI, in browser locally
+  headless: !!process.env.CI || !!process.env.PLAYWRIGHT_HEADLESS,
+  // collectCoverage: !!process.env.PLAYWRIGHT_HEADLESS
+};
+const config: PlaywrightTestConfig = {
+  testDir: './test',
+  use: {
+    ...devices['Desktop Chrome'],
+    baseURL: baseUrl,
+    headless: opts.headless,
+  },
+  retries: process.env.CI ? 3 : 0,
+};
+
+export default config;

--- a/examples/minimal-react-typesafe-errors/server/db.ts
+++ b/examples/minimal-react-typesafe-errors/server/db.ts
@@ -1,0 +1,25 @@
+type User = { id: string; name: string };
+
+// Imaginary database
+const users: User[] = [];
+export const db = {
+  user: {
+    findMany: async () => users,
+    findById: async (id: string) => users.find((user) => user.id === id),
+    findByName: async (name: string) =>
+      users.find((user) => user.name === name),
+    create: async (data: { name: string }) => {
+      const user = { id: String(users.length + 1), ...data };
+      users.push(user);
+      return user;
+    },
+    update: async (data: { id: string; name: string }) => {
+      const user = users.find((user) => user.id === data.id);
+      if (!user) {
+        throw new Error('User not found');
+      }
+      user.name = data.name;
+      return user;
+    },
+  },
+};

--- a/examples/minimal-react-typesafe-errors/server/index.ts
+++ b/examples/minimal-react-typesafe-errors/server/index.ts
@@ -1,0 +1,95 @@
+/**
+ * This is the API-handler of your app that contains all your API routes.
+ * On a bigger app, you will probably want to split this file up into multiple files.
+ */
+import { initTRPC } from '@trpc/server';
+import { createHTTPServer } from '@trpc/server/adapters/standalone';
+import cors from 'cors';
+import { z } from 'zod';
+import { db } from './db';
+
+const t = initTRPC.create();
+
+const publicProcedure = t.procedure;
+const router = t.router;
+
+const appRouter = router({
+  user: {
+    list: publicProcedure.query(async () => {
+      // Retrieve users from a datasource, this is an imaginary database
+      const users = await db.user.findMany();
+      return users;
+    }),
+    create: publicProcedure
+      .input(z.object({ name: z.string() }))
+      .errors({
+        NAME_ALREADY_TAKEN: {
+          code: 'CONFLICT',
+          data: z.object({
+            id: z.string(),
+          }),
+        },
+      })
+      .mutation(async ({ input, errors }) => {
+        // Check if the name is already taken and throw an error if it is
+        const userWithSameName = await db.user.findByName(input.name);
+        if (userWithSameName) {
+          throw new errors.NAME_ALREADY_TAKEN({
+            data: {
+              id: userWithSameName.id,
+            },
+          });
+        }
+
+        // Create a new user in the database
+        const user = await db.user.create(input);
+        return user;
+      }),
+    update: publicProcedure
+      .input(z.object({ id: z.string(), name: z.string() }))
+      .errors({
+        NAME_ALREADY_TAKEN: {
+          code: 'CONFLICT',
+          data: z.object({
+            id: z.string(),
+          }),
+        },
+        USER_NOT_FOUND: {
+          code: 'NOT_FOUND',
+        },
+      })
+      .mutation(async ({ input, errors }) => {
+        // Check if the name is already taken and throw an error if it is
+        const userWithSameName = await db.user.findByName(input.name);
+        if (userWithSameName && userWithSameName.id !== input.id) {
+          throw new errors.NAME_ALREADY_TAKEN({
+            data: {
+              id: userWithSameName.id,
+            },
+          });
+        }
+
+        // Update the user in the database
+        try {
+          const user = await db.user.update(input);
+          return user;
+        } catch (error) {
+          throw new errors.USER_NOT_FOUND();
+        }
+      }),
+  },
+});
+
+// export only the type definition of the API
+// None of the actual implementation is exposed to the client
+export type AppRouter = typeof appRouter;
+
+// create server
+createHTTPServer({
+  middleware: cors(),
+  router: appRouter,
+  createContext() {
+    console.log('context 3');
+    return {};
+  },
+}).listen(2022);

--- a/examples/minimal-react-typesafe-errors/server/package.json
+++ b/examples/minimal-react-typesafe-errors/server/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "examples-minimal-react-typesafe-errors-server",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx watch index.ts",
+    "lint": "eslint --cache index.ts",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@trpc/server": "npm:@trpc/server",
+    "cors": "^2.8.5",
+    "zod": "^3.25.51"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.13",
+    "@types/node": "^22.13.5",
+    "eslint": "^9.26.0",
+    "tsx": "^4.19.3",
+    "typescript": "^5.8.2"
+  },
+  "version": "11.4.3"
+}

--- a/examples/minimal-react-typesafe-errors/server/tsconfig.json
+++ b/examples/minimal-react-typesafe-errors/server/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "lib": ["es2023"],
+    "module": "node16",
+    "target": "es2022",
+
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node16",
+    "outDir": "dist"
+  }
+}

--- a/examples/minimal-typesafe-errors/README.md
+++ b/examples/minimal-typesafe-errors/README.md
@@ -1,0 +1,19 @@
+# A minimal working tRPC example
+
+Requires node 18 (for global fetch).
+
+## Playing around
+
+```
+npm i
+npm run dev
+```
+
+Try editing the ts files to see the type checking in action :)
+
+## Building
+
+```
+npm run build
+npm run start
+```

--- a/examples/minimal-typesafe-errors/package.json
+++ b/examples/minimal-typesafe-errors/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "examples-minimal-typesafe-errors",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "dev:server": "tsx watch src/server",
+    "dev:client": "wait-port 3000 && tsx watch src/client",
+    "dev": "run-p dev:* --print-label",
+    "test-dev": "start-server-and-test 'tsx src/server' 3000 'tsx src/client'",
+    "test-start": "start-server-and-test 'node dist/server' 3000 'node dist/client'"
+  },
+  "dependencies": {
+    "@trpc/client": "npm:@trpc/client",
+    "@trpc/server": "npm:@trpc/server",
+    "superjson": "^1.12.4",
+    "zod": "^3.25.51"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.5",
+    "npm-run-all": "^4.1.5",
+    "start-server-and-test": "^1.12.0",
+    "tsx": "^4.19.3",
+    "typescript": "^5.8.2",
+    "wait-port": "^1.0.1"
+  },
+  "version": "11.4.3"
+}

--- a/examples/minimal-typesafe-errors/src/client/index.ts
+++ b/examples/minimal-typesafe-errors/src/client/index.ts
@@ -1,0 +1,60 @@
+/**
+ * This is the client-side code that uses the inferred types from the server
+ */
+import {
+  createTRPCClient,
+  httpBatchStreamLink,
+  httpSubscriptionLink,
+  safe,
+  safeAsyncIterable,
+  splitLink,
+} from '@trpc/client';
+/**
+ * We only import the `AppRouter` type from the server - this is not available at runtime
+ */
+import type { AppRouter } from '../server/index.js';
+import { transformer } from '../shared/transformer.js';
+
+// Initialize the tRPC client
+const trpc = createTRPCClient<AppRouter>({
+  links: [
+    httpBatchStreamLink({
+      url: 'http://localhost:3000',
+      transformer,
+    }),
+  ],
+});
+
+async function main() {
+  // Call procedure functions
+
+  // 💡 Tip, try to:
+  // - hover any types below to see the inferred types
+  // - Cmd/Ctrl+click on any function to jump to the definition
+  // - Rename any variable and see it reflected across both frontend and backend
+
+  const [users, usersError] = await safe(trpc.user.list.query());
+  console.log('Users:', users, usersError?.message);
+
+  const [createdUser, createUserError] = await safe(
+    trpc.user.create.mutate({ name: 'sachinraja' }),
+  );
+  console.log('Created user:', createdUser, createUserError?.message);
+
+  const [user, userError] = await safe(trpc.user.byId.query('1'));
+  console.log('User 1:', user, userError?.message);
+
+  const iterable = await trpc.examples.iterable.query();
+
+  for await (const [i, iError] of safeAsyncIterable(iterable)) {
+    console.log(
+      'Iterable:',
+      i,
+      iError?.data?.customCode === 'NUMBER_TOO_HIGH'
+        ? `${iError.message} (number: ${iError.data.customData.number})`
+        : iError?.message,
+    );
+  }
+}
+
+void main();

--- a/examples/minimal-typesafe-errors/src/server/db.ts
+++ b/examples/minimal-typesafe-errors/src/server/db.ts
@@ -1,0 +1,25 @@
+type User = { id: string; name: string };
+
+// Imaginary database
+const users: User[] = [];
+export const db = {
+  user: {
+    findMany: async () => users,
+    findById: async (id: string) => users.find((user) => user.id === id),
+    findByName: async (name: string) =>
+      users.find((user) => user.name === name),
+    create: async (data: { name: string }) => {
+      const user = { id: String(users.length + 1), ...data };
+      users.push(user);
+      return user;
+    },
+    update: async (data: { id: string; name: string }) => {
+      const user = users.find((user) => user.id === data.id);
+      if (!user) {
+        throw new Error('User not found');
+      }
+      user.name = data.name;
+      return user;
+    },
+  },
+};

--- a/examples/minimal-typesafe-errors/src/server/index.ts
+++ b/examples/minimal-typesafe-errors/src/server/index.ts
@@ -1,0 +1,109 @@
+/**
+ * This a minimal tRPC server
+ */
+import { createHTTPServer } from '@trpc/server/adapters/standalone';
+import { z } from 'zod';
+import { db } from './db.js';
+import { publicProcedure, router } from './trpc.js';
+
+const appRouter = router({
+  user: {
+    list: publicProcedure.query(async () => {
+      // Retrieve users from a datasource, this is an imaginary database
+      const users = await db.user.findMany();
+      return users;
+    }),
+    byId: publicProcedure.input(z.string()).query(async ({ input }) => {
+      // Retrieve the user with the given ID
+      const user = await db.user.findById(input);
+      return user;
+    }),
+    create: publicProcedure
+      .input(z.object({ name: z.string() }))
+      .errors({
+        NAME_ALREADY_TAKEN: {
+          code: 'CONFLICT',
+          data: z.object({
+            id: z.string(),
+          }),
+        },
+      })
+      .mutation(async ({ input, errors }) => {
+        // Check if the name is already taken and throw an error if it is
+        const userWithSameName = await db.user.findByName(input.name);
+        if (userWithSameName) {
+          throw new errors.NAME_ALREADY_TAKEN({
+            data: {
+              id: userWithSameName.id,
+            },
+          });
+        }
+
+        // Create a new user in the database
+        const user = await db.user.create(input);
+        return user;
+      }),
+    update: publicProcedure
+      .input(z.object({ id: z.string(), name: z.string() }))
+      .errors({
+        NAME_ALREADY_TAKEN: {
+          code: 'CONFLICT',
+          data: z.object({
+            id: z.string(),
+          }),
+        },
+        USER_NOT_FOUND: {
+          code: 'NOT_FOUND',
+        },
+      })
+      .mutation(async ({ input, errors }) => {
+        // Check if the name is already taken and throw an error if it is
+        const userWithSameName = await db.user.findByName(input.name);
+        if (userWithSameName && userWithSameName.id !== input.id) {
+          throw new errors.NAME_ALREADY_TAKEN({
+            data: {
+              id: userWithSameName.id,
+            },
+          });
+        }
+
+        // Update the user in the database
+        try {
+          const user = await db.user.update(input);
+          return user;
+        } catch (error) {
+          throw new errors.USER_NOT_FOUND();
+        }
+      }),
+  },
+  examples: {
+    iterable: publicProcedure
+      .errors({
+        NUMBER_TOO_HIGH: {
+          code: 'INTERNAL_SERVER_ERROR',
+          data: z.object({
+            number: z.number(),
+          }),
+        },
+      })
+      .query(async function* ({ errors }) {
+        for (let i = 0; i < 3; i++) {
+          await new Promise((resolve) => setTimeout(resolve, 500));
+          const number = Math.random();
+          if (number > 0.8) {
+            throw new errors.NUMBER_TOO_HIGH({ data: { number } });
+          }
+          yield number;
+        }
+      }),
+  },
+});
+
+// Export type router type signature, this is used by the client.
+export type AppRouter = typeof appRouter;
+
+const server = createHTTPServer({
+  router: appRouter,
+});
+
+server.listen(3000);

--- a/examples/minimal-typesafe-errors/src/server/trpc.ts
+++ b/examples/minimal-typesafe-errors/src/server/trpc.ts
@@ -1,0 +1,17 @@
+import { initTRPC } from '@trpc/server';
+import { transformer } from '../shared/transformer.js';
+
+/**
+ * Initialization of tRPC backend
+ * Should be done only once per backend!
+ */
+const t = initTRPC.create({
+  transformer,
+});
+
+/**
+ * Export reusable router and procedure helpers
+ * that can be used throughout the router
+ */
+export const router = t.router;
+export const publicProcedure = t.procedure;

--- a/examples/minimal-typesafe-errors/src/shared/transformer.ts
+++ b/examples/minimal-typesafe-errors/src/shared/transformer.ts
@@ -1,0 +1,8 @@
+/**
+ * If you need to add transformers for special data types like `Temporal.Instant` or `Temporal.Date`, `Decimal.js`, etc you can do so here.
+ * Make sure to import this file rather than `superjson` directly.
+ * @see https://github.com/blitz-js/superjson#recipes
+ */
+import superjson from 'superjson';
+
+export const transformer = superjson;

--- a/examples/minimal-typesafe-errors/tsconfig.json
+++ b/examples/minimal-typesafe-errors/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "strict": true,
+    "outDir": "dist",
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/packages/next/src/app-dir/shared.ts
+++ b/packages/next/src/app-dir/shared.ts
@@ -1,5 +1,6 @@
 import type {
   CreateTRPCClientOptions,
+  inferProcedureClientErrors,
   Resolver,
   TRPCClient,
 } from '@trpc/client';
@@ -31,6 +32,7 @@ export type UseProcedureRecord<
           input: inferProcedureInput<$Value>;
           output: inferTransformedProcedureOutput<TRoot, $Value>;
           errorShape: TRoot['errorShape'];
+          error: inferProcedureClientErrors<TRoot, $Value>;
           transformer: TRoot['transformer'];
         }>
       : $Value extends RouterRecord

--- a/packages/next/src/app-dir/types.ts
+++ b/packages/next/src/app-dir/types.ts
@@ -1,4 +1,4 @@
-import type { Resolver } from '@trpc/client';
+import type { inferProcedureClientErrors, Resolver } from '@trpc/client';
 import type {
   AnyProcedure,
   AnyRootTypes,
@@ -13,6 +13,7 @@ type ResolverDef = {
   output: any;
   transformer: boolean;
   errorShape: any;
+  error: any;
 };
 
 export type DecorateProcedureServer<
@@ -49,6 +50,7 @@ export type NextAppDirDecorateRouterRecord<
             input: inferProcedureInput<$Value>;
             output: inferTransformedProcedureOutput<TRoot, $Value>;
             errorShape: TRoot['errorShape'];
+            error: inferProcedureClientErrors<TRoot, $Value>;
             transformer: TRoot['transformer'];
           }
         >

--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -10,7 +10,10 @@ import type {
   UseSuspenseInfiniteQueryResult,
   UseSuspenseQueryResult,
 } from '@tanstack/react-query';
-import type { createTRPCClient, TRPCClientErrorLike } from '@trpc/client';
+import type {
+  createTRPCClient,
+  inferProcedureClientErrorsLike,
+} from '@trpc/client';
 import type {
   AnyProcedure,
   AnyRootTypes,
@@ -58,6 +61,7 @@ type ResolverDef = {
   output: any;
   transformer: boolean;
   errorShape: any;
+  error: any;
 };
 /**
  * @internal
@@ -68,29 +72,20 @@ export interface ProcedureUseQuery<TDef extends ResolverDef> {
     opts: DefinedUseTRPCQueryOptions<
       TQueryFnData,
       TData,
-      TRPCClientErrorLike<{
-        errorShape: TDef['errorShape'];
-        transformer: TDef['transformer'];
-      }>,
+      TDef['error'],
       TDef['output']
     >,
-  ): DefinedUseTRPCQueryResult<
-    TData,
-    TRPCClientErrorLike<{
-      errorShape: TDef['errorShape'];
-      transformer: TDef['transformer'];
-    }>
-  >;
+  ): DefinedUseTRPCQueryResult<TData, TDef['error']>;
 
   <TQueryFnData extends TDef['output'] = TDef['output'], TData = TQueryFnData>(
     input: TDef['input'] | SkipToken,
     opts?: UseTRPCQueryOptions<
       TQueryFnData,
       TData,
-      TRPCClientErrorLike<TDef>,
+      TDef['error'],
       TDef['output']
     >,
-  ): UseTRPCQueryResult<TData, TRPCClientErrorLike<TDef>>;
+  ): UseTRPCQueryResult<TData, TDef['error']>;
 }
 
 /**
@@ -98,7 +93,7 @@ export interface ProcedureUseQuery<TDef extends ResolverDef> {
  */
 export type ProcedureUsePrefetchQuery<TDef extends ResolverDef> = (
   input: TDef['input'] | SkipToken,
-  opts?: TRPCFetchQueryOptions<TDef['output'], TRPCClientErrorLike<TDef>>,
+  opts?: TRPCFetchQueryOptions<TDef['output'], TDef['error']>,
 ) => void;
 
 /**
@@ -192,7 +187,7 @@ export interface useTRPCInfiniteQuery<TDef extends ResolverDef> {
         //     TQueryFnData,
         TDef['output'],
         //     TError,
-        TRPCClientErrorLike<TDef>,
+        TDef['error'],
         //     TData,
         TData,
         //     TQueryKey,
@@ -201,8 +196,7 @@ export interface useTRPCInfiniteQuery<TDef extends ResolverDef> {
         inferCursorType<TDef['input']>
       >
     >,
-  ): TRPCHookResult &
-    DefinedUseInfiniteQueryResult<TData, TRPCClientErrorLike<TDef>>;
+  ): TRPCHookResult & DefinedUseInfiniteQueryResult<TData, TDef['error']>;
 
   // 2nd
   <TData = trpcInfiniteData<TDef>>(
@@ -213,7 +207,7 @@ export interface useTRPCInfiniteQuery<TDef extends ResolverDef> {
         //     TQueryFnData,
         TDef['output'],
         //     TError,
-        TRPCClientErrorLike<TDef>,
+        TDef['error'],
         //     TData,
         TData,
         //     TQueryKey,
@@ -222,7 +216,7 @@ export interface useTRPCInfiniteQuery<TDef extends ResolverDef> {
         inferCursorType<TDef['input']>
       >
     >,
-  ): TRPCHookResult & UseInfiniteQueryResult<TData, TRPCClientErrorLike<TDef>>;
+  ): TRPCHookResult & UseInfiniteQueryResult<TData, TDef['error']>;
 
   // 3rd:
   <TData = trpcInfiniteData<TDef>>(
@@ -233,7 +227,7 @@ export interface useTRPCInfiniteQuery<TDef extends ResolverDef> {
         //     TQueryFnData,
         TDef['output'],
         //     TError,
-        TRPCClientErrorLike<TDef>,
+        TDef['error'],
         //     TData,
         TData,
         //     TQueryKey,
@@ -242,7 +236,7 @@ export interface useTRPCInfiniteQuery<TDef extends ResolverDef> {
         inferCursorType<TDef['input']>
       >
     >,
-  ): TRPCHookResult & UseInfiniteQueryResult<TData, TRPCClientErrorLike<TDef>>;
+  ): TRPCHookResult & UseInfiniteQueryResult<TData, TDef['error']>;
 }
 
 // references from react-query
@@ -272,7 +266,7 @@ export type useTRPCSuspenseInfiniteQuery<TDef extends ResolverDef> = (
       //     TQueryFnData,
       TDef['output'],
       //     TError,
-      TRPCClientErrorLike<TDef>,
+      TDef['error'],
       //     TData,
       trpcInfiniteData<TDef>,
       //     TQueryKey,
@@ -284,10 +278,7 @@ export type useTRPCSuspenseInfiniteQuery<TDef extends ResolverDef> = (
 ) => [
   trpcInfiniteData<TDef>,
   TRPCHookResult &
-    UseSuspenseInfiniteQueryResult<
-      trpcInfiniteData<TDef>,
-      TRPCClientErrorLike<TDef>
-    >,
+    UseSuspenseInfiniteQueryResult<trpcInfiniteData<TDef>, TDef['error']>,
 ];
 
 /**
@@ -310,7 +301,7 @@ export type MaybeDecoratedInfiniteQuery<TDef extends ResolverDef> =
           opts: TRPCFetchInfiniteQueryOptions<
             TDef['input'],
             TDef['output'],
-            TRPCClientErrorLike<TDef>
+            TDef['error']
           >,
         ) => void;
       }
@@ -333,15 +324,8 @@ export type DecoratedQueryMethods<TDef extends ResolverDef> = {
     TData = TQueryFnData,
   >(
     input: TDef['input'],
-    opts?: UseTRPCSuspenseQueryOptions<
-      TQueryFnData,
-      TData,
-      TRPCClientErrorLike<TDef>
-    >,
-  ) => [
-    TData,
-    UseSuspenseQueryResult<TData, TRPCClientErrorLike<TDef>> & TRPCHookResult,
-  ];
+    opts?: UseTRPCSuspenseQueryOptions<TQueryFnData, TData, TDef['error']>,
+  ) => [TData, UseSuspenseQueryResult<TData, TDef['error']> & TRPCHookResult];
 };
 
 /**
@@ -357,13 +341,13 @@ export type DecoratedMutation<TDef extends ResolverDef> = {
   useMutation: <TContext = unknown>(
     opts?: UseTRPCMutationOptions<
       TDef['input'],
-      TRPCClientErrorLike<TDef>,
+      TDef['error'],
       TDef['output'],
       TContext
     >,
   ) => UseTRPCMutationResult<
     TDef['output'],
-    TRPCClientErrorLike<TDef>,
+    TDef['error'],
     TDef['input'],
     TContext
   >;
@@ -375,11 +359,11 @@ interface ProcedureUseSubscription<TDef extends ResolverDef> {
     input: TDef['input'],
     opts?: UseTRPCSubscriptionOptions<
       inferAsyncIterableYield<TDef['output']>,
-      TRPCClientErrorLike<TDef>
+      TDef['error']
     >,
   ): TRPCSubscriptionResult<
     inferAsyncIterableYield<TDef['output']>,
-    TRPCClientErrorLike<TDef>
+    TDef['error']
   >;
 
   // With skip token
@@ -388,13 +372,13 @@ interface ProcedureUseSubscription<TDef extends ResolverDef> {
     opts?: Omit<
       UseTRPCSubscriptionOptions<
         inferAsyncIterableYield<TDef['output']>,
-        TRPCClientErrorLike<TDef>
+        TDef['error']
       >,
       'enabled'
     >,
   ): TRPCSubscriptionResult<
     inferAsyncIterableYield<TDef['output']>,
-    TRPCClientErrorLike<TDef>
+    TDef['error']
   >;
 }
 /**
@@ -432,6 +416,13 @@ export type DecorateRouterRecord<
             output: inferTransformedProcedureOutput<TRoot, $Value>;
             transformer: TRoot['transformer'];
             errorShape: TRoot['errorShape'];
+            error: inferProcedureClientErrorsLike<
+              {
+                errorShape: TRoot['errorShape'];
+                transformer: TRoot['transformer'];
+              },
+              $Value
+            >;
           }
         >
       : $Value extends RouterRecord

--- a/packages/react-query/src/rsc.tsx
+++ b/packages/react-query/src/rsc.tsx
@@ -5,7 +5,7 @@ import {
   HydrationBoundary,
   type QueryClient,
 } from '@tanstack/react-query';
-import type { TRPCClientError } from '@trpc/client';
+import type { inferProcedureClientErrors } from '@trpc/client';
 import type { inferTransformedProcedureOutput } from '@trpc/server';
 import {
   createRecursiveProxy,
@@ -42,7 +42,7 @@ type DecorateProcedure<
     input: inferProcedureInput<TProcedure>,
     opts?: TRPCFetchQueryOptions<
       inferTransformedProcedureOutput<TRoot, TProcedure>,
-      TRPCClientError<TRoot>
+      inferProcedureClientErrors<TRoot, TProcedure>
     >,
   ) => Promise<void>;
   prefetchInfinite: (
@@ -50,7 +50,7 @@ type DecorateProcedure<
     opts?: TRPCFetchInfiniteQueryOptions<
       inferProcedureInput<TProcedure>,
       inferTransformedProcedureOutput<TRoot, TProcedure>,
-      TRPCClientError<TRoot>
+      inferProcedureClientErrors<TRoot, TProcedure>
     >,
   ) => Promise<void>;
 };

--- a/packages/react-query/src/shared/polymorphism/queryLike.ts
+++ b/packages/react-query/src/shared/polymorphism/queryLike.ts
@@ -1,4 +1,4 @@
-import type { TRPCClientErrorLike } from '@trpc/client';
+import type { inferProcedureClientErrorsLike } from '@trpc/client';
 import type {
   AnyProcedure,
   AnyRootTypes,
@@ -30,7 +30,7 @@ export type QueryLike<
     opts?: InferQueryOptions<TRoot, TProcedure, any>,
   ) => UseTRPCSuspenseQueryResult<
     inferProcedureOutput<TProcedure>,
-    TRPCClientErrorLike<TRoot>
+    inferProcedureClientErrorsLike<TRoot, TProcedure>
   >;
 };
 

--- a/packages/react-query/src/shared/proxy/useQueriesProxy.ts
+++ b/packages/react-query/src/shared/proxy/useQueriesProxy.ts
@@ -1,10 +1,6 @@
 import type { QueryOptions } from '@tanstack/react-query';
-import type { TRPCClient } from '@trpc/client';
-import {
-  getUntypedClient,
-  TRPCUntypedClient,
-  type TRPCClientError,
-} from '@trpc/client';
+import type { inferProcedureClientErrors, TRPCClient } from '@trpc/client';
+import { getUntypedClient, TRPCUntypedClient } from '@trpc/client';
 import type {
   AnyProcedure,
   AnyQueryProcedure,
@@ -30,12 +26,12 @@ type GetQueryOptions<
   opts?: TrpcQueryOptionsForUseQueries<
     inferTransformedProcedureOutput<TRoot, TProcedure>,
     TData,
-    TRPCClientError<TRoot>
+    inferProcedureClientErrors<TRoot, TProcedure>
   >,
 ) => TrpcQueryOptionsForUseQueries<
   inferTransformedProcedureOutput<TRoot, TProcedure>,
   TData,
-  TRPCClientError<TRoot>
+  inferProcedureClientErrors<TRoot, TProcedure>
 >;
 
 /**
@@ -62,12 +58,12 @@ type GetSuspenseQueryOptions<
   opts?: TrpcQueryOptionsForUseSuspenseQueries<
     inferTransformedProcedureOutput<TRoot, TProcedure>,
     TData,
-    TRPCClientError<TRoot>
+    inferProcedureClientErrors<TRoot, TProcedure>
   >,
 ) => TrpcQueryOptionsForUseSuspenseQueries<
   inferTransformedProcedureOutput<TRoot, TProcedure>,
   TData,
-  TRPCClientError<TRoot>
+  inferProcedureClientErrors<TRoot, TProcedure>
 >;
 
 /**

--- a/packages/react-query/src/shared/proxy/utilsProxy.ts
+++ b/packages/react-query/src/shared/proxy/utilsProxy.ts
@@ -13,7 +13,7 @@ import type {
   SkipToken,
   Updater,
 } from '@tanstack/react-query';
-import type { TRPCClientError } from '@trpc/client';
+import type { attachError, inferProcedureClientErrors } from '@trpc/client';
 import { createTRPCClientProxy } from '@trpc/client';
 import type {
   AnyMutationProcedure,
@@ -76,9 +76,13 @@ export type DecorateQueryProcedure<
     opts: DefinedTRPCQueryOptionsIn<
       TQueryFnData,
       TData,
-      TRPCClientError<TRoot>
+      inferProcedureClientErrors<TRoot, TProcedure>
     >,
-  ): DefinedTRPCQueryOptionsOut<TQueryFnData, TData, TRPCClientError<TRoot>>;
+  ): DefinedTRPCQueryOptionsOut<
+    TQueryFnData,
+    TData,
+    inferProcedureClientErrors<TRoot, TProcedure>
+  >;
   /**
    * @see https://tanstack.com/query/latest/docs/framework/react/reference/queryOptions#queryoptions
    */
@@ -90,12 +94,12 @@ export type DecorateQueryProcedure<
     opts?: UnusedSkipTokenTRPCQueryOptionsIn<
       TQueryFnData,
       TData,
-      TRPCClientError<TRoot>
+      inferProcedureClientErrors<TRoot, TProcedure>
     >,
   ): UnusedSkipTokenTRPCQueryOptionsOut<
     TQueryFnData,
     TData,
-    TRPCClientError<TRoot>
+    inferProcedureClientErrors<TRoot, TProcedure>
   >;
   /**
    * @see https://tanstack.com/query/latest/docs/framework/react/reference/queryOptions#queryoptions
@@ -108,9 +112,13 @@ export type DecorateQueryProcedure<
     opts?: UndefinedTRPCQueryOptionsIn<
       TQueryFnData,
       TData,
-      TRPCClientError<TRoot>
+      inferProcedureClientErrors<TRoot, TProcedure>
     >,
-  ): UndefinedTRPCQueryOptionsOut<TQueryFnData, TData, TRPCClientError<TRoot>>;
+  ): UndefinedTRPCQueryOptionsOut<
+    TQueryFnData,
+    TData,
+    inferProcedureClientErrors<TRoot, TProcedure>
+  >;
 
   /**
    * @see https://tanstack.com/query/latest/docs/framework/react/reference/infiniteQueryOptions#infinitequeryoptions
@@ -124,13 +132,13 @@ export type DecorateQueryProcedure<
       inferProcedureInput<TProcedure>,
       TQueryFnData,
       TData,
-      TRPCClientError<TRoot>
+      inferProcedureClientErrors<TRoot, TProcedure>
     >,
   ): DefinedTRPCInfiniteQueryOptionsOut<
     inferProcedureInput<TProcedure>,
     TQueryFnData,
     TData,
-    TRPCClientError<TRoot>
+    inferProcedureClientErrors<TRoot, TProcedure>
   >;
   /**
    * @see https://tanstack.com/query/latest/docs/framework/react/reference/infiniteQueryOptions#infinitequeryoptions
@@ -144,13 +152,13 @@ export type DecorateQueryProcedure<
       inferProcedureInput<TProcedure>,
       TQueryFnData,
       TData,
-      TRPCClientError<TRoot>
+      inferProcedureClientErrors<TRoot, TProcedure>
     >,
   ): UnusedSkipTokenTRPCInfiniteQueryOptionsOut<
     inferProcedureInput<TProcedure>,
     TQueryFnData,
     TData,
-    TRPCClientError<TRoot>
+    inferProcedureClientErrors<TRoot, TProcedure>
   >;
   /**
    * @see https://tanstack.com/query/latest/docs/framework/react/reference/infiniteQueryOptions#infinitequeryoptions
@@ -164,13 +172,13 @@ export type DecorateQueryProcedure<
       inferProcedureInput<TProcedure>,
       TQueryFnData,
       TData,
-      TRPCClientError<TRoot>
+      inferProcedureClientErrors<TRoot, TProcedure>
     >,
   ): UndefinedTRPCInfiniteQueryOptionsOut<
     inferProcedureInput<TProcedure>,
     TQueryFnData,
     TData,
-    TRPCClientError<TRoot>
+    inferProcedureClientErrors<TRoot, TProcedure>
   >;
 
   /**
@@ -180,9 +188,12 @@ export type DecorateQueryProcedure<
     input: inferProcedureInput<TProcedure>,
     opts?: TRPCFetchQueryOptions<
       inferTransformedProcedureOutput<TRoot, TProcedure>,
-      TRPCClientError<TRoot>
+      inferProcedureClientErrors<TRoot, TProcedure>
     >,
-  ): Promise<inferTransformedProcedureOutput<TRoot, TProcedure>>;
+  ): attachError<
+    Promise<inferTransformedProcedureOutput<TRoot, TProcedure>>,
+    inferProcedureClientErrors<TRoot, TProcedure>
+  >;
 
   /**
    * @see https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientfetchinfinitequery
@@ -192,13 +203,16 @@ export type DecorateQueryProcedure<
     opts?: TRPCFetchInfiniteQueryOptions<
       inferProcedureInput<TProcedure>,
       inferTransformedProcedureOutput<TRoot, TProcedure>,
-      TRPCClientError<TRoot>
+      inferProcedureClientErrors<TRoot, TProcedure>
     >,
-  ): Promise<
-    InfiniteData<
-      inferTransformedProcedureOutput<TRoot, TProcedure>,
-      NonNullable<ExtractCursorType<inferProcedureInput<TProcedure>>> | null
-    >
+  ): attachError<
+    Promise<
+      InfiniteData<
+        inferTransformedProcedureOutput<TRoot, TProcedure>,
+        NonNullable<ExtractCursorType<inferProcedureInput<TProcedure>>> | null
+      >
+    >,
+    inferProcedureClientErrors<TRoot, TProcedure>
   >;
 
   /**
@@ -208,7 +222,7 @@ export type DecorateQueryProcedure<
     input: inferProcedureInput<TProcedure>,
     opts?: TRPCFetchQueryOptions<
       inferTransformedProcedureOutput<TRoot, TProcedure>,
-      TRPCClientError<TRoot>
+      inferProcedureClientErrors<TRoot, TProcedure>
     >,
   ): Promise<void>;
 
@@ -220,7 +234,7 @@ export type DecorateQueryProcedure<
     opts?: TRPCFetchInfiniteQueryOptions<
       inferProcedureInput<TProcedure>,
       inferTransformedProcedureOutput<TRoot, TProcedure>,
-      TRPCClientError<TRoot>
+      inferProcedureClientErrors<TRoot, TProcedure>
     >,
   ): Promise<void>;
 
@@ -231,9 +245,12 @@ export type DecorateQueryProcedure<
     input: inferProcedureInput<TProcedure>,
     opts?: TRPCFetchQueryOptions<
       inferTransformedProcedureOutput<TRoot, TProcedure>,
-      TRPCClientError<TRoot>
+      inferProcedureClientErrors<TRoot, TProcedure>
     >,
-  ): Promise<inferTransformedProcedureOutput<TRoot, TProcedure>>;
+  ): attachError<
+    Promise<inferTransformedProcedureOutput<TRoot, TProcedure>>,
+    inferProcedureClientErrors<TRoot, TProcedure>
+  >;
 
   /**
    * @see https://tanstack.com/query/v5/docs/reference/QueryClient#queryclientinvalidatequeries
@@ -244,7 +261,7 @@ export type DecorateQueryProcedure<
       predicate?: (
         query: Query<
           inferProcedureOutput<TProcedure>,
-          TRPCClientError<TRoot>,
+          inferProcedureClientErrors<TRoot, TProcedure>,
           inferTransformedProcedureOutput<TRoot, TProcedure>,
           QueryKeyKnown<
             inferProcedureInput<TProcedure>,

--- a/packages/react-query/src/utils/inferReactQueryProcedure.ts
+++ b/packages/react-query/src/utils/inferReactQueryProcedure.ts
@@ -1,4 +1,4 @@
-import type { TRPCClientErrorLike } from '@trpc/client';
+import type { inferProcedureClientErrorsLike } from '@trpc/client';
 import type {
   AnyMutationProcedure,
   AnyProcedure,
@@ -27,7 +27,7 @@ export type InferQueryOptions<
   UseTRPCQueryOptions<
     inferTransformedProcedureOutput<TRoot, TProcedure>,
     inferTransformedProcedureOutput<TRoot, TProcedure>,
-    TRPCClientErrorLike<TRoot>,
+    inferProcedureClientErrorsLike<TRoot, TProcedure>,
     TData
   >,
   'select' | 'queryFn'
@@ -42,7 +42,7 @@ export type InferMutationOptions<
   TMeta = unknown,
 > = UseTRPCMutationOptions<
   inferProcedureInput<TProcedure>,
-  TRPCClientErrorLike<TRoot>,
+  inferProcedureClientErrorsLike<TRoot, TProcedure>,
   inferTransformedProcedureOutput<TRoot, TProcedure>,
   TMeta
 >;
@@ -55,7 +55,7 @@ export type InferQueryResult<
   TProcedure extends AnyProcedure,
 > = UseTRPCQueryResult<
   inferTransformedProcedureOutput<TRoot, TProcedure>,
-  TRPCClientErrorLike<TRoot>
+  inferProcedureClientErrorsLike<TRoot, TProcedure>
 >;
 
 /**
@@ -67,7 +67,7 @@ export type InferMutationResult<
   TContext = unknown,
 > = UseTRPCMutationResult<
   inferTransformedProcedureOutput<TRoot, TProcedure>,
-  TRPCClientErrorLike<TRoot>,
+  inferProcedureClientErrorsLike<TRoot, TProcedure>,
   inferProcedureInput<TProcedure>,
   TContext
 >;

--- a/packages/server/src/unstable-core-do-not-import/error/TRPCError.ts
+++ b/packages/server/src/unstable-core-do-not-import/error/TRPCError.ts
@@ -73,3 +73,36 @@ export class TRPCError extends Error {
     this.cause ??= cause;
   }
 }
+
+/** @internal */
+export type CustomTRPCErrorParams<TData> = {
+  message?: string;
+  cause?: unknown;
+  data: TData;
+};
+
+/** @internal */
+export class CustomTRPCError<
+  TTRPCErrorCode extends TRPC_ERROR_CODE_KEY,
+  TCustomCode extends string,
+  TData,
+> extends TRPCError {
+  public readonly customCode: TCustomCode;
+  public readonly customData: TData;
+
+  constructor(
+    opts: CustomTRPCErrorParams<TData> & {
+      code: TTRPCErrorCode;
+      customCode: TCustomCode;
+    },
+  ) {
+    super({
+      message: opts.message ?? opts.customCode,
+      code: opts.code,
+      cause: opts.cause,
+    });
+
+    this.customCode = opts.customCode;
+    this.customData = opts.data;
+  }
+}

--- a/packages/server/src/unstable-core-do-not-import/error/customErrors.ts
+++ b/packages/server/src/unstable-core-do-not-import/error/customErrors.ts
@@ -1,0 +1,118 @@
+import type { AnyMiddlewareFunction } from '../middleware';
+import { getParseFn, type inferParser, type Parser } from '../parser';
+import type { TRPC_ERROR_CODE_KEY } from '../rpc';
+import {
+  CustomTRPCError,
+  TRPCError,
+  type CustomTRPCErrorParams,
+} from './TRPCError';
+
+export type ErrorDefMap = Record<
+  string,
+  {
+    code: TRPC_ERROR_CODE_KEY;
+    data?: Parser;
+  }
+>;
+
+type CustomErrorClass<
+  TTRPCErrorCode extends TRPC_ERROR_CODE_KEY,
+  TCustomCode extends string,
+  TParser extends Parser | undefined,
+> = TParser extends Parser
+  ? new (
+      opts: CustomTRPCErrorParams<inferParser<TParser>['out']>,
+    ) => CustomTRPCError<
+      TTRPCErrorCode,
+      TCustomCode,
+      inferParser<TParser>['out']
+    >
+  : new (
+      opts?: Omit<CustomTRPCErrorParams<undefined>, 'data'>,
+    ) => CustomTRPCError<TTRPCErrorCode, TCustomCode, undefined>;
+
+/** @internal */
+export type inferErrorClasses<TErrorDefs extends ErrorDefMap> = {
+  [TKey in keyof TErrorDefs]: TKey extends string
+    ? CustomErrorClass<TErrorDefs[TKey]['code'], TKey, TErrorDefs[TKey]['data']>
+    : never;
+};
+
+/** @internal */
+export type AnyCustomErrorClassMap = inferErrorClasses<ErrorDefMap>;
+
+/** @internal */
+export function createErrorClasses<TErrorDefs extends ErrorDefMap>(
+  errorsDefs: TErrorDefs,
+): inferErrorClasses<TErrorDefs> {
+  let errorClasses: AnyCustomErrorClassMap = {};
+
+  for (const [key, errorDef] of Object.entries(errorsDefs)) {
+    // Using object literal to infer the class name from the key
+    errorClasses = {
+      ...errorClasses,
+      [key]: class extends CustomTRPCError<any, any, any> {
+        constructor(opts?: CustomTRPCErrorParams<any>) {
+          super({
+            ...opts,
+            code: errorDef.code,
+            customCode: key,
+            // Do not allow passing data if there's no parser in the error def
+            data: errorDef.data ? opts?.data : undefined,
+          });
+        }
+      },
+    };
+  }
+
+  return errorClasses as inferErrorClasses<TErrorDefs>;
+}
+
+/** @internal */
+export function createErrorMiddleware({
+  errors,
+  errorDefs,
+}: {
+  errors: AnyCustomErrorClassMap;
+  errorDefs: ErrorDefMap;
+}) {
+  const errorMiddleware: AnyMiddlewareFunction =
+    async function errorValidatorMiddleware(opts) {
+      const { next } = opts;
+      const result = await next();
+
+      if (result.ok || !(result.error instanceof CustomTRPCError)) {
+        return result;
+      }
+
+      const errorDef = errorDefs[result.error.customCode];
+      const errorClass = errors[result.error.customCode];
+
+      if (!errorDef?.data || !errorClass) {
+        return result;
+      }
+
+      const parser = getParseFn(errorDef.data);
+
+      let parsedData;
+      try {
+        parsedData = await parser(result.error.customData);
+      } catch (cause) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Error data validation failed',
+          cause,
+        });
+      }
+
+      // Rethrow the error with the parsed data
+      throw new errorClass({
+        message: result.error.message,
+        data: parsedData,
+        cause: result.error.cause,
+      });
+    };
+
+  errorMiddleware._type = 'error';
+  return errorMiddleware;
+}

--- a/packages/server/src/unstable-core-do-not-import/error/formatter.ts
+++ b/packages/server/src/unstable-core-do-not-import/error/formatter.ts
@@ -32,6 +32,16 @@ export type DefaultErrorData = {
    * Stack trace of the error (only in development)
    */
   stack?: string;
+  /**
+   * Code from user-defined errors specified in the `.errors` method of the
+   * procedure builder.
+   */
+  customCode?: undefined;
+  /**
+   * Data sent when throwing user-defined errors specified in the `.errors`
+   * method of the procedure builder.
+   */
+  customData?: undefined;
 };
 
 /**

--- a/packages/server/src/unstable-core-do-not-import/error/getErrorShape.ts
+++ b/packages/server/src/unstable-core-do-not-import/error/getErrorShape.ts
@@ -3,7 +3,7 @@ import type { ProcedureType } from '../procedure';
 import type { AnyRootTypes, RootConfig } from '../rootConfig';
 import { TRPC_ERROR_CODES_BY_KEY } from '../rpc';
 import type { DefaultErrorShape } from './formatter';
-import type { TRPCError } from './TRPCError';
+import { CustomTRPCError, type TRPCError } from './TRPCError';
 
 /**
  * @internal
@@ -31,6 +31,12 @@ export function getErrorShape<TRoot extends AnyRootTypes>(opts: {
   }
   if (typeof path === 'string') {
     shape.data.path = path;
+  }
+  if (error instanceof CustomTRPCError) {
+    shape.data.customCode = error.customCode;
+    if (error.customData) {
+      shape.data.customData = error.customData;
+    }
   }
   return config.errorFormatter({ ...opts, shape });
 }

--- a/packages/server/src/unstable-core-do-not-import/initTRPC.ts
+++ b/packages/server/src/unstable-core-do-not-import/initTRPC.ts
@@ -82,6 +82,7 @@ export interface TRPCRootObject<
     UnsetMarker,
     UnsetMarker,
     UnsetMarker,
+    UnsetMarker,
     false
   >;
 
@@ -90,8 +91,15 @@ export interface TRPCRootObject<
    * @see https://trpc.io/docs/v11/server/middlewares
    */
   middleware: <$ContextOverrides>(
-    fn: MiddlewareFunction<TContext, TMeta, object, $ContextOverrides, unknown>,
-  ) => MiddlewareBuilder<TContext, TMeta, $ContextOverrides, unknown>;
+    fn: MiddlewareFunction<
+      TContext,
+      TMeta,
+      object,
+      $ContextOverrides,
+      unknown,
+      unknown
+    >,
+  ) => MiddlewareBuilder<TContext, TMeta, $ContextOverrides, unknown, unknown>;
 
   /**
    * Create a router

--- a/packages/server/src/unstable-core-do-not-import/middleware.ts
+++ b/packages/server/src/unstable-core-do-not-import/middleware.ts
@@ -45,6 +45,7 @@ export interface MiddlewareBuilder<
   TMeta,
   TContextOverrides,
   TInputOut,
+  TErrors,
 > {
   /**
    * Create a new builder based on the current middleware builder
@@ -56,19 +57,22 @@ export interface MiddlewareBuilder<
           TMeta,
           TContextOverrides,
           $ContextOverridesOut,
-          TInputOut
+          TInputOut,
+          TErrors
         >
       | MiddlewareBuilder<
           Overwrite<TContext, TContextOverrides>,
           TMeta,
           $ContextOverridesOut,
-          TInputOut
+          TInputOut,
+          TErrors
         >,
   ): MiddlewareBuilder<
     TContext,
     TMeta,
     Overwrite<TContextOverrides, $ContextOverridesOut>,
-    TInputOut
+    TInputOut,
+    TErrors
   >;
 
   /**
@@ -79,7 +83,8 @@ export interface MiddlewareBuilder<
     TMeta,
     TContextOverrides,
     object,
-    TInputOut
+    TInputOut,
+    TErrors
   >[];
 }
 
@@ -92,6 +97,7 @@ export type MiddlewareFunction<
   TContextOverridesIn,
   $ContextOverridesOut,
   TInputOut,
+  TErrors,
 > = {
   (opts: {
     ctx: Simplify<Overwrite<TContext, TContextOverridesIn>>;
@@ -99,6 +105,7 @@ export type MiddlewareFunction<
     path: string;
     input: TInputOut;
     getRawInput: GetRawInputFn;
+    errors: TErrors;
     meta: TMeta | undefined;
     signal: AbortSignal | undefined;
     next: {
@@ -115,8 +122,15 @@ export type MiddlewareFunction<
   _type?: string | undefined;
 };
 
-export type AnyMiddlewareFunction = MiddlewareFunction<any, any, any, any, any>;
-export type AnyMiddlewareBuilder = MiddlewareBuilder<any, any, any, any>;
+export type AnyMiddlewareFunction = MiddlewareFunction<
+  any,
+  any,
+  any,
+  any,
+  any,
+  any
+>;
+export type AnyMiddlewareBuilder = MiddlewareBuilder<any, any, any, any, any>;
 /**
  * @internal
  */
@@ -124,6 +138,7 @@ export function createMiddlewareFactory<
   TContext,
   TMeta,
   TInputOut = unknown,
+  TErrors = unknown,
 >() {
   function createMiddlewareInner(
     middlewares: AnyMiddlewareFunction[],
@@ -147,9 +162,10 @@ export function createMiddlewareFactory<
       TMeta,
       object,
       $ContextOverrides,
-      TInputOut
+      TInputOut,
+      TErrors
     >,
-  ): MiddlewareBuilder<TContext, TMeta, $ContextOverrides, TInputOut> {
+  ): MiddlewareBuilder<TContext, TMeta, $ContextOverrides, TInputOut, TErrors> {
     return createMiddlewareInner([fn]);
   }
 

--- a/packages/server/src/unstable-core-do-not-import/procedure.ts
+++ b/packages/server/src/unstable-core-do-not-import/procedure.ts
@@ -12,6 +12,7 @@ interface BuiltProcedureDef {
   meta: unknown;
   input: unknown;
   output: unknown;
+  errors: unknown;
 }
 
 /**
@@ -30,6 +31,7 @@ export interface Procedure<
     $types: {
       input: TDef['input'];
       output: TDef['output'];
+      errors: TDef['errors'];
     };
     procedure: true;
     type: TType;
@@ -90,6 +92,9 @@ export type inferProcedureParams<TProcedure> = TProcedure extends AnyProcedure
   : never;
 export type inferProcedureOutput<TProcedure> =
   inferProcedureParams<TProcedure>['$types']['output'];
+
+export type inferProcedureErrors<TProcedure> =
+  inferProcedureParams<TProcedure>['$types']['errors'];
 
 /**
  * @internal

--- a/packages/tanstack-react-query/src/internals/createOptionsProxy.ts
+++ b/packages/tanstack-react-query/src/internals/createOptionsProxy.ts
@@ -1,7 +1,7 @@
 import type { DataTag, QueryClient, QueryFilters } from '@tanstack/react-query';
 import type {
+  inferProcedureClientErrorsLike,
   TRPCClient,
-  TRPCClientErrorLike,
   TRPCRequestOptions,
 } from '@trpc/client';
 import { getUntypedClient, TRPCUntypedClient } from '@trpc/client';
@@ -106,13 +106,12 @@ export interface DecorateInfiniteQueryProcedure<TDef extends ResolverDef>
    * @see https://tanstack.com/query/latest/docs/framework/react/guides/query-keys
    * @see https://trpc.io/docs/client/tanstack-react-query/usage#queryKey
    */
-  infiniteQueryKey: (input?: Partial<TDef['input']>) => DataTag<
+  infiniteQueryKey: (
+    input?: Partial<TDef['input']>,
+  ) => DataTag<
     TRPCQueryKey,
     TRPCInfiniteData<TDef['input'], TDef['output']>,
-    TRPCClientErrorLike<{
-      transformer: TDef['transformer'];
-      errorShape: TDef['errorShape'];
-    }>
+    TDef['error']
   >;
 
   /**
@@ -127,10 +126,7 @@ export interface DecorateInfiniteQueryProcedure<TDef extends ResolverDef>
       DataTag<
         TRPCQueryKey,
         TRPCInfiniteData<TDef['input'], TDef['output']>,
-        TRPCClientErrorLike<{
-          transformer: TDef['transformer'];
-          errorShape: TDef['errorShape'];
-        }>
+        TDef['error']
       >
     >,
   ) => WithRequired<
@@ -138,10 +134,7 @@ export interface DecorateInfiniteQueryProcedure<TDef extends ResolverDef>
       DataTag<
         TRPCQueryKey,
         TRPCInfiniteData<TDef['input'], TDef['output']>,
-        TRPCClientErrorLike<{
-          transformer: TDef['transformer'];
-          errorShape: TDef['errorShape'];
-        }>
+        TDef['error']
       >
     >,
     'queryKey'
@@ -164,14 +157,9 @@ export interface DecorateQueryProcedure<TDef extends ResolverDef>
    * @see https://tanstack.com/query/latest/docs/framework/react/guides/query-keys
    * @see https://trpc.io/docs/client/tanstack-react-query/usage#queryKey
    */
-  queryKey: (input?: Partial<TDef['input']>) => DataTag<
-    TRPCQueryKey,
-    TDef['output'],
-    TRPCClientErrorLike<{
-      transformer: TDef['transformer'];
-      errorShape: TDef['errorShape'];
-    }>
-  >;
+  queryKey: (
+    input?: Partial<TDef['input']>,
+  ) => DataTag<TRPCQueryKey, TDef['output'], TDef['error']>;
 
   /**
    * Calculate a TanStack Query Filter for a Query Procedure
@@ -182,26 +170,10 @@ export interface DecorateQueryProcedure<TDef extends ResolverDef>
   queryFilter: (
     input?: Partial<TDef['input']>,
     filters?: QueryFilters<
-      DataTag<
-        TRPCQueryKey,
-        TDef['output'],
-        TRPCClientErrorLike<{
-          transformer: TDef['transformer'];
-          errorShape: TDef['errorShape'];
-        }>
-      >
+      DataTag<TRPCQueryKey, TDef['output'], TDef['error']>
     >,
   ) => WithRequired<
-    QueryFilters<
-      DataTag<
-        TRPCQueryKey,
-        TDef['output'],
-        TRPCClientErrorLike<{
-          transformer: TDef['transformer'];
-          errorShape: TDef['errorShape'];
-        }>
-      >
-    >,
+    QueryFilters<DataTag<TRPCQueryKey, TDef['output'], TDef['error']>>,
     'queryKey'
   >;
 }
@@ -264,6 +236,13 @@ export type DecoratedRouterRecord<
               output: inferTransformedProcedureOutput<TRoot, $Value>;
               transformer: TRoot['transformer'];
               errorShape: TRoot['errorShape'];
+              error: inferProcedureClientErrorsLike<
+                {
+                  transformer: TRoot['transformer'];
+                  errorShape: TRoot['errorShape'];
+                },
+                $Value
+              >;
             }
           >
         : never

--- a/packages/tanstack-react-query/src/internals/infiniteQueryOptions.ts
+++ b/packages/tanstack-react-query/src/internals/infiniteQueryOptions.ts
@@ -8,7 +8,7 @@ import type {
   UnusedSkipTokenInfiniteOptions,
 } from '@tanstack/react-query';
 import { infiniteQueryOptions, skipToken } from '@tanstack/react-query';
-import type { TRPCClientErrorLike, TRPCUntypedClient } from '@trpc/client';
+import type { TRPCUntypedClient } from '@trpc/client';
 import type { DistributiveOmit } from '@trpc/server/unstable-core-do-not-import';
 import type {
   ExtractCursorType,
@@ -147,19 +147,13 @@ export interface TRPCInfiniteQueryOptions<TDef extends ResolverDef> {
       TDef['input'],
       TQueryFnData,
       TData,
-      TRPCClientErrorLike<{
-        transformer: TDef['transformer'];
-        errorShape: TDef['errorShape'];
-      }>
+      TDef['error']
     >,
   ): DefinedTRPCInfiniteQueryOptionsOut<
     TDef['input'],
     TQueryFnData,
     TData,
-    TRPCClientErrorLike<{
-      transformer: TDef['transformer'];
-      errorShape: TDef['errorShape'];
-    }>
+    TDef['error']
   >;
   <TQueryFnData extends TDef['output'], TData = TQueryFnData>(
     input: TDef['input'],
@@ -167,19 +161,13 @@ export interface TRPCInfiniteQueryOptions<TDef extends ResolverDef> {
       TDef['input'],
       TQueryFnData,
       TData,
-      TRPCClientErrorLike<{
-        transformer: TDef['transformer'];
-        errorShape: TDef['errorShape'];
-      }>
+      TDef['error']
     >,
   ): UnusedSkipTokenTRPCInfiniteQueryOptionsOut<
     TDef['input'],
     TQueryFnData,
     TData,
-    TRPCClientErrorLike<{
-      transformer: TDef['transformer'];
-      errorShape: TDef['errorShape'];
-    }>
+    TDef['error']
   >;
   <TQueryFnData extends TDef['output'], TData = TQueryFnData>(
     input: TDef['input'] | SkipToken,
@@ -187,19 +175,13 @@ export interface TRPCInfiniteQueryOptions<TDef extends ResolverDef> {
       TDef['input'],
       TQueryFnData,
       TData,
-      TRPCClientErrorLike<{
-        transformer: TDef['transformer'];
-        errorShape: TDef['errorShape'];
-      }>
+      TDef['error']
     >,
   ): UndefinedTRPCInfiniteQueryOptionsOut<
     TDef['input'],
     TQueryFnData,
     TData,
-    TRPCClientErrorLike<{
-      transformer: TDef['transformer'];
-      errorShape: TDef['errorShape'];
-    }>
+    TDef['error']
   >;
 }
 

--- a/packages/tanstack-react-query/src/internals/mutationOptions.ts
+++ b/packages/tanstack-react-query/src/internals/mutationOptions.ts
@@ -3,7 +3,7 @@ import type {
   QueryClient,
   UseMutationOptions,
 } from '@tanstack/react-query';
-import type { TRPCClientErrorLike, TRPCUntypedClient } from '@trpc/client';
+import type { TRPCUntypedClient } from '@trpc/client';
 import type {
   DistributiveOmit,
   MaybePromise,
@@ -40,13 +40,13 @@ export interface TRPCMutationOptions<TDef extends ResolverDef> {
   <TContext = unknown>(
     opts?: TRPCMutationOptionsIn<
       TDef['input'],
-      TRPCClientErrorLike<TDef>,
+      TDef['error'],
       TDef['output'],
       TContext
     >,
   ): TRPCMutationOptionsOut<
     TDef['input'],
-    TRPCClientErrorLike<TDef>,
+    TDef['error'],
     TDef['output'],
     TContext
   >;

--- a/packages/tanstack-react-query/src/internals/queryOptions.ts
+++ b/packages/tanstack-react-query/src/internals/queryOptions.ts
@@ -8,7 +8,7 @@ import type {
   UnusedSkipTokenOptions,
 } from '@tanstack/react-query';
 import { queryOptions, skipToken } from '@tanstack/react-query';
-import type { TRPCClientErrorLike, TRPCUntypedClient } from '@trpc/client';
+import type { TRPCUntypedClient } from '@trpc/client';
 import type {
   coerceAsyncIterableToArray,
   DistributiveOmit,
@@ -101,58 +101,20 @@ interface UnusedSkipTokenTRPCQueryOptionsOut<TQueryFnData, TOutput, TError>
 export interface TRPCQueryOptions<TDef extends ResolverDef> {
   <TQueryFnData extends TDef['output'], TData = TQueryFnData>(
     input: TDef['input'] | SkipToken,
-    opts: DefinedTRPCQueryOptionsIn<
-      TQueryFnData,
-      TData,
-      TRPCClientErrorLike<{
-        transformer: TDef['transformer'];
-        errorShape: TDef['errorShape'];
-      }>
-    >,
-  ): DefinedTRPCQueryOptionsOut<
-    TQueryFnData,
-    TData,
-    TRPCClientErrorLike<{
-      transformer: TDef['transformer'];
-      errorShape: TDef['errorShape'];
-    }>
-  >;
+    opts: DefinedTRPCQueryOptionsIn<TQueryFnData, TData, TDef['error']>,
+  ): DefinedTRPCQueryOptionsOut<TQueryFnData, TData, TDef['error']>;
   <TQueryFnData extends TDef['output'], TData = TQueryFnData>(
     input: TDef['input'],
     opts?: UnusedSkipTokenTRPCQueryOptionsIn<
       TQueryFnData,
       TData,
-      TRPCClientErrorLike<{
-        transformer: TDef['transformer'];
-        errorShape: TDef['errorShape'];
-      }>
+      TDef['error']
     >,
-  ): UnusedSkipTokenTRPCQueryOptionsOut<
-    TQueryFnData,
-    TData,
-    TRPCClientErrorLike<{
-      transformer: TDef['transformer'];
-      errorShape: TDef['errorShape'];
-    }>
-  >;
+  ): UnusedSkipTokenTRPCQueryOptionsOut<TQueryFnData, TData, TDef['error']>;
   <TQueryFnData extends TDef['output'], TData = TQueryFnData>(
     input: TDef['input'] | SkipToken,
-    opts?: UndefinedTRPCQueryOptionsIn<
-      TQueryFnData,
-      TData,
-      TRPCClientErrorLike<{
-        transformer: TDef['transformer'];
-        errorShape: TDef['errorShape'];
-      }>
-    >,
-  ): UndefinedTRPCQueryOptionsOut<
-    TQueryFnData,
-    TData,
-    TRPCClientErrorLike<{
-      transformer: TDef['transformer'];
-      errorShape: TDef['errorShape'];
-    }>
-  >;
+    opts?: UndefinedTRPCQueryOptionsIn<TQueryFnData, TData, TDef['error']>,
+  ): UndefinedTRPCQueryOptionsOut<TQueryFnData, TData, TDef['error']>;
 }
 
 type AnyTRPCQueryOptionsIn =

--- a/packages/tanstack-react-query/src/internals/subscriptionOptions.ts
+++ b/packages/tanstack-react-query/src/internals/subscriptionOptions.ts
@@ -1,6 +1,6 @@
 import type { SkipToken } from '@tanstack/react-query';
 import { hashKey, skipToken } from '@tanstack/react-query';
-import type { TRPCClientErrorLike, TRPCUntypedClient } from '@trpc/client';
+import type { TRPCUntypedClient } from '@trpc/client';
 import type { TRPCConnectionState } from '@trpc/client/unstable-internals';
 import type { Unsubscribable } from '@trpc/server/observable';
 import type { inferAsyncIterableYield } from '@trpc/server/unstable-core-do-not-import';
@@ -42,21 +42,21 @@ export interface TRPCSubscriptionOptions<TDef extends ResolverDef> {
     input: TDef['input'],
     opts?: UnusedSkipTokenTRPCSubscriptionOptionsIn<
       inferAsyncIterableYield<TDef['output']>,
-      TRPCClientErrorLike<TDef>
+      TDef['error']
     >,
   ): TRPCSubscriptionOptionsOut<
     inferAsyncIterableYield<TDef['output']>,
-    TRPCClientErrorLike<TDef>
+    TDef['error']
   >;
   (
     input: TDef['input'] | SkipToken,
     opts?: BaseTRPCSubscriptionOptionsIn<
       inferAsyncIterableYield<TDef['output']>,
-      TRPCClientErrorLike<TDef>
+      TDef['error']
     >,
   ): TRPCSubscriptionOptionsOut<
     inferAsyncIterableYield<TDef['output']>,
-    TRPCClientErrorLike<TDef>
+    TDef['error']
   >;
 }
 export type TRPCSubscriptionStatus =

--- a/packages/tanstack-react-query/src/internals/types.ts
+++ b/packages/tanstack-react-query/src/internals/types.ts
@@ -17,6 +17,7 @@ export type ResolverDef = {
   output: any;
   transformer: boolean;
   errorShape: any;
+  error: any;
 };
 
 /**

--- a/packages/tests/server/regression/issue-5037-context-inference.test.ts
+++ b/packages/tests/server/regression/issue-5037-context-inference.test.ts
@@ -102,6 +102,7 @@ describe('context inference w/ middlewares', () => {
         TInputOut,
         TOutputIn,
         TOutputOut,
+        TErrors,
       >(
         builder: ProcedureBuilder<
           TContext,
@@ -111,6 +112,7 @@ describe('context inference w/ middlewares', () => {
           TInputOut,
           TOutputIn,
           TOutputOut,
+          TErrors,
           false
         >,
       ) {

--- a/packages/tests/server/regression/issue-5297-description-key-on-input-turns-to-void.test.ts
+++ b/packages/tests/server/regression/issue-5297-description-key-on-input-turns-to-void.test.ts
@@ -44,6 +44,7 @@ describe('Serialization of Record types', () => {
           description: string;
         };
         output: { description: string };
+        errors: void;
         meta: object;
       }>
     >(appRouter.withDescriptionKey);
@@ -54,6 +55,7 @@ describe('Serialization of Record types', () => {
           description?: string | undefined;
         };
         output: { description?: string | undefined };
+        errors: void;
         meta: object;
       }>
     >(appRouter.maybeDescriptionKey);

--- a/packages/tests/server/streaming.test.ts
+++ b/packages/tests/server/streaming.test.ts
@@ -274,9 +274,7 @@ describe('no transformer', () => {
 
     const iterable = await client.iterable.query();
 
-    expectTypeOf(iterable).toEqualTypeOf<
-      AsyncIterable<number, string, unknown>
-    >();
+    expectTypeOf(iterable).toExtend<AsyncIterable<number, string, unknown>>();
     const aggregated: unknown[] = [];
     for await (const value of iterable) {
       aggregated.push(value);
@@ -603,9 +601,7 @@ describe('with transformer', () => {
 
     const iterable = await client.iterable.query();
 
-    expectTypeOf(iterable).toEqualTypeOf<
-      AsyncIterable<number, string, unknown>
-    >();
+    expectTypeOf(iterable).toExtend<AsyncIterable<number, string, unknown>>();
 
     const aggregated: unknown[] = [];
     for await (const value of iterable) {

--- a/packages/tests/server/websockets.test.ts
+++ b/packages/tests/server/websockets.test.ts
@@ -1959,6 +1959,7 @@ describe('subscriptions with createCaller', () => {
       SubscriptionProcedure<{
         input: string | null | undefined;
         output: AsyncIterable<Message, void, any>;
+        errors: void;
         meta: object;
       }>
     >();
@@ -2017,6 +2018,7 @@ describe('subscriptions with createCaller', () => {
       LegacyObservableSubscriptionProcedure<{
         input: string | null | undefined;
         output: Message;
+        errors: void;
         meta: object;
       }>
     >();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -922,6 +922,80 @@ importers:
         specifier: ^1.0.1
         version: 1.0.4
 
+  examples/minimal-react-typesafe-errors:
+    devDependencies:
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
+
+  examples/minimal-react-typesafe-errors/client:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.80.3
+        version: 5.80.3(react@19.1.0)
+      '@trpc/client':
+        specifier: npm:@trpc/client
+        version: link:../../../packages/client
+      '@trpc/server':
+        specifier: npm:@trpc/server
+        version: link:../../../packages/server
+      '@trpc/tanstack-react-query':
+        specifier: npm:@trpc/tanstack-react-query
+        version: link:../../../packages/tanstack-react-query
+      react:
+        specifier: ^19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.1.0(react@19.1.0)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.1.0
+        version: 19.1.0
+      '@types/react-dom':
+        specifier: ^19.1.1
+        version: 19.1.1(@types/react@19.1.0)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.3.4(vite@6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.4)(yaml@2.7.0))
+      eslint:
+        specifier: ^9.26.0
+        version: 9.26.0(jiti@2.4.2)
+      typescript:
+        specifier: ^5.8.2
+        version: 5.8.2
+      vite:
+        specifier: ^6.1.1
+        version: 6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.4)(yaml@2.7.0)
+
+  examples/minimal-react-typesafe-errors/server:
+    dependencies:
+      '@trpc/server':
+        specifier: npm:@trpc/server
+        version: link:../../../packages/server
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.5
+      zod:
+        specifier: ^3.25.51
+        version: 3.25.51
+    devDependencies:
+      '@types/cors':
+        specifier: ^2.8.13
+        version: 2.8.13
+      '@types/node':
+        specifier: 20.17.46
+        version: 20.17.46
+      eslint:
+        specifier: ^9.26.0
+        version: 9.26.0(jiti@2.4.2)
+      tsx:
+        specifier: ^4.19.3
+        version: 4.19.4
+      typescript:
+        specifier: ^5.8.2
+        version: 5.8.2
+
   examples/minimal-react/client:
     dependencies:
       '@tanstack/react-query':
@@ -24353,215 +24427,215 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
 
-  '@csstools/postcss-cascade-layers@5.0.1(postcss@8.4.39)':
+  '@csstools/postcss-cascade-layers@5.0.1(postcss@8.5.4)':
     dependencies:
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.0.0)
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-selector-parser: 7.0.0
 
-  '@csstools/postcss-color-function@4.0.7(postcss@8.4.39)':
+  '@csstools/postcss-color-function@4.0.7(postcss@8.5.4)':
     dependencies:
       '@csstools/css-color-parser': 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.39)
-      '@csstools/utilities': 2.0.0(postcss@8.4.39)
-      postcss: 8.4.39
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.4)
+      '@csstools/utilities': 2.0.0(postcss@8.5.4)
+      postcss: 8.5.4
 
-  '@csstools/postcss-color-mix-function@3.0.7(postcss@8.4.39)':
+  '@csstools/postcss-color-mix-function@3.0.7(postcss@8.5.4)':
     dependencies:
       '@csstools/css-color-parser': 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.39)
-      '@csstools/utilities': 2.0.0(postcss@8.4.39)
-      postcss: 8.4.39
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.4)
+      '@csstools/utilities': 2.0.0(postcss@8.5.4)
+      postcss: 8.5.4
 
-  '@csstools/postcss-content-alt-text@2.0.4(postcss@8.4.39)':
+  '@csstools/postcss-content-alt-text@2.0.4(postcss@8.5.4)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.39)
-      '@csstools/utilities': 2.0.0(postcss@8.4.39)
-      postcss: 8.4.39
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.4)
+      '@csstools/utilities': 2.0.0(postcss@8.5.4)
+      postcss: 8.5.4
 
-  '@csstools/postcss-exponential-functions@2.0.6(postcss@8.4.39)':
+  '@csstools/postcss-exponential-functions@2.0.6(postcss@8.5.4)':
     dependencies:
       '@csstools/css-calc': 2.1.1(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      postcss: 8.4.39
+      postcss: 8.5.4
 
-  '@csstools/postcss-font-format-keywords@4.0.0(postcss@8.4.39)':
+  '@csstools/postcss-font-format-keywords@4.0.0(postcss@8.5.4)':
     dependencies:
-      '@csstools/utilities': 2.0.0(postcss@8.4.39)
-      postcss: 8.4.39
+      '@csstools/utilities': 2.0.0(postcss@8.5.4)
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-gamut-mapping@2.0.7(postcss@8.4.39)':
+  '@csstools/postcss-gamut-mapping@2.0.7(postcss@8.5.4)':
     dependencies:
       '@csstools/css-color-parser': 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      postcss: 8.4.39
+      postcss: 8.5.4
 
-  '@csstools/postcss-gradients-interpolation-method@5.0.7(postcss@8.4.39)':
+  '@csstools/postcss-gradients-interpolation-method@5.0.7(postcss@8.5.4)':
     dependencies:
       '@csstools/css-color-parser': 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.39)
-      '@csstools/utilities': 2.0.0(postcss@8.4.39)
-      postcss: 8.4.39
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.4)
+      '@csstools/utilities': 2.0.0(postcss@8.5.4)
+      postcss: 8.5.4
 
-  '@csstools/postcss-hwb-function@4.0.7(postcss@8.4.39)':
+  '@csstools/postcss-hwb-function@4.0.7(postcss@8.5.4)':
     dependencies:
       '@csstools/css-color-parser': 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.39)
-      '@csstools/utilities': 2.0.0(postcss@8.4.39)
-      postcss: 8.4.39
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.4)
+      '@csstools/utilities': 2.0.0(postcss@8.5.4)
+      postcss: 8.5.4
 
-  '@csstools/postcss-ic-unit@4.0.0(postcss@8.4.39)':
+  '@csstools/postcss-ic-unit@4.0.0(postcss@8.5.4)':
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.39)
-      '@csstools/utilities': 2.0.0(postcss@8.4.39)
-      postcss: 8.4.39
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.4)
+      '@csstools/utilities': 2.0.0(postcss@8.5.4)
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-initial@2.0.0(postcss@8.4.39)':
+  '@csstools/postcss-initial@2.0.0(postcss@8.5.4)':
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
 
-  '@csstools/postcss-is-pseudo-class@5.0.1(postcss@8.4.39)':
+  '@csstools/postcss-is-pseudo-class@5.0.1(postcss@8.5.4)':
     dependencies:
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.0.0)
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-selector-parser: 7.0.0
 
-  '@csstools/postcss-light-dark-function@2.0.7(postcss@8.4.39)':
+  '@csstools/postcss-light-dark-function@2.0.7(postcss@8.5.4)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.39)
-      '@csstools/utilities': 2.0.0(postcss@8.4.39)
-      postcss: 8.4.39
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.4)
+      '@csstools/utilities': 2.0.0(postcss@8.5.4)
+      postcss: 8.5.4
 
-  '@csstools/postcss-logical-float-and-clear@3.0.0(postcss@8.4.39)':
+  '@csstools/postcss-logical-float-and-clear@3.0.0(postcss@8.5.4)':
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
 
-  '@csstools/postcss-logical-overflow@2.0.0(postcss@8.4.39)':
+  '@csstools/postcss-logical-overflow@2.0.0(postcss@8.5.4)':
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
 
-  '@csstools/postcss-logical-overscroll-behavior@2.0.0(postcss@8.4.39)':
+  '@csstools/postcss-logical-overscroll-behavior@2.0.0(postcss@8.5.4)':
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
 
-  '@csstools/postcss-logical-resize@3.0.0(postcss@8.4.39)':
+  '@csstools/postcss-logical-resize@3.0.0(postcss@8.5.4)':
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-logical-viewport-units@3.0.3(postcss@8.4.39)':
+  '@csstools/postcss-logical-viewport-units@3.0.3(postcss@8.5.4)':
     dependencies:
       '@csstools/css-tokenizer': 3.0.3
-      '@csstools/utilities': 2.0.0(postcss@8.4.39)
-      postcss: 8.4.39
+      '@csstools/utilities': 2.0.0(postcss@8.5.4)
+      postcss: 8.5.4
 
-  '@csstools/postcss-media-minmax@2.0.6(postcss@8.4.39)':
+  '@csstools/postcss-media-minmax@2.0.6(postcss@8.5.4)':
     dependencies:
       '@csstools/css-calc': 2.1.1(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
-      postcss: 8.4.39
+      postcss: 8.5.4
 
-  '@csstools/postcss-media-queries-aspect-ratio-number-values@3.0.4(postcss@8.4.39)':
+  '@csstools/postcss-media-queries-aspect-ratio-number-values@3.0.4(postcss@8.5.4)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
-      postcss: 8.4.39
+      postcss: 8.5.4
 
-  '@csstools/postcss-nested-calc@4.0.0(postcss@8.4.39)':
+  '@csstools/postcss-nested-calc@4.0.0(postcss@8.5.4)':
     dependencies:
-      '@csstools/utilities': 2.0.0(postcss@8.4.39)
-      postcss: 8.4.39
+      '@csstools/utilities': 2.0.0(postcss@8.5.4)
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-normalize-display-values@4.0.0(postcss@8.4.39)':
+  '@csstools/postcss-normalize-display-values@4.0.0(postcss@8.5.4)':
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-oklab-function@4.0.7(postcss@8.4.39)':
+  '@csstools/postcss-oklab-function@4.0.7(postcss@8.5.4)':
     dependencies:
       '@csstools/css-color-parser': 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.39)
-      '@csstools/utilities': 2.0.0(postcss@8.4.39)
-      postcss: 8.4.39
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.4)
+      '@csstools/utilities': 2.0.0(postcss@8.5.4)
+      postcss: 8.5.4
 
-  '@csstools/postcss-progressive-custom-properties@4.0.0(postcss@8.4.39)':
+  '@csstools/postcss-progressive-custom-properties@4.0.0(postcss@8.5.4)':
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-random-function@1.0.2(postcss@8.4.39)':
+  '@csstools/postcss-random-function@1.0.2(postcss@8.5.4)':
     dependencies:
       '@csstools/css-calc': 2.1.1(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      postcss: 8.4.39
+      postcss: 8.5.4
 
-  '@csstools/postcss-relative-color-syntax@3.0.7(postcss@8.4.39)':
+  '@csstools/postcss-relative-color-syntax@3.0.7(postcss@8.5.4)':
     dependencies:
       '@csstools/css-color-parser': 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.39)
-      '@csstools/utilities': 2.0.0(postcss@8.4.39)
-      postcss: 8.4.39
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.4)
+      '@csstools/utilities': 2.0.0(postcss@8.5.4)
+      postcss: 8.5.4
 
-  '@csstools/postcss-scope-pseudo-class@4.0.1(postcss@8.4.39)':
+  '@csstools/postcss-scope-pseudo-class@4.0.1(postcss@8.5.4)':
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-selector-parser: 7.0.0
 
-  '@csstools/postcss-sign-functions@1.1.1(postcss@8.4.39)':
+  '@csstools/postcss-sign-functions@1.1.1(postcss@8.5.4)':
     dependencies:
       '@csstools/css-calc': 2.1.1(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      postcss: 8.4.39
+      postcss: 8.5.4
 
-  '@csstools/postcss-stepped-value-functions@4.0.6(postcss@8.4.39)':
+  '@csstools/postcss-stepped-value-functions@4.0.6(postcss@8.5.4)':
     dependencies:
       '@csstools/css-calc': 2.1.1(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      postcss: 8.4.39
+      postcss: 8.5.4
 
-  '@csstools/postcss-text-decoration-shorthand@4.0.1(postcss@8.4.39)':
+  '@csstools/postcss-text-decoration-shorthand@4.0.1(postcss@8.5.4)':
     dependencies:
       '@csstools/color-helpers': 5.0.1
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  '@csstools/postcss-trigonometric-functions@4.0.6(postcss@8.4.39)':
+  '@csstools/postcss-trigonometric-functions@4.0.6(postcss@8.5.4)':
     dependencies:
       '@csstools/css-calc': 2.1.1(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      postcss: 8.4.39
+      postcss: 8.5.4
 
-  '@csstools/postcss-unset-value@4.0.0(postcss@8.4.39)':
+  '@csstools/postcss-unset-value@4.0.0(postcss@8.5.4)':
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
 
   '@csstools/selector-resolve-nested@3.0.0(postcss-selector-parser@7.0.0)':
     dependencies:
@@ -24571,9 +24645,9 @@ snapshots:
     dependencies:
       postcss-selector-parser: 7.0.0
 
-  '@csstools/utilities@2.0.0(postcss@8.4.39)':
+  '@csstools/utilities@2.0.0(postcss@8.5.4)':
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
 
   '@dabh/diagnostics@2.0.3':
     dependencies:
@@ -24650,14 +24724,14 @@ snapshots:
       copy-webpack-plugin: 11.0.0(webpack@5.95.0(@swc/core@1.9.1(@swc/helpers@0.5.15)))
       css-loader: 6.11.0(@rspack/core@1.1.8(@swc/helpers@0.5.15))(webpack@5.95.0(@swc/core@1.9.1(@swc/helpers@0.5.15)))
       css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(lightningcss@1.28.2)(webpack@5.95.0(@swc/core@1.9.1(@swc/helpers@0.5.15)))
-      cssnano: 6.1.2(postcss@8.4.39)
+      cssnano: 6.1.2(postcss@8.5.4)
       file-loader: 6.2.0(webpack@5.95.0(@swc/core@1.9.1(@swc/helpers@0.5.15)))
       html-minifier-terser: 7.2.0
       mini-css-extract-plugin: 2.9.1(webpack@5.95.0(@swc/core@1.9.1(@swc/helpers@0.5.15)))
       null-loader: 4.0.1(webpack@5.95.0(@swc/core@1.9.1(@swc/helpers@0.5.15)))
-      postcss: 8.4.39
-      postcss-loader: 7.3.4(postcss@8.4.39)(typescript@5.8.2)(webpack@5.95.0(@swc/core@1.9.1(@swc/helpers@0.5.15)))
-      postcss-preset-env: 10.1.3(postcss@8.4.39)
+      postcss: 8.5.4
+      postcss-loader: 7.3.4(postcss@8.5.4)(typescript@5.8.2)(webpack@5.95.0(@swc/core@1.9.1(@swc/helpers@0.5.15)))
+      postcss-preset-env: 10.1.3(postcss@8.5.4)
       react-dev-utils: 12.0.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.2)(webpack@5.95.0(@swc/core@1.9.1(@swc/helpers@0.5.15)))
       terser-webpack-plugin: 5.3.10(@swc/core@1.9.1(@swc/helpers@0.5.15))(webpack@5.95.0(@swc/core@1.9.1(@swc/helpers@0.5.15)))
       tslib: 2.8.1
@@ -24751,9 +24825,9 @@ snapshots:
 
   '@docusaurus/cssnano-preset@3.7.0':
     dependencies:
-      cssnano-preset-advanced: 6.1.2(postcss@8.4.39)
-      postcss: 8.4.39
-      postcss-sort-media-queries: 5.2.0(postcss@8.4.39)
+      cssnano-preset-advanced: 6.1.2(postcss@8.5.4)
+      postcss: 8.5.4
+      postcss-sort-media-queries: 5.2.0(postcss@8.5.4)
       tslib: 2.8.1
 
   '@docusaurus/faster@3.7.0(@docusaurus/types@3.7.0(@swc/core@1.9.1(@swc/helpers@0.5.15))(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@swc/helpers@0.5.15)':
@@ -27287,7 +27361,7 @@ snapshots:
       consola: 3.4.2
       cssnano: 7.0.6(postcss@8.5.4)
       defu: 6.1.4
-      esbuild: 0.25.2
+      esbuild: 0.25.5
       escape-string-regexp: 5.0.0
       exsolve: 1.0.4
       externality: 1.0.2
@@ -30385,6 +30459,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitejs/plugin-react@4.3.4(vite@6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.4)(yaml@2.7.0))':
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
+      '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.14.2
+      vite: 6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.4)(yaml@2.7.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitejs/plugin-vue-jsx@4.1.2(vite@6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.4)(yaml@2.7.0))(vue@3.5.13(typescript@5.8.2))':
     dependencies:
       '@babel/core': 7.26.9
@@ -30423,13 +30508,21 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.3(vite@6.2.7(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.3)(yaml@2.7.0))':
+  '@vitest/mocker@3.1.3(vite@6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.1.3
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.7(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.3)(yaml@2.7.0)
+
+  '@vitest/mocker@3.1.3(vite@6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.4)(yaml@2.7.0))':
+    dependencies:
+      '@vitest/spy': 3.1.3
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.4)(yaml@2.7.0)
 
   '@vitest/pretty-format@3.1.3':
     dependencies:
@@ -31175,14 +31268,14 @@ snapshots:
       postcss: 8.4.39
       postcss-value-parser: 4.2.0
 
-  autoprefixer@10.4.20(postcss@8.4.39):
+  autoprefixer@10.4.20(postcss@8.5.4):
     dependencies:
       browserslist: 4.24.4
       caniuse-lite: 1.0.30001715
       fraction.js: 4.3.7
       normalize-range: 0.1.2
       picocolors: 1.1.1
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
   autoprefixer@10.4.21(postcss@8.5.4):
@@ -32376,9 +32469,9 @@ snapshots:
 
   css-background-parser@0.1.0: {}
 
-  css-blank-pseudo@7.0.1(postcss@8.4.39):
+  css-blank-pseudo@7.0.1(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-selector-parser: 7.0.0
 
   css-box-shadow@1.0.0-3: {}
@@ -32393,21 +32486,21 @@ snapshots:
     dependencies:
       postcss: 8.5.4
 
-  css-has-pseudo@7.0.2(postcss@8.4.39):
+  css-has-pseudo@7.0.2(postcss@8.5.4):
     dependencies:
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.0.0)
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-selector-parser: 7.0.0
       postcss-value-parser: 4.2.0
 
   css-loader@6.11.0(@rspack/core@1.1.8(@swc/helpers@0.5.15))(webpack@5.95.0(@swc/core@1.9.1(@swc/helpers@0.5.15))):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.39)
-      postcss: 8.4.39
-      postcss-modules-extract-imports: 3.1.0(postcss@8.4.39)
-      postcss-modules-local-by-default: 4.0.5(postcss@8.4.39)
-      postcss-modules-scope: 3.2.0(postcss@8.4.39)
-      postcss-modules-values: 4.0.0(postcss@8.4.39)
+      icss-utils: 5.1.0(postcss@8.5.4)
+      postcss: 8.5.4
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.4)
+      postcss-modules-local-by-default: 4.0.5(postcss@8.5.4)
+      postcss-modules-scope: 3.2.0(postcss@8.5.4)
+      postcss-modules-values: 4.0.0(postcss@8.5.4)
       postcss-value-parser: 4.2.0
       semver: 7.7.2
     optionalDependencies:
@@ -32417,9 +32510,9 @@ snapshots:
   css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(lightningcss@1.28.2)(webpack@5.95.0(@swc/core@1.9.1(@swc/helpers@0.5.15))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      cssnano: 6.1.2(postcss@8.4.39)
+      cssnano: 6.1.2(postcss@8.5.4)
       jest-worker: 29.7.0
-      postcss: 8.4.39
+      postcss: 8.5.4
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
       webpack: 5.95.0(@swc/core@1.9.1(@swc/helpers@0.5.15))
@@ -32427,9 +32520,9 @@ snapshots:
       clean-css: 5.3.3
       lightningcss: 1.28.2
 
-  css-prefers-color-scheme@10.0.0(postcss@8.4.39):
+  css-prefers-color-scheme@10.0.0(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
 
   css-select@4.3.0:
     dependencies:
@@ -32471,50 +32564,50 @@ snapshots:
 
   cssesc@3.0.0: {}
 
-  cssnano-preset-advanced@6.1.2(postcss@8.4.39):
+  cssnano-preset-advanced@6.1.2(postcss@8.5.4):
     dependencies:
-      autoprefixer: 10.4.20(postcss@8.4.39)
+      autoprefixer: 10.4.20(postcss@8.5.4)
       browserslist: 4.24.4
-      cssnano-preset-default: 6.1.2(postcss@8.4.39)
-      postcss: 8.4.39
-      postcss-discard-unused: 6.0.5(postcss@8.4.39)
-      postcss-merge-idents: 6.0.3(postcss@8.4.39)
-      postcss-reduce-idents: 6.0.3(postcss@8.4.39)
-      postcss-zindex: 6.0.2(postcss@8.4.39)
+      cssnano-preset-default: 6.1.2(postcss@8.5.4)
+      postcss: 8.5.4
+      postcss-discard-unused: 6.0.5(postcss@8.5.4)
+      postcss-merge-idents: 6.0.3(postcss@8.5.4)
+      postcss-reduce-idents: 6.0.3(postcss@8.5.4)
+      postcss-zindex: 6.0.2(postcss@8.5.4)
 
-  cssnano-preset-default@6.1.2(postcss@8.4.39):
+  cssnano-preset-default@6.1.2(postcss@8.5.4):
     dependencies:
       browserslist: 4.24.4
-      css-declaration-sorter: 7.2.0(postcss@8.4.39)
-      cssnano-utils: 4.0.2(postcss@8.4.39)
-      postcss: 8.4.39
-      postcss-calc: 9.0.1(postcss@8.4.39)
-      postcss-colormin: 6.1.0(postcss@8.4.39)
-      postcss-convert-values: 6.1.0(postcss@8.4.39)
-      postcss-discard-comments: 6.0.2(postcss@8.4.39)
-      postcss-discard-duplicates: 6.0.3(postcss@8.4.39)
-      postcss-discard-empty: 6.0.3(postcss@8.4.39)
-      postcss-discard-overridden: 6.0.2(postcss@8.4.39)
-      postcss-merge-longhand: 6.0.5(postcss@8.4.39)
-      postcss-merge-rules: 6.1.1(postcss@8.4.39)
-      postcss-minify-font-values: 6.1.0(postcss@8.4.39)
-      postcss-minify-gradients: 6.0.3(postcss@8.4.39)
-      postcss-minify-params: 6.1.0(postcss@8.4.39)
-      postcss-minify-selectors: 6.0.4(postcss@8.4.39)
-      postcss-normalize-charset: 6.0.2(postcss@8.4.39)
-      postcss-normalize-display-values: 6.0.2(postcss@8.4.39)
-      postcss-normalize-positions: 6.0.2(postcss@8.4.39)
-      postcss-normalize-repeat-style: 6.0.2(postcss@8.4.39)
-      postcss-normalize-string: 6.0.2(postcss@8.4.39)
-      postcss-normalize-timing-functions: 6.0.2(postcss@8.4.39)
-      postcss-normalize-unicode: 6.1.0(postcss@8.4.39)
-      postcss-normalize-url: 6.0.2(postcss@8.4.39)
-      postcss-normalize-whitespace: 6.0.2(postcss@8.4.39)
-      postcss-ordered-values: 6.0.2(postcss@8.4.39)
-      postcss-reduce-initial: 6.1.0(postcss@8.4.39)
-      postcss-reduce-transforms: 6.0.2(postcss@8.4.39)
-      postcss-svgo: 6.0.3(postcss@8.4.39)
-      postcss-unique-selectors: 6.0.4(postcss@8.4.39)
+      css-declaration-sorter: 7.2.0(postcss@8.5.4)
+      cssnano-utils: 4.0.2(postcss@8.5.4)
+      postcss: 8.5.4
+      postcss-calc: 9.0.1(postcss@8.5.4)
+      postcss-colormin: 6.1.0(postcss@8.5.4)
+      postcss-convert-values: 6.1.0(postcss@8.5.4)
+      postcss-discard-comments: 6.0.2(postcss@8.5.4)
+      postcss-discard-duplicates: 6.0.3(postcss@8.5.4)
+      postcss-discard-empty: 6.0.3(postcss@8.5.4)
+      postcss-discard-overridden: 6.0.2(postcss@8.5.4)
+      postcss-merge-longhand: 6.0.5(postcss@8.5.4)
+      postcss-merge-rules: 6.1.1(postcss@8.5.4)
+      postcss-minify-font-values: 6.1.0(postcss@8.5.4)
+      postcss-minify-gradients: 6.0.3(postcss@8.5.4)
+      postcss-minify-params: 6.1.0(postcss@8.5.4)
+      postcss-minify-selectors: 6.0.4(postcss@8.5.4)
+      postcss-normalize-charset: 6.0.2(postcss@8.5.4)
+      postcss-normalize-display-values: 6.0.2(postcss@8.5.4)
+      postcss-normalize-positions: 6.0.2(postcss@8.5.4)
+      postcss-normalize-repeat-style: 6.0.2(postcss@8.5.4)
+      postcss-normalize-string: 6.0.2(postcss@8.5.4)
+      postcss-normalize-timing-functions: 6.0.2(postcss@8.5.4)
+      postcss-normalize-unicode: 6.1.0(postcss@8.5.4)
+      postcss-normalize-url: 6.0.2(postcss@8.5.4)
+      postcss-normalize-whitespace: 6.0.2(postcss@8.5.4)
+      postcss-ordered-values: 6.0.2(postcss@8.5.4)
+      postcss-reduce-initial: 6.1.0(postcss@8.5.4)
+      postcss-reduce-transforms: 6.0.2(postcss@8.5.4)
+      postcss-svgo: 6.0.3(postcss@8.5.4)
+      postcss-unique-selectors: 6.0.4(postcss@8.5.4)
 
   cssnano-preset-default@7.0.0(postcss@8.4.39):
     dependencies:
@@ -32584,9 +32677,9 @@ snapshots:
       postcss-svgo: 7.0.1(postcss@8.5.4)
       postcss-unique-selectors: 7.0.3(postcss@8.5.4)
 
-  cssnano-utils@4.0.2(postcss@8.4.39):
+  cssnano-utils@4.0.2(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
 
   cssnano-utils@5.0.0(postcss@8.4.39):
     dependencies:
@@ -32596,11 +32689,11 @@ snapshots:
     dependencies:
       postcss: 8.5.4
 
-  cssnano@6.1.2(postcss@8.4.39):
+  cssnano@6.1.2(postcss@8.5.4):
     dependencies:
-      cssnano-preset-default: 6.1.2(postcss@8.4.39)
+      cssnano-preset-default: 6.1.2(postcss@8.5.4)
       lilconfig: 3.1.1
-      postcss: 8.4.39
+      postcss: 8.5.4
 
   cssnano@7.0.0(postcss@8.4.39):
     dependencies:
@@ -35576,9 +35669,9 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  icss-utils@5.1.0(postcss@8.4.39):
+  icss-utils@5.1.0(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
 
   ieee754@1.1.13: {}
 
@@ -38103,7 +38196,7 @@ snapshots:
       defu: 6.1.4
       destr: 2.0.3
       dot-prop: 9.0.0
-      esbuild: 0.25.2
+      esbuild: 0.25.5
       escape-string-regexp: 5.0.0
       etag: 1.8.1
       exsolve: 1.0.4
@@ -39300,9 +39393,9 @@ snapshots:
 
   possible-typed-array-names@1.0.0: {}
 
-  postcss-attribute-case-insensitive@7.0.1(postcss@8.4.39):
+  postcss-attribute-case-insensitive@7.0.1(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-selector-parser: 7.0.0
 
   postcss-calc@10.1.1(postcss@8.5.4):
@@ -39317,38 +39410,44 @@ snapshots:
       postcss-selector-parser: 6.0.16
       postcss-value-parser: 4.2.0
 
-  postcss-clamp@4.1.0(postcss@8.4.39):
+  postcss-calc@9.0.1(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
+      postcss-selector-parser: 6.0.16
       postcss-value-parser: 4.2.0
 
-  postcss-color-functional-notation@7.0.7(postcss@8.4.39):
+  postcss-clamp@4.1.0(postcss@8.5.4):
+    dependencies:
+      postcss: 8.5.4
+      postcss-value-parser: 4.2.0
+
+  postcss-color-functional-notation@7.0.7(postcss@8.5.4):
     dependencies:
       '@csstools/css-color-parser': 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.39)
-      '@csstools/utilities': 2.0.0(postcss@8.4.39)
-      postcss: 8.4.39
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.4)
+      '@csstools/utilities': 2.0.0(postcss@8.5.4)
+      postcss: 8.5.4
 
-  postcss-color-hex-alpha@10.0.0(postcss@8.4.39):
+  postcss-color-hex-alpha@10.0.0(postcss@8.5.4):
     dependencies:
-      '@csstools/utilities': 2.0.0(postcss@8.4.39)
-      postcss: 8.4.39
+      '@csstools/utilities': 2.0.0(postcss@8.5.4)
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  postcss-color-rebeccapurple@10.0.0(postcss@8.4.39):
+  postcss-color-rebeccapurple@10.0.0(postcss@8.5.4):
     dependencies:
-      '@csstools/utilities': 2.0.0(postcss@8.4.39)
-      postcss: 8.4.39
+      '@csstools/utilities': 2.0.0(postcss@8.5.4)
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  postcss-colormin@6.1.0(postcss@8.4.39):
+  postcss-colormin@6.1.0(postcss@8.5.4):
     dependencies:
       browserslist: 4.24.4
       caniuse-api: 3.0.0
       colord: 2.9.3
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
   postcss-colormin@7.0.0(postcss@8.4.39):
@@ -39367,10 +39466,10 @@ snapshots:
       postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  postcss-convert-values@6.1.0(postcss@8.4.39):
+  postcss-convert-values@6.1.0(postcss@8.5.4):
     dependencies:
       browserslist: 4.24.4
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
   postcss-convert-values@7.0.0(postcss@8.4.39):
@@ -39385,39 +39484,39 @@ snapshots:
       postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  postcss-custom-media@11.0.5(postcss@8.4.39):
+  postcss-custom-media@11.0.5(postcss@8.5.4):
     dependencies:
       '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
       '@csstools/media-query-list-parser': 4.0.2(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
-      postcss: 8.4.39
+      postcss: 8.5.4
 
-  postcss-custom-properties@14.0.4(postcss@8.4.39):
+  postcss-custom-properties@14.0.4(postcss@8.5.4):
     dependencies:
       '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      '@csstools/utilities': 2.0.0(postcss@8.4.39)
-      postcss: 8.4.39
+      '@csstools/utilities': 2.0.0(postcss@8.5.4)
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  postcss-custom-selectors@8.0.4(postcss@8.4.39):
+  postcss-custom-selectors@8.0.4(postcss@8.5.4):
     dependencies:
       '@csstools/cascade-layer-name-parser': 2.0.4(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-selector-parser: 7.0.0
 
-  postcss-dir-pseudo-class@9.0.1(postcss@8.4.39):
+  postcss-dir-pseudo-class@9.0.1(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-selector-parser: 7.0.0
 
-  postcss-discard-comments@6.0.2(postcss@8.4.39):
+  postcss-discard-comments@6.0.2(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
 
   postcss-discard-comments@7.0.0(postcss@8.4.39):
     dependencies:
@@ -39428,9 +39527,9 @@ snapshots:
       postcss: 8.5.4
       postcss-selector-parser: 6.1.2
 
-  postcss-discard-duplicates@6.0.3(postcss@8.4.39):
+  postcss-discard-duplicates@6.0.3(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
 
   postcss-discard-duplicates@7.0.0(postcss@8.4.39):
     dependencies:
@@ -39440,9 +39539,9 @@ snapshots:
     dependencies:
       postcss: 8.5.4
 
-  postcss-discard-empty@6.0.3(postcss@8.4.39):
+  postcss-discard-empty@6.0.3(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
 
   postcss-discard-empty@7.0.0(postcss@8.4.39):
     dependencies:
@@ -39452,9 +39551,9 @@ snapshots:
     dependencies:
       postcss: 8.5.4
 
-  postcss-discard-overridden@6.0.2(postcss@8.4.39):
+  postcss-discard-overridden@6.0.2(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
 
   postcss-discard-overridden@7.0.0(postcss@8.4.39):
     dependencies:
@@ -39464,40 +39563,40 @@ snapshots:
     dependencies:
       postcss: 8.5.4
 
-  postcss-discard-unused@6.0.5(postcss@8.4.39):
+  postcss-discard-unused@6.0.5(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-selector-parser: 6.0.16
 
-  postcss-double-position-gradients@6.0.0(postcss@8.4.39):
+  postcss-double-position-gradients@6.0.0(postcss@8.5.4):
     dependencies:
-      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.39)
-      '@csstools/utilities': 2.0.0(postcss@8.4.39)
-      postcss: 8.4.39
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.4)
+      '@csstools/utilities': 2.0.0(postcss@8.5.4)
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  postcss-focus-visible@10.0.1(postcss@8.4.39):
+  postcss-focus-visible@10.0.1(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-selector-parser: 7.0.0
 
-  postcss-focus-within@9.0.1(postcss@8.4.39):
+  postcss-focus-within@9.0.1(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-selector-parser: 7.0.0
 
-  postcss-font-variant@5.0.0(postcss@8.4.39):
+  postcss-font-variant@5.0.0(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
 
-  postcss-gap-properties@6.0.0(postcss@8.4.39):
+  postcss-gap-properties@6.0.0(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
 
-  postcss-image-set-function@7.0.0(postcss@8.4.39):
+  postcss-image-set-function@7.0.0(postcss@8.5.4):
     dependencies:
-      '@csstools/utilities': 2.0.0(postcss@8.4.39)
-      postcss: 8.4.39
+      '@csstools/utilities': 2.0.0(postcss@8.5.4)
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
   postcss-import@15.1.0(postcss@8.4.39):
@@ -39524,14 +39623,14 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.47
 
-  postcss-lab-function@7.0.7(postcss@8.4.39):
+  postcss-lab-function@7.0.7(postcss@8.5.4):
     dependencies:
       '@csstools/css-color-parser': 3.0.7(@csstools/css-parser-algorithms@3.0.4(@csstools/css-tokenizer@3.0.3))(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-parser-algorithms': 3.0.4(@csstools/css-tokenizer@3.0.3)
       '@csstools/css-tokenizer': 3.0.3
-      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.39)
-      '@csstools/utilities': 2.0.0(postcss@8.4.39)
-      postcss: 8.4.39
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.4)
+      '@csstools/utilities': 2.0.0(postcss@8.5.4)
+      postcss: 8.5.4
 
   postcss-load-config@4.0.2(postcss@8.4.39):
     dependencies:
@@ -39547,32 +39646,32 @@ snapshots:
     optionalDependencies:
       postcss: 8.4.47
 
-  postcss-loader@7.3.4(postcss@8.4.39)(typescript@5.8.2)(webpack@5.95.0(@swc/core@1.9.1(@swc/helpers@0.5.15))):
+  postcss-loader@7.3.4(postcss@8.5.4)(typescript@5.8.2)(webpack@5.95.0(@swc/core@1.9.1(@swc/helpers@0.5.15))):
     dependencies:
       cosmiconfig: 8.3.6(typescript@5.8.2)
       jiti: 1.21.6
-      postcss: 8.4.39
+      postcss: 8.5.4
       semver: 7.7.2
       webpack: 5.95.0(@swc/core@1.9.1(@swc/helpers@0.5.15))
     transitivePeerDependencies:
       - typescript
 
-  postcss-logical@8.0.0(postcss@8.4.39):
+  postcss-logical@8.0.0(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  postcss-merge-idents@6.0.3(postcss@8.4.39):
+  postcss-merge-idents@6.0.3(postcss@8.5.4):
     dependencies:
-      cssnano-utils: 4.0.2(postcss@8.4.39)
-      postcss: 8.4.39
+      cssnano-utils: 4.0.2(postcss@8.5.4)
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  postcss-merge-longhand@6.0.5(postcss@8.4.39):
+  postcss-merge-longhand@6.0.5(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
-      stylehacks: 6.1.1(postcss@8.4.39)
+      stylehacks: 6.1.1(postcss@8.5.4)
 
   postcss-merge-longhand@7.0.0(postcss@8.4.39):
     dependencies:
@@ -39586,12 +39685,12 @@ snapshots:
       postcss-value-parser: 4.2.0
       stylehacks: 7.0.4(postcss@8.5.4)
 
-  postcss-merge-rules@6.1.1(postcss@8.4.39):
+  postcss-merge-rules@6.1.1(postcss@8.5.4):
     dependencies:
       browserslist: 4.24.4
       caniuse-api: 3.0.0
-      cssnano-utils: 4.0.2(postcss@8.4.39)
-      postcss: 8.4.39
+      cssnano-utils: 4.0.2(postcss@8.5.4)
+      postcss: 8.5.4
       postcss-selector-parser: 6.0.16
 
   postcss-merge-rules@7.0.0(postcss@8.4.39):
@@ -39610,9 +39709,9 @@ snapshots:
       postcss: 8.5.4
       postcss-selector-parser: 6.1.2
 
-  postcss-minify-font-values@6.1.0(postcss@8.4.39):
+  postcss-minify-font-values@6.1.0(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
   postcss-minify-font-values@7.0.0(postcss@8.4.39):
@@ -39625,11 +39724,11 @@ snapshots:
       postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  postcss-minify-gradients@6.0.3(postcss@8.4.39):
+  postcss-minify-gradients@6.0.3(postcss@8.5.4):
     dependencies:
       colord: 2.9.3
-      cssnano-utils: 4.0.2(postcss@8.4.39)
-      postcss: 8.4.39
+      cssnano-utils: 4.0.2(postcss@8.5.4)
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
   postcss-minify-gradients@7.0.0(postcss@8.4.39):
@@ -39646,11 +39745,11 @@ snapshots:
       postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  postcss-minify-params@6.1.0(postcss@8.4.39):
+  postcss-minify-params@6.1.0(postcss@8.5.4):
     dependencies:
       browserslist: 4.24.4
-      cssnano-utils: 4.0.2(postcss@8.4.39)
-      postcss: 8.4.39
+      cssnano-utils: 4.0.2(postcss@8.5.4)
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
   postcss-minify-params@7.0.0(postcss@8.4.39):
@@ -39667,9 +39766,9 @@ snapshots:
       postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  postcss-minify-selectors@6.0.4(postcss@8.4.39):
+  postcss-minify-selectors@6.0.4(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-selector-parser: 6.0.16
 
   postcss-minify-selectors@7.0.0(postcss@8.4.39):
@@ -39683,26 +39782,26 @@ snapshots:
       postcss: 8.5.4
       postcss-selector-parser: 6.1.2
 
-  postcss-modules-extract-imports@3.1.0(postcss@8.4.39):
+  postcss-modules-extract-imports@3.1.0(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
 
-  postcss-modules-local-by-default@4.0.5(postcss@8.4.39):
+  postcss-modules-local-by-default@4.0.5(postcss@8.5.4):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.39)
-      postcss: 8.4.39
+      icss-utils: 5.1.0(postcss@8.5.4)
+      postcss: 8.5.4
       postcss-selector-parser: 6.0.16
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.2.0(postcss@8.4.39):
+  postcss-modules-scope@3.2.0(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-selector-parser: 6.0.16
 
-  postcss-modules-values@4.0.0(postcss@8.4.39):
+  postcss-modules-values@4.0.0(postcss@8.5.4):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.39)
-      postcss: 8.4.39
+      icss-utils: 5.1.0(postcss@8.5.4)
+      postcss: 8.5.4
 
   postcss-nested@6.0.1(postcss@8.4.39):
     dependencies:
@@ -39714,16 +39813,16 @@ snapshots:
       postcss: 8.4.47
       postcss-selector-parser: 6.0.16
 
-  postcss-nesting@13.0.1(postcss@8.4.39):
+  postcss-nesting@13.0.1(postcss@8.5.4):
     dependencies:
       '@csstools/selector-resolve-nested': 3.0.0(postcss-selector-parser@7.0.0)
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.0.0)
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-selector-parser: 7.0.0
 
-  postcss-normalize-charset@6.0.2(postcss@8.4.39):
+  postcss-normalize-charset@6.0.2(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
 
   postcss-normalize-charset@7.0.0(postcss@8.4.39):
     dependencies:
@@ -39733,9 +39832,9 @@ snapshots:
     dependencies:
       postcss: 8.5.4
 
-  postcss-normalize-display-values@6.0.2(postcss@8.4.39):
+  postcss-normalize-display-values@6.0.2(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
   postcss-normalize-display-values@7.0.0(postcss@8.4.39):
@@ -39748,9 +39847,9 @@ snapshots:
       postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-positions@6.0.2(postcss@8.4.39):
+  postcss-normalize-positions@6.0.2(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
   postcss-normalize-positions@7.0.0(postcss@8.4.39):
@@ -39763,9 +39862,9 @@ snapshots:
       postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-repeat-style@6.0.2(postcss@8.4.39):
+  postcss-normalize-repeat-style@6.0.2(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
   postcss-normalize-repeat-style@7.0.0(postcss@8.4.39):
@@ -39778,9 +39877,9 @@ snapshots:
       postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-string@6.0.2(postcss@8.4.39):
+  postcss-normalize-string@6.0.2(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
   postcss-normalize-string@7.0.0(postcss@8.4.39):
@@ -39793,9 +39892,9 @@ snapshots:
       postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-timing-functions@6.0.2(postcss@8.4.39):
+  postcss-normalize-timing-functions@6.0.2(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
   postcss-normalize-timing-functions@7.0.0(postcss@8.4.39):
@@ -39808,10 +39907,10 @@ snapshots:
       postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-unicode@6.1.0(postcss@8.4.39):
+  postcss-normalize-unicode@6.1.0(postcss@8.5.4):
     dependencies:
       browserslist: 4.24.4
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
   postcss-normalize-unicode@7.0.0(postcss@8.4.39):
@@ -39826,9 +39925,9 @@ snapshots:
       postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-url@6.0.2(postcss@8.4.39):
+  postcss-normalize-url@6.0.2(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
   postcss-normalize-url@7.0.0(postcss@8.4.39):
@@ -39841,9 +39940,9 @@ snapshots:
       postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-whitespace@6.0.2(postcss@8.4.39):
+  postcss-normalize-whitespace@6.0.2(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
   postcss-normalize-whitespace@7.0.0(postcss@8.4.39):
@@ -39856,14 +39955,14 @@ snapshots:
       postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  postcss-opacity-percentage@3.0.0(postcss@8.4.39):
+  postcss-opacity-percentage@3.0.0(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
 
-  postcss-ordered-values@6.0.2(postcss@8.4.39):
+  postcss-ordered-values@6.0.2(postcss@8.5.4):
     dependencies:
-      cssnano-utils: 4.0.2(postcss@8.4.39)
-      postcss: 8.4.39
+      cssnano-utils: 4.0.2(postcss@8.5.4)
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
   postcss-ordered-values@7.0.0(postcss@8.4.39):
@@ -39878,102 +39977,102 @@ snapshots:
       postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  postcss-overflow-shorthand@6.0.0(postcss@8.4.39):
+  postcss-overflow-shorthand@6.0.0(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  postcss-page-break@3.0.4(postcss@8.4.39):
+  postcss-page-break@3.0.4(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
 
-  postcss-place@10.0.0(postcss@8.4.39):
+  postcss-place@10.0.0(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  postcss-preset-env@10.1.3(postcss@8.4.39):
+  postcss-preset-env@10.1.3(postcss@8.5.4):
     dependencies:
-      '@csstools/postcss-cascade-layers': 5.0.1(postcss@8.4.39)
-      '@csstools/postcss-color-function': 4.0.7(postcss@8.4.39)
-      '@csstools/postcss-color-mix-function': 3.0.7(postcss@8.4.39)
-      '@csstools/postcss-content-alt-text': 2.0.4(postcss@8.4.39)
-      '@csstools/postcss-exponential-functions': 2.0.6(postcss@8.4.39)
-      '@csstools/postcss-font-format-keywords': 4.0.0(postcss@8.4.39)
-      '@csstools/postcss-gamut-mapping': 2.0.7(postcss@8.4.39)
-      '@csstools/postcss-gradients-interpolation-method': 5.0.7(postcss@8.4.39)
-      '@csstools/postcss-hwb-function': 4.0.7(postcss@8.4.39)
-      '@csstools/postcss-ic-unit': 4.0.0(postcss@8.4.39)
-      '@csstools/postcss-initial': 2.0.0(postcss@8.4.39)
-      '@csstools/postcss-is-pseudo-class': 5.0.1(postcss@8.4.39)
-      '@csstools/postcss-light-dark-function': 2.0.7(postcss@8.4.39)
-      '@csstools/postcss-logical-float-and-clear': 3.0.0(postcss@8.4.39)
-      '@csstools/postcss-logical-overflow': 2.0.0(postcss@8.4.39)
-      '@csstools/postcss-logical-overscroll-behavior': 2.0.0(postcss@8.4.39)
-      '@csstools/postcss-logical-resize': 3.0.0(postcss@8.4.39)
-      '@csstools/postcss-logical-viewport-units': 3.0.3(postcss@8.4.39)
-      '@csstools/postcss-media-minmax': 2.0.6(postcss@8.4.39)
-      '@csstools/postcss-media-queries-aspect-ratio-number-values': 3.0.4(postcss@8.4.39)
-      '@csstools/postcss-nested-calc': 4.0.0(postcss@8.4.39)
-      '@csstools/postcss-normalize-display-values': 4.0.0(postcss@8.4.39)
-      '@csstools/postcss-oklab-function': 4.0.7(postcss@8.4.39)
-      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.4.39)
-      '@csstools/postcss-random-function': 1.0.2(postcss@8.4.39)
-      '@csstools/postcss-relative-color-syntax': 3.0.7(postcss@8.4.39)
-      '@csstools/postcss-scope-pseudo-class': 4.0.1(postcss@8.4.39)
-      '@csstools/postcss-sign-functions': 1.1.1(postcss@8.4.39)
-      '@csstools/postcss-stepped-value-functions': 4.0.6(postcss@8.4.39)
-      '@csstools/postcss-text-decoration-shorthand': 4.0.1(postcss@8.4.39)
-      '@csstools/postcss-trigonometric-functions': 4.0.6(postcss@8.4.39)
-      '@csstools/postcss-unset-value': 4.0.0(postcss@8.4.39)
-      autoprefixer: 10.4.20(postcss@8.4.39)
+      '@csstools/postcss-cascade-layers': 5.0.1(postcss@8.5.4)
+      '@csstools/postcss-color-function': 4.0.7(postcss@8.5.4)
+      '@csstools/postcss-color-mix-function': 3.0.7(postcss@8.5.4)
+      '@csstools/postcss-content-alt-text': 2.0.4(postcss@8.5.4)
+      '@csstools/postcss-exponential-functions': 2.0.6(postcss@8.5.4)
+      '@csstools/postcss-font-format-keywords': 4.0.0(postcss@8.5.4)
+      '@csstools/postcss-gamut-mapping': 2.0.7(postcss@8.5.4)
+      '@csstools/postcss-gradients-interpolation-method': 5.0.7(postcss@8.5.4)
+      '@csstools/postcss-hwb-function': 4.0.7(postcss@8.5.4)
+      '@csstools/postcss-ic-unit': 4.0.0(postcss@8.5.4)
+      '@csstools/postcss-initial': 2.0.0(postcss@8.5.4)
+      '@csstools/postcss-is-pseudo-class': 5.0.1(postcss@8.5.4)
+      '@csstools/postcss-light-dark-function': 2.0.7(postcss@8.5.4)
+      '@csstools/postcss-logical-float-and-clear': 3.0.0(postcss@8.5.4)
+      '@csstools/postcss-logical-overflow': 2.0.0(postcss@8.5.4)
+      '@csstools/postcss-logical-overscroll-behavior': 2.0.0(postcss@8.5.4)
+      '@csstools/postcss-logical-resize': 3.0.0(postcss@8.5.4)
+      '@csstools/postcss-logical-viewport-units': 3.0.3(postcss@8.5.4)
+      '@csstools/postcss-media-minmax': 2.0.6(postcss@8.5.4)
+      '@csstools/postcss-media-queries-aspect-ratio-number-values': 3.0.4(postcss@8.5.4)
+      '@csstools/postcss-nested-calc': 4.0.0(postcss@8.5.4)
+      '@csstools/postcss-normalize-display-values': 4.0.0(postcss@8.5.4)
+      '@csstools/postcss-oklab-function': 4.0.7(postcss@8.5.4)
+      '@csstools/postcss-progressive-custom-properties': 4.0.0(postcss@8.5.4)
+      '@csstools/postcss-random-function': 1.0.2(postcss@8.5.4)
+      '@csstools/postcss-relative-color-syntax': 3.0.7(postcss@8.5.4)
+      '@csstools/postcss-scope-pseudo-class': 4.0.1(postcss@8.5.4)
+      '@csstools/postcss-sign-functions': 1.1.1(postcss@8.5.4)
+      '@csstools/postcss-stepped-value-functions': 4.0.6(postcss@8.5.4)
+      '@csstools/postcss-text-decoration-shorthand': 4.0.1(postcss@8.5.4)
+      '@csstools/postcss-trigonometric-functions': 4.0.6(postcss@8.5.4)
+      '@csstools/postcss-unset-value': 4.0.0(postcss@8.5.4)
+      autoprefixer: 10.4.20(postcss@8.5.4)
       browserslist: 4.24.4
-      css-blank-pseudo: 7.0.1(postcss@8.4.39)
-      css-has-pseudo: 7.0.2(postcss@8.4.39)
-      css-prefers-color-scheme: 10.0.0(postcss@8.4.39)
+      css-blank-pseudo: 7.0.1(postcss@8.5.4)
+      css-has-pseudo: 7.0.2(postcss@8.5.4)
+      css-prefers-color-scheme: 10.0.0(postcss@8.5.4)
       cssdb: 8.2.3
-      postcss: 8.4.39
-      postcss-attribute-case-insensitive: 7.0.1(postcss@8.4.39)
-      postcss-clamp: 4.1.0(postcss@8.4.39)
-      postcss-color-functional-notation: 7.0.7(postcss@8.4.39)
-      postcss-color-hex-alpha: 10.0.0(postcss@8.4.39)
-      postcss-color-rebeccapurple: 10.0.0(postcss@8.4.39)
-      postcss-custom-media: 11.0.5(postcss@8.4.39)
-      postcss-custom-properties: 14.0.4(postcss@8.4.39)
-      postcss-custom-selectors: 8.0.4(postcss@8.4.39)
-      postcss-dir-pseudo-class: 9.0.1(postcss@8.4.39)
-      postcss-double-position-gradients: 6.0.0(postcss@8.4.39)
-      postcss-focus-visible: 10.0.1(postcss@8.4.39)
-      postcss-focus-within: 9.0.1(postcss@8.4.39)
-      postcss-font-variant: 5.0.0(postcss@8.4.39)
-      postcss-gap-properties: 6.0.0(postcss@8.4.39)
-      postcss-image-set-function: 7.0.0(postcss@8.4.39)
-      postcss-lab-function: 7.0.7(postcss@8.4.39)
-      postcss-logical: 8.0.0(postcss@8.4.39)
-      postcss-nesting: 13.0.1(postcss@8.4.39)
-      postcss-opacity-percentage: 3.0.0(postcss@8.4.39)
-      postcss-overflow-shorthand: 6.0.0(postcss@8.4.39)
-      postcss-page-break: 3.0.4(postcss@8.4.39)
-      postcss-place: 10.0.0(postcss@8.4.39)
-      postcss-pseudo-class-any-link: 10.0.1(postcss@8.4.39)
-      postcss-replace-overflow-wrap: 4.0.0(postcss@8.4.39)
-      postcss-selector-not: 8.0.1(postcss@8.4.39)
+      postcss: 8.5.4
+      postcss-attribute-case-insensitive: 7.0.1(postcss@8.5.4)
+      postcss-clamp: 4.1.0(postcss@8.5.4)
+      postcss-color-functional-notation: 7.0.7(postcss@8.5.4)
+      postcss-color-hex-alpha: 10.0.0(postcss@8.5.4)
+      postcss-color-rebeccapurple: 10.0.0(postcss@8.5.4)
+      postcss-custom-media: 11.0.5(postcss@8.5.4)
+      postcss-custom-properties: 14.0.4(postcss@8.5.4)
+      postcss-custom-selectors: 8.0.4(postcss@8.5.4)
+      postcss-dir-pseudo-class: 9.0.1(postcss@8.5.4)
+      postcss-double-position-gradients: 6.0.0(postcss@8.5.4)
+      postcss-focus-visible: 10.0.1(postcss@8.5.4)
+      postcss-focus-within: 9.0.1(postcss@8.5.4)
+      postcss-font-variant: 5.0.0(postcss@8.5.4)
+      postcss-gap-properties: 6.0.0(postcss@8.5.4)
+      postcss-image-set-function: 7.0.0(postcss@8.5.4)
+      postcss-lab-function: 7.0.7(postcss@8.5.4)
+      postcss-logical: 8.0.0(postcss@8.5.4)
+      postcss-nesting: 13.0.1(postcss@8.5.4)
+      postcss-opacity-percentage: 3.0.0(postcss@8.5.4)
+      postcss-overflow-shorthand: 6.0.0(postcss@8.5.4)
+      postcss-page-break: 3.0.4(postcss@8.5.4)
+      postcss-place: 10.0.0(postcss@8.5.4)
+      postcss-pseudo-class-any-link: 10.0.1(postcss@8.5.4)
+      postcss-replace-overflow-wrap: 4.0.0(postcss@8.5.4)
+      postcss-selector-not: 8.0.1(postcss@8.5.4)
 
-  postcss-pseudo-class-any-link@10.0.1(postcss@8.4.39):
+  postcss-pseudo-class-any-link@10.0.1(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-selector-parser: 7.0.0
 
-  postcss-reduce-idents@6.0.3(postcss@8.4.39):
+  postcss-reduce-idents@6.0.3(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  postcss-reduce-initial@6.1.0(postcss@8.4.39):
+  postcss-reduce-initial@6.1.0(postcss@8.5.4):
     dependencies:
       browserslist: 4.24.4
       caniuse-api: 3.0.0
-      postcss: 8.4.39
+      postcss: 8.5.4
 
   postcss-reduce-initial@7.0.0(postcss@8.4.39):
     dependencies:
@@ -39987,9 +40086,9 @@ snapshots:
       caniuse-api: 3.0.0
       postcss: 8.5.4
 
-  postcss-reduce-transforms@6.0.2(postcss@8.4.39):
+  postcss-reduce-transforms@6.0.2(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
   postcss-reduce-transforms@7.0.0(postcss@8.4.39):
@@ -40002,13 +40101,13 @@ snapshots:
       postcss: 8.5.4
       postcss-value-parser: 4.2.0
 
-  postcss-replace-overflow-wrap@4.0.0(postcss@8.4.39):
+  postcss-replace-overflow-wrap@4.0.0(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
 
-  postcss-selector-not@8.0.1(postcss@8.4.39):
+  postcss-selector-not@8.0.1(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-selector-parser: 7.0.0
 
   postcss-selector-parser@6.0.16:
@@ -40026,14 +40125,14 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-sort-media-queries@5.2.0(postcss@8.4.39):
+  postcss-sort-media-queries@5.2.0(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       sort-css-media-queries: 2.2.0
 
-  postcss-svgo@6.0.3(postcss@8.4.39):
+  postcss-svgo@6.0.3(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-value-parser: 4.2.0
       svgo: 3.2.0
 
@@ -40049,9 +40148,9 @@ snapshots:
       postcss-value-parser: 4.2.0
       svgo: 3.3.2
 
-  postcss-unique-selectors@6.0.4(postcss@8.4.39):
+  postcss-unique-selectors@6.0.4(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-selector-parser: 6.0.16
 
   postcss-unique-selectors@7.0.0(postcss@8.4.39):
@@ -40073,9 +40172,9 @@ snapshots:
       postcss: 8.5.4
       quote-unquote: 1.0.0
 
-  postcss-zindex@6.0.2(postcss@8.4.39):
+  postcss-zindex@6.0.2(postcss@8.5.4):
     dependencies:
-      postcss: 8.4.39
+      postcss: 8.5.4
 
   postcss@8.4.31:
     dependencies:
@@ -41041,7 +41140,7 @@ snapshots:
     dependencies:
       escalade: 3.2.0
       picocolors: 1.1.1
-      postcss: 8.4.39
+      postcss: 8.5.4
       strip-json-comments: 3.1.1
 
   run-applescript@7.0.0: {}
@@ -42094,10 +42193,10 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.23.2
 
-  stylehacks@6.1.1(postcss@8.4.39):
+  stylehacks@6.1.1(postcss@8.5.4):
     dependencies:
       browserslist: 4.24.4
-      postcss: 8.4.39
+      postcss: 8.5.4
       postcss-selector-parser: 6.0.16
 
   stylehacks@7.0.0(postcss@8.4.39):
@@ -43238,7 +43337,7 @@ snapshots:
     dependencies:
       browserslist: 4.21.5
       escalade: 3.2.0
-      picocolors: 1.0.0
+      picocolors: 1.1.1
 
   update-browserslist-db@1.1.1(browserslist@4.23.1):
     dependencies:
@@ -43440,7 +43539,7 @@ snapshots:
       unctx: 2.4.1
       unenv: 1.10.0
       unstorage: 1.15.0(db0@0.2.4(drizzle-orm@0.31.2(@cloudflare/workers-types@4.20250505.0)(@types/better-sqlite3@7.6.2)(@types/react@19.1.0)(bun-types@1.1.32)(postgres@3.4.4)(react@19.1.0)))(ioredis@5.4.1)
-      vite: 6.2.4(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.4)(yaml@2.7.0)
+      vite: 6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.4)(yaml@2.7.0)
       zod: 3.25.51
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -43526,7 +43625,7 @@ snapshots:
       debug: 4.4.1(supports-color@9.4.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.2.7(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -43547,7 +43646,7 @@ snapshots:
       debug: 4.4.1(supports-color@9.4.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.2.7(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.4)(yaml@2.7.0)
+      vite: 6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.4)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -43671,23 +43770,26 @@ snapshots:
       tsx: 4.19.3
       yaml: 2.7.0
 
-  vite@6.2.7(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.4)(yaml@2.7.0):
+  vite@6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.5
+      fdir: 6.4.5(picomatch@4.0.2)
+      picomatch: 4.0.2
       postcss: 8.5.4
-      rollup: 4.34.8
+      rollup: 4.41.1
+      tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 20.17.46
       fsevents: 2.3.3
       jiti: 2.4.2
       lightningcss: 1.28.2
       terser: 5.34.0
-      tsx: 4.19.4
+      tsx: 4.19.3
       yaml: 2.7.0
 
   vite@6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.4)(yaml@2.7.0):
     dependencies:
-      esbuild: 0.25.2
+      esbuild: 0.25.5
       fdir: 6.4.5(picomatch@4.0.2)
       picomatch: 4.0.2
       postcss: 8.5.4
@@ -43705,7 +43807,7 @@ snapshots:
   vitest@3.1.3(@edge-runtime/vm@2.0.2)(@types/debug@4.1.12)(@types/node@20.17.46)(@vitest/ui@3.1.3)(jiti@2.4.2)(jsdom@24.0.0)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.3)(yaml@2.7.0):
     dependencies:
       '@vitest/expect': 3.1.3
-      '@vitest/mocker': 3.1.3(vite@6.2.7(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.3)(yaml@2.7.0))
+      '@vitest/mocker': 3.1.3(vite@6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.3)(yaml@2.7.0))
       '@vitest/pretty-format': 3.1.3
       '@vitest/runner': 3.1.3
       '@vitest/snapshot': 3.1.3
@@ -43722,7 +43824,7 @@ snapshots:
       tinyglobby: 0.2.13
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.7(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.3)(yaml@2.7.0)
+      vite: 6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.3)(yaml@2.7.0)
       vite-node: 3.1.3(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.3)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -43748,7 +43850,7 @@ snapshots:
   vitest@3.1.3(@edge-runtime/vm@2.0.2)(@types/debug@4.1.12)(@types/node@20.17.46)(@vitest/ui@3.1.3)(jiti@2.4.2)(jsdom@24.0.0)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.4)(yaml@2.7.0):
     dependencies:
       '@vitest/expect': 3.1.3
-      '@vitest/mocker': 3.1.3(vite@6.2.7(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.3)(yaml@2.7.0))
+      '@vitest/mocker': 3.1.3(vite@6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.4)(yaml@2.7.0))
       '@vitest/pretty-format': 3.1.3
       '@vitest/runner': 3.1.3
       '@vitest/snapshot': 3.1.3
@@ -43765,7 +43867,7 @@ snapshots:
       tinyglobby: 0.2.13
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.7(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.4)(yaml@2.7.0)
+      vite: 6.3.5(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.4)(yaml@2.7.0)
       vite-node: 3.1.3(@types/node@20.17.46)(jiti@2.4.2)(lightningcss@1.28.2)(terser@5.34.0)(tsx@4.19.4)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1064,6 +1064,40 @@ importers:
         specifier: ^5.8.2
         version: 5.8.2
 
+  examples/minimal-typesafe-errors:
+    dependencies:
+      '@trpc/client':
+        specifier: npm:@trpc/client
+        version: link:../../packages/client
+      '@trpc/server':
+        specifier: npm:@trpc/server
+        version: link:../../packages/server
+      superjson:
+        specifier: ^1.12.4
+        version: 1.12.4
+      zod:
+        specifier: ^3.25.51
+        version: 3.25.51
+    devDependencies:
+      '@types/node':
+        specifier: 20.17.46
+        version: 20.17.46
+      npm-run-all:
+        specifier: ^4.1.5
+        version: 4.1.5
+      start-server-and-test:
+        specifier: ^1.12.0
+        version: 1.14.0
+      tsx:
+        specifier: ^4.19.3
+        version: 4.19.4
+      typescript:
+        specifier: ^5.8.2
+        version: 5.8.2
+      wait-port:
+        specifier: ^1.0.1
+        version: 1.0.4
+
   examples/next-big-router:
     dependencies:
       '@tanstack/react-query':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - 'examples/.*/*'
   - 'examples/minimal/*'
   - 'examples/minimal-react/*'
+  - 'examples/minimal-react-typesafe-errors/*'
   - 'examples/minimal-content-types/*'
   - 'www'
   - 'www/og-image'


### PR DESCRIPTION
Closes #6832

## 🎯 Changes

- Add an `errors` method to the procedure builder for defining custom error types.
  - Errors can be thrown from resolvers and middlewares.
  - Each error type may include an optional schema for validating attached data at runtime.
- Propagate typed errors to:
  - Subscription resolvers (`onError`)
  - React Query hooks and utilities
  - Vanilla client utilities:
    - `safe` (for non-iterable queries/mutations)
    - `safeAsyncIterable` (for iterable queries)

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.