### PR TITLE
fix: export DataTransformer type from @trpc/server and @trpc/client

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -18,3 +18,4 @@ export {
 } from './createTRPCClient';
 
 export { type TRPCProcedureOptions } from './internals/types';
+export { type TRPCDataTransformer } from '@trpc/server';

--- a/packages/server/src/@trpc/server/index.ts
+++ b/packages/server/src/@trpc/server/index.ts
@@ -33,6 +33,7 @@ export {
   type MiddlewareBuilder as TRPCMiddlewareBuilder,
   type AnyMiddlewareFunction as AnyTRPCMiddlewareFunction,
   type CombinedDataTransformer as TRPCCombinedDataTransformer,
+  type DataTransformer as TRPCDataTransformer,
   type ProcedureType as TRPCProcedureType,
   type AnyMutationProcedure as AnyTRPCMutationProcedure,
   type AnyQueryProcedure as AnyTRPCQueryProcedure,


### PR DESCRIPTION
Closes #6916 

## 🎯 Changes

**Bug Fix**

The DataTransformer type was marked as @public but not exported from the public API packages, making it impossible for developers to properly type their transformer objects.

- Export DataTransformer as TRPCDataTransformer from @trpc/server
- Re-export TRPCDataTransformer from @trpc/client

I created a test file in the `examples/minimal` directory to verify that the type import works correctly.
(It was deleted in the commit.)

<img width="448" height="168" alt="스크린샷 2025-09-04 오전 12 50 00" src="https://github.com/user-attachments/assets/0519baa7-c05a-4170-880e-6cfe959cfa18" />


Since this is a type-related fix, I didn't modify documentation or tests separately. If you have any feedback or opinions on this, please feel free to share them!

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
