### PR TITLE
fix(react-query): always inject cursor field in infinite queries

### DIFF
--- a/packages/react-query/src/internals/getClientArgs.ts
+++ b/packages/react-query/src/internals/getClientArgs.ts
@@ -1,6 +1,12 @@
 import type { TRPCQueryKey } from './getQueryKey';
 
 /**
+ * Constructs arguments for tRPC client calls from query key and options.
+ * For infinite queries, cursor is injected only when pageParam is not
+ * undefined. This preserves schema defaults (e.g. `z.number().default(0)`)
+ * while correctly forwarding explicit null cursors (e.g. `z.number().nullable()`
+ * with `initialCursor: null`) and fixing the falsy-check bug where pageParam 0
+ * was silently dropped (fixes #6862).
  * @internal
  */
 export function getClientArgs<TOptions>(
@@ -16,7 +22,9 @@ export function getClientArgs<TOptions>(
   if (infiniteParams) {
     input = {
       ...(input ?? {}),
-      ...(infiniteParams.pageParam ? { cursor: infiniteParams.pageParam } : {}),
+      ...(infiniteParams.pageParam !== undefined
+        ? { cursor: infiniteParams.pageParam }
+        : {}),
       direction: infiniteParams.direction,
     };
   }

--- a/packages/react-query/src/utils/createUtilityFunctions.ts
+++ b/packages/react-query/src/utils/createUtilityFunctions.ts
@@ -63,7 +63,7 @@ export function createUtilityFunctions<TRouter extends AnyRouter>(
         const result = await untypedClient.query(
           ...getClientArgs(queryKey, actualOpts, {
             direction: queryFnContext.direction,
-            pageParam: queryFnContext.pageParam,
+            pageParam: queryFnContext.pageParam ?? opts?.initialCursor,
           }),
         );
 
@@ -138,7 +138,10 @@ export function createUtilityFunctions<TRouter extends AnyRouter>(
         queryKey,
         queryFn: ({ pageParam, direction }) => {
           return untypedClient.query(
-            ...getClientArgs(queryKey, opts, { pageParam, direction }),
+            ...getClientArgs(queryKey, opts, {
+              pageParam: pageParam ?? opts?.initialCursor,
+              direction,
+            }),
           );
         },
         initialPageParam: opts?.initialCursor ?? null,
@@ -159,7 +162,10 @@ export function createUtilityFunctions<TRouter extends AnyRouter>(
         queryKey,
         queryFn: ({ pageParam, direction }) => {
           return untypedClient.query(
-            ...getClientArgs(queryKey, opts, { pageParam, direction }),
+            ...getClientArgs(queryKey, opts, {
+              pageParam: pageParam ?? opts?.initialCursor,
+              direction,
+            }),
           );
         },
         initialPageParam: opts?.initialCursor ?? null,

--- a/packages/react-query/test/regression/issue-6862-infinite-query-cursor-initial-load.test.tsx
+++ b/packages/react-query/test/regression/issue-6862-infinite-query-cursor-initial-load.test.tsx
@@ -1,0 +1,148 @@
+import { getServerAndReactClient } from '../__reactHelpers';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { initTRPC } from '@trpc/server';
+import { konn } from 'konn';
+import React from 'react';
+import { z } from 'zod';
+
+/**
+ * Regression test for issue #6862
+ * https://github.com/trpc/trpc/issues/6862
+ *
+ * The cursor schema is intentionally strict: `z.number().nullable()` requires
+ * the cursor field to be present (null is accepted, undefined/missing is not).
+ * Using `.nullish()` or `.default(null)` would mask the bug because Zod would
+ * silently supply the missing field.
+ *
+ * The pre-fix code used a truthy check (`pageParam ? { cursor } : {}`) which
+ * treated null as falsy, omitting the cursor field entirely and causing a Zod
+ * "Required" validation error. The fix switches to a strict `!== undefined`
+ * check so that null and 0 are forwarded correctly.
+ *
+ * For schemas where the cursor can be null, callers must pass `initialCursor:
+ * null` to `useInfiniteQuery` so that tRPC forwards null (rather than
+ * `undefined`) as the initial pageParam.
+ */
+
+const ctx = konn()
+  .beforeEach(() => {
+    const t = initTRPC.create();
+
+    const posts = [
+      { id: 0, title: 'first post' },
+      { id: 1, title: 'second post' },
+      { id: 2, title: 'third post' },
+    ];
+
+    const appRouter = t.router({
+      posts: t.procedure
+        .input(
+          z.object({
+            // Strict: required field, accepts null, no default.
+            // Must fail if cursor is not injected at all.
+            cursor: z.number().nullable(),
+          }),
+        )
+        .query(({ input }) => {
+          const offset = input.cursor ?? 0;
+          return {
+            items: [posts[offset]!],
+            nextCursor: offset + 1 < posts.length ? offset + 1 : null,
+          };
+        }),
+    });
+
+    return getServerAndReactClient(appRouter);
+  })
+  .afterEach(async (ctx) => {
+    await ctx?.close?.();
+  })
+  .done();
+
+test('issue #6862: useInfiniteQuery loads on initial render with strict nullable cursor', async () => {
+  const { App, client } = ctx;
+
+  function MyComponent() {
+    const q = client.posts.useInfiniteQuery(
+      {},
+      {
+        getNextPageParam: (lastPage) => lastPage.nextCursor,
+        initialCursor: null,
+      },
+    );
+
+    if (q.status === 'error') return <p>Error: {q.error.message}</p>;
+    if (q.status !== 'success') return <p>Loading...</p>;
+
+    return (
+      <>
+        {q.data.pages.map((page, i) => (
+          <div key={i}>
+            {page.items.map((post) => (
+              <div key={post.id}>{post.title}</div>
+            ))}
+          </div>
+        ))}
+      </>
+    );
+  }
+
+  const utils = render(
+    <App>
+      <MyComponent />
+    </App>,
+  );
+
+  await vi.waitFor(() => {
+    expect(utils.container).toHaveTextContent('first post');
+  });
+});
+
+test('issue #6862: useInfiniteQuery works after refetch when cursor resets to initialCursor', async () => {
+  const { App, client } = ctx;
+
+  function MyComponent() {
+    const q = client.posts.useInfiniteQuery(
+      {},
+      {
+        getNextPageParam: (lastPage) => lastPage.nextCursor,
+        initialCursor: null,
+      },
+    );
+
+    if (q.status === 'error') return <p>Error: {q.error.message}</p>;
+    if (q.status !== 'success') return <p>Loading...</p>;
+
+    return (
+      <>
+        {q.data.pages.map((page, i) => (
+          <div key={i}>
+            {page.items.map((post) => (
+              <div key={post.id}>{post.title}</div>
+            ))}
+          </div>
+        ))}
+        <button onClick={() => q.refetch()} data-testid="refetch">
+          Refetch
+        </button>
+      </>
+    );
+  }
+
+  const utils = render(
+    <App>
+      <MyComponent />
+    </App>,
+  );
+
+  await vi.waitFor(() => {
+    expect(utils.container).toHaveTextContent('first post');
+  });
+
+  await userEvent.click(utils.getByTestId('refetch'));
+
+  await vi.waitFor(() => {
+    expect(utils.container).toHaveTextContent('first post');
+  });
+});


### PR DESCRIPTION
Closes #6862

## 🎯 Changes

\`useInfiniteQuery\` fails on initial render when the cursor schema is \`z.number().nullable()\`. The cursor field gets omitted from the request, producing a Zod \`"Required"\` validation error before any data loads. A separate issue causes page \`0\` cursors to be silently dropped.

**Root cause**

\`getClientArgs.ts\` used a truthy check to decide whether to inject cursor:

\`\`\`ts
// Before: null and 0 are falsy -- cursor silently omitted
...(infiniteParams.pageParam ? { cursor: infiniteParams.pageParam } : {})
\`\`\`

Three call sites in \`createUtilityFunctions.ts\` (\`infiniteQueryOptions\`, \`fetchInfiniteQuery\`, \`prefetchInfiniteQuery\`) also passed TanStack's raw \`pageParam\` directly to \`getClientArgs\`. Because \`initialPageParam\` defaults to \`null\` in tRPC, those paths always received \`pageParam = null\` on the first fetch and forwarded it straight through. \`createHooksInternal.tsx\` already applied \`pageParam ?? opts.initialCursor\` to convert that internal null to \`undefined\` (meaning "no cursor, apply schema default"), but \`createUtilityFunctions.ts\` was missing it for all three.

**Fix**

Replace the truthy check with \`!== undefined\`:

\`\`\`ts
// After: undefined = "no cursor, use schema default"; null and 0 are real values
...(infiniteParams.pageParam !== undefined
  ? { cursor: infiniteParams.pageParam }
  : {})
\`\`\`

Apply \`pageParam ?? opts?.initialCursor\` at all three call sites in \`createUtilityFunctions.ts\` to match \`createHooksInternal.tsx\`.

**For \`z.number().nullable()\` schemas:** pass \`initialCursor: null\` so tRPC forwards null rather than collapsing it to undefined:

\`\`\`ts
client.posts.useInfiniteQuery(
  {},
  { getNextPageParam: ..., initialCursor: null },
)
\`\`\`

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.