### PR TITLE
fix(server): make batch stream content-type configurable

### DIFF
--- a/packages/client/skills/links/references/link-options.md
+++ b/packages/client/skills/links/references/link-options.md
@@ -73,7 +73,7 @@ httpBatchStreamLink({
 | All `httpBatchLink` options |                             |                 | Inherits all httpBatchLink options                                                                |
 | `streamHeader`              | `'trpc-accept' \| 'accept'` | `'trpc-accept'` | Header used to signal streaming. Use `'accept'` to avoid CORS preflight on cross-origin requests. |
 
-Sends `trpc-accept: application/jsonl` (or `Accept: application/jsonl`). Response arrives as `transfer-encoding: chunked` with `content-type: application/json` by default. Servers can opt into `application/jsonl` or `application/x-ndjson` via `initTRPC.create({ jsonl: { contentType: ... } })`. Cannot set response headers (including cookies) after stream begins.
+Sends `trpc-accept: application/jsonl` (or `Accept: application/jsonl`). Response arrives as `transfer-encoding: chunked` with `content-type: application/json` by default. Servers can set the streamed response `content-type` to `application/jsonl`, `application/x-ndjson`, or another value via `initTRPC.create({ jsonl: { contentType: ... } })`. Cannot set response headers (including cookies) after stream begins.
 
 ## splitLink
 

--- a/packages/client/skills/links/references/link-options.md
+++ b/packages/client/skills/links/references/link-options.md
@@ -73,7 +73,7 @@ httpBatchStreamLink({
 | All `httpBatchLink` options |                             |                 | Inherits all httpBatchLink options                                                                |
 | `streamHeader`              | `'trpc-accept' \| 'accept'` | `'trpc-accept'` | Header used to signal streaming. Use `'accept'` to avoid CORS preflight on cross-origin requests. |
 
-Sends `trpc-accept: application/jsonl` (or `Accept: application/jsonl`). Response arrives as `transfer-encoding: chunked` with `content-type: application/jsonl`. Cannot set response headers (including cookies) after stream begins.
+Sends `trpc-accept: application/jsonl` (or `Accept: application/jsonl`). Response arrives as `transfer-encoding: chunked` with `content-type: application/json` by default. Servers can opt into `application/jsonl` or `application/x-ndjson` via `initTRPC.create({ jsonl: { contentType: ... } })`. Cannot set response headers (including cookies) after stream begins.
 
 ## splitLink
 

--- a/packages/server/src/unstable-core-do-not-import/http/resolveResponse.ts
+++ b/packages/server/src/unstable-core-do-not-import/http/resolveResponse.ts
@@ -572,7 +572,10 @@ export async function resolveResponse<TRouter extends AnyRouter>(
     // batch response handlers
     if (info.accept === 'application/jsonl') {
       // httpBatchStreamLink
-      headers.set('content-type', 'application/jsonl');
+      headers.set(
+        'content-type',
+        config.jsonl?.contentType ?? 'application/json',
+      );
       headers.set('transfer-encoding', 'chunked');
       const headResponse = initResponse({
         ctx: ctxManager.valueOrUndefined(),

--- a/packages/server/src/unstable-core-do-not-import/http/resolveResponse.ts
+++ b/packages/server/src/unstable-core-do-not-import/http/resolveResponse.ts
@@ -572,7 +572,7 @@ export async function resolveResponse<TRouter extends AnyRouter>(
     // batch response handlers
     if (info.accept === 'application/jsonl') {
       // httpBatchStreamLink
-      headers.set('content-type', 'application/json');
+      headers.set('content-type', 'application/jsonl');
       headers.set('transfer-encoding', 'chunked');
       const headResponse = initResponse({
         ctx: ctxManager.valueOrUndefined(),

--- a/packages/server/src/unstable-core-do-not-import/rootConfig.ts
+++ b/packages/server/src/unstable-core-do-not-import/rootConfig.ts
@@ -14,6 +14,20 @@ export interface RootTypes {
   transformer: boolean;
 }
 
+export type JSONLContentType =
+  | 'application/json'
+  | 'application/jsonl'
+  | 'application/x-ndjson';
+
+export interface JSONLConfig extends Pick<JSONLProducerOptions, 'pingMs'> {
+  /**
+   * The `content-type` header to use for batch stream responses.
+   * Defaults to `application/json` for backwards compatibility.
+   * @default 'application/json'
+   */
+  contentType?: JSONLContentType;
+}
+
 /**
  * The default check to see if we're in a server
  */
@@ -85,7 +99,7 @@ export interface RootConfig<TTypes extends RootTypes> {
    * Options for batch stream
    * @see https://trpc.io/docs/client/links/httpBatchStreamLink
    */
-  jsonl?: Pick<JSONLProducerOptions, 'pingMs'>;
+  jsonl?: JSONLConfig;
   experimental?: {};
 }
 

--- a/packages/server/src/unstable-core-do-not-import/rootConfig.ts
+++ b/packages/server/src/unstable-core-do-not-import/rootConfig.ts
@@ -14,14 +14,22 @@ export interface RootTypes {
   transformer: boolean;
 }
 
+/**
+ * Recommended content types for batch stream responses.
+ *
+ * `application/json` remains the default for backwards compatibility, while
+ * other string values are allowed for tooling or infrastructure compatibility.
+ */
 export type JSONLContentType =
   | 'application/json'
   | 'application/jsonl'
-  | 'application/x-ndjson';
+  | 'application/x-ndjson'
+  | (string & {});
 
 export interface JSONLConfig extends Pick<JSONLProducerOptions, 'pingMs'> {
   /**
    * The `content-type` header to use for batch stream responses.
+   * Supports any valid content type string.
    * Defaults to `application/json` for backwards compatibility.
    * @default 'application/json'
    */

--- a/packages/tests/server/adapters/fetch.test.ts
+++ b/packages/tests/server/adapters/fetch.test.ts
@@ -100,6 +100,9 @@ function createContentTypeSpy(onData?: (value: number) => void): {
             observer.next(value);
           },
           error: observer.error,
+          complete() {
+            observer.complete();
+          },
         });
         return unsubscribe;
       });

--- a/packages/tests/server/adapters/fetch.test.ts
+++ b/packages/tests/server/adapters/fetch.test.ts
@@ -29,8 +29,17 @@ const createContext = ({ req, resHeaders }: FetchCreateContextFnOptions) => {
 
 type Context = Awaited<ReturnType<typeof createContext>>;
 
-function createAppRouter() {
-  const t = initTRPC.context<Context>().create();
+type AppRouterServerOptions = {
+  jsonl?: {
+    contentType?:
+      | 'application/json'
+      | 'application/jsonl'
+      | 'application/x-ndjson';
+  };
+};
+
+function createAppRouter(opts?: AppRouterServerOptions) {
+  const t = initTRPC.context<Context>().create(opts);
   const router = t.router;
   const publicProcedure = t.procedure;
 
@@ -72,8 +81,11 @@ function createAppRouter() {
 
 type AppRouter = ReturnType<typeof createAppRouter>;
 
-async function startServer(endpoint = '') {
-  const router = createAppRouter();
+async function startServer(
+  endpoint = '',
+  routerOptions?: AppRouterServerOptions,
+) {
+  const router = createAppRouter(routerOptions);
 
   const server = serve({
     port: 0,
@@ -187,8 +199,62 @@ describe('with default server', () => {
 
     expect(results).toEqual([3, 1, 2]);
     expect(orderedResults).toEqual([1, 2, 3]);
-    expect([...new Set(responseContentTypes)]).toEqual(['application/jsonl']);
+    expect([...new Set(responseContentTypes)]).toEqual(['application/json']);
   });
+
+  test.each(['application/jsonl', 'application/x-ndjson'] as const)(
+    'streaming can opt into %s content-type',
+    async (contentType) => {
+      const custom = await startServer('', {
+        jsonl: {
+          contentType,
+        },
+      });
+
+      const responseContentTypes: string[] = [];
+      const linkSpy: TRPCLink<AppRouter> = () => {
+        return ({ next, op }) => {
+          return observable((observer) => {
+            const unsubscribe = next(op).subscribe({
+              next(value) {
+                responseContentTypes.push(
+                  (
+                    (
+                      value.context as { response: Response }
+                    ).response.headers.get('content-type') ?? ''
+                  ).split(';')[0]!,
+                );
+                observer.next(value);
+              },
+              error: observer.error,
+            });
+            return unsubscribe;
+          });
+        };
+      };
+
+      const client = createTRPCClient<AppRouter>({
+        links: [
+          linkSpy,
+          httpBatchStreamLink({
+            url: custom.url,
+            fetch: fetch as any,
+          }),
+        ],
+      });
+
+      const results = await Promise.all([
+        client.deferred.query({ wait: 3 }),
+        client.deferred.query({ wait: 1 }),
+        client.deferred.query({ wait: 2 }),
+      ]);
+
+      expect(results).toEqual([3, 1, 2]);
+      expect([...new Set(responseContentTypes)]).toEqual([contentType]);
+
+      await custom.close();
+    },
+  );
 
   test('query with headers', async () => {
     const client = createTRPCClient<AppRouter>({

--- a/packages/tests/server/adapters/fetch.test.ts
+++ b/packages/tests/server/adapters/fetch.test.ts
@@ -142,6 +142,7 @@ describe('with default server', () => {
 
   test('streaming', async () => {
     const orderedResults: number[] = [];
+    const responseContentTypes: string[] = [];
     const linkSpy: TRPCLink<AppRouter> = () => {
       // here we just got initialized in the app - this happens once per app
       // useful for storing cache for instance
@@ -152,6 +153,13 @@ describe('with default server', () => {
           const unsubscribe = next(op).subscribe({
             next(value) {
               orderedResults.push(value.result.data as number);
+              responseContentTypes.push(
+                (
+                  (value.context as { response: Response }).response.headers.get(
+                    'content-type',
+                  ) ?? ''
+                ).split(';')[0]!,
+              );
               observer.next(value);
             },
             error: observer.error,
@@ -179,6 +187,7 @@ describe('with default server', () => {
 
     expect(results).toEqual([3, 1, 2]);
     expect(orderedResults).toEqual([1, 2, 3]);
+    expect([...new Set(responseContentTypes)]).toEqual(['application/jsonl']);
   });
 
   test('query with headers', async () => {

--- a/packages/tests/server/adapters/fetch.test.ts
+++ b/packages/tests/server/adapters/fetch.test.ts
@@ -8,6 +8,7 @@ import { initTRPC } from '@trpc/server';
 import type { FetchCreateContextFnOptions } from '@trpc/server/adapters/fetch';
 import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
 import { observable, tap } from '@trpc/server/observable';
+import { makeAsyncResource } from '@trpc/server/unstable-core-do-not-import/stream/utils/disposable';
 import { serve } from 'srvx';
 import { z } from 'zod';
 
@@ -77,6 +78,36 @@ function createAppRouter(opts?: AppRouterServerOptions) {
 }
 
 type AppRouter = ReturnType<typeof createAppRouter>;
+
+function createContentTypeSpy(onData?: (value: number) => void): {
+  contentTypes: string[];
+  link: TRPCLink<AppRouter>;
+} {
+  const contentTypes: string[] = [];
+  const link: TRPCLink<AppRouter> = () => {
+    return ({ next, op }) => {
+      return observable((observer) => {
+        const unsubscribe = next(op).subscribe({
+          next(value) {
+            onData?.(value.result.data as number);
+            contentTypes.push(
+              (
+                (value.context as { response: Response }).response.headers.get(
+                  'content-type',
+                ) ?? ''
+              ).split(';')[0]!,
+            );
+            observer.next(value);
+          },
+          error: observer.error,
+        });
+        return unsubscribe;
+      });
+    };
+  };
+
+  return { contentTypes, link };
+}
 
 async function startServer(
   endpoint = '',
@@ -151,36 +182,13 @@ describe('with default server', () => {
 
   test('streaming', async () => {
     const orderedResults: number[] = [];
-    const responseContentTypes: string[] = [];
-    const linkSpy: TRPCLink<AppRouter> = () => {
-      // here we just got initialized in the app - this happens once per app
-      // useful for storing cache for instance
-      return ({ next, op }) => {
-        // this is when passing the result to the next link
-        // each link needs to return an observable which propagates results
-        return observable((observer) => {
-          const unsubscribe = next(op).subscribe({
-            next(value) {
-              orderedResults.push(value.result.data as number);
-              responseContentTypes.push(
-                (
-                  (
-                    value.context as { response: Response }
-                  ).response.headers.get('content-type') ?? ''
-                ).split(';')[0]!,
-              );
-              observer.next(value);
-            },
-            error: observer.error,
-          });
-          return unsubscribe;
-        });
-      };
-    };
+    const { contentTypes, link } = createContentTypeSpy((value) => {
+      orderedResults.push(value);
+    });
 
     const client = createTRPCClient<AppRouter>({
       links: [
-        linkSpy,
+        link,
         httpBatchStreamLink({
           url: t.url,
           fetch: fetch as any,
@@ -196,7 +204,7 @@ describe('with default server', () => {
 
     expect(results).toEqual([3, 1, 2]);
     expect(orderedResults).toEqual([1, 2, 3]);
-    expect([...new Set(responseContentTypes)]).toEqual(['application/json']);
+    expect([...new Set(contentTypes)]).toEqual(['application/json']);
   });
 
   test.each([
@@ -204,37 +212,17 @@ describe('with default server', () => {
     'application/x-ndjson',
     'text/plain',
   ] as const)('streaming can opt into %s content-type', async (contentType) => {
-    const custom = await startServer('', {
+    const server = await startServer('', {
       jsonl: {
         contentType,
       },
     });
-
-    const responseContentTypes: string[] = [];
-    const linkSpy: TRPCLink<AppRouter> = () => {
-      return ({ next, op }) => {
-        return observable((observer) => {
-          const unsubscribe = next(op).subscribe({
-            next(value) {
-              responseContentTypes.push(
-                (
-                  (
-                    value.context as { response: Response }
-                  ).response.headers.get('content-type') ?? ''
-                ).split(';')[0]!,
-              );
-              observer.next(value);
-            },
-            error: observer.error,
-          });
-          return unsubscribe;
-        });
-      };
-    };
+    await using custom = makeAsyncResource(server, server.close);
+    const { contentTypes, link } = createContentTypeSpy();
 
     const client = createTRPCClient<AppRouter>({
       links: [
-        linkSpy,
+        link,
         httpBatchStreamLink({
           url: custom.url,
           fetch: fetch as any,
@@ -249,9 +237,7 @@ describe('with default server', () => {
     ]);
 
     expect(results).toEqual([3, 1, 2]);
-    expect([...new Set(responseContentTypes)]).toEqual([contentType]);
-
-    await custom.close();
+    expect([...new Set(contentTypes)]).toEqual([contentType]);
   });
 
   test('query with headers', async () => {

--- a/packages/tests/server/adapters/fetch.test.ts
+++ b/packages/tests/server/adapters/fetch.test.ts
@@ -155,9 +155,9 @@ describe('with default server', () => {
               orderedResults.push(value.result.data as number);
               responseContentTypes.push(
                 (
-                  (value.context as { response: Response }).response.headers.get(
-                    'content-type',
-                  ) ?? ''
+                  (
+                    value.context as { response: Response }
+                  ).response.headers.get('content-type') ?? ''
                 ).split(';')[0]!,
               );
               observer.next(value);

--- a/packages/tests/server/adapters/fetch.test.ts
+++ b/packages/tests/server/adapters/fetch.test.ts
@@ -31,10 +31,7 @@ type Context = Awaited<ReturnType<typeof createContext>>;
 
 type AppRouterServerOptions = {
   jsonl?: {
-    contentType?:
-      | 'application/json'
-      | 'application/jsonl'
-      | 'application/x-ndjson';
+    contentType?: string;
   };
 };
 
@@ -202,59 +199,60 @@ describe('with default server', () => {
     expect([...new Set(responseContentTypes)]).toEqual(['application/json']);
   });
 
-  test.each(['application/jsonl', 'application/x-ndjson'] as const)(
-    'streaming can opt into %s content-type',
-    async (contentType) => {
-      const custom = await startServer('', {
-        jsonl: {
-          contentType,
-        },
-      });
+  test.each([
+    'application/jsonl',
+    'application/x-ndjson',
+    'text/plain',
+  ] as const)('streaming can opt into %s content-type', async (contentType) => {
+    const custom = await startServer('', {
+      jsonl: {
+        contentType,
+      },
+    });
 
-      const responseContentTypes: string[] = [];
-      const linkSpy: TRPCLink<AppRouter> = () => {
-        return ({ next, op }) => {
-          return observable((observer) => {
-            const unsubscribe = next(op).subscribe({
-              next(value) {
-                responseContentTypes.push(
+    const responseContentTypes: string[] = [];
+    const linkSpy: TRPCLink<AppRouter> = () => {
+      return ({ next, op }) => {
+        return observable((observer) => {
+          const unsubscribe = next(op).subscribe({
+            next(value) {
+              responseContentTypes.push(
+                (
                   (
-                    (
-                      value.context as { response: Response }
-                    ).response.headers.get('content-type') ?? ''
-                  ).split(';')[0]!,
-                );
-                observer.next(value);
-              },
-              error: observer.error,
-            });
-            return unsubscribe;
+                    value.context as { response: Response }
+                  ).response.headers.get('content-type') ?? ''
+                ).split(';')[0]!,
+              );
+              observer.next(value);
+            },
+            error: observer.error,
           });
-        };
+          return unsubscribe;
+        });
       };
+    };
 
-      const client = createTRPCClient<AppRouter>({
-        links: [
-          linkSpy,
-          httpBatchStreamLink({
-            url: custom.url,
-            fetch: fetch as any,
-          }),
-        ],
-      });
+    const client = createTRPCClient<AppRouter>({
+      links: [
+        linkSpy,
+        httpBatchStreamLink({
+          url: custom.url,
+          fetch: fetch as any,
+        }),
+      ],
+    });
 
-      const results = await Promise.all([
-        client.deferred.query({ wait: 3 }),
-        client.deferred.query({ wait: 1 }),
-        client.deferred.query({ wait: 2 }),
-      ]);
+    const results = await Promise.all([
+      client.deferred.query({ wait: 3 }),
+      client.deferred.query({ wait: 1 }),
+      client.deferred.query({ wait: 2 }),
+    ]);
 
-      expect(results).toEqual([3, 1, 2]);
-      expect([...new Set(responseContentTypes)]).toEqual([contentType]);
+    expect(results).toEqual([3, 1, 2]);
+    expect([...new Set(responseContentTypes)]).toEqual([contentType]);
 
-      await custom.close();
-    },
-  );
+    await custom.close();
+  });
 
   test('query with headers', async () => {
     const client = createTRPCClient<AppRouter>({

--- a/www/docs/client/links/httpBatchStreamLink.md
+++ b/www/docs/client/links/httpBatchStreamLink.md
@@ -101,7 +101,7 @@ const client = createTRPCClient<AppRouter>({
 Compared to a regular `httpBatchLink`, a `httpBatchStreamLink` will:
 
 - Cause the requests to be sent with a `trpc-accept: application/jsonl` header (or `Accept: application/jsonl` when using `streamHeader: 'accept'`)
-- Cause the response to be sent with a `transfer-encoding: chunked` and `content-type: application/jsonl`
+- Cause the response to be sent with `transfer-encoding: chunked` and `content-type: application/json` by default. You can opt into `application/jsonl` or `application/x-ndjson` on the server via `initTRPC.create({ jsonl: { contentType: ... } })`
 - Remove the `data` key from the argument object passed to `responseMeta` (because with a streamed response, the headers are sent before the data is available)
 
 ## Async generators and deferred promises {#generators}
@@ -205,9 +205,9 @@ You need to enable the `ReadableStream` API through a feature flag: [`streams_en
 
 You can check out the source code for this link on [GitHub.](https://github.com/trpc/trpc/blob/main/packages/client/src/links/httpBatchStreamLink.ts)
 
-## Configure a ping option to keep the connection alive
+## Configure JSONL streaming options
 
-When setting up your root config, you can pass in a `jsonl` option to configure a ping option to keep the connection alive.
+When setting up your root config, you can pass in a `jsonl` option to configure ping behavior and the response `content-type` for streamed batch responses.
 
 ```ts twoslash
 import { initTRPC } from '@trpc/server';
@@ -215,6 +215,7 @@ import { initTRPC } from '@trpc/server';
 const t = initTRPC.create({
   jsonl: {
     pingMs: 1000,
+    contentType: 'application/jsonl',
   },
 });
 ```

--- a/www/docs/client/links/httpBatchStreamLink.md
+++ b/www/docs/client/links/httpBatchStreamLink.md
@@ -101,7 +101,7 @@ const client = createTRPCClient<AppRouter>({
 Compared to a regular `httpBatchLink`, a `httpBatchStreamLink` will:
 
 - Cause the requests to be sent with a `trpc-accept: application/jsonl` header (or `Accept: application/jsonl` when using `streamHeader: 'accept'`)
-- Cause the response to be sent with `transfer-encoding: chunked` and `content-type: application/json` by default. You can opt into `application/jsonl` or `application/x-ndjson` on the server via `initTRPC.create({ jsonl: { contentType: ... } })`
+- Cause the response to be sent with `transfer-encoding: chunked` and `content-type: application/json` by default. You can set the streamed response `content-type` to `application/jsonl`, `application/x-ndjson`, or another value on the server via `initTRPC.create({ jsonl: { contentType: ... } })`.
 - Remove the `data` key from the argument object passed to `responseMeta` (because with a streamed response, the headers are sent before the data is available)
 
 ## Async generators and deferred promises {#generators}
@@ -219,3 +219,5 @@ const t = initTRPC.create({
   },
 });
 ```
+
+The default `contentType` remains `application/json` for backwards compatibility. Use `application/jsonl` if you want the response header to match the `trpc-accept` / `Accept` header sent by `httpBatchStreamLink`, or choose another value that works better with your tooling.


### PR DESCRIPTION
Addresses #6819

## 🎯 Changes

- make the streamed batch response `content-type` configurable via `initTRPC.create({ jsonl: { contentType } })`
- keep `application/json` as the default for backward compatibility, matching the stability concerns raised in `#7258`
- support `application/jsonl`, `application/x-ndjson`, or another content type string when a server wants to opt in
- document how to configure the response header and add tests for the default plus opt-in content types

## Why

`httpBatchStreamLink` advertises JSON Lines, but changing the default response header for all existing users could be a breaking change. This keeps the current default stable while adding the setting requested in `#7258`, so servers can choose the streamed `content-type` that works best for their tooling or infrastructure.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.

## Validation

- `corepack pnpm --dir packages/server build`
- `corepack pnpm --dir packages/server typecheck`
- `corepack pnpm --dir packages/tests typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Servers can configure the streamed response content-type (e.g., application/jsonl, application/x-ndjson, etc.); default is now application/json.

* **Documentation**
  * Streaming docs updated to reflect the new default and show how to configure JSONL streaming options.

* **Tests**
  * Streaming tests added/updated to verify configurable content-type values and streamed response behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->