### PR TITLE
fix(www): render sponsor links in static HTML for SEO

### DIFF
--- a/www/src/components/sponsors/SponsorBubbles.jsx
+++ b/www/src/components/sponsors/SponsorBubbles.jsx
@@ -23,7 +23,32 @@ export function SponsorBubbles() {
   return (
     <ParentSize>
       {({ width = 800 }) => {
-        return width < 10 ? null : (
+        if (width < 10) {
+          // SSR/SSG fallback: render plain links so search engines can discover sponsor URLs
+          return (
+            <div className="flex flex-wrap items-center justify-center gap-4 p-4">
+              {allSponsors.map((sponsor) => (
+                <a
+                  key={sponsor.login}
+                  href={sponsor.link}
+                  title={sponsor.name}
+                  className="block rounded-full"
+                >
+                  <img
+                    src={sponsor.imgSrc}
+                    alt={sponsor.name}
+                    width={48}
+                    height={48}
+                    loading="lazy"
+                    className="rounded-full"
+                  />
+                </a>
+              ))}
+            </div>
+          );
+        }
+
+        return (
           <div
             style={{
               width,


### PR DESCRIPTION
## Problem

The `SponsorBubbles` component renders **zero HTML** during Docusaurus SSG, making all sponsor links in the "All Sponsors" section invisible to search engine crawlers.

**Root cause:** `@visx/responsive`'s `ParentSize` uses `useParentSize` which returns `{ width: 0 }` during SSG (no DOM/ResizeObserver). The component's guard `width < 10 ? null : (...)` then returns `null`, producing no HTML output.

**Verified:** Fetching `trpc.io` raw HTML confirms the "All Sponsors" section contains only a heading and "Become a Sponsor" button — zero sponsor `<a>` tags. The `TopSponsors` component (top 5) renders fine since it doesn't depend on `ParentSize`.

## Fix

Replace the `null` SSG fallback with a simple grid of sponsor links. When `ParentSize` can't measure (SSG/SSR), render plain `<a>` + `<img>` tags for all sponsors. Once the client hydrates and measures the parent width, the interactive bubble visualization takes over as before.

**Changes:** 1 file, ~25 lines added — only `SponsorBubbles.jsx`.

## Verification

Built the Docusaurus site locally and confirmed:
- **Before:** `grep -c "automatio.ai" build/index.html` → **0** (no sponsor links in HTML)
- **After:** `grep -c "automatio.ai" build/index.html` → **1** (all sponsor links present)
- **19 unique sponsor URLs** now appear in the static HTML
- Zero new build warnings (111 pre-existing HTML minifier warnings unchanged)
- Interactive bubble visualization still works identically on the client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed sponsor display on extremely small viewports. Sponsors now render with a simplified layout instead of being hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->