### PR TITLE
docs(adapters/fastify): usage of routerOptions

### DIFF
--- a/www/docs/server/adapters/fastify.md
+++ b/www/docs/server/adapters/fastify.md
@@ -135,7 +135,9 @@ import { createContext } from './context';
 import { appRouter, type AppRouter } from './router';
 
 const server = fastify({
-  maxParamLength: 5000,
+  routerOptions: {
+    maxParamLength: 5000,
+  },
 });
 
 server.register(fastifyTRPCPlugin, {


### PR DESCRIPTION
Since Fastify v5.5.0, there is the following deprecation warning:
> [FSTDPE022] FastifyWarning: The router options for maxParamLength property access is deprecated. Please use "options.routerOptions" instead for acce
ssing router options. The router options will be removed in `fastify@6`.

Related https://github.com/fastify/fastify/pull/6282, https://github.com/fastify/fastify/pull/5985

## 🎯 Changes

Update the Fastify adapter documentation to fix the deprecation warning.

Should we put the 2 possible ways for both v5.4 and prior Fastify versions, and for v5.5.0 and above, or it's fine to only put the "latest" way (like how it is done currently in this PR)?

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
