### PR TITLE
fix(tanstack-react-query): add prefix support for mutation options

### DIFF
--- a/packages/tanstack-react-query/src/internals/createOptionsProxy.ts
+++ b/packages/tanstack-react-query/src/internals/createOptionsProxy.ts
@@ -468,6 +468,7 @@ export function createTRPCOptionsProxy<
         return trpcMutationOptions({
           opts: arg1,
           path,
+          prefix,
           queryClient: opts.queryClient,
           mutate: callIt('mutation'),
           overrides: opts.overrides?.mutations,

--- a/packages/tanstack-react-query/src/internals/mutationOptions.ts
+++ b/packages/tanstack-react-query/src/internals/mutationOptions.ts
@@ -101,15 +101,16 @@ export function trpcMutationOptions<TFeatureFlags extends FeatureFlags>(args: {
   mutate: typeof TRPCUntypedClient.prototype.mutation;
   queryClient: QueryClient | (() => QueryClient);
   path: string[];
+  prefix: string | undefined;
   opts: AnyTRPCMutationOptionsIn<TFeatureFlags> | undefined;
   overrides: MutationOptionsOverride | undefined;
 }): AnyTRPCMutationOptionsOut<TFeatureFlags> {
-  const { mutate, path, opts, overrides } = args;
+  const { mutate, path, prefix, opts, overrides } = args;
   const queryClient = unwrapLazyArg(args.queryClient);
 
   const mutationKey = getMutationKeyInternal({
     path,
-    prefix: opts?.keyPrefix,
+    prefix: opts?.keyPrefix ?? prefix,
   }) as TRPCMutationKey<TFeatureFlags['keyPrefix']>;
 
   const defaultOpts = queryClient.defaultMutationOptions(

--- a/packages/tanstack-react-query/test/mutationOptions.test.tsx
+++ b/packages/tanstack-react-query/test/mutationOptions.test.tsx
@@ -216,5 +216,53 @@ describe.each(['userid-123', undefined])(
       });
       expect(calls).toEqual(['onMutate', 'onSettled']);
     });
+
+    test('uses proxy keyPrefix for mutationKey + defaults', async () => {
+      await using ctx = testContext(keyPrefix);
+      const { useTRPC, queryClient } = ctx;
+
+      const calls: string[] = [];
+
+      // mutationOptions() should incorporate the proxy/context keyPrefix
+      // even when the caller doesn't pass `opts.keyPrefix`.
+      const expectedKey = keyPrefix
+        ? ([[keyPrefix], ['post', 'create']] as const)
+        : ([['post', 'create']] as const);
+
+      queryClient.setMutationDefaults(expectedKey as any, {
+        onSuccess() {
+          calls.push('defaultOnSuccess');
+        },
+      });
+
+      function MyComponent() {
+        const trpc = useTRPC();
+
+        const options = trpc.post.create.mutationOptions();
+        expect(options.mutationKey).toEqual(expectedKey);
+
+        const mutation = useMutation(options);
+
+        React.useEffect(() => {
+          mutation.mutate({
+            text: 'hello',
+          });
+          // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, []);
+
+        if (!mutation.data) {
+          return <>...</>;
+        }
+
+        return <pre>{JSON.stringify(mutation.data ?? 'n/a', null, 4)}</pre>;
+      }
+
+      const utils = ctx.renderApp(<MyComponent />);
+      await vi.waitFor(() => {
+        expect(utils.container).toHaveTextContent(`__mutationResult`);
+      });
+
+      expect(calls).toEqual(['defaultOnSuccess']);
+    });
   },
 );


### PR DESCRIPTION
Closes #7369

## 🎯 Changes

Add prefix parameter to mutation options to support key prefixing from proxy/context level. This allows mutation key prefixes to be defined at a higher level while still allowing per-mutation overrides.

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mutation option generation to properly include prefix context when constructing mutation keys, ensuring consistent key prefixing behavior when explicit overrides are not provided.

* **Tests**
  * Added coverage for prefix context fallback in mutation key generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trpc/trpc/pull/7370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->