### PR TITLE
docs: add Next.js App Router context example to context docs

### DIFF
--- a/www/docs/server/context.md
+++ b/www/docs/server/context.md
@@ -41,6 +41,30 @@ t.procedure.use((opts) => {
 });
 ```
 
+### Next.js App Router
+
+When using the Next.js App Router with the [fetch adapter](adapters/fetch), your context function receives a `FetchCreateContextFnOptions` object instead of `CreateHTTPContextOptions`. You can access request headers using the Web standard `Headers` API:
+
+```ts twoslash
+import { initTRPC } from '@trpc/server';
+import type { FetchCreateContextFnOptions } from '@trpc/server/adapters/fetch';
+
+export const createContext = async (opts: FetchCreateContextFnOptions) => {
+  const token = opts.req.headers.get('authorization');
+
+  return {
+    token,
+  };
+};
+
+export type Context = Awaited<ReturnType<typeof createContext>>;
+const t = initTRPC.context<Context>().create();
+```
+
+:::tip
+`CreateHTTPContextOptions` and `CreateNextContextOptions` are designed for Node.js HTTP servers and the Next.js Pages Router respectively. If you're using the App Router, use `FetchCreateContextFnOptions` instead. See the [App Router setup guide](/docs/client/nextjs/app-router-setup) for a complete walkthrough.
+:::
+
 ## Creating the context
 
 The `createContext()` function must be passed to the handler mounting your appRouter. The handler may use HTTP or a [server-side call](server-side-calls).


### PR DESCRIPTION
## Summary
Adds a "Next.js App Router" section to the context documentation (`www/docs/server/context.md`) showing how to use `FetchCreateContextFnOptions` instead of `CreateHTTPContextOptions`.

Addresses #6741

## Problem
The context docs only showed `CreateHTTPContextOptions` and `CreateNextContextOptions` examples, which are Pages Router / standalone server types. Users building with the App Router were confused about which types to use, leading them to incorrectly import `CreateNextContextOptions` in App Router projects (as reported in the issue discussion).

## Changes
- Added a "Next.js App Router" subsection after "Defining the context type" with a `FetchCreateContextFnOptions` code example
- Added a tip callout explaining when to use each context type
- Links to the existing App Router setup guide for full walkthrough

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Next.js App Router documentation to the context guide, detailing how the `createContext` function receives different parameters when using the fetch adapter.
  * Included practical code examples demonstrating header access and proper context establishment.
  * Added clarification distinguishing which context options apply to different deployment scenarios: Node.js HTTP servers, Next.js Pages Router, and App Router environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->