### PR TITLE
docs: include JEST/VITEST worker checks in isServer @default

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/rootConfig.ts
+++ b/packages/server/src/unstable-core-do-not-import/rootConfig.ts
@@ -54,7 +54,7 @@ export interface RootConfig<TTypes extends RootTypes> {
   /**
    * Is this a server environment?
    * @warning **Use with caution**, this should likely mainly be used within testing.
-   * @default typeof window === 'undefined' || 'Deno' in window || process.env.NODE_ENV === 'test'
+   * @default typeof window === 'undefined' || 'Deno' in window || process.env.NODE_ENV === 'test' || !!process.env.JEST_WORKER_ID || !!process.env.VITEST_WORKER_ID
    */
   isServer: boolean;
   /**

--- a/www/docs/server/routers.md
+++ b/www/docs/server/routers.md
@@ -140,7 +140,7 @@ interface RootConfig {
   /**
    * Is this a server environment?
    * @warning **Use with caution**, this should likely mainly be used within testing.
-   * @default typeof window === 'undefined' || 'Deno' in window || process.env.NODE_ENV === 'test'
+   * @default typeof window === 'undefined' || 'Deno' in window || process.env.NODE_ENV === 'test' || !!process.env.JEST_WORKER_ID || !!process.env.VITEST_WORKER_ID
    */
   isServer: boolean;
 


### PR DESCRIPTION
The `isServer` option's documented `@default` lists three checks, but the actual `isServerDefault` constant also includes the `JEST_WORKER_ID` and `VITEST_WORKER_ID` worker checks. Since the option is mainly relevant in testing, those omitted checks matter. Updated the `@default` to match the constant, in the `RootConfig` source JSDoc and the matching docs example.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test environment detection to better recognize Jest and Vitest test runners, ensuring proper server configuration in testing scenarios.

* **Documentation**
  * Updated runtime configuration documentation to reflect enhanced test environment handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->