### PR TITLE
fix: correct typo 'commitedFiles' → 'committedFiles'

### DIFF
--- a/packages/upgrade/src/bin/index.ts
+++ b/packages/upgrade/src/bin/index.ts
@@ -74,12 +74,12 @@ const possibleReferences = findTRPCImportReferences(program);
 const trpcFile = possibleReferences.mostUsed.file;
 const trpcImportName = possibleReferences.importName;
 
-const commitedFiles = await filterIgnored(sourceFiles);
+const committedFiles = await filterIgnored(sourceFiles);
 
 for (const transform of sortedTransforms) {
   log.step(`Running transform: ${basename(transform, extname(transform))}`);
   const { run } = await import('jscodeshift/src/Runner.js');
-  await run(transform, commitedFiles, {
+  await run(transform, committedFiles, {
     ...args,
     trpcFile,
     trpcImportName,


### PR DESCRIPTION
Fix spelling of variable name `commitedFiles` → `committedFiles` in `packages/upgrade/src/bin/index.ts`.

No behavioral changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor code quality improvement with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->