### PR TITLE
feat(next): add server gcTime Infinity safeguard for SSR query caches

### DIFF
--- a/packages/next/src/getQueryClientWithServerGcTimeInfinity.ts
+++ b/packages/next/src/getQueryClientWithServerGcTimeInfinity.ts
@@ -1,0 +1,138 @@
+import { QueryCache, QueryClient } from '@tanstack/react-query';
+import type { CreateTRPCReactQueryClientConfig } from '@trpc/react-query/shared';
+import { getQueryClient } from '@trpc/react-query/shared';
+import { isServer } from './runtime';
+
+const gcTimePatchedSymbol = Symbol.for(
+  '@trpc/next.forceServerGcTimeInfinity.patched',
+);
+
+type PatchedQueryCache = QueryCache & {
+  [gcTimePatchedSymbol]?: boolean;
+  build: (...args: any[]) => any;
+};
+
+let didWarnPatchFailure = false;
+
+/**
+ * Dev-only warning for unsupported patch scenarios.
+ * We deliberately avoid throwing here to keep request handling resilient.
+ */
+function warnPatchFailure() {
+  if (process.env.NODE_ENV === 'production' || didWarnPatchFailure) {
+    return;
+  }
+  didWarnPatchFailure = true;
+  // eslint-disable-next-line no-console
+  console.warn(
+    '[@trpc/next] `forceServerGcTimeInfinity` is enabled, but QueryCache.build could not be patched. Server gcTime/cacheTime may not be forced to Infinity.',
+  );
+}
+
+/**
+ * Build wrapper used by both patching strategies:
+ * - dedicated `ServerSafeQueryCache` for internally created clients
+ * - in-place patching for externally provided QueryClient instances
+ *
+ * We intentionally set both keys for cross-version behavior:
+ * - `cacheTime` for TanStack Query v4
+ * - `gcTime` for TanStack Query v5
+ */
+function createBuildWithInfinity(originalBuild: (...args: any[]) => any) {
+  return (...args: any[]) => {
+    const [client, options, state] = args;
+    return originalBuild(
+      client,
+      {
+        ...options,
+        // `cacheTime` is for v4 compatibility and `gcTime` is used by v5.
+        cacheTime: Infinity,
+        gcTime: Infinity,
+      },
+      state,
+    );
+  };
+}
+
+function tryPatchBuildToInfinity(queryCache: PatchedQueryCache): boolean {
+  // Guard against unexpected QueryCache shapes from future versions or wrappers.
+  if (typeof queryCache.build !== 'function') {
+    return false;
+  }
+
+  const ownDesc = Object.getOwnPropertyDescriptor(queryCache, 'build');
+  const protoDesc = Object.getOwnPropertyDescriptor(
+    Object.getPrototypeOf(queryCache),
+    'build',
+  );
+  const desc = ownDesc ?? protoDesc;
+
+  if (desc && desc.writable === false && !desc.set) {
+    return false;
+  }
+
+  const previousBuild = queryCache.build;
+  const originalBuild = queryCache.build.bind(queryCache);
+  const nextBuild = createBuildWithInfinity(originalBuild);
+
+  if (!Reflect.set(queryCache, 'build', nextBuild)) {
+    return false;
+  }
+
+  return queryCache.build !== previousBuild;
+}
+
+/**
+ * Internal creation path.
+ * When we control QueryClient construction we prefer an explicit QueryCache class,
+ * then apply the same patching logic used by the external-client fallback path.
+ */
+export class ServerSafeQueryCache extends QueryCache {
+  constructor(...args: ConstructorParameters<typeof QueryCache>) {
+    super(...args);
+    const patched = tryPatchBuildToInfinity(this as PatchedQueryCache);
+    if (!patched) {
+      warnPatchFailure();
+    }
+  }
+}
+
+function patchQueryCacheBuildToInfinity(queryClient: QueryClient): QueryClient {
+  const queryCache = queryClient.getQueryCache() as PatchedQueryCache;
+
+  // Idempotent guard for reused QueryClient instances across renders/requests.
+  if (queryCache[gcTimePatchedSymbol]) {
+    return queryClient;
+  }
+
+  const patched = tryPatchBuildToInfinity(queryCache);
+  if (!patched) {
+    warnPatchFailure();
+    return queryClient;
+  }
+
+  queryCache[gcTimePatchedSymbol] = true;
+
+  return queryClient;
+}
+
+export function getQueryClientWithServerGcTimeInfinity(
+  config: CreateTRPCReactQueryClientConfig,
+  forceServerGcTimeInfinity: boolean | undefined,
+): QueryClient {
+  // Feature is opt-in and server-only by design.
+  if (!forceServerGcTimeInfinity || !isServer()) {
+    return getQueryClient(config);
+  }
+
+  // External QueryClient: cannot replace instance, so patch in-place.
+  if (config.queryClient) {
+    return patchQueryCacheBuildToInfinity(config.queryClient);
+  }
+
+  // Internal QueryClient: install dedicated server-safe QueryCache.
+  return new QueryClient({
+    ...config.queryClientConfig,
+    queryCache: new ServerSafeQueryCache(),
+  });
+}

