### PR TITLE
Add oRPC to tRPC Community Extensions

### DIFF
--- a/www/docs/community/awesome-trpc.mdx
+++ b/www/docs/community/awesome-trpc.mdx
@@ -29,6 +29,7 @@ A collection of resources on tRPC.
 | trpc-cli - Turn a tRPC router into a type-safe, fully documented CLI          | https://github.com/mmkal/trpc-cli                    |
 | trpc-live - Live query solution for tRPC                                      | https://github.com/strblr/trpc-live                  |
 | trpc-navigation-plugin - Fix goto-definition with emit declarations           | https://github.com/ebg1223/trpc-navigation-plugin    |
+| oRPC - OpenAPI support for your tRPC routers                                  | https://orpc.unnoq.com/docs/openapi/integrations/trpc|
 
 ### Frontend frameworks
 

--- a/www/docs/community/awesome-trpc.mdx
+++ b/www/docs/community/awesome-trpc.mdx
@@ -17,19 +17,19 @@ A collection of resources on tRPC.
 
 ### Extensions
 
-| Description                                                                   | Link                                                 |
-| ----------------------------------------------------------------------------- | ---------------------------------------------------- |
-| tRPC-ui - Automatically generates a UI for manually testing your tRPC backend | https://github.com/aidansunbury/trpc-ui              |
-| trpc-to-openapi - OpenAPI & REST support for your tRPC routers                | https://github.com/mcampa/trpc-to-openapi            |
-| tRPC Client Devtools browser extension                                        | https://github.com/rhenriquez28/trpc-client-devtools |
-| tRPC Playground - sandbox for testing tRPC queries in the browser             | https://github.com/sachinraja/trpc-playground        |
-| tRPC-Chrome - Web extensions messaging support for tRPC                       | https://github.com/jlalmes/trpc-chrome               |
-| Step CI - Automated API Testing and Quality Assurance                         | https://github.com/stepci/stepci                     |
-| msw-trpc - tRPC support for MSW                                               | https://github.com/maloguertin/msw-trpc              |
-| trpc-cli - Turn a tRPC router into a type-safe, fully documented CLI          | https://github.com/mmkal/trpc-cli                    |
-| trpc-live - Live query solution for tRPC                                      | https://github.com/strblr/trpc-live                  |
-| trpc-navigation-plugin - Fix goto-definition with emit declarations           | https://github.com/ebg1223/trpc-navigation-plugin    |
-| oRPC - OpenAPI support for your tRPC routers                                  | https://orpc.unnoq.com/docs/openapi/integrations/trpc|
+| Description                                                                   | Link                                                  |
+| ----------------------------------------------------------------------------- | ----------------------------------------------------- |
+| tRPC-ui - Automatically generates a UI for manually testing your tRPC backend | https://github.com/aidansunbury/trpc-ui               |
+| trpc-to-openapi - OpenAPI & REST support for your tRPC routers                | https://github.com/mcampa/trpc-to-openapi             |
+| tRPC Client Devtools browser extension                                        | https://github.com/rhenriquez28/trpc-client-devtools  |
+| tRPC Playground - sandbox for testing tRPC queries in the browser             | https://github.com/sachinraja/trpc-playground         |
+| tRPC-Chrome - Web extensions messaging support for tRPC                       | https://github.com/jlalmes/trpc-chrome                |
+| Step CI - Automated API Testing and Quality Assurance                         | https://github.com/stepci/stepci                      |
+| msw-trpc - tRPC support for MSW                                               | https://github.com/maloguertin/msw-trpc               |
+| trpc-cli - Turn a tRPC router into a type-safe, fully documented CLI          | https://github.com/mmkal/trpc-cli                     |
+| trpc-live - Live query solution for tRPC                                      | https://github.com/strblr/trpc-live                   |
+| trpc-navigation-plugin - Fix goto-definition with emit declarations           | https://github.com/ebg1223/trpc-navigation-plugin     |
+| oRPC - OpenAPI support for your tRPC routers                                  | https://orpc.unnoq.com/docs/openapi/integrations/trpc |
 
 ### Frontend frameworks
 


### PR DESCRIPTION
## 🎯 Changes

Adding oRPC project to community extensions.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new entry for "oRPC" in the Extensions table, highlighting OpenAPI support for tRPC routers with a link to its documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->