### PR TITLE
 fixed vitest.config.ts windows path error, backward comatible ensure…

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,11 +2,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import path, { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 const aliases: Record<string, string> = {};
-const packagesDir = new URL('./packages', import.meta.url).pathname;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packagesDir = path.resolve(__dirname, 'packages');
 
 const dirs = readdirSync(packagesDir)
   .filter((it) => it !== 'tests' && !it.startsWith('.'))


### PR DESCRIPTION
**🐛 Fix cross-platform path handling on Windows**  

### Changes  
This PR fixes a bug where the dev environment would fail on Windows due to incorrect path handling.  

**Issue:**  
The original code:  
```typescript  
const packagesDir = new URL('./packages', import.meta.url).pathname;  
```  
produced an invalid path on Windows (e.g., `C:\C:\`), breaking filesystem operations.  

**Fix:**  
Replaced it with a cross-platform solution using `fileURLToPath` and `path.resolve`:  
```typescript  
import path from 'node:path';  
import { fileURLToPath } from 'node:url';  

const __dirname = path.dirname(fileURLToPath(import.meta.url));  
const packagesDir = path.resolve(__dirname, 'packages');  
```  

**Result:**  
- Tests now run correctly on Windows.  
- Remaining test failures are unrelated (due to other cross-platform filesystem handling issues probably I will try to fix next).  


Let me know if you'd like any further refinements!


## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the method for determining the base directory of the packages folder to use a file system path-based approach instead of a URL-based method. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->