### PR TITLE
fix(client): omit content type header in GET requests

### DIFF
--- a/packages/client/src/links/internals/httpUtils.ts
+++ b/packages/client/src/links/internals/httpUtils.ts
@@ -197,7 +197,7 @@ export async function fetchHTTPResponse(opts: HTTPRequestOptions) {
 
   const url = opts.getUrl(opts);
   const body = opts.getBody(opts);
-  const { type } = opts;
+  const method = opts.methodOverride ?? METHOD[opts.type];
   const resolvedHeaders = await (async () => {
     const heads = await opts.headers();
     if (Symbol.iterator in heads) {
@@ -206,7 +206,7 @@ export async function fetchHTTPResponse(opts: HTTPRequestOptions) {
     return heads;
   })();
   const headers = {
-    ...(opts.contentTypeHeader
+    ...(opts.contentTypeHeader && method !== 'GET'
       ? { 'content-type': opts.contentTypeHeader }
       : {}),
     ...(opts.trpcAcceptHeader
@@ -216,7 +216,7 @@ export async function fetchHTTPResponse(opts: HTTPRequestOptions) {
   };
 
   return getFetch(opts.fetch)(url, {
-    method: opts.methodOverride ?? METHOD[type],
+    method,
     signal: opts.signal,
     body,
     headers,

--- a/packages/tests/server/contentTypeHeaders.test.ts
+++ b/packages/tests/server/contentTypeHeaders.test.ts
@@ -1,0 +1,105 @@
+import { routerToServerAndClientNew } from './___testHelpers';
+import { createTRPCClient, httpLink } from '@trpc/client';
+import { initTRPC } from '@trpc/server';
+import { z } from 'zod';
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  mockFetch.mockClear();
+  mockFetch.mockImplementation((url, options) => {
+    return fetch(url, options);
+  });
+});
+
+test('query should not have content-type header', async () => {
+  const t = initTRPC.create();
+
+  const router = t.router({
+    hello: t.procedure
+      .input(z.string().optional())
+      .query(({ input }) => `Hello ${input ?? 'world'}`),
+  });
+
+  const { httpUrl, close } = routerToServerAndClientNew(router);
+
+  const client = createTRPCClient<typeof router>({
+    links: [httpLink({ url: httpUrl, fetch: mockFetch as any })],
+  });
+
+  const result = await client.hello.query('test');
+  expect(result).toBe('Hello test');
+
+  expect(mockFetch).toHaveBeenCalledTimes(1);
+  const [url, options] = mockFetch.mock.calls[0]!;
+
+  expect(options.method).toBe('GET');
+
+  expect(options.headers).not.toHaveProperty('content-type');
+
+  await close();
+});
+
+test('mutation should have content-type header', async () => {
+  const t = initTRPC.create();
+
+  const router = t.router({
+    hello: t.procedure
+      .input(z.string())
+      .mutation(({ input }) => `Hello ${input}`),
+  });
+
+  const { httpUrl, close } = routerToServerAndClientNew(router);
+
+  const client = createTRPCClient<typeof router>({
+    links: [httpLink({ url: httpUrl, fetch: mockFetch as any })],
+  });
+
+  const result = await client.hello.mutate('test');
+  expect(result).toBe('Hello test');
+
+  expect(mockFetch).toHaveBeenCalledTimes(1);
+  const [url, options] = mockFetch.mock.calls[0]!;
+
+  expect(options.method).toBe('POST');
+
+  expect(options.headers).toHaveProperty('content-type', 'application/json');
+
+  await close();
+});
+
+test('query with methodOverride should have content-type header', async () => {
+  const t = initTRPC.create();
+
+  const router = t.router({
+    hello: t.procedure.input(z.string()).query(({ input }) => `Hello ${input}`),
+  });
+
+  const { httpUrl, close } = routerToServerAndClientNew(router, {
+    server: {
+      allowMethodOverride: true,
+    },
+  });
+
+  const client = createTRPCClient<typeof router>({
+    links: [
+      httpLink({
+        url: httpUrl,
+        methodOverride: 'POST',
+        fetch: mockFetch as any,
+      }),
+    ],
+  });
+
+  const result = await client.hello.query('test');
+  expect(result).toBe('Hello test');
+
+  expect(mockFetch).toHaveBeenCalledTimes(1);
+  const [url, options] = mockFetch.mock.calls[0]!;
+
+  expect(options.method).toBe('POST');
+
+  expect(options.headers).toHaveProperty('content-type', 'application/json');
+
+  await close();
+});


### PR DESCRIPTION
Closes #6913

## 🎯 Changes

Omit the content-type request header when sending a GET request. This prevents the GET request from triggering pre-flight requests that would potentially not occur otherwise.

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures HTTP method is determined consistently.
  * GET requests no longer send a Content-Type header.
  * POST/mutation requests include Content-Type: application/json.
  * Queries using an allowed method override set to POST send POST with the correct Content-Type header.

* **Tests**
  * Added end-to-end tests validating request method and Content-Type header behavior for queries, mutations, and method-override scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->