### PR TITLE
docs(tanstack-react-query): document abortOnUnmount upgrade path for new client

### DIFF
--- a/www/docs/client/tanstack-react-query/migrating.mdx
+++ b/www/docs/client/tanstack-react-query/migrating.mdx
@@ -206,7 +206,7 @@ function Users() {
 }
 ```
 
-## `abortOnUnmount`
+## abortOnUnmount
 
 In the classic client you could enable request aborting globally:
 

--- a/www/docs/client/tanstack-react-query/migrating.mdx
+++ b/www/docs/client/tanstack-react-query/migrating.mdx
@@ -205,3 +205,17 @@ function Users() {
   createUserMutation.mutate({ name: 'Jerry' });
 }
 ```
+
+## `abortOnUnmount`
+
+In the classic client you could enable request aborting globally:
+
+```ts
+export const trpc = createTRPCReact<AppRouter>({ abortOnUnmount: true });
+```
+
+`createTRPCContext` does not accept this option. In the new integration,
+TanStack Query v5 automatically passes an `AbortSignal` to the query function
+and cancels in-flight requests when a component unmounts with no remaining
+observers — the behaviour you expected from `abortOnUnmount: true` is now
+the default.


### PR DESCRIPTION
Closes #6864

## 🎯 Changes

Documentation only. The new `@trpc/tanstack-react-query` integration does not accept `abortOnUnmount` in `createTRPCContext`. This adds a migration note to `www/docs/client/tanstack-react-query/migrating.mdx` explaining that TanStack Query v5 passes an `AbortSignal` automatically, so the abort-on-unmount behaviour is on by default and no explicit configuration is needed.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made (N/A — documentation-only change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a guide clarifying request cancellation behavior on component unmount when using the new integration.
  * Explains that request aborts are now provided automatically by the underlying query library (no manual abort option needed) and how this differs from the previous client behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trpc/trpc/pull/7398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->