### PR TITLE
fix(server): reject routers with incompatible procedure context

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/procedure.ts
+++ b/packages/server/src/unstable-core-do-not-import/procedure.ts
@@ -10,10 +10,17 @@ export const procedureTypes = ['query', 'mutation', 'subscription'] as const;
 export type ProcedureType = (typeof procedureTypes)[number];
 
 interface BuiltProcedureDef {
+  ctx?: unknown;
   meta: unknown;
   input: unknown;
   output: unknown;
 }
+
+type inferBuiltProcedureContext<TDef extends BuiltProcedureDef> = TDef extends {
+  ctx: infer TContext;
+}
+  ? TContext
+  : object;
 
 /**
  *
@@ -29,6 +36,7 @@ export interface Procedure<
      * @internal
      */
     $types: {
+      ctx: inferBuiltProcedureContext<TDef>;
       input: TDef['input'];
       output: TDef['output'];
     };
@@ -52,14 +60,17 @@ export interface Procedure<
   (opts: ProcedureCallOptions<unknown>): Promise<TDef['output']>;
 }
 
-export interface QueryProcedure<TDef extends BuiltProcedureDef>
-  extends Procedure<'query', TDef> {}
+export interface QueryProcedure<
+  TDef extends BuiltProcedureDef,
+> extends Procedure<'query', TDef> {}
 
-export interface MutationProcedure<TDef extends BuiltProcedureDef>
-  extends Procedure<'mutation', TDef> {}
+export interface MutationProcedure<
+  TDef extends BuiltProcedureDef,
+> extends Procedure<'mutation', TDef> {}
 
-export interface SubscriptionProcedure<TDef extends BuiltProcedureDef>
-  extends Procedure<'subscription', TDef> {}
+export interface SubscriptionProcedure<
+  TDef extends BuiltProcedureDef,
+> extends Procedure<'subscription', TDef> {}
 
 /**
  * @deprecated

--- a/packages/server/src/unstable-core-do-not-import/procedure.ts
+++ b/packages/server/src/unstable-core-do-not-import/procedure.ts
@@ -20,7 +20,7 @@ type inferBuiltProcedureContext<TDef extends BuiltProcedureDef> = TDef extends {
   ctx: infer TContext;
 }
   ? TContext
-  : object;
+  : unknown;
 
 /**
  *

--- a/packages/server/src/unstable-core-do-not-import/procedureBuilder.ts
+++ b/packages/server/src/unstable-core-do-not-import/procedureBuilder.ts
@@ -373,6 +373,7 @@ export interface ProcedureBuilder<
         input: DefaultValue<TInputIn, void>,
       ) => Promise<DefaultValue<TOutputOut, $Output>>
     : QueryProcedure<{
+        ctx: TContext;
         input: DefaultValue<TInputIn, void>;
         output: DefaultValue<TOutputOut, $Output>;
         meta: TMeta;
@@ -396,6 +397,7 @@ export interface ProcedureBuilder<
         input: DefaultValue<TInputIn, void>,
       ) => Promise<DefaultValue<TOutputOut, $Output>>
     : MutationProcedure<{
+        ctx: TContext;
         input: DefaultValue<TInputIn, void>;
         output: DefaultValue<TOutputOut, $Output>;
         meta: TMeta;
@@ -417,6 +419,7 @@ export interface ProcedureBuilder<
   ): TCaller extends true
     ? TypeError<'Not implemented'>
     : SubscriptionProcedure<{
+        ctx: TContext;
         input: DefaultValue<TInputIn, void>;
         output: inferSubscriptionOutput<DefaultValue<TOutputOut, $Output>>;
         meta: TMeta;
@@ -438,6 +441,7 @@ export interface ProcedureBuilder<
   ): TCaller extends true
     ? TypeError<'Not implemented'>
     : LegacyObservableSubscriptionProcedure<{
+        ctx: TContext;
         input: DefaultValue<TInputIn, void>;
         output: inferObservableValue<DefaultValue<TOutputOut, $Output>>;
         meta: TMeta;

--- a/packages/server/src/unstable-core-do-not-import/router.mergeRouters.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/router.mergeRouters.test.ts
@@ -76,7 +76,7 @@ test('good merge: one has default transformer', async () => {
     foo: t1.procedure.query(() => 'foo'),
   });
   const router2 = t2.router({
-    bar: t1.procedure.query(() => 'bar'),
+    bar: t2.procedure.query(() => 'bar'),
   });
 
   const merged = t1.mergeRouters(router1, router2);

--- a/packages/server/src/unstable-core-do-not-import/router.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/router.test.ts
@@ -4,6 +4,27 @@ import { lazy } from './router';
 const t = initTRPC.create();
 
 describe('router', () => {
+  test('rejects procedures with incompatible context', () => {
+    const ta = initTRPC.context<{ a: string }>().create();
+    const tb = initTRPC.context<{ b: string }>().create();
+    const tab = initTRPC.context<{ a: string; b: string }>().create();
+
+    ta.router({
+      a: ta.procedure.query(({ ctx }) => ctx.a.slice()),
+    });
+
+    tab.router({
+      a: ta.procedure.query(({ ctx }) => ctx.a.slice()),
+      b: tb.procedure.query(({ ctx }) => ctx.b.slice()),
+    });
+
+    ta.router({
+      a: ta.procedure.query(({ ctx }) => ctx.a.slice()),
+      // @ts-expect-error context requires "b", which is missing from this router
+      b: tb.procedure.query(({ ctx }) => ctx.b.slice()),
+    });
+  });
+
   test('is a reserved word', async () => {
     expect(() => {
       return t.router({

--- a/packages/server/src/unstable-core-do-not-import/router.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/router.test.ts
@@ -10,18 +10,18 @@ describe('router', () => {
     const tab = initTRPC.context<{ a: string; b: string }>().create();
 
     ta.router({
-      a: ta.procedure.query(({ ctx }) => ctx.a.slice()),
+      a: ta.procedure.query((opts) => opts.ctx.a.slice()),
     });
 
     tab.router({
-      a: ta.procedure.query(({ ctx }) => ctx.a.slice()),
-      b: tb.procedure.query(({ ctx }) => ctx.b.slice()),
+      a: ta.procedure.query((opts) => opts.ctx.a.slice()),
+      b: tb.procedure.query((opts) => opts.ctx.b.slice()),
     });
 
     ta.router({
-      a: ta.procedure.query(({ ctx }) => ctx.a.slice()),
+      a: ta.procedure.query((opts) => opts.ctx.a.slice()),
       // @ts-expect-error context requires "b", which is missing from this router
-      b: tb.procedure.query(({ ctx }) => ctx.b.slice()),
+      b: tb.procedure.query((opts) => opts.ctx.b.slice()),
     });
   });
 

--- a/packages/server/src/unstable-core-do-not-import/router.ts
+++ b/packages/server/src/unstable-core-do-not-import/router.ts
@@ -12,7 +12,7 @@ import type {
 import type { ProcedureCallOptions } from './procedureBuilder';
 import type { AnyRootTypes, RootConfig } from './rootConfig';
 import { defaultTransformer } from './transformer';
-import type { MaybePromise, ValueOf } from './types';
+import type { MaybePromise, TypeError, ValueOf } from './types';
 import {
   emptyObject,
   isFunction,
@@ -171,7 +171,7 @@ export type BuiltRouter<
 
 export interface RouterBuilder<TRoot extends AnyRootTypes> {
   <TIn extends CreateRouterOptions>(
-    _: TIn,
+    _: TIn & ValidateCreateRouterOptions<TRoot, TIn>,
   ): BuiltRouter<TRoot, DecorateCreateRouterOptions<TIn>>;
 }
 
@@ -229,6 +229,29 @@ export type CreateRouterOptions = {
     | Lazy<AnyRouter>;
 };
 
+type ValidateCreateRouterOptions<
+  TRoot extends AnyRootTypes,
+  TRouterOptions extends CreateRouterOptions,
+> = {
+  [K in keyof TRouterOptions]: TRouterOptions[K] extends infer $Value
+    ? $Value extends AnyProcedure
+      ? TRoot['ctx'] extends $Value['_def']['$types']['ctx']
+        ? $Value
+        : TypeError<'Procedure context is not compatible with router context'>
+      : $Value extends Router<infer TChildRoot, any>
+        ? TRoot['ctx'] extends TChildRoot['ctx']
+          ? $Value
+          : TypeError<'Router context is not compatible with parent router context'>
+        : $Value extends Lazy<Router<infer TChildRoot, any>>
+          ? TRoot['ctx'] extends TChildRoot['ctx']
+            ? $Value
+            : TypeError<'Lazy router context is not compatible with parent router context'>
+          : $Value extends CreateRouterOptions
+            ? ValidateCreateRouterOptions<TRoot, $Value>
+            : never
+    : never;
+};
+
 /** @internal */
 export type DecorateCreateRouterOptions<
   TRouterOptions extends CreateRouterOptions,
