### PR TITLE
Improve testing for react-query packages

### DIFF
--- a/packages/react-query/test/__testHelpers.tsx
+++ b/packages/react-query/test/__testHelpers.tsx
@@ -353,3 +353,5 @@ export function createAppRouter() {
     linkSpy,
   };
 }
+
+export { getServerAndReactClient } from './__reactHelpers';

--- a/packages/react-query/test/errors.test.tsx
+++ b/packages/react-query/test/errors.test.tsx
@@ -1,4 +1,4 @@
-import { getServerAndReactClient } from './__reactHelpers';
+import { getServerAndReactClient } from './__testHelpers';
 import { render } from '@testing-library/react';
 import type { TRPCClientErrorLike } from '@trpc/client';
 import { TRPCClientError } from '@trpc/client';

--- a/packages/react-query/test/getQueryKey.test.tsx
+++ b/packages/react-query/test/getQueryKey.test.tsx
@@ -1,4 +1,4 @@
-import { getServerAndReactClient } from './__reactHelpers';
+import { getServerAndReactClient } from './__testHelpers';
 import { useIsFetching } from '@tanstack/react-query';
 import { render } from '@testing-library/react';
 import { getQueryKey } from '@trpc/react-query';

--- a/packages/react-query/test/invalidateRouters.test.tsx
+++ b/packages/react-query/test/invalidateRouters.test.tsx
@@ -1,4 +1,4 @@
-import { getServerAndReactClient } from './__reactHelpers';
+import { getServerAndReactClient } from './__testHelpers';
 import { ignoreErrors } from '@trpc/server/__tests__/suppressLogs';
 import { useIsFetching } from '@tanstack/react-query';
 import { render } from '@testing-library/react';

--- a/packages/react-query/test/mutationkey.test.tsx
+++ b/packages/react-query/test/mutationkey.test.tsx
@@ -1,4 +1,4 @@
-import { getServerAndReactClient } from './__reactHelpers';
+import { getServerAndReactClient } from './__testHelpers';
 import { useIsMutating, useQueryClient } from '@tanstack/react-query';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/packages/react-query/test/offline.test.tsx
+++ b/packages/react-query/test/offline.test.tsx
@@ -1,4 +1,4 @@
-import { getServerAndReactClient } from './__reactHelpers';
+import { getServerAndReactClient } from './__testHelpers';
 import { createSyncStoragePersister } from '@tanstack/query-sync-storage-persister';
 import { onlineManager } from '@tanstack/react-query';
 import { render } from '@testing-library/react';

--- a/packages/react-query/test/queryOptions.test.tsx
+++ b/packages/react-query/test/queryOptions.test.tsx
@@ -1,4 +1,4 @@
-import { getServerAndReactClient } from './__reactHelpers';
+import { getServerAndReactClient } from './__testHelpers';
 import {
   infiniteQueryOptions,
   skipToken,

--- a/packages/react-query/test/rsc-prefetch.test.tsx
+++ b/packages/react-query/test/rsc-prefetch.test.tsx
@@ -1,4 +1,4 @@
-import { getServerAndReactClient } from './__reactHelpers';
+import { getServerAndReactClient } from './__testHelpers';
 import {
   defaultShouldDehydrateQuery,
   QueryClient,

--- a/packages/react-query/test/ssgExternal.test.ts
+++ b/packages/react-query/test/ssgExternal.test.ts
@@ -1,4 +1,4 @@
-import { getServerAndReactClient } from './__reactHelpers';
+import { getServerAndReactClient } from './__testHelpers';
 import type { InfiniteData } from '@tanstack/react-query';
 import { createServerSideHelpers } from '@trpc/react-query/server';
 import { initTRPC } from '@trpc/server';

--- a/packages/react-query/test/trpc-options.test.tsx
+++ b/packages/react-query/test/trpc-options.test.tsx
@@ -1,4 +1,4 @@
-import { getServerAndReactClient } from './__reactHelpers';
+import { getServerAndReactClient } from './__testHelpers';
 import { render } from '@testing-library/react';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';

--- a/packages/react-query/test/useMutation.test.tsx
+++ b/packages/react-query/test/useMutation.test.tsx
@@ -1,4 +1,4 @@
-import { getServerAndReactClient } from './__reactHelpers';
+import { getServerAndReactClient } from './__testHelpers';
 import { render } from '@testing-library/react';
 import type { inferReactQueryProcedureOptions } from '@trpc/react-query';
 import { initTRPC } from '@trpc/server';

--- a/packages/react-query/test/useQueries.test.tsx
+++ b/packages/react-query/test/useQueries.test.tsx
@@ -1,4 +1,4 @@
-import { getServerAndReactClient } from './__reactHelpers';
+import { getServerAndReactClient } from './__testHelpers';
 import { render } from '@testing-library/react';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';

--- a/packages/react-query/test/useQuery.test.tsx
+++ b/packages/react-query/test/useQuery.test.tsx
@@ -1,4 +1,4 @@
-import { getServerAndReactClient } from './__reactHelpers';
+import { getServerAndReactClient } from './__testHelpers';
 import { skipToken, type InfiniteData } from '@tanstack/react-query';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/packages/react-query/test/useSubscription.test.tsx
+++ b/packages/react-query/test/useSubscription.test.tsx
@@ -1,4 +1,4 @@
-import { getServerAndReactClient } from './__reactHelpers';
+import { getServerAndReactClient } from './__testHelpers';
 import { IterableEventEmitter } from '@trpc/server/__tests__/iterableEventEmitter';
 import {
   ignoreErrors,

--- a/packages/react-query/test/useSuspenseInfiniteQuery.test.tsx
+++ b/packages/react-query/test/useSuspenseInfiniteQuery.test.tsx
@@ -1,4 +1,4 @@
-import { getServerAndReactClient } from './__reactHelpers';
+import { getServerAndReactClient } from './__testHelpers';
 import type { InfiniteData } from '@tanstack/react-query';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/packages/react-query/test/useSuspenseQueries.test.tsx
+++ b/packages/react-query/test/useSuspenseQueries.test.tsx
@@ -1,4 +1,4 @@
-import { getServerAndReactClient } from './__reactHelpers';
+import { getServerAndReactClient } from './__testHelpers';
 import { render } from '@testing-library/react';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';

--- a/packages/react-query/test/useSuspenseQuery.test.tsx
+++ b/packages/react-query/test/useSuspenseQuery.test.tsx
@@ -1,4 +1,4 @@
-import { getServerAndReactClient } from './__reactHelpers';
+import { getServerAndReactClient } from './__testHelpers';
 import { doNotExecute } from '@trpc/server/__tests__/suppressLogs';
 import { skipToken } from '@tanstack/react-query';
 import { render } from '@testing-library/react';

--- a/packages/react-query/test/useUtils.test.tsx
+++ b/packages/react-query/test/useUtils.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import { getServerAndReactClient } from './__reactHelpers';
+import { getServerAndReactClient } from './__testHelpers';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { initTRPC } from '@trpc/server';


### PR DESCRIPTION
Closes #

## 🎯 Changes

This PR refactors the import paths for `getServerAndReactClient` in `packages/react-query` tests. `getServerAndReactClient` is now re-exported from `packages/react-query/test/__testHelpers.tsx`, and all affected tests have been updated to import it from this consolidated helper file, aligning with internal testing guidelines.

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b89bf44-c95f-4d27-9cf4-e1730df802fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5b89bf44-c95f-4d27-9cf4-e1730df802fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

