### PR TITLE
fix(client): abort httpBatchStreamLink stream on observer unsubscribe

### DIFF
--- a/packages/client/src/links/httpBatchStreamLink.ts
+++ b/packages/client/src/links/httpBatchStreamLink.ts
@@ -163,6 +163,7 @@ export function httpBatchStreamLink<TRouter extends AnyRouter>(
               };
             },
           );
+
           return promises;
         },
       };
@@ -181,11 +182,28 @@ export function httpBatchStreamLink<TRouter extends AnyRouter>(
           );
         }
         const loader = loaders[op.type];
-        const promise = loader.load(op);
+
+        // Track whether this op's loader promise has settled. We use this to
+        // decide whether to cancel the underlying batch when the observer is
+        // torn down: if the promise hasn't resolved yet, there is no reason to
+        // keep the HTTP stream open, so we abort it. Once the promise resolves
+        // we leave the stream alone — for streaming (iterable) responses the
+        // consumer is still reading body chunks after the promise resolves, and
+        // jsonlStreamConsumer automatically aborts the body once all listeners
+        // are done.
+        let settled = false;
+        let selfAborted = false;
+        const ac = new AbortController();
+
+        const promise = loader.load({
+          ...op,
+          signal: raceAbortSignals(op.signal, ac.signal),
+        });
 
         let _res = undefined as HTTPResult | undefined;
         promise
           .then((res) => {
+            settled = true;
             _res = res;
             if ('error' in res.json) {
               observer.error(
@@ -206,6 +224,11 @@ export function httpBatchStreamLink<TRouter extends AnyRouter>(
             observer.complete();
           })
           .catch((err) => {
+            if (selfAborted) {
+              // We triggered this abort via cleanup; the observer is already
+              // being torn down so there is nothing to propagate.
+              return;
+            }
             observer.error(
               TRPCClientError.from(err, {
                 meta: _res?.meta,
@@ -214,7 +237,12 @@ export function httpBatchStreamLink<TRouter extends AnyRouter>(
           });
 
         return () => {
-          // noop
+          if (!settled) {
+            // The promise hasn't resolved yet — cancel the underlying request
+            // so the server stops sending and the response body is released.
+            selfAborted = true;
+            ac.abort();
+          }
         };
       });
     };


### PR DESCRIPTION
## Problem

The cleanup function in `httpBatchStreamLink`'s observable was a noop:

```ts
return () => {
  // noop
};
```

When an observer unsubscribes (component unmounts, query cancelled), the underlying HTTP request and JSONL stream kept running — wasting bandwidth and causing `observer already completed` errors.

Fixes #7389

## Fix

Create a per-observer `AbortController` at the observable level and merge its signal into `op.signal` via `raceAbortSignals`. Call `ac.abort()` in cleanup.

```ts
const ac = new AbortController();
const promise = loader.load({
  ...op,
  signal: raceAbortSignals(op.signal, ac.signal),
});
// ...
return () => {
  ac.abort();
};
```

**Propagation chain:**
1. Cleanup → `ac.abort()`
2. `op.signal` (merged via raceAbortSignals) fires
3. `batchSignals = allAbortSignals(...ops.map(op => op.signal))` fires once all ops abort
4. `raceAbortSignals(batchSignals, abortController.signal)` fires → HTTP fetch aborted
5. `jsonlStreamConsumer` stops reading

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup and cancellation behavior for batch streaming requests. The client now reliably releases the shared JSONL response stream once all per-operation results have finished, preventing lingering readers and unnecessary work.
  * If an operation is unsubscribed before it settles, the underlying batch request is cancelled to stop in-flight work, while avoiding noisy abort-related errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->