### PR TITLE
docs: document Fastify v5+ requirement for tRPC adapter

### DIFF
--- a/www/docs/server/adapters/fastify.md
+++ b/www/docs/server/adapters/fastify.md
@@ -41,11 +41,11 @@ The best way to start with the Fastify adapter is to take a look at the example 
 ```bash
 yarn add @trpc/server fastify zod
 ```
+
 > ⚠️ **Fastify version requirement**
 >
 > The tRPC v11 Fastify adapter requires **Fastify v5+**.
 > Using Fastify v4 may cause requests to return empty responses without errors.
-
 
 > [Zod](https://github.com/colinhacks/zod) isn't a required dependency, but it's used in the sample router below.
 


### PR DESCRIPTION
Fixes #7092. Add Fastify v5+ requirement for the tRPC v11 Fastify adapter.

## 🎯 Changes

This PR updates the Fastify adapter documentation to clearly specify that
**tRPC v11 requires Fastify v5 or newer**.

Using Fastify v4 can lead to silent failures (e.g. tRPC queries returning
empty objects `{}` without errors). This change makes the requirement
explicit to prevent confusion and reduce debugging time.

This is a **documentation-only** change.

## ✅ Checklist

- [x] I have followed the steps listed in the Contributing guide.
- [x] I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made (not applicable for docs-only change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a compatibility warning to the Fastify adapter docs: tRPC v11 requires Fastify v5+, and using Fastify v4 can lead to requests returning empty responses without errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->