### PR TITLE
fix: remove duplicate words in code comments

### DIFF
--- a/packages/server/src/adapters/aws-lambda/getPlanner.ts
+++ b/packages/server/src/adapters/aws-lambda/getPlanner.ts
@@ -16,7 +16,7 @@ export type APIGatewayResult =
 
 function determinePayloadFormat(event: LambdaEvent): string {
   // https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html
-  // According to AWS support, version is is extracted from the version property in the event.
+  // According to AWS support, version is extracted from the version property in the event.
   // If there is no version property, then the version is implied as 1.0
   const unknownEvent = event as { version?: string };
   if (typeof unknownEvent.version === 'undefined') {


### PR DESCRIPTION
## Summary

Removes duplicate words in 2 files:
- `packages/server/src/unstable-core-do-not-import.ts:6` — "the the" → "the"
- `packages/server/src/adapters/aws-lambda/getPlanner.ts:19` — "is is" → "is"

Comment-only changes, no functional impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Corrected a typo in a code comment for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->