### PR TITLE
feat(server): expose procedure path in resolver options

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/procedureBuilder.ts
+++ b/packages/server/src/unstable-core-do-not-import/procedureBuilder.ts
@@ -107,6 +107,10 @@ export interface ProcedureResolverOptions<
    * The AbortSignal of the request
    */
   signal: AbortSignal | undefined;
+  /**
+   * The path of the procedure
+   */
+  path: string;
 }
 
 /**

--- a/packages/tests/server/smoke.test.ts
+++ b/packages/tests/server/smoke.test.ts
@@ -292,3 +292,29 @@ test('lazy', async () => {
   await using ctx = testServerAndClientResource(router);
   expect(await ctx.client.inSomeOtherFile.hello.query()).toBe('world');
 });
+
+test('query can return path', async () => {
+  const proc = procedure.query((opts) => opts.path);
+  const router = t.router({
+    hello: proc,
+    lazy: lazy(async () => {
+      return t.router({
+        hello2: proc,
+      });
+    }),
+  });
+
+  await using ctx = testServerAndClientResource(router);
+  {
+    const result = await ctx.client.hello.query();
+    expect(result).toBe('hello');
+    expectTypeOf(result).not.toBeAny();
+    expectTypeOf(result).toEqualTypeOf<string>();
+  }
+  {
+    const result = await ctx.client.lazy.hello2.query();
+    expect(result).toBe('lazy.hello2');
+    expectTypeOf(result).not.toBeAny();
+    expectTypeOf(result).toEqualTypeOf<string>();
+  }
+});


### PR DESCRIPTION
Closes https://discord-questions.trpc.io/m/1407646931928350833

## 🎯 Changes

Expose procedure path

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Procedure resolvers now receive the procedure path, enabling handlers to read or return their own path.
  - Path propagation works for both direct routes and nested/lazy-loaded routes.

- Tests
  - Added smoke tests covering path availability in resolvers.
  - Verified correct path resolution for a root query (“hello”) and a lazy sub-route (“lazy.hello2”), including type checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->