### PR TITLE
docs(www): clarify stack trace behavior in error handling docs

### DIFF
--- a/www/docs/server/error-handling.md
+++ b/www/docs/server/error-handling.md
@@ -25,7 +25,7 @@ Here's an example error response caused by a bad request input:
 }
 ```
 
-:::note Stack traces in production
+## Stack traces in production
 
 By default, tRPC includes `error.data.stack` only when [`isDev`](routers#initialize-trpc) is `true`.
 `initTRPC.create()` sets `isDev` to `process.env.NODE_ENV !== 'production'` by default.
@@ -38,8 +38,6 @@ const t = initTRPC.create({ isDev: false });
 ```
 
 If you need stricter control over which error fields are returned, use [error formatting](error-formatting).
-
-:::
 
 ## Error codes
 


### PR DESCRIPTION
Closes #6946

## 🎯 Changes

The docs already mentioned that stack traces are available in development, but this update makes the control point (`isDev`) and default behavior clearer for production usage.

- Clarify that stack trace exposure is controlled by `isDev`
- Clarify the default behavior and explicit override path


  

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked error-handling docs: replaced the short inline note with a structured "Stack traces in production" guidance block.
  * Documents isDev behavior and default logic, explains how to override it, includes a concise code example, and links to error formatting for reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->