### PR TITLE
feat(openapi): Add server url support

### DIFF
--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -29,6 +29,7 @@ const doc = generateOpenAPIDocument('./src/server/router.ts', {
   exportName: 'AppRouter',
   title: 'My API',
   version: '1.0.0',
+  servers: [{ url: 'https://api.example.com/trpc' }],
 });
 ```
 

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -25,7 +25,7 @@ pnpm exec trpc-openapi ./src/server/router.ts
 ```ts
 import { generateOpenAPIDocument } from '@trpc/openapi';
 
-const doc = generateOpenAPIDocument('./src/server/router.ts', {
+const doc = await generateOpenAPIDocument('./src/server/router.ts', {
   exportName: 'AppRouter',
   title: 'My API',
   version: '1.0.0',

--- a/packages/openapi/src/cli.ts
+++ b/packages/openapi/src/cli.ts
@@ -12,6 +12,7 @@
  *   --output, -o   Output file path                    (default: openapi.json)
  *   --title        OpenAPI info.title                  (default: tRPC API)
  *   --version      OpenAPI info.version                (default: 0.0.0)
+ *   --server-url   OpenAPI servers[].url (include any tRPC prefix)
  *   --help, -h     Show this help message
  */
 import * as fs from 'node:fs';
@@ -29,6 +30,7 @@ interface ParsedArgs {
   output: string;
   title: string;
   version: string;
+  serverUrl: string | undefined;
   help: boolean;
 }
 
@@ -43,6 +45,7 @@ function parseArgs(argv: string[]): ParsedArgs {
         output: { type: 'string', short: 'o', default: 'openapi.json' },
         title: { type: 'string', default: 'tRPC API' },
         version: { type: 'string', default: '0.0.0' },
+        'server-url': { type: 'string' },
       },
       strict: true,
       allowPositionals: true,
@@ -59,6 +62,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     output: parsed.values.output,
     title: parsed.values.title,
     version: parsed.values.version,
+    serverUrl: parsed.values['server-url'],
     help: parsed.values.help,
   };
 }
@@ -81,11 +85,13 @@ Options:
   -o, --output <file>  Output file path                    [default: openapi.json]
       --title  <text>  OpenAPI info.title                  [default: tRPC API]
       --version <ver>  OpenAPI info.version                [default: 0.0.0]
+      --server-url <url>  OpenAPI servers[].url (include any tRPC mount prefix)
   -h, --help           Show this help message
 
 Examples:
   trpc-openapi ./src/server/router.ts
   trpc-openapi ./src/server/router.ts --output api.json --title "My API" --version 1.0.0
+  trpc-openapi ./src/server/router.ts --server-url https://api.example.com/trpc
   trpc-openapi ./src/server/router.ts --export appRouter
 `.trim();
 
@@ -118,6 +124,7 @@ async function main(): Promise<void> {
       exportName: args.exportName,
       title: args.title,
       version: args.version,
+      servers: args.serverUrl ? [{ url: args.serverUrl }] : undefined,
     });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);

--- a/packages/openapi/src/generate.ts
+++ b/packages/openapi/src/generate.ts
@@ -13,6 +13,7 @@ import type {
   PathItemObject,
   PathsObject,
   SchemaObject,
+  ServerObject,
 } from './types';
 
 interface ProcedureInfo {
@@ -39,6 +40,13 @@ export interface GenerateOptions {
   title?: string;
   /** Version string for the generated OpenAPI `info` object. */
   version?: string;
+  /**
+   * OpenAPI `servers` array, passed through to the generated document. Each
+   * `url` should include any tRPC mount prefix, since the generated paths
+   * (`/user.create`, …) are relative to it — e.g.
+   * `https://api.example.com/trpc`. When omitted, no `servers` entry is added.
+   */
+  servers?: ServerObject[];
 }
 
 // ---------------------------------------------------------------------------
@@ -1429,6 +1437,7 @@ function buildOpenAPIDocument(
       title: options.title ?? 'tRPC API',
       version: options.version ?? '0.0.0',
     },
+    ...(options.servers?.length ? { servers: options.servers } : {}),
     paths,
     components: {
       ...(hasNamedSchemas && meta.schemas ? { schemas: meta.schemas } : {}),

--- a/packages/openapi/src/types.ts
+++ b/packages/openapi/src/types.ts
@@ -23,6 +23,7 @@ export type ExternalDocumentationObject =
 export type XMLObject = BaseOpenAPIV3_1.XMLObject;
 export type LinkObject = BaseOpenAPIV3_1.LinkObject;
 export type SecuritySchemeObject = BaseOpenAPIV3_1.SecuritySchemeObject;
+export type ServerObject = BaseOpenAPIV3_1.ServerObject;
 
 export type SchemaObject = Replace<
   BaseOpenAPIV3_1.BaseSchemaObject,

--- a/packages/openapi/test/cli.test.ts
+++ b/packages/openapi/test/cli.test.ts
@@ -115,6 +115,32 @@ describe('CLI', () => {
     expect(doc.paths).toHaveProperty('/greeting');
   });
 
+  it('emits a servers entry with --server-url', () => {
+    const outputPath = path.join(outDir, 'cli-server-url.json');
+
+    const result = runCli([
+      appRouterPath,
+      '-o',
+      outputPath,
+      '--server-url',
+      'https://api.example.com/trpc',
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    const doc = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+    expect(doc.servers).toEqual([{ url: 'https://api.example.com/trpc' }]);
+  });
+
+  it('omits servers when --server-url is not provided', () => {
+    const outputPath = path.join(outDir, 'cli-no-server-url.json');
+
+    const result = runCli([appRouterPath, '-o', outputPath]);
+
+    expect(result.exitCode).toBe(0);
+    const doc = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+    expect(doc.servers).toBeUndefined();
+  });
+
   it('uses -e shorthand for --export', () => {
     const outputPath = path.join(outDir, 'cli-export-test.json');
 

--- a/packages/openapi/test/generate.test.ts
+++ b/packages/openapi/test/generate.test.ts
@@ -394,6 +394,44 @@ describe('generateOpenAPIDocument', () => {
     });
   });
 
+  describe('servers', () => {
+    it('passes the servers array through to the document', async () => {
+      const doc = await generateOpenAPIDocument(appRouterPath, {
+        title: 'Test API',
+        version: '1.0.0',
+        servers: [
+          { url: 'https://api.example.com/trpc', description: 'production' },
+          { url: 'http://localhost:3000/trpc' },
+        ],
+      });
+
+      expect(doc.servers).toEqual([
+        { url: 'https://api.example.com/trpc', description: 'production' },
+        { url: 'http://localhost:3000/trpc' },
+      ]);
+    });
+
+    it('produces a valid spec with a servers entry', async () => {
+      const doc = await generateOpenAPIDocument(appRouterPath, {
+        title: 'Test API',
+        version: '1.0.0',
+        servers: [{ url: 'https://api.example.com/trpc' }],
+      });
+      const problems = await validateOpenApi(JSON.stringify(doc, null, 2));
+
+      expect(JSON.stringify(problems, null, 2)).toEqual('[]');
+    });
+
+    it('omits servers when none are provided', async () => {
+      const doc = await generateOpenAPIDocument(appRouterPath, {
+        title: 'Test API',
+        version: '1.0.0',
+      });
+
+      expect(doc.servers).toBeUndefined();
+    });
+  });
+
   describe('hey-api client generation', () => {
     const genDir = path.resolve(routersDir, 'appRouter-heyapi');
 

--- a/www/docs/client/openapi.md
+++ b/www/docs/client/openapi.md
@@ -57,7 +57,7 @@ pnpm exec trpc-openapi ./src/server/router.ts
 | `-o, --output <file>` | `openapi.json` | Output file path                                   |
 | `--title <text>`      | `tRPC API`     | OpenAPI `info.title`                               |
 | `--version <ver>`     | `0.0.0`        | OpenAPI `info.version`                             |
-| `--server-url <url>`  |                | Base URL (including any prefix) ie. `https://api.example.com/trpc` |
+| `--server-url <url>`  |                | Base URL (including any prefix), e.g. `https://api.example.com/trpc` |
 
 ```bash
 pnpm exec trpc-openapi ./src/server/router.ts -o api.json --title "My API" --version 1.0.0 --server-url https://api.example.com/trpc
@@ -68,7 +68,7 @@ pnpm exec trpc-openapi ./src/server/router.ts -o api.json --title "My API" --ver
 ```ts title='scripts/generate-openapi.ts'
 import { generateOpenAPIDocument } from '@trpc/openapi';
 
-const doc = generateOpenAPIDocument('./src/server/router.ts', {
+const doc = await generateOpenAPIDocument('./src/server/router.ts', {
   exportName: 'AppRouter',
   title: 'My API',
   version: '1.0.0',

--- a/www/docs/client/openapi.md
+++ b/www/docs/client/openapi.md
@@ -51,12 +51,12 @@ The generator works with your existing router — no annotations or decorators r
 pnpm exec trpc-openapi ./src/server/router.ts
 ```
 
-| Option                | Default        | Description                                        |
-| --------------------- | -------------- | -------------------------------------------------- |
-| `-e, --export <name>` | `AppRouter`    | Name of the exported router type                   |
-| `-o, --output <file>` | `openapi.json` | Output file path                                   |
-| `--title <text>`      | `tRPC API`     | OpenAPI `info.title`                               |
-| `--version <ver>`     | `0.0.0`        | OpenAPI `info.version`                             |
+| Option                | Default        | Description                                                          |
+| --------------------- | -------------- | -------------------------------------------------------------------- |
+| `-e, --export <name>` | `AppRouter`    | Name of the exported router type                                     |
+| `-o, --output <file>` | `openapi.json` | Output file path                                                     |
+| `--title <text>`      | `tRPC API`     | OpenAPI `info.title`                                                 |
+| `--version <ver>`     | `0.0.0`        | OpenAPI `info.version`                                               |
 | `--server-url <url>`  |                | Base URL (including any prefix), e.g. `https://api.example.com/trpc` |
 
 ```bash

--- a/www/docs/client/openapi.md
+++ b/www/docs/client/openapi.md
@@ -51,15 +51,16 @@ The generator works with your existing router — no annotations or decorators r
 pnpm exec trpc-openapi ./src/server/router.ts
 ```
 
-| Option                | Default        | Description                      |
-| --------------------- | -------------- | -------------------------------- |
-| `-e, --export <name>` | `AppRouter`    | Name of the exported router type |
-| `-o, --output <file>` | `openapi.json` | Output file path                 |
-| `--title <text>`      | `tRPC API`     | OpenAPI `info.title`             |
-| `--version <ver>`     | `0.0.0`        | OpenAPI `info.version`           |
+| Option                | Default        | Description                                        |
+| --------------------- | -------------- | -------------------------------------------------- |
+| `-e, --export <name>` | `AppRouter`    | Name of the exported router type                   |
+| `-o, --output <file>` | `openapi.json` | Output file path                                   |
+| `--title <text>`      | `tRPC API`     | OpenAPI `info.title`                               |
+| `--version <ver>`     | `0.0.0`        | OpenAPI `info.version`                             |
+| `--server-url <url>`  |                | Base URL (including any prefix) ie. `https://api.example.com/trpc` |
 
 ```bash
-pnpm exec trpc-openapi ./src/server/router.ts -o api.json --title "My API" --version 1.0.0
+pnpm exec trpc-openapi ./src/server/router.ts -o api.json --title "My API" --version 1.0.0 --server-url https://api.example.com/trpc
 ```
 
 ### Programmatic
@@ -71,6 +72,7 @@ const doc = generateOpenAPIDocument('./src/server/router.ts', {
   exportName: 'AppRouter',
   title: 'My API',
   version: '1.0.0',
+  servers: [{ url: 'https://api.example.com/trpc' }],
 });
 ```
 


### PR DESCRIPTION
Closes #

## 🎯 Changes

Adds ServerURLs support to OpenAPI support

<!--
Note: once you create a Pull request, we will automatically fix auto-fixable lint issues in your branch
-->

## ✅ Checklist

- [ ] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI option to configure the OpenAPI server base URL
  * OpenAPI document generation now accepts an optional servers configuration

* **Documentation**
  * Updated docs and examples to show server URL usage, including quick-start/programmatic examples

* **Tests**
  * Added tests for CLI server URL handling
  * Added tests for servers behavior in document generation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->