### PR TITLE
chore(react-query,tanstack-react-query,next): migrate to automatic JSX runtime

### DIFF
--- a/packages/next/src/app-dir/client.test.tsx
+++ b/packages/next/src/app-dir/client.test.tsx
@@ -1,7 +1,6 @@
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { initTRPC } from '@trpc/server';
-import React from 'react';
 import superjson from 'superjson';
 import { z } from 'zod';
 import type { UseTRPCActionResult } from './create-action-hook';

--- a/packages/next/src/withTRPC.tsx
+++ b/packages/next/src/withTRPC.tsx
@@ -33,7 +33,7 @@ import type {
   NextPageContext,
 } from 'next/dist/shared/lib/utils';
 import type { NextRouter } from 'next/router';
-import { useState, useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 export type WithTRPCConfig<TRouter extends AnyRouter> =
   CreateTRPCClientOptions<TRouter> &

--- a/packages/next/src/withTRPC.tsx
+++ b/packages/next/src/withTRPC.tsx
@@ -33,7 +33,7 @@ import type {
   NextPageContext,
 } from 'next/dist/shared/lib/utils';
 import type { NextRouter } from 'next/router';
-import React, { useState } from 'react';
+import { useState, useMemo } from 'react';
 
 export type WithTRPCConfig<TRouter extends AnyRouter> =
   CreateTRPCClientOptions<TRouter> &
@@ -128,7 +128,7 @@ export function withTRPC<
       // allow normal components to be wrapped, not just app/pages
       const trpcState = props.pageProps?.trpcState;
 
-      const hydratedState: DehydratedState | undefined = React.useMemo(() => {
+      const hydratedState: DehydratedState | undefined = useMemo(() => {
         if (!trpcState) {
           return trpcState;
         }

--- a/packages/next/test/issue-4130-ssr-different-transformers.test.tsx
+++ b/packages/next/test/issue-4130-ssr-different-transformers.test.tsx
@@ -9,7 +9,6 @@ import type { CombinedDataTransformer } from '@trpc/server/unstable-core-do-not-
 import { uneval } from 'devalue';
 import { konn } from 'konn';
 import type { AppType } from 'next/dist/shared/lib/utils';
-import React from 'react';
 import superjson from 'superjson';
 
 // [...]

--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -24,7 +24,7 @@ import type {
   Simplify,
 } from '@trpc/server/unstable-core-do-not-import';
 import { createFlatProxy } from '@trpc/server/unstable-core-do-not-import';
-import * as React from 'react';
+import { useMemo } from 'react';
 import type {
   TRPCUseQueries,
   TRPCUseSuspenseQueries,
@@ -491,7 +491,7 @@ export function createHooksInternal<
       return () => {
         const context = trpc.useUtils();
         // create a stable reference of the utils context
-        return React.useMemo(() => {
+        return useMemo(() => {
           return (createReactQueryUtils as any)(context);
         }, [context]);
       };

--- a/packages/react-query/src/internals/context.tsx
+++ b/packages/react-query/src/internals/context.tsx
@@ -26,7 +26,7 @@ import type {
   AnyRouter,
   DistributiveOmit,
 } from '@trpc/server/unstable-core-do-not-import';
-import * as React from 'react';
+import { createContext } from 'react';
 import type {
   DefinedTRPCInfiniteQueryOptionsIn,
   DefinedTRPCInfiniteQueryOptionsOut,
@@ -347,4 +347,4 @@ export interface TRPCQueryUtils<TRouter extends AnyRouter> {
    */
   isMutating: (filters: { mutationKey: TRPCMutationKey }) => number;
 }
-export const TRPCContext = React.createContext?.(null as any);
+export const TRPCContext = createContext?.(null as any);

--- a/packages/react-query/src/rsc.tsx
+++ b/packages/react-query/src/rsc.tsx
@@ -22,7 +22,7 @@ import type {
   RouterCaller,
   TypeError,
 } from '@trpc/server/unstable-core-do-not-import';
-import * as React from 'react';
+import type { ReactNode } from 'react';
 import { getQueryKeyInternal } from './internals/getQueryKey';
 import type {
   TRPCFetchInfiniteQueryOptions,
@@ -143,7 +143,7 @@ export function createHydrationHelpers<TRouter extends AnyRouter>(
     return promise;
   });
 
-  function HydrateClient(props: { children: React.ReactNode }) {
+  function HydrateClient(props: { children: ReactNode }) {
     const dehydratedState = dehydrate(getQueryClient());
 
     return (

--- a/packages/react-query/test/__reactHelpers.tsx
+++ b/packages/react-query/test/__reactHelpers.tsx
@@ -16,7 +16,6 @@ import { createTRPCReact } from '@trpc/react-query';
 import type { CreateTRPCReactBase } from '@trpc/react-query/createTRPCReact';
 import type { AnyRouter } from '@trpc/server';
 import type { ReactNode } from 'react';
-import React from 'react';
 
 export function getServerAndReactClient<TRouter extends AnyRouter>(
   appRouter: TRouter,

--- a/packages/react-query/test/__testHelpers.tsx
+++ b/packages/react-query/test/__testHelpers.tsx
@@ -16,7 +16,6 @@ import type { Observable, Observer } from '@trpc/server/observable';
 import { observable } from '@trpc/server/observable';
 import hash from 'hash-sum';
 import type { ReactNode } from 'react';
-import React from 'react';
 import type { Mock } from 'vitest';
 import { z, ZodError } from 'zod';
 

--- a/packages/react-query/test/abortOnUnmount.test.tsx
+++ b/packages/react-query/test/abortOnUnmount.test.tsx
@@ -8,7 +8,7 @@ import { createTRPCReact } from '@trpc/react-query';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 import type { ReactNode } from 'react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { z } from 'zod';
 
 const ctx = konn()

--- a/packages/react-query/test/createClient.test.tsx
+++ b/packages/react-query/test/createClient.test.tsx
@@ -7,7 +7,7 @@ import { createTRPCReact } from '@trpc/react-query';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 import type { ReactNode } from 'react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 const ctx = konn()
   .beforeEach(() => {

--- a/packages/react-query/test/ensureQueryData.test.tsx
+++ b/packages/react-query/test/ensureQueryData.test.tsx
@@ -1,7 +1,7 @@
 import { createAppRouter } from './__testHelpers';
 import { useQueryClient } from '@tanstack/react-query';
 import { render } from '@testing-library/react';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 let factory: ReturnType<typeof createAppRouter>;
 beforeEach(() => {

--- a/packages/react-query/test/errors.test.tsx
+++ b/packages/react-query/test/errors.test.tsx
@@ -8,7 +8,6 @@ import type {
   Maybe,
 } from '@trpc/server/unstable-core-do-not-import';
 import { konn } from 'konn';
-import React from 'react';
 import { z, ZodError } from 'zod';
 
 describe('custom error formatter', () => {

--- a/packages/react-query/test/formData.test.tsx
+++ b/packages/react-query/test/formData.test.tsx
@@ -17,7 +17,6 @@ import { initTRPC } from '@trpc/server';
 import type { CreateHTTPContextOptions } from '@trpc/server/adapters/standalone';
 import { konn } from 'konn';
 import type { ReactNode } from 'react';
-import React from 'react';
 import transformer from 'superjson';
 import { z } from 'zod';
 import { zfd } from 'zod-form-data';

--- a/packages/react-query/test/formatError.test.tsx
+++ b/packages/react-query/test/formatError.test.tsx
@@ -1,7 +1,7 @@
 import { createAppRouter } from './__testHelpers';
 import { render } from '@testing-library/react';
 import type { DefaultErrorShape } from '@trpc/server/unstable-core-do-not-import';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 
 let factory: ReturnType<typeof createAppRouter>;
 beforeEach(() => {

--- a/packages/react-query/test/getQueryKey.test.tsx
+++ b/packages/react-query/test/getQueryKey.test.tsx
@@ -4,7 +4,6 @@ import { render } from '@testing-library/react';
 import { getQueryKey } from '@trpc/react-query';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
-import React from 'react';
 import { z } from 'zod';
 
 type Post = {

--- a/packages/react-query/test/invalidateQueries.test.tsx
+++ b/packages/react-query/test/invalidateQueries.test.tsx
@@ -5,7 +5,7 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getUntypedClient } from '@trpc/client';
 import type { TRPCQueryKey } from '@trpc/react-query/internals/getQueryKey';
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 let factory: ReturnType<typeof createAppRouter>;
 beforeEach(() => {

--- a/packages/react-query/test/invalidateRouters.test.tsx
+++ b/packages/react-query/test/invalidateRouters.test.tsx
@@ -5,7 +5,6 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
-import React from 'react';
 import { z } from 'zod';
 
 export type Post = {

--- a/packages/react-query/test/multiple-trpc-providers.test.tsx
+++ b/packages/react-query/test/multiple-trpc-providers.test.tsx
@@ -6,7 +6,7 @@ import { getUntypedClient } from '@trpc/client';
 import { createTRPCReact } from '@trpc/react-query';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
-import React, { createContext } from 'react';
+import { createContext } from 'react';
 
 const ctx = konn()
   .beforeEach(() => {

--- a/packages/react-query/test/mutationkey.test.tsx
+++ b/packages/react-query/test/mutationkey.test.tsx
@@ -4,7 +4,6 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
-import React from 'react';
 
 const ctx = konn()
   .beforeEach(() => {

--- a/packages/react-query/test/octetStreams.test.tsx
+++ b/packages/react-query/test/octetStreams.test.tsx
@@ -17,7 +17,6 @@ import type { CreateHTTPContextOptions } from '@trpc/server/adapters/standalone'
 import { octetInputParser } from '@trpc/server/http';
 import { konn } from 'konn';
 import type { ReactNode } from 'react';
-import React from 'react';
 
 const ctx = konn()
   .beforeEach(() => {

--- a/packages/react-query/test/offline.test.tsx
+++ b/packages/react-query/test/offline.test.tsx
@@ -6,7 +6,6 @@ import userEvent from '@testing-library/user-event';
 import { createTRPCQueryUtils } from '@trpc/react-query';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
-import React from 'react';
 import { z } from 'zod';
 
 type Post = {

--- a/packages/react-query/test/overrides.test.tsx
+++ b/packages/react-query/test/overrides.test.tsx
@@ -7,7 +7,6 @@ import { createTRPCReact } from '@trpc/react-query';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 import type { ReactNode } from 'react';
-import React from 'react';
 import { z } from 'zod';
 
 describe('mutation override', () => {

--- a/packages/react-query/test/polymorphism.test.tsx
+++ b/packages/react-query/test/polymorphism.test.tsx
@@ -22,7 +22,7 @@ import { createTRPCReact } from '@trpc/react-query';
 import type { InferQueryLikeData } from '@trpc/react-query/shared';
 import { konn } from 'konn';
 import type { ReactNode } from 'react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { z } from 'zod';
 import { t } from './polymorphism.common';
 /**

--- a/packages/react-query/test/prefetchQuery.test.tsx
+++ b/packages/react-query/test/prefetchQuery.test.tsx
@@ -1,7 +1,7 @@
 import { createAppRouter } from './__testHelpers';
 import { dehydrate, useQueryClient } from '@tanstack/react-query';
 import { render } from '@testing-library/react';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 let factory: ReturnType<typeof createAppRouter>;
 beforeEach(() => {

--- a/packages/react-query/test/queryClientDefaults.test.tsx
+++ b/packages/react-query/test/queryClientDefaults.test.tsx
@@ -7,7 +7,6 @@ import { createTRPCReact } from '@trpc/react-query';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
 import type { ReactNode } from 'react';
-import React from 'react';
 import { z } from 'zod';
 
 describe('query client defaults', () => {

--- a/packages/react-query/test/queryOptions.test.tsx
+++ b/packages/react-query/test/queryOptions.test.tsx
@@ -13,7 +13,6 @@ import userEvent from '@testing-library/user-event';
 import { initTRPC } from '@trpc/server';
 import { createDeferred } from '@trpc/server/unstable-core-do-not-import/stream/utils/createDeferred';
 import { konn } from 'konn';
-import React from 'react';
 import { z } from 'zod';
 
 const fixtureData = ['1', '2', '3', '4'];

--- a/packages/react-query/test/regression/issue-1645-setErrorStatusSSR.test.tsx
+++ b/packages/react-query/test/regression/issue-1645-setErrorStatusSSR.test.tsx
@@ -3,7 +3,6 @@ import { createAppRouter } from '../__testHelpers';
 import { withTRPC } from '@trpc/next';
 import { ssrPrepass } from '@trpc/next/ssrPrepass';
 import type { AppType } from 'next/dist/shared/lib/utils';
-import React from 'react';
 
 let factory: ReturnType<typeof createAppRouter>;
 beforeEach(() => {

--- a/packages/react-query/test/regression/issue-2942-useInfiniteQuery-setData.test.tsx
+++ b/packages/react-query/test/regression/issue-2942-useInfiniteQuery-setData.test.tsx
@@ -5,7 +5,6 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
-import React from 'react';
 import { z } from 'zod';
 
 const fixtureData = ['1', '2'];

--- a/packages/react-query/test/regression/issue-2996-defined-data.test.tsx
+++ b/packages/react-query/test/regression/issue-2996-defined-data.test.tsx
@@ -3,7 +3,6 @@ import { useQuery } from '@tanstack/react-query';
 import { render } from '@testing-library/react';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
-import React from 'react';
 
 const posts = [
   { id: 1, title: 'foo' },

--- a/packages/react-query/test/regression/issue-3455-56-invalidate-queries.test.tsx
+++ b/packages/react-query/test/regression/issue-3455-56-invalidate-queries.test.tsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
-import React from 'react';
+import { useEffect } from 'react';
 import { z } from 'zod';
 
 const post = { id: 1, text: 'foo' };
@@ -50,10 +50,10 @@ test('invalidate with filter', async () => {
       structuralSharing: false,
     });
 
-    React.useEffect(() => {
+    useEffect(() => {
       if (allPosts.data) postSpy();
     }, [allPosts.data]);
-    React.useEffect(() => {
+    useEffect(() => {
       if (greeting.data) greetingSpy();
     }, [greeting.data]);
 

--- a/packages/react-query/test/regression/issue-3461-reserved-properties.test.tsx
+++ b/packages/react-query/test/regression/issue-3461-reserved-properties.test.tsx
@@ -3,7 +3,6 @@ import { render } from '@testing-library/react';
 import { createServerSideHelpers } from '@trpc/react-query/server';
 import { initTRPC } from '@trpc/server';
 import type { IntersectionError } from '@trpc/server/unstable-core-do-not-import';
-import React from 'react';
 import { z } from 'zod';
 
 test('utils client', async () => {

--- a/packages/react-query/test/regression/issue-5808-proxy-in-dep-array.test.tsx
+++ b/packages/react-query/test/regression/issue-5808-proxy-in-dep-array.test.tsx
@@ -7,7 +7,7 @@ import { render } from '@testing-library/react';
 import { createHydrationHelpers } from '@trpc/react-query/rsc';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
-import * as React from 'react';
+import { useEffect } from 'react';
 import { z } from 'zod';
 
 describe('original regression', () => {
@@ -43,7 +43,7 @@ describe('original regression', () => {
       });
       const utils = client.useUtils();
 
-      React.useEffect(() => {
+      useEffect(() => {
         utils.deeply.nested.greeting.setData(undefined, nonce);
         effectCount++;
       }, [utils.deeply.nested.greeting]);

--- a/packages/react-query/test/rsc-prefetch.test.tsx
+++ b/packages/react-query/test/rsc-prefetch.test.tsx
@@ -7,7 +7,6 @@ import { render } from '@testing-library/react';
 import { createHydrationHelpers } from '@trpc/react-query/rsc';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
-import React from 'react';
 import { z } from 'zod';
 
 const ctx = konn()

--- a/packages/react-query/test/setInfiniteQueryData.test.tsx
+++ b/packages/react-query/test/setInfiniteQueryData.test.tsx
@@ -1,7 +1,6 @@
 import { createAppRouter } from './__testHelpers';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 
 let factory: ReturnType<typeof createAppRouter>;
 beforeEach(() => {

--- a/packages/react-query/test/setQueriesData.test.tsx
+++ b/packages/react-query/test/setQueriesData.test.tsx
@@ -1,7 +1,6 @@
 import { createAppRouter } from './__testHelpers';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 
 let factory: ReturnType<typeof createAppRouter>;
 beforeEach(() => {

--- a/packages/react-query/test/setQueryData.test.tsx
+++ b/packages/react-query/test/setQueryData.test.tsx
@@ -1,7 +1,6 @@
 import { createAppRouter } from './__testHelpers';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 
 let factory: ReturnType<typeof createAppRouter>;
 beforeEach(() => {

--- a/packages/react-query/test/trpc-options.test.tsx
+++ b/packages/react-query/test/trpc-options.test.tsx
@@ -2,7 +2,7 @@ import { getServerAndReactClient } from './__reactHelpers';
 import { render } from '@testing-library/react';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { z } from 'zod';
 
 const ctx = konn()

--- a/packages/react-query/test/useInfiniteQuery.test.tsx
+++ b/packages/react-query/test/useInfiniteQuery.test.tsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createServerSideHelpers } from '@trpc/react-query/server';
 import type { inferProcedureInput } from '@trpc/server';
-import React, { Fragment } from 'react';
+import { Fragment } from 'react';
 
 let factory: ReturnType<typeof createAppRouter>;
 beforeEach(() => {

--- a/packages/react-query/test/useMutation.test.tsx
+++ b/packages/react-query/test/useMutation.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import type { inferReactQueryProcedureOptions } from '@trpc/react-query';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { z } from 'zod';
 
 const ctx = konn()

--- a/packages/react-query/test/useQueries.test.tsx
+++ b/packages/react-query/test/useQueries.test.tsx
@@ -2,7 +2,6 @@ import { getServerAndReactClient } from './__reactHelpers';
 import { render } from '@testing-library/react';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
-import React from 'react';
 import { z } from 'zod';
 
 const ctx = konn()

--- a/packages/react-query/test/useQuery.test.tsx
+++ b/packages/react-query/test/useQuery.test.tsx
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { initTRPC } from '@trpc/server';
 import { createDeferred } from '@trpc/server/unstable-core-do-not-import';
 import { konn } from 'konn';
-import React, { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { z } from 'zod';
 
 const fixtureData = ['1', '2', '3', '4'];
@@ -138,7 +138,7 @@ describe('useQuery()', () => {
     const { client, App } = ctx;
     let onEnable: () => void;
     function MyComponent() {
-      const [enabled, setEnabled] = React.useState(false);
+      const [enabled, setEnabled] = useState(false);
       const query1 = client.post.byId.useQuery(
         enabled
           ? {

--- a/packages/react-query/test/useSubscription.test.tsx
+++ b/packages/react-query/test/useSubscription.test.tsx
@@ -9,7 +9,7 @@ import type { TRPCSubscriptionResult } from '@trpc/react-query/shared';
 import { initTRPC } from '@trpc/server';
 import { observable } from '@trpc/server/observable';
 import { konn } from 'konn';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { z } from 'zod';
 
 const returnSymbol = Symbol();

--- a/packages/react-query/test/useSuspenseInfiniteQuery.test.tsx
+++ b/packages/react-query/test/useSuspenseInfiniteQuery.test.tsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
-import React, { Suspense } from 'react';
+import { Suspense } from 'react';
 import { z } from 'zod';
 
 const fixtureData = ['1', '2', '3', '4'];

--- a/packages/react-query/test/useSuspenseQueries.test.tsx
+++ b/packages/react-query/test/useSuspenseQueries.test.tsx
@@ -2,7 +2,6 @@ import { getServerAndReactClient } from './__reactHelpers';
 import { render } from '@testing-library/react';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
-import React from 'react';
 import { z } from 'zod';
 
 const ctx = konn()

--- a/packages/react-query/test/useSuspenseQuery.test.tsx
+++ b/packages/react-query/test/useSuspenseQuery.test.tsx
@@ -4,7 +4,6 @@ import { skipToken } from '@tanstack/react-query';
 import { render } from '@testing-library/react';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
-import React from 'react';
 import { z } from 'zod';
 
 const ctx = konn()

--- a/packages/react-query/test/useUtils.test.tsx
+++ b/packages/react-query/test/useUtils.test.tsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { initTRPC } from '@trpc/server';
 import { konn } from 'konn';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { z } from 'zod';
 
 type Post = {

--- a/packages/react-query/test/withTRPC.test.tsx
+++ b/packages/react-query/test/withTRPC.test.tsx
@@ -6,7 +6,6 @@ import { withTRPC } from '@trpc/next';
 import { ssrPrepass } from '@trpc/next/ssrPrepass';
 import { konn } from 'konn';
 import type { AppType, NextPageContext } from 'next/dist/shared/lib/utils';
-import React from 'react';
 import { expect, vitest } from 'vitest';
 
 const ctx = konn()

--- a/packages/tanstack-react-query/src/internals/Context.tsx
+++ b/packages/tanstack-react-query/src/internals/Context.tsx
@@ -1,7 +1,8 @@
 import type { QueryClient } from '@tanstack/react-query';
 import type { TRPCClient } from '@trpc/client';
 import type { AnyTRPCRouter } from '@trpc/server';
-import * as React from 'react';
+import { createContext, useContext, useMemo } from 'react';
+import type { FC, ReactNode } from 'react';
 import type { TRPCOptionsProxy } from './createOptionsProxy';
 import { createTRPCOptionsProxy } from './createOptionsProxy';
 import type {
@@ -13,9 +14,9 @@ import type {
 type TRPCProviderType<
   TRouter extends AnyTRPCRouter,
   TFeatureFlags extends FeatureFlags = DefaultFeatureFlags,
-> = React.FC<
+> = FC<
   {
-    children: React.ReactNode;
+    children: ReactNode;
     queryClient: QueryClient;
     trpcClient: TRPCClient<TRouter>;
   } & KeyPrefixOptions<TFeatureFlags>
@@ -39,16 +40,14 @@ export function createTRPCContext<
   TRouter extends AnyTRPCRouter,
   TFeatureFlags extends FeatureFlags = DefaultFeatureFlags,
 >(): CreateTRPCContextResult<TRouter, TFeatureFlags> {
-  const TRPCClientContext = React.createContext<TRPCClient<TRouter> | null>(
-    null,
-  );
-  const TRPCContext = React.createContext<TRPCOptionsProxy<
+  const TRPCClientContext = createContext<TRPCClient<TRouter> | null>(null);
+  const TRPCContext = createContext<TRPCOptionsProxy<
     TRouter,
     TFeatureFlags
   > | null>(null);
 
   const TRPCProvider: TRPCProviderType<TRouter, TFeatureFlags> = (props) => {
-    const value = React.useMemo(
+    const value = useMemo(
       () =>
         createTRPCOptionsProxy<TRouter, TFeatureFlags>({
           client: props.trpcClient,
@@ -68,7 +67,7 @@ export function createTRPCContext<
   TRPCProvider.displayName = 'TRPCProvider';
 
   function useTRPC() {
-    const utils = React.useContext(TRPCContext);
+    const utils = useContext(TRPCContext);
     if (!utils) {
       throw new Error('useTRPC() can only be used inside of a <TRPCProvider>');
     }
@@ -76,7 +75,7 @@ export function createTRPCContext<
   }
 
   function useTRPCClient() {
-    const client = React.useContext(TRPCClientContext);
+    const client = useContext(TRPCClientContext);
     if (!client) {
       throw new Error(
         'useTRPCClient() can only be used inside of a <TRPCProvider>',

--- a/packages/tanstack-react-query/src/internals/Context.tsx
+++ b/packages/tanstack-react-query/src/internals/Context.tsx
@@ -1,7 +1,7 @@
 import type { QueryClient } from '@tanstack/react-query';
 import type { TRPCClient } from '@trpc/client';
 import type { AnyTRPCRouter } from '@trpc/server';
-import { createContext, useContext, useMemo } from 'react';
+import * as React from 'react';
 import type { FC, ReactNode } from 'react';
 import type { TRPCOptionsProxy } from './createOptionsProxy';
 import { createTRPCOptionsProxy } from './createOptionsProxy';
@@ -40,14 +40,16 @@ export function createTRPCContext<
   TRouter extends AnyTRPCRouter,
   TFeatureFlags extends FeatureFlags = DefaultFeatureFlags,
 >(): CreateTRPCContextResult<TRouter, TFeatureFlags> {
-  const TRPCClientContext = createContext<TRPCClient<TRouter> | null>(null);
-  const TRPCContext = createContext<TRPCOptionsProxy<
+  const TRPCClientContext = React.createContext<TRPCClient<TRouter> | null>(
+    null,
+  );
+  const TRPCContext = React.createContext<TRPCOptionsProxy<
     TRouter,
     TFeatureFlags
   > | null>(null);
 
   const TRPCProvider: TRPCProviderType<TRouter, TFeatureFlags> = (props) => {
-    const value = useMemo(
+    const value = React.useMemo(
       () =>
         createTRPCOptionsProxy<TRouter, TFeatureFlags>({
           client: props.trpcClient,
@@ -67,7 +69,7 @@ export function createTRPCContext<
   TRPCProvider.displayName = 'TRPCProvider';
 
   function useTRPC() {
-    const utils = useContext(TRPCContext);
+    const utils = React.useContext(TRPCContext);
     if (!utils) {
       throw new Error('useTRPC() can only be used inside of a <TRPCProvider>');
     }
@@ -75,7 +77,7 @@ export function createTRPCContext<
   }
 
   function useTRPCClient() {
-    const client = useContext(TRPCClientContext);
+    const client = React.useContext(TRPCClientContext);
     if (!client) {
       throw new Error(
         'useTRPCClient() can only be used inside of a <TRPCProvider>',

--- a/packages/tanstack-react-query/test/__helpers.tsx
+++ b/packages/tanstack-react-query/test/__helpers.tsx
@@ -7,7 +7,7 @@ import type { RenderResult } from '@testing-library/react';
 import { render } from '@testing-library/react';
 import { getUntypedClient } from '@trpc/client';
 import type { AnyTRPCRouter } from '@trpc/server';
-import * as React from 'react';
+import type { ReactNode } from 'react';
 import type { ofFeatureFlags } from '../src';
 import { createTRPCContext, createTRPCOptionsProxy } from '../src';
 
@@ -48,7 +48,7 @@ export function testReactResource<
     $Flags
   >();
 
-  function renderApp(ui: React.ReactNode) {
+  function renderApp(ui: ReactNode) {
     return render(
       <QueryClientProvider client={queryClient}>
         <TRPCProvider
@@ -62,7 +62,7 @@ export function testReactResource<
     );
   }
 
-  function rerenderApp(render: RenderResult, ui: React.ReactNode) {
+  function rerenderApp(render: RenderResult, ui: ReactNode) {
     return render.rerender(
       <QueryClientProvider client={queryClient}>
         <TRPCProvider

--- a/packages/tanstack-react-query/test/client.test.tsx
+++ b/packages/tanstack-react-query/test/client.test.tsx
@@ -3,7 +3,7 @@ import '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { initTRPC } from '@trpc/server';
 import { createDeferred } from '@trpc/server/unstable-core-do-not-import';
-import * as React from 'react';
+import { useState } from 'react';
 import { describe, expect, test } from 'vitest';
 import { z } from 'zod';
 
@@ -40,7 +40,7 @@ describe('useTRPCClient', () => {
     const { useTRPCClient } = ctx;
     function MyComponent() {
       const vanillaClient = useTRPCClient();
-      const [fetchedState, setFetchedState] = React.useState('');
+      const [fetchedState, setFetchedState] = useState('');
 
       async function fetch() {
         const state = await vanillaClient.post.byId.query({ id: '1' });

--- a/packages/tanstack-react-query/test/infiniteQueryOptions.test.tsx
+++ b/packages/tanstack-react-query/test/infiniteQueryOptions.test.tsx
@@ -14,7 +14,7 @@ import userEvent from '@testing-library/user-event';
 import type { TRPCClientErrorLike } from '@trpc/client';
 import type { inferRouterError } from '@trpc/server';
 import { initTRPC } from '@trpc/server';
-import { useState, Suspense } from 'react';
+import { Suspense, useState } from 'react';
 import { describe, expect, expectTypeOf, test } from 'vitest';
 import { z } from 'zod';
 

--- a/packages/tanstack-react-query/test/infiniteQueryOptions.test.tsx
+++ b/packages/tanstack-react-query/test/infiniteQueryOptions.test.tsx
@@ -14,7 +14,7 @@ import userEvent from '@testing-library/user-event';
 import type { TRPCClientErrorLike } from '@trpc/client';
 import type { inferRouterError } from '@trpc/server';
 import { initTRPC } from '@trpc/server';
-import * as React from 'react';
+import { useState, Suspense } from 'react';
 import { describe, expect, expectTypeOf, test } from 'vitest';
 import { z } from 'zod';
 
@@ -61,7 +61,7 @@ describe('infiniteQueryOptions', () => {
     function MyComponent() {
       const trpc = useTRPC();
       const queryClient = useQueryClient();
-      const [invalidated, setInvalidated] = React.useState(false);
+      const [invalidated, setInvalidated] = useState(false);
 
       const queryOptions = trpc.post.list.infiniteQueryOptions(
         {},
@@ -207,7 +207,7 @@ describe('infiniteQueryOptions', () => {
     function MyComponent() {
       const trpc = useTRPC();
       const queryClient = useQueryClient();
-      const [invalidated, setInvalidated] = React.useState(false);
+      const [invalidated, setInvalidated] = useState(false);
 
       const queryOptions = trpc.post.list.infiniteQueryOptions(
         {},
@@ -307,9 +307,9 @@ describe('infiniteQueryOptions', () => {
     }
 
     const utils = ctx.renderApp(
-      <React.Suspense fallback="loading">
+      <Suspense fallback="loading">
         <MyComponent />
-      </React.Suspense>,
+      </Suspense>,
     );
 
     await vi.waitFor(() => {

--- a/packages/tanstack-react-query/test/multipleTrpcProviders.test.tsx
+++ b/packages/tanstack-react-query/test/multipleTrpcProviders.test.tsx
@@ -10,7 +10,6 @@ import { createTRPCClient } from '@trpc/client';
 import { httpBatchLink } from '@trpc/client/links/httpBatchLink';
 import { initTRPC } from '@trpc/server';
 import { createTRPCContext } from '@trpc/tanstack-react-query';
-import * as React from 'react';
 import { useState } from 'react';
 import { expect, test, vi } from 'vitest';
 

--- a/packages/tanstack-react-query/test/mutationOptions.test.tsx
+++ b/packages/tanstack-react-query/test/mutationOptions.test.tsx
@@ -2,7 +2,7 @@ import { testReactResource } from './__helpers';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import '@testing-library/react';
 import { initTRPC } from '@trpc/server';
-import * as React from 'react';
+import { useEffect } from 'react';
 import { describe, expect, expectTypeOf, test } from 'vitest';
 import { z } from 'zod';
 
@@ -78,7 +78,7 @@ describe.each(['userid-123', undefined])(
 
         const mutation = useMutation(options);
 
-        React.useEffect(() => {
+        useEffect(() => {
           mutation.mutate({
             text: 'hello',
           });
@@ -116,7 +116,7 @@ describe.each(['userid-123', undefined])(
 
         const mutation = useMutation(options);
 
-        React.useEffect(() => {
+        useEffect(() => {
           calls.push('onMutate');
           mutation.mutate(
             {
@@ -197,7 +197,7 @@ describe.each(['userid-123', undefined])(
           }),
         );
 
-        React.useEffect(() => {
+        useEffect(() => {
           mutation.mutate({
             text: 'optimistic',
           });

--- a/packages/tanstack-react-query/test/polymorphism.test.tsx
+++ b/packages/tanstack-react-query/test/polymorphism.test.tsx
@@ -13,7 +13,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { describe, expect, test } from 'vitest';
 import { z } from 'zod';
 import type { inferOutput } from '../src';

--- a/packages/tanstack-react-query/test/queryKeyable.test.tsx
+++ b/packages/tanstack-react-query/test/queryKeyable.test.tsx
@@ -16,7 +16,6 @@ import {
   type TRPCQueryKeyWithoutPrefix,
   type TRPCQueryKeyWithPrefix,
 } from '@trpc/tanstack-react-query';
-import * as React from 'react';
 import { useState } from 'react';
 import { describe, expect, test } from 'vitest';
 import { z } from 'zod';

--- a/packages/tanstack-react-query/test/queryOptions.test.tsx
+++ b/packages/tanstack-react-query/test/queryOptions.test.tsx
@@ -11,7 +11,6 @@ import type { TRPCClientErrorLike } from '@trpc/client';
 import type { inferRouterError } from '@trpc/server';
 import { initTRPC } from '@trpc/server';
 import { createDeferred } from '@trpc/server/unstable-core-do-not-import';
-import * as React from 'react';
 import { describe, expect, expectTypeOf, test, vi } from 'vitest';
 import { z } from 'zod';
 

--- a/packages/tanstack-react-query/test/skipToken.test.tsx
+++ b/packages/tanstack-react-query/test/skipToken.test.tsx
@@ -3,7 +3,6 @@ import { skipToken } from '@tanstack/react-query';
 import '@testing-library/react';
 import { initTRPC } from '@trpc/server';
 import { createDeferred } from '@trpc/server/unstable-core-do-not-import';
-import * as React from 'react';
 import { describe, expect, test } from 'vitest';
 import { z } from 'zod';
 

--- a/packages/tanstack-react-query/test/useSubscription.test.tsx
+++ b/packages/tanstack-react-query/test/useSubscription.test.tsx
@@ -6,7 +6,7 @@ import { initTRPC } from '@trpc/server';
 import { observable } from '@trpc/server/observable';
 import { makeResource } from '@trpc/server/unstable-core-do-not-import';
 import { isAbortError } from '@trpc/server/unstable-core-do-not-import/http/abortError';
-import * as React from 'react';
+import { useState } from 'react';
 import { describe, expect, expectTypeOf, test, vi } from 'vitest';
 import { z } from 'zod';
 import type { TRPCSubscriptionResult } from '../src';
@@ -144,7 +144,7 @@ describe.each([
     const { useTRPC } = ctx;
 
     function MyComponent() {
-      const [enabled, setEnabled] = React.useState(true);
+      const [enabled, setEnabled] = useState(true);
 
       const trpc = useTRPC();
       const result = useSubscription(
@@ -226,8 +226,8 @@ describe.each([
     const { useTRPC } = ctx;
 
     function MyComponent() {
-      const [data, setData] = React.useState<number>();
-      const [enabled, setEnabled] = React.useState(true);
+      const [data, setData] = useState<number>();
+      const [enabled, setEnabled] = useState(true);
 
       const trpc = useTRPC();
       const result = useSubscription(

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -13,7 +13,7 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "noPropertyAccessFromIndexSignature": true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -38,6 +38,9 @@ for (const pkg of dirs.sort()) {
 
 export default defineConfig({
   clearScreen: true,
+  esbuild: {
+    jsx: 'automatic',
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## What

Enables the automatic JSX runtime and removes unnecessary `import React` across ~58 TSX files in `react-query`, `tanstack-react-query`, and `next`.

**Config changes:**
- `tsconfig.build.json`: `"jsx": "react"` → `"jsx": "react-jsx"`
- `vitest.config.ts`: add `esbuild: { jsx: 'automatic' }` at the top level (required for Vite/esbuild to apply the automatic transform during tests)

**Import changes:**
- Test files with bare `import React from 'react'` or `import * as React from 'react'` and no actual `React.X` usage: import removed
- Test/source files using only a few React APIs: converted to named imports (`import { useEffect, useState } from 'react'`, etc.)
- Type-only imports: converted to `import type { ReactNode } from 'react'`
- `createHooksInternal.tsx` is left unchanged. Converting it to named imports causes a collision with the locally-defined `useContext` function in that file.

## Why

CodeRabbit flagged the explicit `import React` on PR #7361 as unnecessary. That was correct in spirit, but the tooling (tsconfig and esbuild) was still configured for the classic transform, which actually requires the import. The project convention already says not to import React explicitly. This aligns the tooling with that convention.

## Test plan

- [x] `pnpm test --project "@trpc/react-query"`
- [x] `pnpm test --project "@trpc/tanstack-react-query"`
- [x] `pnpm test --project "@trpc/next"`
- 3 pre-existing failures in unrelated packages (`upgrade`, `tests`, `openapi`), not caused by this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized React imports across the project to use named hooks and type imports, removing unused default/namespace React imports and embracing the automatic JSX runtime.
  * Adjusted internal provider/component typing imports to use direct named types.

* **Chores**
  * Switched TypeScript build config to the modern JSX runtime.
  * Enabled automatic JSX handling in the test runner configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->