@@ -253,7 +276,7 @@ export function createRouterFactory<TRoot extends AnyRootTypes>(
   config: RootConfig<TRoot>,
 ) {
   function createRouterInner<TInput extends CreateRouterOptions>(
-    input: TInput,
+    input: TInput & ValidateCreateRouterOptions<TRoot, TInput>,
   ): BuiltRouter<TRoot, DecorateCreateRouterOptions<TInput>> {
     const reservedWordsUsed = new Set(
       Object.keys(input).filter((v) => reservedWords.includes(v)),


### PR DESCRIPTION
## Summary
- carry the base context type on built procedure definitions
- validate router inputs so procedures, routers, and lazy routers require a context satisfied by the parent router
- add a regression test for mixing procedures from incompatible `initTRPC.context()` roots

Fixes #4306

## Tests
- pnpm.cmd test packages/server/src/unstable-core-do-not-import/router.test.ts packages/server/src/unstable-core-do-not-import/procedureBuilder.test.ts packages/server/src/unstable-core-do-not-import/router.mergeRouters.test.ts --run
- pnpm.cmd exec prettier --check packages/server/src/unstable-core-do-not-import/procedure.ts packages/server/src/unstable-core-do-not-import/procedureBuilder.ts packages/server/src/unstable-core-do-not-import/router.ts packages/server/src/unstable-core-do-not-import/router.test.ts packages/server/src/unstable-core-do-not-import/router.mergeRouters.test.ts

Note: `pnpm.cmd --filter @trpc/server typecheck` still fails locally in `src/adapters/ws.ts` because the installed `ws` typings are resolved without `ws.WebSocket` / `ws.WebSocketServer` namespace members in this environment. No errors from the router/procedure context changes remain before that unrelated failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stronger compile-time type safety for procedure contexts and router-procedure compatibility; procedure/context types are now surfaced to catch mismatches early.

* **Developer API**
  * Procedure builder signatures now carry explicit context typing so created procedures reflect the expected context.

* **Tests**
  * Added and adjusted tests to validate context compatibility and merging behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trpc/trpc/pull/7377)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->