### PR TITLE
fix: empty string fallback on pathExtractor

### DIFF
--- a/www/docs/client/nextjs/app-router/server-actions.mdx
+++ b/www/docs/client/nextjs/app-router/server-actions.mdx
@@ -31,7 +31,7 @@ export const t = initTRPC.meta<Meta>().create();
 
 export const serverActionProcedure = t.procedure.experimental_caller(
   experimental_nextAppDirCaller({
-    pathExtractor: ({ meta }) => (meta as Meta).span,
+    pathExtractor: ({ meta }) => (meta as Meta)?.span ?? '',
   }),
 );
 ```
@@ -59,7 +59,7 @@ export const t = initTRPC.meta<Meta>().create();
 export const serverActionProcedure = t.procedure
   .experimental_caller(
     experimental_nextAppDirCaller({
-      pathExtractor: ({ meta }) => (meta as Meta).span,
+      pathExtractor: ({ meta }) => (meta as Meta)?.span ?? '',
     }),
   )
   .use(async (opts) => {
@@ -84,7 +84,7 @@ interface Meta { span: string; }
 const t = initTRPC.meta<Meta>().create();
 const serverActionProcedure = t.procedure
   .experimental_caller(
-    experimental_nextAppDirCaller({ pathExtractor: ({ meta }) => (meta as Meta).span }),
+    experimental_nextAppDirCaller({ pathExtractor: ({ meta }) => (meta as Meta)?.span ?? '' }),
   )
   .use(async (opts) => {
     const user = await currentUser();
@@ -187,7 +187,7 @@ import { experimental_nextAppDirCaller } from '@trpc/server/adapters/next-app-di
 interface Meta { span: string; }
 const t = initTRPC.meta<Meta>().create();
 const serverActionProcedure = t.procedure.experimental_caller(
-  experimental_nextAppDirCaller({ pathExtractor: ({ meta }) => (meta as Meta).span }),
+  experimental_nextAppDirCaller({ pathExtractor: ({ meta }) => (meta as Meta)?.span ?? '' }),
 );
 export const protectedAction = serverActionProcedure;
 


### PR DESCRIPTION

I'm not 100% about this usage is ok or not

ref #7269


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation examples to safely handle potentially undefined metadata by using optional chaining and a safe empty-string fallback. This prevents runtime errors in the reference snippets when metadata or its identifier is missing, making the examples more robust and reliable for implementers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->