### PR TITLE
Chore: Update Hey API to use new type exports and peer range

### DIFF
--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -77,7 +77,7 @@
     "openapi-types": "^12.1.3"
   },
   "devDependencies": {
-    "@hey-api/openapi-ts": "^0.94.1",
+    "@hey-api/openapi-ts": "^0.94.5",
     "@swagger-api/apidom-ls": "^1.6.0",
     "@tanstack/intent": "^0.0.23",
     "@trpc/server": "11.16.0",
@@ -93,7 +93,7 @@
     "zod": "^4.2.1"
   },
   "peerDependencies": {
-    "@hey-api/openapi-ts": ">=0.13.0",
+    "@hey-api/openapi-ts": ">=0.94.5",
     "@trpc/server": "11.16.0",
     "typescript": ">=5.7.2",
     "zod": ">=4.0.0"

--- a/packages/openapi/src/heyapi/index.ts
+++ b/packages/openapi/src/heyapi/index.ts
@@ -1,7 +1,4 @@
-import type {
-  FetchClient as HeyApiFetchClient,
-  UserConfig,
-} from '@hey-api/openapi-ts';
+import type { Plugins } from '@hey-api/openapi-ts';
 import type {
   TRPCCombinedDataTransformer,
   TRPCDataTransformer,
@@ -11,13 +8,7 @@ export type DataTransformerOptions =
   | TRPCDataTransformer
   | TRPCCombinedDataTransformer;
 
-type HeyAPIResolvers = Exclude<
-  Extract<
-    Exclude<UserConfig['plugins'], undefined | string>[number],
-    { name: '@hey-api/typescript' }
-  >['~resolvers'],
-  undefined
->;
+export type HeyAPIResolvers = Plugins.HeyApiTypeScript.Resolvers;
 
 function resolveTransformer(
   transformer: DataTransformerOptions,
@@ -32,7 +23,9 @@ export interface TRPCHeyApiClientOptions {
   transformer?: DataTransformerOptions;
 }
 
-export type HeyApiConfig = ReturnType<HeyApiFetchClient['getConfig']>;
+export type HeyApiConfig = ReturnType<
+  Plugins.HeyApiClientFetch.Client['getConfig']
+>;
 export type TRPCHeyApiClientConfig = Required<
   Pick<HeyApiConfig, 'querySerializer'>
 > &
@@ -159,7 +152,7 @@ export function createTRPCErrorInterceptor(
  * ```
  */
 export function configureTRPCHeyApiClient(
-  client: HeyApiFetchClient,
+  client: Plugins.HeyApiClientFetch.Client,
   opts: TRPCHeyApiClientOptions &
     Omit<HeyApiConfig, keyof TRPCHeyApiClientConfig>,
 ) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1716,8 +1716,8 @@ importers:
         version: 4.2.1
     devDependencies:
       '@hey-api/openapi-ts':
-        specifier: ^0.94.1
-        version: 0.94.1(magicast@0.5.2)(typescript@5.9.2)
+        specifier: ^0.94.5
+        version: 0.94.5(magicast@0.5.2)(typescript@5.9.2)
       '@types/node':
         specifier: ^22.13.5
         version: 22.19.11


### PR DESCRIPTION
Replaces messy merge history in previous version of this PR.

## Changes (3 files, single clean commit on top of main)
- Bump `@hey-api/openapi-ts` devDependency from `^0.94.1` to `^0.94.5`
- Bump `@hey-api/openapi-ts` peerDependency minimum from `>=0.13.0` to `>=0.94.5`
- Refactor `packages/openapi/src/heyapi/index.ts` to use `Plugins.HeyApiTypeScript.Resolvers` and `Plugins.HeyApiClientFetch.Client` types

<!-- START COPILOT CODING AGENT TIPS -->
---

📍 Connect Copilot coding agent with [Jira](https://gh.io/cca-jira-docs), [Azure Boards](https://gh.io/cca-azure-boards-docs) or [Linear](https://gh.io/cca-linear-docs) to delegate work to Copilot in one click without leaving your project management tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenAPI code generation library to the latest version for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->