### PR TITLE
fix(server): delete clientSubscriptions entry on failed teardown

### DIFF
--- a/packages/server/src/adapters/ws.ts
+++ b/packages/server/src/adapters/ws.ts
@@ -404,7 +404,6 @@ export function getWSConnectionHandler<TRouter extends AnyRouter>(
               type: 'stopped',
             },
           });
-          clientSubscriptions.delete(id);
         }).catch((cause) => {
           const error = getTRPCErrorFromUnknown(cause);
           opts.onError?.({ error, path, type, ctx, req, input });
@@ -421,6 +420,8 @@ export function getWSConnectionHandler<TRouter extends AnyRouter>(
             }),
           });
           abortController.abort();
+        }).finally(() => {
+          clientSubscriptions.delete(id);
         });
         clientSubscriptions.set(id, abortController);
 

--- a/packages/server/src/adapters/ws.ts
+++ b/packages/server/src/adapters/ws.ts
@@ -404,25 +404,27 @@ export function getWSConnectionHandler<TRouter extends AnyRouter>(
               type: 'stopped',
             },
           });
-        }).catch((cause) => {
-          const error = getTRPCErrorFromUnknown(cause);
-          opts.onError?.({ error, path, type, ctx, req, input });
-          respond({
-            id,
-            jsonrpc,
-            error: getErrorShape({
-              config: router._def._config,
-              error,
-              type,
-              path,
-              input,
-              ctx,
-            }),
+        })
+          .catch((cause) => {
+            const error = getTRPCErrorFromUnknown(cause);
+            opts.onError?.({ error, path, type, ctx, req, input });
+            respond({
+              id,
+              jsonrpc,
+              error: getErrorShape({
+                config: router._def._config,
+                error,
+                type,
+                path,
+                input,
+                ctx,
+              }),
+            });
+            abortController.abort();
+          })
+          .finally(() => {
+            clientSubscriptions.delete(id);
           });
-          abortController.abort();
-        }).finally(() => {
-          clientSubscriptions.delete(id);
-        });
         clientSubscriptions.set(id, abortController);
 
         respond({

--- a/packages/tests/server/websockets.test.ts
+++ b/packages/tests/server/websockets.test.ts
@@ -2235,7 +2235,9 @@ describe('subscription cleanup on failed teardown (#7400)', () => {
           [Symbol.asyncIterator]() {
             return {
               next(): Promise<IteratorResult<number>> {
-                return new Promise((_resolve) => {});
+                return new Promise((_resolve) => {
+                  // never resolves - keeps subscription active
+                });
               },
               async return(): Promise<IteratorResult<number>> {
                 throw new Error('teardown failed');

--- a/packages/tests/server/websockets.test.ts
+++ b/packages/tests/server/websockets.test.ts
@@ -2235,7 +2235,7 @@ describe('subscription cleanup on failed teardown (#7400)', () => {
           [Symbol.asyncIterator]() {
             return {
               next(): Promise<IteratorResult<number>> {
-                return new Promise(() => {});
+                return new Promise((_resolve) => {});
               },
               async return(): Promise<IteratorResult<number>> {
                 throw new Error('teardown failed');

--- a/packages/tests/server/websockets.test.ts
+++ b/packages/tests/server/websockets.test.ts
@@ -2290,9 +2290,7 @@ describe('subscription cleanup on failed teardown (#7400)', () => {
     rawClient.send(JSON.stringify(stop));
 
     await vi.waitFor(() => {
-      expect(
-        responses.find((r) => r.id === 1 && 'error' in r),
-      ).toBeDefined();
+      expect(responses.find((r) => r.id === 1 && 'error' in r)).toBeDefined();
     });
 
     responses.length = 0;
@@ -2304,9 +2302,7 @@ describe('subscription cleanup on failed teardown (#7400)', () => {
       expect(responses.length).toBeGreaterThan(0);
     });
 
-    const reuse = responses.find(
-      (r) => r.id === 1 && !('error' in r),
-    );
+    const reuse = responses.find((r) => r.id === 1 && !('error' in r));
     expect(reuse).toBeDefined();
     expect((reuse as any).result.type).toBe('started');
 

--- a/packages/tests/server/websockets.test.ts
+++ b/packages/tests/server/websockets.test.ts
@@ -2224,3 +2224,100 @@ test('connection state should not be updated for subscriptions', async () => {
   // Clean up
   subscription.unsubscribe();
 });
+
+describe('subscription cleanup on failed teardown (#7400)', () => {
+  function throwingFactory() {
+    const t = initTRPC.create();
+
+    const appRouter = t.router({
+      brokenTeardown: t.procedure.subscription(() => {
+        return {
+          [Symbol.asyncIterator]() {
+            return {
+              next(): Promise<IteratorResult<number>> {
+                return new Promise(() => {});
+              },
+              async return(): Promise<IteratorResult<number>> {
+                throw new Error('teardown failed');
+              },
+            };
+          },
+        };
+      }),
+    });
+
+    return testServerAndClientResource(appRouter, {
+      wssServer: { router: appRouter },
+    });
+  }
+
+  test('reusing a subscription id after a failed teardown does not throw "Duplicate id"', async () => {
+    await using ctx = throwingFactory();
+    const rawClient = new WebSocket(ctx.wssUrl);
+
+    const responses: TRPCResponse[] = [];
+    rawClient.addEventListener('message', (msg) => {
+      responses.push(JSON.parse(msg.data as string));
+    });
+
+    await new Promise<void>((resolve) => {
+      rawClient.onopen = () => resolve();
+    });
+
+    const start: TRPCClientOutgoingMessage = {
+      id: 1,
+      jsonrpc: '2.0',
+      method: 'subscription',
+      params: { path: 'brokenTeardown', input: null },
+    };
+    rawClient.send(JSON.stringify(start));
+
+    await vi.waitFor(() => {
+      expect(
+        responses.find(
+          (r) => r.id === 1 && (r as any).result?.type === 'started',
+        ),
+      ).toBeDefined();
+    });
+
+    // stopping triggers the throwing teardown, whose rejection lands in the
+    // ws adapter's run().catch() and (before the fix) leaves a stale entry.
+    const stop: TRPCClientOutgoingMessage = {
+      id: 1,
+      jsonrpc: '2.0',
+      method: 'subscription.stop',
+    };
+    rawClient.send(JSON.stringify(stop));
+
+    await vi.waitFor(() => {
+      expect(
+        responses.find((r) => r.id === 1 && 'error' in r),
+      ).toBeDefined();
+    });
+
+    responses.length = 0;
+
+    // a stale entry makes the server reject the reused id with "Duplicate id 1".
+    rawClient.send(JSON.stringify(start));
+
+    await vi.waitFor(() => {
+      expect(responses.length).toBeGreaterThan(0);
+    });
+
+    const reuse = responses.find(
+      (r) => r.id === 1 && !('error' in r),
+    );
+    expect(reuse).toBeDefined();
+    expect((reuse as any).result.type).toBe('started');
+
+    const duplicateError = responses.find(
+      (r) =>
+        r.id === 1 &&
+        'error' in r &&
+        (r as any).error?.message?.includes('Duplicate id'),
+    );
+    expect(duplicateError).toBeUndefined();
+
+    rawClient.close();
+  });
+});


### PR DESCRIPTION
fixes #7400.

**problem:** when a subscription's async iterator rejects during teardown, the rejection lands in `run().catch()` but `clientSubscriptions.delete(id)` never runs. the entry is set synchronously after `run()` is called, so the stale `AbortController` stays for the connection's lifetime and the id can't be reused.

**fix:** move cleanup to `.finally()` so it runs on both the happy path and on rejection.

regression test drives a subscription whose `return()` throws on stop, then reuses the same id and asserts it starts cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket subscription cleanup is now always performed when errors occur during teardown, preventing lingering subscriptions.
  * Subscriptions can be reliably restarted after a failed teardown without triggering duplicate-id conflicts.

* **Tests**
  * Added a regression test that reproduces teardown failures and verifies restart behavior to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->