### PR TITLE
chore: fix duplicate "the" in unstable-core JSDoc comment

### DIFF
--- a/packages/server/src/unstable-core-do-not-import.ts
+++ b/packages/server/src/unstable-core-do-not-import.ts
@@ -3,7 +3,7 @@
  *
  * This file is here to:
  * - make TypeScript happy and prevent _"The inferred type of 'createContext' cannot be named without a reference to [...]"_.
- * - the the glue between the official `@trpc/*`-packages
+ * - the glue between the official `@trpc/*`-packages
  *
  *
  * If you seem to need to import anything from here, please open an issue at https://github.com/trpc/trpc/issues


### PR DESCRIPTION
Removes a duplicate "the" in the JSDoc header of `packages/server/src/unstable-core-do-not-import.ts` ("the the glue" -> "the glue"). Comment-only change, no behavior impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed a duplicated word in internal comments to improve clarity; no functional or public API changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trpc/trpc/pull/7366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->