--- a/packages/next/src/getQueryClientWithServerGcTimeInfinity.ts
+++ b/packages/next/src/getQueryClientWithServerGcTimeInfinity.ts
@@ -19,7 +19,7 @@ let didWarnPatchFailure = false;
  * We deliberately avoid throwing here to keep request handling resilient.
  */
 function warnPatchFailure() {
-  if (process.env['NODE_ENV'] === 'production' || didWarnPatchFailure) {
+  if (process.env.NODE_ENV === 'production' || didWarnPatchFailure) {
     return;
   }
   didWarnPatchFailure = true;

--- a/packages/next/src/getQueryClientWithServerGcTimeInfinity.ts
+++ b/packages/next/src/getQueryClientWithServerGcTimeInfinity.ts
@@ -19,7 +19,7 @@ let didWarnPatchFailure = false;
  * We deliberately avoid throwing here to keep request handling resilient.
  */
 function warnPatchFailure() {
-  if (process.env.NODE_ENV === 'production' || didWarnPatchFailure) {
+  if (process.env['NODE_ENV'] === 'production' || didWarnPatchFailure) {
     return;
   }
   didWarnPatchFailure = true;

--- a/packages/next/src/runtime.ts
+++ b/packages/next/src/runtime.ts
@@ -1,0 +1,3 @@
+export function isServer() {
+  return typeof window === 'undefined';
+}

--- a/packages/next/src/ssrPrepass.ts
+++ b/packages/next/src/ssrPrepass.ts
@@ -8,7 +8,6 @@ import { createTRPCUntypedClient } from '@trpc/client';
 import type { TRPCClientError, TRPCClientErrorLike } from '@trpc/client';
 import type { CoercedTransformerParameters } from '@trpc/client/unstable-internals';
 import { getTransformer } from '@trpc/client/unstable-internals';
-import { getQueryClient } from '@trpc/react-query/shared';
 import type {
   AnyRouter,
   Dict,
@@ -19,6 +18,8 @@ import type {
   NextPageContext,
 } from 'next/dist/shared/lib/utils';
 import { createElement } from 'react';
+import { getQueryClientWithServerGcTimeInfinity } from './getQueryClientWithServerGcTimeInfinity';
+import { isServer } from './runtime';
 import type { TRPCPrepassHelper, TRPCPrepassProps } from './withTRPC';
 
 function transformQueryOrMutationCacheErrors<
@@ -53,7 +54,7 @@ export const ssrPrepass: TRPCPrepassHelper = (opts) => {
   );
   WithTRPC.getInitialProps = async (appOrPageCtx: AppContextType) => {
     const shouldSsr = async () => {
-      if (typeof window !== 'undefined') {
+      if (!isServer()) {
         return false;
       }
       if (typeof parent.ssr === 'function') {
@@ -92,13 +93,16 @@ export const ssrPrepass: TRPCPrepassHelper = (opts) => {
     const getAppTreeProps = (props: Record<string, unknown>) =>
       isApp ? { pageProps: props } : props;
 
-    if (typeof window !== 'undefined' || !ssrEnabled) {
+    if (!isServer() || !ssrEnabled) {
       return getAppTreeProps(pageProps);
     }
 
     const config = parent.config({ ctx });
     const trpcClient = createTRPCUntypedClient(config);
-    const queryClient = getQueryClient(config);
+    const queryClient = getQueryClientWithServerGcTimeInfinity(
+      config,
+      parent.forceServerGcTimeInfinity,
+    );
 
     const trpcProp: $PrepassProps = {
       config,

--- a/packages/next/src/withTRPC.tsx
+++ b/packages/next/src/withTRPC.tsx
@@ -19,7 +19,7 @@ import type {
   CreateTRPCReactOptions,
   CreateTRPCReactQueryClientConfig,
 } from '@trpc/react-query/shared';
-import { createRootHooks, getQueryClient } from '@trpc/react-query/shared';
+import { createRootHooks } from '@trpc/react-query/shared';
 import type {
   AnyRouter,
   Dict,
@@ -34,6 +34,7 @@ import type {
 } from 'next/dist/shared/lib/utils';
 import type { NextRouter } from 'next/router';
 import React, { useState } from 'react';
+import { getQueryClientWithServerGcTimeInfinity } from './getQueryClientWithServerGcTimeInfinity';
 
 export type WithTRPCConfig<TRouter extends AnyRouter> =
   CreateTRPCClientOptions<TRouter> &
@@ -44,6 +45,7 @@ export type WithTRPCConfig<TRouter extends AnyRouter> =
 type WithTRPCOptions<TRouter extends AnyRouter> =
   CreateTRPCReactOptions<TRouter> & {
     config: (info: { ctx?: NextPageContext }) => WithTRPCConfig<TRouter>;
+    forceServerGcTimeInfinity?: boolean;
   } & TransformerOptions<inferClientTypes<TRouter>>;
 
 export type TRPCPrepassHelper = (opts: {
@@ -111,7 +113,10 @@ export function withTRPC<
         }
 
         const config = getClientConfig({});
-        const queryClient = getQueryClient(config);
+        const queryClient = getQueryClientWithServerGcTimeInfinity(
+          config,
+          opts.forceServerGcTimeInfinity,
+        );
         const trpcClient = trpc.createClient(config);
 
         return {

--- a/packages/next/test/forceServerGcTimeInfinity.test.tsx
+++ b/packages/next/test/forceServerGcTimeInfinity.test.tsx
@@ -1,0 +1,96 @@
+import { testServerAndClientResource } from '@trpc/client/__tests__/testClientResource';
+import { QueryCache, QueryClient } from '@tanstack/react-query';
+import { createTRPCNext } from '@trpc/next';
+import { ssrPrepass } from '@trpc/next/ssrPrepass';
+import { initTRPC } from '@trpc/server';
+import { konn } from 'konn';
+import type { AppType } from 'next/dist/shared/lib/utils';
+import React from 'react';
+
+const FINITE_GC_TIME = 1_234;
+
+const ctx = konn()
+  .beforeEach(() => {
+    const t = initTRPC.create();
+    const appRouter = t.router({
+      foo: t.procedure.query(() => 'bar' as const),
+    });
+    const opts = testServerAndClientResource(appRouter);
+
+    return opts;
+  })
+  .afterEach(async (ctx) => {
+    await ctx?.close?.();
+  })
+  .done();
+
+async function runSsrAndCollectGcTimes(
+  forceServerGcTimeInfinity: boolean,
+  queryClient?: QueryClient,
+): Promise<unknown[]> {
+  const windowRef = (globalThis as any).window;
+  delete (globalThis as any).window;
+
+  const seenGcTimes: unknown[] = [];
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const originalBuild = QueryCache.prototype.build as any;
+  const buildSpy = vi
+    .spyOn(QueryCache.prototype as any, 'build')
+    .mockImplementation(function (this: QueryCache, ...args: any[]) {
+      seenGcTimes.push(args[1]?.gcTime ?? args[1]?.cacheTime);
+      return originalBuild.apply(this, args);
+    });
+
+  try {
+    const trpc = createTRPCNext({
+      config() {
+        return {
+          ...ctx.trpcClientOptions,
+          ...(queryClient ? { queryClient } : {}),
+        };
+      },
+      ssr: true,
+      ssrPrepass,
+      forceServerGcTimeInfinity,
+    });
+
+    const App: AppType = () => {
+      trpc.foo.useQuery(undefined, {
+        gcTime: FINITE_GC_TIME,
+      });
+      return null;
+    };
+
+    const Wrapped = trpc.withTRPC(App);
+    await Wrapped.getInitialProps!({
+      AppTree: Wrapped,
+      Component: <div />,
+    } as any);
+
+    return seenGcTimes;
+  } finally {
+    buildSpy.mockRestore();
+    (globalThis as any).window = windowRef;
+  }
+}
+
+test('forceServerGcTimeInfinity=true forces gcTime to Infinity on server', async () => {
+  const gcTimes = await runSsrAndCollectGcTimes(true);
+
+  expect(gcTimes).toContain(Infinity);
+  expect(gcTimes).not.toContain(FINITE_GC_TIME);
+});
+
+test('forceServerGcTimeInfinity=false keeps finite gcTime from query options', async () => {
+  const gcTimes = await runSsrAndCollectGcTimes(false);
+
+  expect(gcTimes).toContain(FINITE_GC_TIME);
+});
+
+test('forceServerGcTimeInfinity=true also works when user passes queryClient', async () => {
+  const queryClient = new QueryClient();
+  const gcTimes = await runSsrAndCollectGcTimes(true, queryClient);
+
+  expect(gcTimes).toContain(Infinity);
+  expect(gcTimes).not.toContain(FINITE_GC_TIME);
+});

--- a/packages/next/test/getQueryClientWithServerGcTimeInfinity.test.ts
+++ b/packages/next/test/getQueryClientWithServerGcTimeInfinity.test.ts
@@ -1,0 +1,244 @@
+import { QueryCache, QueryClient } from '@tanstack/react-query';
+
+const FINITE_GC_TIME = 1_234;
+
+async function importModule() {
+  vi.resetModules();
+  return import('../src/getQueryClientWithServerGcTimeInfinity');
+}
+
+async function runOnServer<T>(fn: () => Promise<T> | T): Promise<T> {
+  const windowRef = (globalThis as any).window;
+  delete (globalThis as any).window;
+  try {
+    return await fn();
+  } finally {
+    (globalThis as any).window = windowRef;
+  }
+}
+
+async function runOnBrowser<T>(fn: () => Promise<T> | T): Promise<T> {
+  const windowRef = (globalThis as any).window;
+  (globalThis as any).window = {};
+  try {
+    return await fn();
+  } finally {
+    (globalThis as any).window = windowRef;
+  }
+}
+
+async function createClientAndGetBuildGcTime(
+  createQueryClient: () => QueryClient,
+) {
+  const seenGcTimes: unknown[] = [];
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  const originalBuild = QueryCache.prototype.build as any;
+  const buildSpy = vi
+    .spyOn(QueryCache.prototype as any, 'build')
+    .mockImplementation(function (this: QueryCache, ...args: any[]) {
+      seenGcTimes.push(args[1]?.gcTime ?? args[1]?.cacheTime);
+      return originalBuild.apply(this, args);
+    });
+
+  try {
+    const queryClient = createQueryClient();
+    await queryClient.fetchQuery({
+      queryKey: ['gc-check'],
+      gcTime: FINITE_GC_TIME,
+      queryFn: async () => 'ok',
+    });
+    return seenGcTimes.at(-1);
+  } finally {
+    buildSpy.mockRestore();
+  }
+}
+
+test('forces Infinity on server for internally created QueryClient', async () => {
+  await runOnServer(async () => {
+    const { getQueryClientWithServerGcTimeInfinity } = await importModule();
+    const gcTime = await createClientAndGetBuildGcTime(() =>
+      getQueryClientWithServerGcTimeInfinity({ queryClientConfig: {} }, true),
+    );
+    expect(gcTime).toBe(Infinity);
+  });
+});
+
+test('keeps finite gcTime when feature flag is off', async () => {
+  await runOnServer(async () => {
+    const { getQueryClientWithServerGcTimeInfinity } = await importModule();
+    const gcTime = await createClientAndGetBuildGcTime(() =>
+      getQueryClientWithServerGcTimeInfinity({ queryClientConfig: {} }, false),
+    );
+    expect(gcTime).toBe(FINITE_GC_TIME);
+  });
+});
+
+test('keeps client behavior unchanged even when feature flag is on', async () => {
+  await runOnBrowser(async () => {
+    const { getQueryClientWithServerGcTimeInfinity } = await importModule();
+    const gcTime = await createClientAndGetBuildGcTime(() =>
+      getQueryClientWithServerGcTimeInfinity({ queryClientConfig: {} }, true),
+    );
+    expect(gcTime).toBe(FINITE_GC_TIME);
+  });
+});
+
+test('forces Infinity for externally provided QueryClient', async () => {
+  await runOnServer(async () => {
+    const { getQueryClientWithServerGcTimeInfinity } = await importModule();
+    const providedQueryClient = new QueryClient();
+    const gcTime = await createClientAndGetBuildGcTime(() => {
+      const wrapped = getQueryClientWithServerGcTimeInfinity(
+        { queryClient: providedQueryClient },
+        true,
+      );
+      expect(wrapped).toBe(providedQueryClient);
+      return providedQueryClient;
+    });
+
+    expect(gcTime).toBe(Infinity);
+  });
+});
+
+test('uses ServerSafeQueryCache when creating client internally', async () => {
+  await runOnServer(async () => {
+    const { getQueryClientWithServerGcTimeInfinity, ServerSafeQueryCache } =
+      await importModule();
+    const queryClient = getQueryClientWithServerGcTimeInfinity(
+      { queryClientConfig: {} },
+      true,
+    );
+    expect(queryClient.getQueryCache()).toBeInstanceOf(ServerSafeQueryCache);
+  });
+});
+
+test('warns once in dev when external QueryCache cannot be patched', async () => {
+  await runOnServer(async () => {
+    const warnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const { getQueryClientWithServerGcTimeInfinity } = await importModule();
+
+    const queryCache = new QueryCache();
+    const build = queryCache.build.bind(queryCache);
+    Object.defineProperty(queryCache, 'build', {
+      value: build,
+      writable: false,
+      configurable: true,
+    });
+
+    const queryClient = new QueryClient({ queryCache });
+
+    const first = getQueryClientWithServerGcTimeInfinity({ queryClient }, true);
+    const second = getQueryClientWithServerGcTimeInfinity(
+      { queryClient },
+      true,
+    );
+    expect(first).toBe(queryClient);
+    expect(second).toBe(queryClient);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+  });
+});
+
+test('does not warn in production when patch fails', async () => {
+  await runOnServer(async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const warnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const { getQueryClientWithServerGcTimeInfinity } = await importModule();
+
+    const queryCache = new QueryCache();
+    const build = queryCache.build.bind(queryCache);
+    Object.defineProperty(queryCache, 'build', {
+      value: build,
+      writable: false,
+      configurable: true,
+    });
+    const queryClient = new QueryClient({ queryCache });
+
+    getQueryClientWithServerGcTimeInfinity({ queryClient }, true);
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    vi.unstubAllEnvs();
+  });
+});
+
+test('does not double patch the same external QueryClient', async () => {
+  await runOnServer(async () => {
+    const { getQueryClientWithServerGcTimeInfinity } = await importModule();
+    const reflectSetSpy = vi.spyOn(Reflect, 'set');
+    const queryClient = new QueryClient();
+
+    getQueryClientWithServerGcTimeInfinity({ queryClient }, true);
+    getQueryClientWithServerGcTimeInfinity({ queryClient }, true);
+
+    expect(reflectSetSpy).toHaveBeenCalledTimes(1);
+    reflectSetSpy.mockRestore();
+  });
+});
+
+test('warns when QueryCache.build is not a function on provided queryClient', async () => {
+  await runOnServer(async () => {
+    const warnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const { getQueryClientWithServerGcTimeInfinity } = await importModule();
+
+    const queryCache = new QueryCache();
+    Object.defineProperty(queryCache, 'build', {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+    const queryClient = new QueryClient({ queryCache });
+
+    const result = getQueryClientWithServerGcTimeInfinity(
+      { queryClient },
+      true,
+    );
+    expect(result).toBe(queryClient);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+});
+
+test('warns when Reflect.set returns false while patching', async () => {
+  await runOnServer(async () => {
+    const warnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const reflectSetSpy = vi.spyOn(Reflect, 'set').mockReturnValue(false);
+    const { getQueryClientWithServerGcTimeInfinity } = await importModule();
+    const queryClient = new QueryClient();
+
+    const result = getQueryClientWithServerGcTimeInfinity(
+      { queryClient },
+      true,
+    );
+    expect(result).toBe(queryClient);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    reflectSetSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+});
+
+test('warns when internal ServerSafeQueryCache cannot patch build', async () => {
+  await runOnServer(async () => {
+    const warnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    const reflectSetSpy = vi.spyOn(Reflect, 'set').mockReturnValue(false);
+    const { getQueryClientWithServerGcTimeInfinity } = await importModule();
+
+    getQueryClientWithServerGcTimeInfinity({ queryClientConfig: {} }, true);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    reflectSetSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+});

--- a/www/docs/client/nextjs/pages-router/setup.mdx
+++ b/www/docs/client/nextjs/pages-router/setup.mdx
@@ -325,6 +325,17 @@ Configure [overrides for React Query's hooks](/docs/client/react/useUtils#invali
 
 Whether tRPC should await queries when server-side rendering a page. Defaults to `false`.
 
+### `forceServerGcTimeInfinity`-boolean (default: `false`)
+
+Opt-in safety guard for server-side renders.  
+When enabled, `@trpc/next` forces query `gcTime/cacheTime` to `Infinity` on the server-side request-scoped `QueryCache`.
+
+This helps prevent delayed server memory reclamation when component-level queries set finite `gcTime`/`cacheTime` during SSR render paths.
+
+- Only affects server-side behavior.
+- Client-side React Query behavior is unchanged.
+- Works for both internally created `QueryClient` and user-provided `queryClient`.
+
 ### `responseMeta`-callback
 
 Ability to set request headers and HTTP status when server-side rendering.
@@ -351,6 +362,8 @@ export const trpc = createTRPCNext<AppRouter>({
       ],
     };
   },
+  // Optional server-side guard against finite gcTime/cacheTime retention.
+  forceServerGcTimeInfinity: true,
 });
 ```
 

--- a/www/versioned_docs/version-10.x/client/nextjs/setup.mdx
+++ b/www/versioned_docs/version-10.x/client/nextjs/setup.mdx
@@ -279,6 +279,17 @@ Configure [overrides for React Query's hooks](/docs/client/react/useUtils#invali
 
 Whether tRPC should await queries when server-side rendering a page. Defaults to `false`.
 
+### `forceServerGcTimeInfinity`-boolean (default: `false`)
+
+Opt-in safety guard for server-side renders.  
+When enabled, `@trpc/next` forces query `gcTime/cacheTime` to `Infinity` on the server-side request-scoped `QueryCache`.
+
+This helps prevent delayed server memory reclamation when component-level queries set finite `gcTime`/`cacheTime` during SSR render paths.
+
+- Only affects server-side behavior.
+- Client-side React Query behavior is unchanged.
+- Works for both internally created `QueryClient` and user-provided `queryClient`.
+
 ### `responseMeta`-callback
 
 Ability to set request headers and HTTP status when server-side rendering.
@@ -294,6 +305,8 @@ export const trpc = createTRPCNext<AppRouter>({
     /* [...] */
   },
   ssr: true,
+  // Optional server-side guard against finite gcTime/cacheTime retention.
+  forceServerGcTimeInfinity: true,
   responseMeta(opts) {
     const { clientErrors } = opts;
     if (clientErrors.length) {


### PR DESCRIPTION
Refs: #7342 

## 🎯 Changes

This PR introduces an opt-in server-side safeguard in `@trpc/next` to prevent delayed `QueryCache` retention caused by finite `gcTime` / `cacheTime` during SSR rendering.

### Type of change
- Bug fix (memory-retention mitigation for SSR request-scoped caches)

### What changed
- Added a new option on `createTRPCNext`/`withTRPC` config:
  - `forceServerGcTimeInfinity?: boolean`
- Added a server-safe QueryClient factory path:
  - New helper: `packages/next/src/getQueryClientWithServerGcTimeInfinity.ts`
  - New runtime helper: `packages/next/src/runtime.ts` (`isServer()` / `isBrowser()`)
- Wired the option into both server-side paths in `@trpc/next`:
  - `packages/next/src/withTRPC.tsx`
  - `packages/next/src/ssrPrepass.ts`
- Behavior when enabled:
  - Server only: force query `gcTime/cacheTime` to `Infinity` at query-build time
  - Client behavior unchanged
- Compatibility + resilience details:
  - Handles both internally created QueryClient and user-provided QueryClient
  - Supports TanStack v4/v5 naming (`cacheTime` + `gcTime`)
  - Includes safe patch attempt flow + dev-only warn-once fallback if patching is not possible

### Why
In Next.js Pages Router scenarios, even with `ssr: false`, server rendering can still instantiate request-scoped query caches. Finite query gc windows can keep those caches alive via timers, causing overlapping per-request memory retention under load. This opt-in guard avoids that by enforcing infinite server gc for request-scoped caches.

## ✅ Checklist

- [x] I have followed the steps listed in the `https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md` .
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.

### Tests added/updated
- `packages/next/test/forceServerGcTimeInfinity.test.tsx`
  - validates enabled/disabled behavior
  - validates user-provided QueryClient path
- `packages/next/test/getQueryClientWithServerGcTimeInfinity.test.ts`
  - covers server/client branches
  - covers internal/external QueryClient paths
  - covers patch failure fallback + dev/prod warning behavior
  - covers idempotent patching behavior

### Coverage
- `packages/next/src/getQueryClientWithServerGcTimeInfinity.ts`: 100% statements / 100% branches / 100% funcs / 100% lines



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added forceServerGcTimeInfinity option for Next.js to optionally make server-side query cache eviction persist indefinitely; applies to both internally created and user-provided query clients.
  * Added a runtime server-detection utility to gate server-only behavior and wired option into SSR flow.

* **Documentation**
  * Documented the new option with examples and default value (false).

* **Tests**
  * Added tests covering server vs browser behavior, external-client handling, and warning/patching scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->