### PR TITLE
chore: export `HTTPBatchStreamLinkOptions`

### DIFF
--- a/packages/client/src/links/httpBatchStreamLink.ts
+++ b/packages/client/src/links/httpBatchStreamLink.ts
@@ -18,7 +18,7 @@ import {
 } from './internals/httpUtils';
 import type { Operation, TRPCLink } from './types';
 
-type HTTPBatchStreamLinkOptions<TRoot extends AnyClientTypes> =
+export type HTTPBatchStreamLinkOptions<TRoot extends AnyClientTypes> =
   HTTPBatchLinkOptions<TRoot> & {
     /**
      * Which header to use to signal the server that the client wants a streaming response.


### PR DESCRIPTION
## 🎯 Changes

export `HTTPBatchStreamLinkOptions` similar to how HTTPBatchLinkOptions is exported

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTPBatchStreamLinkOptions type is now publicly available for external use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->