### PR TITLE
Refactor all tests in packages/tests

### DIFF
--- a/packages/tests/server/httpSubscriptionLink.headers.retryLink.test.ts
+++ b/packages/tests/server/httpSubscriptionLink.headers.retryLink.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'node:events';
-import { routerToServerAndClientNew } from './___testHelpers';
+/// <reference types="vitest" />
+import { testServerAndClientResource } from '@trpc/client/__tests__/testClientResource';
 import { suppressLogsUntil } from '@trpc/server/__tests__/suppressLogs';
 import '@testing-library/react';
 import type { TRPCLink } from '@trpc/client';
@@ -85,7 +86,7 @@ const ctx = konn()
 
     const recreateOnErrorTypes: string[] = [];
 
-    const opts = routerToServerAndClientNew(router, {
+    const opts = testServerAndClientResource(router, {
       server: {
         onError(_err) {
           // console.error('caught server error:', _err.error.message);

--- a/packages/tests/server/httpSubscriptionLink.test.ts
+++ b/packages/tests/server/httpSubscriptionLink.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter, on } from 'node:events';
-import { routerToServerAndClientNew } from './___testHelpers';
-import { IterableEventEmitter } from './../../server/src/__tests__/iterableEventEmitter';
+/// <reference types="vitest" />
 import { testServerAndClientResource } from '@trpc/client/__tests__/testClientResource';
+import { IterableEventEmitter } from './../../server/src/__tests__/iterableEventEmitter';
 import { fakeTimersResource } from '@trpc/server/__tests__/fakeTimersResource';
 import {
   suppressLogs,
@@ -125,7 +125,7 @@ const ctx = konn()
         });
       };
     };
-    const opts = routerToServerAndClientNew(router, {
+    const opts = testServerAndClientResource(router, {
       server: {},
       client(opts) {
         return {
@@ -460,7 +460,7 @@ describe('auth / connectionParams', async () => {
         }),
       });
 
-      const opts = routerToServerAndClientNew(appRouter, {
+      const opts = testServerAndClientResource(appRouter, {
         server: {
           async createContext(opts) {
             let user: User | null = null;
@@ -598,7 +598,7 @@ describe('headers / eventSourceOptions', async () => {
         }),
       });
 
-      const opts = routerToServerAndClientNew(appRouter, {
+      const opts = testServerAndClientResource(appRouter, {
         server: {
           async createContext(opts) {
             let user: User | null = null;
@@ -743,7 +743,7 @@ describe('transformers / different serialize-deserialize', async () => {
         }),
       });
 
-      const opts = routerToServerAndClientNew(appRouter, {});
+      const opts = testServerAndClientResource(appRouter, {});
 
       return { ...opts, eeEmit };
     })
@@ -861,7 +861,7 @@ describe('timeouts', async () => {
         });
       };
     };
-    const opts = routerToServerAndClientNew(router, {
+    const opts = testServerAndClientResource(router, {
       server: {},
       client(opts) {
         return {
@@ -1117,7 +1117,7 @@ test('tracked() without transformer', async () => {
         }),
     });
 
-    const opts = routerToServerAndClientNew(router, {
+    const opts = testServerAndClientResource(router, {
       server: {},
       client(opts) {
         return {

--- a/packages/tests/server/regression/issue-2506-headers-throwing.test.ts
+++ b/packages/tests/server/regression/issue-2506-headers-throwing.test.ts
@@ -1,8 +1,8 @@
-import { routerToServerAndClientNew } from '../___testHelpers';
+/// <reference types="vitest" />
+import { testServerAndClientResource } from '@trpc/client/__tests__/testClientResource';
 import { waitError } from '@trpc/server/__tests__/waitError';
 import { httpBatchLink, httpLink, TRPCClientError } from '@trpc/client';
 import { initTRPC } from '@trpc/server';
-import { konn } from 'konn';
 import { z } from 'zod';
 
 const t = initTRPC.create();
@@ -16,31 +16,22 @@ const appRouter = t.router({
 });
 
 describe('httpLink', () => {
-  const ctx = konn()
-    .beforeEach(() => {
-      const opts = routerToServerAndClientNew(appRouter, {
-        client({ httpUrl }) {
-          return {
-            links: [
-              httpLink({
-                url: httpUrl,
-                headers() {
-                  throw new Error('Bad headers fn');
-                },
-              }),
-            ],
-          };
-        },
-      });
-
-      return opts;
-    })
-    .afterEach(async (ctx) => {
-      await ctx?.close?.();
-    })
-    .done();
-
   test('headers() failure', async () => {
+    await using ctx = testServerAndClientResource(appRouter, {
+      client({ httpUrl }) {
+        return {
+          links: [
+            httpLink({
+              url: httpUrl,
+              headers() {
+                throw new Error('Bad headers fn');
+              },
+            }),
+          ],
+        };
+      },
+    });
+
     const error = (await waitError(
       ctx.client.q.query('bad'),
       TRPCClientError,
@@ -51,31 +42,22 @@ describe('httpLink', () => {
 });
 
 describe('httpBatchLink', () => {
-  const ctx = konn()
-    .beforeEach(() => {
-      const opts = routerToServerAndClientNew(appRouter, {
-        client({ httpUrl }) {
-          return {
-            links: [
-              httpBatchLink({
-                url: httpUrl,
-                headers() {
-                  throw new Error('Bad headers fn');
-                },
-              }),
-            ],
-          };
-        },
-      });
-
-      return opts;
-    })
-    .afterEach(async (ctx) => {
-      await ctx?.close?.();
-    })
-    .done();
-
   test('headers() failure', async () => {
+    await using ctx = testServerAndClientResource(appRouter, {
+      client({ httpUrl }) {
+        return {
+          links: [
+            httpBatchLink({
+              url: httpUrl,
+              headers() {
+                throw new Error('Bad headers fn');
+              },
+            }),
+          ],
+        };
+      },
+    });
+
     const error = (await waitError(
       ctx.client.q.query('bad'),
       TRPCClientError,

--- a/packages/tests/server/regression/issue-4049-stripped-undefined.test.tsx
+++ b/packages/tests/server/regression/issue-4049-stripped-undefined.test.tsx
@@ -1,54 +1,42 @@
-import { routerToServerAndClientNew } from '../___testHelpers';
+/// <reference types="vitest" />
+import { testServerAndClientResource } from '@trpc/client/__tests__/testClientResource';
 import { httpLink } from '@trpc/client';
 import { createTRPCReact } from '@trpc/react-query';
 import { initTRPC } from '@trpc/server';
-import { konn } from 'konn';
 
 describe('undefined on server response is inferred on the client', () => {
-  const ctx = konn()
-    .beforeEach(() => {
-      const t = initTRPC.create();
-      const appRouter = t.router({
-        num: t.procedure.query(() => {
-          const nums = [1, 2, 3, 4, 5];
-          const num = nums.find((n) => n === Math.floor(Math.random() * 10));
-          //    ^?
-          expectTypeOf(num).toEqualTypeOf<number | undefined>();
-          return num;
-        }),
-        obj: t.procedure.query(() => {
-          const objs = [{ id: 1 } as { id: number | undefined }];
-          const obj = objs.find((n) => n.id === Math.floor(Math.random() * 5));
-          //    ^?
-          expectTypeOf(obj).toEqualTypeOf<
-            { id: number | undefined } | undefined
-          >();
-          return obj;
-        }),
-        und: t.procedure.query(() => {
-          return undefined;
-        }),
-      });
-
-      return routerToServerAndClientNew(appRouter, {
-        client({ httpUrl }) {
-          return {
-            links: [httpLink({ url: httpUrl })],
-          };
-        },
-      });
-    })
-    .afterEach(async (ctx) => {
-      await ctx?.close?.();
-    })
-    .done();
+  const t = initTRPC.create();
+  const appRouter = t.router({
+    num: t.procedure.query(() => {
+      const nums = [1, 2, 3, 4, 5];
+      const num = nums.find((n) => n === Math.floor(Math.random() * 10));
+      expectTypeOf(num).toEqualTypeOf<number | undefined>();
+      return num;
+    }),
+    obj: t.procedure.query(() => {
+      const objs = [{ id: 1 } as { id: number | undefined }];
+      const obj = objs.find((n) => n.id === Math.floor(Math.random() * 5));
+      expectTypeOf(obj).toEqualTypeOf<
+        { id: number | undefined } | undefined
+      >();
+      return obj;
+    }),
+    und: t.procedure.query(() => {
+      return undefined;
+    }),
+  });
 
   test('using vanilla client', async () => {
+    await using ctx = testServerAndClientResource(appRouter, {
+      client({ httpUrl }) {
+        return { links: [httpLink({ url: httpUrl })] };
+      },
+    });
+
     const num = await ctx.client.num.query();
     expectTypeOf(num).toEqualTypeOf<number | undefined>();
 
     const obj = await ctx.client.obj.query();
-    // key might be stripped entirely   👇, or value should be defined
     expectTypeOf(obj).toEqualTypeOf<{ id?: number } | undefined>();
 
     const und = await ctx.client.und.query();
@@ -56,13 +44,11 @@ describe('undefined on server response is inferred on the client', () => {
   });
 
   test('using createCaller', async () => {
-    const router = ctx.router;
-    const caller = router.createCaller({});
+    const caller = appRouter.createCaller({});
     const num = await caller.num();
     expectTypeOf(num).toEqualTypeOf<number | undefined>();
 
     const obj = await caller.obj();
-    // key should not be stripped       👇, since we're not calling JSON.stringify/parse on createCaller, value can be undefined though
     expectTypeOf(obj).toEqualTypeOf<{ id: number | undefined } | undefined>();
 
     const und = await caller.und();
@@ -70,7 +56,7 @@ describe('undefined on server response is inferred on the client', () => {
   });
 
   test('using react hooks', async () => {
-    const hooks = createTRPCReact<typeof ctx.router>();
+    const hooks = createTRPCReact<typeof appRouter>();
     () => {
       const { data: num, isSuccess: numSuccess } = hooks.num.useQuery();
       if (numSuccess) expectTypeOf(num).toEqualTypeOf<number | undefined>();

--- a/packages/tests/server/regression/issue-4673-url-encoded-batching.test.ts
+++ b/packages/tests/server/regression/issue-4673-url-encoded-batching.test.ts
@@ -1,25 +1,17 @@
-import { routerToServerAndClientNew } from '../___testHelpers';
+/// <reference types="vitest" />
+import { testServerAndClientResource } from '@trpc/client/__tests__/testClientResource';
 import { initTRPC } from '@trpc/server';
-import { konn } from 'konn';
 import { z } from 'zod';
 
-const ctx = konn()
-  .beforeEach(() => {
-    const t = initTRPC.create();
-    const appRouter = t.router({
-      a: t.procedure.query(() => 'a'),
-      b: t.procedure.query(() => 'b'),
-      withInput: t.procedure.input(z.string()).query((opts) => opts.input),
-    });
-
-    return routerToServerAndClientNew(appRouter);
-  })
-  .afterEach(async (ctx) => {
-    await ctx?.close?.();
-  })
-  .done();
-
 test('handle URL encoded commas in URL.pathname', async () => {
+  const t = initTRPC.create();
+  const appRouter = t.router({
+    a: t.procedure.query(() => 'a'),
+    b: t.procedure.query(() => 'b'),
+    withInput: t.procedure.input(z.string()).query((opts) => opts.input),
+  });
+
+  await using ctx = testServerAndClientResource(appRouter);
   const url = ctx.httpUrl;
 
   const normalResult = await (
@@ -47,6 +39,14 @@ test('handle URL encoded commas in URL.pathname', async () => {
 });
 
 test('handle URL encoded input in search params', async () => {
+  const t = initTRPC.create();
+  const appRouter = t.router({
+    a: t.procedure.query(() => 'a'),
+    b: t.procedure.query(() => 'b'),
+    withInput: t.procedure.input(z.string()).query((opts) => opts.input),
+  });
+
+  await using ctx = testServerAndClientResource(appRouter);
   const url = ctx.httpUrl;
 
   const normalResult = await (

--- a/packages/tests/server/regression/issue-5945-stream-null.test.ts
+++ b/packages/tests/server/regression/issue-5945-stream-null.test.ts
@@ -1,96 +1,138 @@
-import { routerToServerAndClientNew } from '../___testHelpers';
+/// <reference types="vitest" />
+import { testServerAndClientResource } from '@trpc/client/__tests__/testClientResource';
 import { httpBatchStreamLink } from '@trpc/client';
 import { initTRPC } from '@trpc/server';
-import { konn } from 'konn';
 import superjson from 'superjson';
 
 describe('without transformer', () => {
-  const ctx = konn()
-    .beforeEach(() => {
-      const t = initTRPC.create();
-      const appRouter = t.router({
-        returnNull: t.procedure.query(() => {
-          return null;
-        }),
-        returnUndefined: t.procedure.query(() => {
-          return undefined;
-        }),
-        returnString: t.procedure.query(() => {
-          return 'hello';
-        }),
-      });
-
-      return routerToServerAndClientNew(appRouter, {
-        client({ httpUrl }) {
-          return {
-            links: [httpBatchStreamLink({ url: httpUrl })],
-          };
-        },
-      });
-    })
-    .afterEach(async (ctx) => {
-      await ctx?.close?.();
-    })
-    .done();
-
   test('return string', async () => {
+    const t = initTRPC.create();
+    const appRouter = t.router({
+      returnNull: t.procedure.query(() => null),
+      returnUndefined: t.procedure.query(() => undefined),
+      returnString: t.procedure.query(() => 'hello'),
+    });
+
+    await using ctx = testServerAndClientResource(appRouter, {
+      client({ httpUrl }) {
+        return {
+          links: [httpBatchStreamLink({ url: httpUrl })],
+        };
+      },
+    });
+
     expect(await ctx.client.returnString.query()).toBe('hello');
   });
 
   test('return null', async () => {
+    const t = initTRPC.create();
+    const appRouter = t.router({
+      returnNull: t.procedure.query(() => null),
+      returnUndefined: t.procedure.query(() => undefined),
+      returnString: t.procedure.query(() => 'hello'),
+    });
+
+    await using ctx = testServerAndClientResource(appRouter, {
+      client({ httpUrl }) {
+        return {
+          links: [httpBatchStreamLink({ url: httpUrl })],
+        };
+      },
+    });
+
     expect(await ctx.client.returnNull.query()).toBe(null);
   });
 
   test('return undefined', async () => {
+    const t = initTRPC.create();
+    const appRouter = t.router({
+      returnNull: t.procedure.query(() => null),
+      returnUndefined: t.procedure.query(() => undefined),
+      returnString: t.procedure.query(() => 'hello'),
+    });
+
+    await using ctx = testServerAndClientResource(appRouter, {
+      client({ httpUrl }) {
+        return {
+          links: [httpBatchStreamLink({ url: httpUrl })],
+        };
+      },
+    });
+
     expect(await ctx.client.returnUndefined.query()).toBe(undefined);
   });
 });
 
 describe('with transformer', () => {
-  const ctx = konn()
-    .beforeEach(() => {
-      const t = initTRPC.create({
-        transformer: superjson,
-      });
-      const appRouter = t.router({
-        returnNull: t.procedure.query(() => {
-          return null;
-        }),
-        returnUndefined: t.procedure.query(() => {
-          return undefined;
-        }),
-        returnString: t.procedure.query(() => {
-          return 'hello';
-        }),
-      });
-
-      return routerToServerAndClientNew(appRouter, {
-        client({ httpUrl }) {
-          return {
-            links: [
-              httpBatchStreamLink({
-                url: httpUrl,
-                transformer: superjson,
-              }),
-            ],
-          };
-        },
-      });
-    })
-    .afterEach(async (ctx) => {
-      await ctx?.close?.();
-    })
-    .done();
-
   test('return string', async () => {
+    const t = initTRPC.create({ transformer: superjson });
+    const appRouter = t.router({
+      returnNull: t.procedure.query(() => null),
+      returnUndefined: t.procedure.query(() => undefined),
+      returnString: t.procedure.query(() => 'hello'),
+    });
+
+    await using ctx = testServerAndClientResource(appRouter, {
+      client({ httpUrl }) {
+        return {
+          links: [
+            httpBatchStreamLink({
+              url: httpUrl,
+              transformer: superjson,
+            }),
+          ],
+        };
+      },
+    });
+
     expect(await ctx.client.returnString.query()).toBe('hello');
   });
 
   test('return null', async () => {
+    const t = initTRPC.create({ transformer: superjson });
+    const appRouter = t.router({
+      returnNull: t.procedure.query(() => null),
+      returnUndefined: t.procedure.query(() => undefined),
+      returnString: t.procedure.query(() => 'hello'),
+    });
+
+    await using ctx = testServerAndClientResource(appRouter, {
+      client({ httpUrl }) {
+        return {
+          links: [
+            httpBatchStreamLink({
+              url: httpUrl,
+              transformer: superjson,
+            }),
+          ],
+        };
+      },
+    });
+
     expect(await ctx.client.returnNull.query()).toBe(null);
   });
 
   test('return undefined', async () => {
+    const t = initTRPC.create({ transformer: superjson });
+    const appRouter = t.router({
+      returnNull: t.procedure.query(() => null),
+      returnUndefined: t.procedure.query(() => undefined),
+      returnString: t.procedure.query(() => 'hello'),
+    });
+
+    await using ctx = testServerAndClientResource(appRouter, {
+      client({ httpUrl }) {
+        return {
+          links: [
+            httpBatchStreamLink({
+              url: httpUrl,
+              transformer: superjson,
+            }),
+          ],
+        };
+      },
+    });
+
     expect(await ctx.client.returnUndefined.query()).toBe(undefined);
   });
 });


### PR DESCRIPTION
Closes #

## 🎯 Changes

This PR systematically refactors tests within `packages/tests/server` to align with new testing guidelines. The primary change involves replacing the deprecated `routerToServerAndClientNew` helper with `await using ctx = testServerAndClientResource(...)` to improve test setup consistency and resource management. Additionally, `websockets.test.ts` has been stabilized to prevent flakiness with the new setup by adjusting connection logic, snapshot assertions, and timer advancements.

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.

---
<a href="https://cursor.com/background-agent?bcId=bc-107e31da-42e1-4c50-b330-bae2209901bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-107e31da-42e1-4c50-b330-bae2209901bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

