### PR TITLE
docs: fix typo to use "validated" instead of "validate" in input comment

### DIFF
--- a/www/docs/server/procedures.md
+++ b/www/docs/server/procedures.md
@@ -135,7 +135,7 @@ export const appRouter = t.router({
       const { ctx } = opts;
       //       ^?
 
-      // input includes the validate email of the user being invited & the validated organizationId
+      // input includes the validated email of the user being invited & the validated organizationId
       const { input } = opts;
       //       ^?
 


### PR DESCRIPTION
Closes #

## 🎯 Changes

Fixes a typo in the documentation for server procedures. The comment in the `addMember` mutation now correctly states that the input includes the **_validated_** `email` of the user being invited and the validated `organizationId`.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
