### PR TITLE
test(transformer): add failing test that demonstrates error responses are not transformer-serialized

### DIFF
--- a/packages/server/src/adapters/transformer-error-serialization.test.ts
+++ b/packages/server/src/adapters/transformer-error-serialization.test.ts
@@ -1,27 +1,38 @@
 import { createServer } from 'http';
+import { initTRPC } from '@trpc/server';
+import { createExpressMiddleware } from '@trpc/server/adapters/express';
 import express from 'express';
 import fetch from 'node-fetch';
 import superjson from 'superjson';
-import { initTRPC } from '@trpc/server';
-import { createExpressMiddleware } from '@trpc/server/adapters/express';
 import { z } from 'zod';
 
 // This is a focused integration test: start a tiny express server with a router configured
 // with transformer: superjson; trigger a validation error and assert that the HTTP error
 // body is parseable by superjson.parse().
 test('error responses are parseable by superjson when transformer: superjson is configured', async () => {
-  const t = initTRPC.create({ transformer: superjson, errorFormatter({ shape }) { return shape; } });
+  const t = initTRPC.create({
+    transformer: superjson,
+    errorFormatter({ shape }) {
+      return shape;
+    },
+  });
   const router = t.router({
-    demo: t.procedure.input(z.object({ x: z.string() })).mutation(() => ({ ok: true })),
+    demo: t.procedure
+      .input(z.object({ x: z.string() }))
+      .mutation(() => ({ ok: true })),
   });
 
   const app = express();
   app.use(express.json());
-  app.use('/api/trpc', createExpressMiddleware({ router, createContext: () => ({}) }));
+  app.use(
+    '/api/trpc',
+    createExpressMiddleware({ router, createContext: () => ({}) }),
+  );
 
   const server = createServer(app);
-  await new Promise(resolve => server.listen(0, resolve));
-  const port = (server.address() && (server.address() as { port: number }).port) || 0;
+  await new Promise((resolve) => server.listen(0, resolve));
+  const port =
+    (server.address() && (server.address() as { port: number }).port) || 0;
 
   // Intentionally call demo mutation with missing input to trigger validation error
   const res = await fetch(`http://localhost:${port}/api/trpc/demo.mutate`, {
@@ -38,9 +49,13 @@ test('error responses are parseable by superjson when transformer: superjson is 
     expect(parsed).toBeDefined();
   } catch (e) {
     server.close();
-    throw new Error('Expected error response to be parseable by superjson. Parsing failed with: ' + (e instanceof Error ? e.message : String(e)) + '\nRaw response:\n' + text.slice(0, 2000));
+    throw new Error(
+      'Expected error response to be parseable by superjson. Parsing failed with: ' +
+        (e instanceof Error ? e.message : String(e)) +
+        '\nRaw response:\n' +
+        text.slice(0, 2000),
+    );
   }
 
   server.close();
 });
-


### PR DESCRIPTION
**Test-only PR: reproduce issue where error responses are not serialized with router transformer (superjson)**

This PR adds a focused integration test that demonstrates a server configured with `transformer: superjson` returns an error response for invalid input that is **not** parseable by `superjson`. The intent is to produce a minimal failing test for maintainers to reproduce and fix the adapter/transformer behavior described in https://github.com/trpc/trpc/issues/7083 and repro repo https://github.com/gerome650/trpc-superjson-repro.

The PR intentionally contains **only** the test. After maintainers fix the adapter, the test should pass. This approach ensures an easy-to-run failure case and avoids touching core logic until the fix is well-understood.