### PR TITLE
fix(react-query): support select() in useSuspenseInfiniteQuery

### DIFF
--- a/packages/react-query/src/createTRPCReact.tsx
+++ b/packages/react-query/src/createTRPCReact.tsx
@@ -264,7 +264,9 @@ export interface useTRPCInfiniteQuery<TDef extends ResolverDef> {
 //   queryClient?: QueryClient,
 // ): UseSuspenseInfiniteQueryResult<TData, TError>;
 
-export type useTRPCSuspenseInfiniteQuery<TDef extends ResolverDef> = (
+export type useTRPCSuspenseInfiniteQuery<TDef extends ResolverDef> = <
+  TData = trpcInfiniteData<TDef>,
+>(
   input: InfiniteInput<TDef['input']>,
   opts: makeInfiniteQueryOptions<
     inferCursorType<TDef['input']>,
@@ -274,7 +276,7 @@ export type useTRPCSuspenseInfiniteQuery<TDef extends ResolverDef> = (
       //     TError,
       TRPCClientErrorLike<TDef>,
       //     TData,
-      trpcInfiniteData<TDef>,
+      TData,
       //     TQueryKey,
       any,
       //     TPageParam
@@ -282,12 +284,9 @@ export type useTRPCSuspenseInfiniteQuery<TDef extends ResolverDef> = (
     >
   >,
 ) => [
-  trpcInfiniteData<TDef>,
+  TData,
   TRPCHookResult &
-    UseSuspenseInfiniteQueryResult<
-      trpcInfiniteData<TDef>,
-      TRPCClientErrorLike<TDef>
-    >,
+    UseSuspenseInfiniteQueryResult<TData, TRPCClientErrorLike<TDef>>,
 ];
 
 /**

--- a/packages/react-query/test/useSuspenseInfiniteQuery.test.tsx
+++ b/packages/react-query/test/useSuspenseInfiniteQuery.test.tsx
@@ -107,3 +107,39 @@ test('useSuspenseInfiniteQuery()', async () => {
     expect(utils.container).toHaveTextContent(`[ "2" ]`);
   });
 });
+
+test('regression 6195: select()', async () => {
+  const { App, client } = ctx;
+  function MyComponent() {
+    const [data, query] = client.post.list.useSuspenseInfiniteQuery(
+      {},
+      {
+        getNextPageParam(lastPage) {
+          return lastPage.next;
+        },
+        select: (data) => ({
+          ...data,
+          pages: data.pages.map((page) => ({ ...page, foo: 'bar' as const })),
+        }),
+      },
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
+    expectTypeOf(data.pages[0]?.foo!).toEqualTypeOf<'bar'>();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain
+    expectTypeOf(query.data.pages[0]?.foo!).toEqualTypeOf<'bar'>();
+
+    return <div>foo:{data.pages[0]?.foo}</div>;
+  }
+
+  const utils = render(
+    <App>
+      <Suspense fallback="loading">
+        <MyComponent />
+      </Suspense>
+    </App>,
+  );
+  await vi.waitFor(() => {
+    expect(utils.container).toHaveTextContent('foo:bar');
+  });
+});


### PR DESCRIPTION
Closes #6195

## 🎯 Changes

Bug fix. `useSuspenseInfiniteQuery` ignored a custom `select` return type and forced the result to the page shape, so `select: (data) => 1` failed to type-check. `useInfiniteQuery` already handles this. The hook type now takes a `TData` parameter that defaults to the inferred page data, the same as `useInfiniteQuery` and `useSuspenseQuery`.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type inference for infinite query operations when using custom data selectors, ensuring accurate and consistent type information across all states, with enhanced IDE autocomplete support and stronger compile-time type safety
* **Tests**
  * Added comprehensive regression test for custom data selector functionality to validate both type inference accuracy and runtime behavior under various conditions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trpc/trpc/pull/7388?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->