### PR TITLE
docs: Fix broken documentation links to RPC TypeScript definitions

### DIFF
--- a/www/docs/further/rpc.md
+++ b/www/docs/further/rpc.md
@@ -289,5 +289,5 @@ const client = createTRPCClient<AppRouter>({
 
 You can read more details by drilling into the TypeScript definitions in
 
-- [/packages/server/src/rpc/envelopes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/rpc/envelopes.ts)
-- [/packages/server/src/rpc/codes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/rpc/codes.ts)
+- [/packages/server/src/unstable-core-do-not-import/rpc/envelopes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/unstable-core-do-not-import/rpc/envelopes.ts)
+- [/packages/server/src/unstable-core-do-not-import/rpc/codes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/unstable-core-do-not-import/rpc/codes.ts)

--- a/www/docs/server/websockets.md
+++ b/www/docs/server/websockets.md
@@ -172,8 +172,8 @@ export const subRouter = router({
 
 > You can read more details by drilling into the TypeScript definitions:
 >
-> - [/packages/server/src/rpc/envelopes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/rpc/envelopes.ts)
-> - [/packages/server/src/rpc/codes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/rpc/codes.ts).
+> - [/packages/server/src/unstable-core-do-not-import/rpc/envelopes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/unstable-core-do-not-import/rpc/envelopes.ts)
+> - [/packages/server/src/unstable-core-do-not-import/rpc/codes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/unstable-core-do-not-import/rpc/codes.ts).
 
 ### `query` / `mutation`
 

--- a/www/versioned_docs/version-10.x/further/rpc.md
+++ b/www/versioned_docs/version-10.x/further/rpc.md
@@ -257,5 +257,5 @@ export const TRPC_ERROR_CODES_BY_KEY = {
 
 You can read more details by drilling into the TypeScript definitions in
 
-- [/packages/server/src/rpc/envelopes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/rpc/envelopes.ts)
-- [/packages/server/src/rpc/codes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/rpc/codes.ts)
+- [/packages/server/src/unstable-core-do-not-import/rpc/envelopes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/unstable-core-do-not-import/rpc/envelopes.ts)
+- [/packages/server/src/unstable-core-do-not-import/rpc/codes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/unstable-core-do-not-import/rpc/codes.ts)

--- a/www/versioned_docs/version-10.x/further/subscriptions.md
+++ b/www/versioned_docs/version-10.x/further/subscriptions.md
@@ -126,8 +126,8 @@ See [/examples/next-prisma-starter-websockets](https://github.com/trpc/examples-
 
 > You can read more details by drilling into the TypeScript definitions:
 >
-> - [/packages/server/src/rpc/envelopes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/rpc/envelopes.ts)
-> - [/packages/server/src/rpc/codes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/rpc/codes.ts).
+> - [/packages/server/src/unstable-core-do-not-import/rpc/envelopes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/unstable-core-do-not-import/rpc/envelopes.ts)
+> - [/packages/server/src/unstable-core-do-not-import/rpc/codes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/unstable-core-do-not-import/rpc/codes.ts).
 
 ### `query` / `mutation`
 

--- a/www/versioned_docs/version-9.x/further/rpc.md
+++ b/www/versioned_docs/version-9.x/further/rpc.md
@@ -252,5 +252,5 @@ export const TRPC_ERROR_CODES_BY_KEY = {
 
 You can read more details by drilling into the TypeScript definitions in
 
-- [/packages/server/src/rpc/envelopes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/rpc/envelopes.ts)
-- [/packages/server/src/rpc/codes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/rpc/codes.ts).
+- [/packages/server/src/unstable-core-do-not-import/rpc/envelopes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/unstable-core-do-not-import/rpc/envelopes.ts)
+- [/packages/server/src/unstable-core-do-not-import/rpc/codes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/unstable-core-do-not-import/rpc/codes.ts).

--- a/www/versioned_docs/version-9.x/further/subscriptions.md
+++ b/www/versioned_docs/version-9.x/further/subscriptions.md
@@ -125,8 +125,8 @@ See [/examples/next-prisma-starter-websockets](https://github.com/trpc/examples-
 
 > You can read more details by drilling into the TypeScript definitions:
 >
-> - [/packages/server/src/rpc/envelopes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/rpc/envelopes.ts)
-> - [/packages/server/src/rpc/codes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/rpc/codes.ts).
+> - [/packages/server/src/unstable-core-do-not-import/rpc/envelopes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/unstable-core-do-not-import/rpc/envelopes.ts)
+> - [/packages/server/src/unstable-core-do-not-import/rpc/codes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/unstable-core-do-not-import/rpc/codes.ts).
 
 ### `query` / `mutation`
 


### PR DESCRIPTION
Update all documentation references from the old paths:
- /packages/server/src/rpc/envelopes.ts
- /packages/server/src/rpc/codes.ts

To the new paths:
- /packages/server/src/unstable-core-do-not-import/rpc/envelopes.ts
- /packages/server/src/unstable-core-do-not-import/rpc/codes.ts

This fixes broken GitHub links in the documentation that were pointing to non-existent files after the RPC code was moved to the unstable-core-do-not-import directory.

🤖 Generated with [Claude Code](https://claude.ai/code) & verified by human :) 

## 🎯 Changes

Docs bugfix

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated RPC and WebSockets/Subscriptions docs to point “Dig deeper” and related references to the correct internal specification sources.
  - Applied changes across current docs and versioned 9.x and 10.x pages to keep guidance consistent.
  - Harmonized link targets in WebSockets RPC Specification sections for clarity.
  - No code, API, or behavior changes; this is a links-only documentation update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->