### PR TITLE
fix: make self-signed test certificate generation cross-platform compatible

### DIFF
--- a/packages/tests/server/adapters/standalone.http2.test.ts
+++ b/packages/tests/server/adapters/standalone.http2.test.ts
@@ -23,16 +23,30 @@ const cert = run(() => {
   const nonce = () => Math.random().toString(36).substring(2, 15);
   const name = `${__dirname}/localhost-${nonce()}`;
 
-  childProcess.execSync(
-    `
-    openssl req -x509 -newkey rsa:4096 \
-        -keyout ${name}.key \
-        -out ${name}.crt \
-        -days 365 -nodes \
-        -subj '/CN=localhost' \
-        -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"`.trim(),
-    { stdio: 'ignore' },
-  );
+  // cross platform
+  const args = [
+    'req',
+    '-x509',
+    '-newkey',
+    'rsa:4096',
+    '-keyout',
+    `${name}.key`,
+    '-out',
+    `${name}.crt`,
+    '-days',
+    '365',
+    '-nodes',
+    '-subj',
+    '/CN=localhost',
+    '-addext',
+    'subjectAltName=DNS:localhost,IP:127.0.0.1',
+  ];
+
+  // Execute with proper argument handling
+  childProcess.execFileSync('openssl', args, {
+    stdio: 'ignore',
+    windowsHide: true,
+  });
 
   const key = fs.readFileSync(`${name}.key`);
   const cert = fs.readFileSync(`${name}.crt`);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,11 +2,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import path, { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 const aliases: Record<string, string> = {};
-const packagesDir = new URL('./packages', import.meta.url).pathname;
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packagesDir = path.resolve(__dirname, 'packages');
 
 const dirs = readdirSync(packagesDir)
   .filter((it) => it !== 'tests' && !it.startsWith('.'))


### PR DESCRIPTION
Closes #

## 🎯 Changes

Issues with cross-platform dev environments  were fixed, related to running commands as well, file-path.


## ✅ Checklist

- [x ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x ] If necessary, I have added documentation related to the changes made.
- [x ] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the process for generating self-signed TLS certificates during testing, enhancing compatibility and suppressing unnecessary console windows on Windows. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->