### PR TITLE
fix: missing sse options when using mergeRouter

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/router.ts
+++ b/packages/server/src/unstable-core-do-not-import/router.ts
@@ -557,6 +557,7 @@ export function mergeRouters<TRouters extends AnyRouter[]>(
     ),
     isServer: routerList.every((r) => r._def._config.isServer),
     $types: routerList[0]?._def._config.$types,
+    sse: routerList[0]?._def._config.sse,
   })(record);
 
   return router as MergeRouters<TRouters>;


### PR DESCRIPTION
## 🎯 Changes

When using mergeRouter sse options from `initTRPC.create({..})` weren't being honored, this PR adds sse options to mergeRouter's createRouterFactory config.


<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Router merging now preserves Server-Sent Events (SSE) configuration from the primary router, enabling seamless router composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->