### PR TITLE
feat(client): return origin error in cause in localLink

### DIFF
--- a/packages/client/src/TRPCClientError.ts
+++ b/packages/client/src/TRPCClientError.ts
@@ -86,7 +86,7 @@ export class TRPCClientError<TRouterOrProcedure extends InferrableClientTypes>
 
   public static from<TRouterOrProcedure extends InferrableClientTypes>(
     _cause: Error | TRPCErrorResponse<any> | object,
-    opts: { meta?: Record<string, unknown> } = {},
+    opts: { meta?: Record<string, unknown>; cause?: Error } = {},
   ): TRPCClientError<TRouterOrProcedure> {
     const cause = _cause as unknown;
 
@@ -104,6 +104,7 @@ export class TRPCClientError<TRouterOrProcedure extends InferrableClientTypes>
       return new TRPCClientError(cause.error.message, {
         ...opts,
         result: cause,
+        cause: opts.cause,
       });
     }
     return new TRPCClientError(

--- a/packages/client/src/links/localLink.ts
+++ b/packages/client/src/links/localLink.ts
@@ -112,9 +112,10 @@ export function unstable_localLink<TRouter extends AnyRouter>(
             path: op.path,
             type: op.type,
           });
-          return TRPCClientError.from({
-            error: transformChunk(shape),
-          });
+          return TRPCClientError.from(
+            { error: transformChunk(shape) },
+            { cause: cause instanceof Error ? cause : undefined },
+          );
         }
 
         run(async () => {


### PR DESCRIPTION
Closes #7127

## 🎯 Changes

**Feature:** Forward the origin error on `TRPCClientError` when using `unstable_localLink`.

With `unstable_localLink`, the client and server run in the same JavaScript context, so the thrown error (e.g. `TRPCError` or `Error`) is still available. Previously, localLink only passed the serialized error shape into `TRPCClientError`, so `error.cause` was never set and the original error was lost.

- **`TRPCClientError.from()`** — The second argument now accepts an optional `cause?: Error`. When building from a `TRPCErrorResponse`, that `cause` is passed to the constructor so the client error’s `.cause` is the original server error.
- **`unstable_localLink`** — When coercing a thrown value to `TRPCClientError`, the original value is passed as `cause` when it is an `Error` instance (including `TRPCError`).
- **Tests** — Added a test that asserts a plain `Error` and a `TRPCError` thrown from procedures are forwarded as `TRPCClientError.cause` when using localLink.

Callers can now use `error.cause` (and e.g. `error.cause?.cause` for validation errors) for debugging and handling when using localLink, without changing behavior for HTTP/WebSocket links (they do not pass `cause`).

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error causes are now preserved through error chains when using local links, improving error tracking and debugging capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->