### PR TITLE
chore(examples): remove unused observable import from minimal 

### DIFF
--- a/examples/minimal/src/server/index.ts
+++ b/examples/minimal/src/server/index.ts
@@ -2,7 +2,6 @@
  * This a minimal tRPC server
  */
 import { createHTTPServer } from '@trpc/server/adapters/standalone';
-import { observable } from '@trpc/server/observable';
 import { z } from 'zod';
 import { db } from './db.js';
 import { publicProcedure, router } from './trpc.js';


### PR DESCRIPTION
## 🎯 Changes
<img width="1512" height="982" alt="스크린샷 2025-09-06 오후 5 09 57" src="https://github.com/user-attachments/assets/ff9ef426-af5e-4e8b-8af3-f12ce73b6f8f" />

Remove unused `@trpc/server/observable` import from the minimal example
server to keep the example code clean and focused.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Removed an unused import in the minimal example server.
  - No changes to public APIs or exported types; existing behavior remains unchanged.
  - No impact on runtime behavior or error handling.
  - Slight reduction in build warnings for the example.
  - No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->