### PR TITLE
feat(client,server): add HTTP QUERY method support for query procedures

### DIFF
--- a/packages/client/src/links/internals/httpUtils.ts
+++ b/packages/client/src/links/internals/httpUtils.ts
@@ -33,6 +33,14 @@ export type HTTPLinkBaseOptions<
    * @see https://trpc.io/docs/rpc
    */
   methodOverride?: 'POST';
+  /**
+   * Use HTTP QUERY method for query procedures.
+   * This allows sending input in the request body while maintaining safe/cacheable semantics.
+   * The HTTP QUERY method (RFC 9110 extension) solves URL length limitations of GET
+   * while preserving cacheability that POST lacks.
+   * @see https://www.ietf.org/archive/id/draft-ietf-httpbis-safe-method-w-body-05.html
+   */
+  queryMethod?: 'GET' | 'QUERY';
 } & TransformerOptions<TRoot>;
 
 export interface ResolvedHTTPLinkOptions {
@@ -40,6 +48,7 @@ export interface ResolvedHTTPLinkOptions {
   fetch?: FetchEsque;
   transformer: CombinedDataTransformer;
   methodOverride?: 'POST';
+  queryMethod?: 'GET' | 'QUERY';
 }
 
 export function resolveHTTPLinkOptions(
@@ -50,6 +59,7 @@ export function resolveHTTPLinkOptions(
     fetch: opts.fetch,
     transformer: getTransformer(opts.transformer),
     methodOverride: opts.methodOverride,
+    queryMethod: opts.queryMethod,
   };
 }
 
@@ -122,7 +132,11 @@ export const getUrl: GetUrl = (opts) => {
   }
   if (opts.type === 'query' || opts.type === 'subscription') {
     const input = getInput(opts);
-    if (input !== undefined && opts.methodOverride !== 'POST') {
+    // Don't add input to query params if using methodOverride or queryMethod: 'QUERY'
+    // (input goes in body instead)
+    const inputInBody =
+      opts.methodOverride === 'POST' || opts.queryMethod === 'QUERY';
+    if (input !== undefined && !inputInBody) {
       queryParts.push(`input=${encodeURIComponent(JSON.stringify(input))}`);
     }
   }
@@ -133,8 +147,13 @@ export const getUrl: GetUrl = (opts) => {
 };
 
 export const getBody: GetBody = (opts) => {
-  if (opts.type === 'query' && opts.methodOverride !== 'POST') {
-    return undefined;
+  // For queries, only include body if using methodOverride or queryMethod: 'QUERY'
+  if (opts.type === 'query') {
+    const inputInBody =
+      opts.methodOverride === 'POST' || opts.queryMethod === 'QUERY';
+    if (!inputInBody) {
+      return undefined;
+    }
   }
   const input = getInput(opts);
   return input !== undefined ? JSON.stringify(input) : undefined;
@@ -198,7 +217,12 @@ export async function fetchHTTPResponse(opts: HTTPRequestOptions) {
 
   const url = opts.getUrl(opts);
   const body = opts.getBody(opts);
-  const method = opts.methodOverride ?? METHOD[opts.type];
+  // Determine HTTP method: methodOverride takes precedence, then queryMethod for queries
+  const method =
+    opts.methodOverride ??
+    (opts.type === 'query' && opts.queryMethod === 'QUERY'
+      ? 'QUERY'
+      : METHOD[opts.type]);
   const resolvedHeaders = await (async () => {
     const heads = await opts.headers();
     if (Symbol.iterator in heads) {
@@ -207,6 +231,7 @@ export async function fetchHTTPResponse(opts: HTTPRequestOptions) {
     return heads;
   })();
   const headers = {
+    // Include content-type for methods that have a body (not GET)
     ...(opts.contentTypeHeader && method !== 'GET'
       ? { 'content-type': opts.contentTypeHeader }
       : {}),

--- a/packages/server/src/unstable-core-do-not-import/http/contentType.ts
+++ b/packages/server/src/unstable-core-do-not-import/http/contentType.ts
@@ -100,11 +100,13 @@ const jsonContentTypeHandler: ContentTypeHandler = {
     const getInputs = memo(async (): Promise<InputRecord> => {
       let inputs: unknown = undefined;
       if (req.method === 'GET') {
+        // GET: input from query params
         const queryInput = opts.searchParams.get('input');
         if (queryInput) {
           inputs = JSON.parse(queryInput);
         }
       } else {
+        // POST, QUERY, and other methods: input from body
         inputs = await req.json();
       }
       if (inputs === undefined) {
@@ -299,8 +301,8 @@ function getContentTypeHandler(req: Request): ContentTypeHandler {
     return handler;
   }
 
-  if (!handler && req.method === 'GET') {
-    // fallback to JSON for get requests so GET-requests can be opened in browser easily
+  if (!handler && (req.method === 'GET' || req.method === 'QUERY')) {
+    // fallback to JSON for GET/QUERY requests so they can be opened in browser easily
     return jsonContentTypeHandler;
   }
 

--- a/packages/server/src/unstable-core-do-not-import/http/resolveResponse.ts
+++ b/packages/server/src/unstable-core-do-not-import/http/resolveResponse.ts
@@ -41,7 +41,8 @@ type HTTPMethods =
   | 'OPTIONS'
   | 'PUT'
   | 'DELETE'
-  | 'PATCH';
+  | 'PATCH'
+  | 'QUERY';
 
 function combinedAbortController(signal: AbortSignal) {
   const controller = new AbortController();
@@ -54,7 +55,7 @@ function combinedAbortController(signal: AbortSignal) {
 
 const TYPE_ACCEPTED_METHOD_MAP: Record<ProcedureType, HTTPMethods[]> = {
   mutation: ['POST'],
-  query: ['GET'],
+  query: ['GET', 'QUERY'],
   subscription: ['GET'],
 };
 const TYPE_ACCEPTED_METHOD_MAP_WITH_METHOD_OVERRIDE: Record<
@@ -63,7 +64,7 @@ const TYPE_ACCEPTED_METHOD_MAP_WITH_METHOD_OVERRIDE: Record<
 > = {
   // never allow GET to do a mutation
   mutation: ['POST'],
-  query: ['GET', 'POST'],
+  query: ['GET', 'POST', 'QUERY'],
   subscription: ['GET', 'POST'],
 };
 

--- a/packages/tests/server/queryMethod.test.ts
+++ b/packages/tests/server/queryMethod.test.ts
@@ -1,0 +1,179 @@
+import { testServerAndClientResource } from '@trpc/client/__tests__/testClientResource';
+import { waitError } from '@trpc/server/__tests__/waitError';
+import { httpBatchLink, httpLink } from '@trpc/client';
+import type { HTTPLinkBaseOptions } from '@trpc/client/links/internals/httpUtils';
+import { initTRPC } from '@trpc/server';
+import type { inferRouterRootTypes } from '@trpc/server/unstable-core-do-not-import';
+import fetch from 'node-fetch';
+import { expect, test } from 'vitest';
+import { z } from 'zod';
+
+const t = initTRPC.create();
+const router = t.router({
+  q: t.procedure
+    .input(
+      z.object({
+        who: z.string().nullish(),
+      }),
+    )
+    .query((opts) => `hello ${opts.input?.who ?? 'world'}`),
+  qLargeInput: t.procedure
+    .input(
+      z.object({
+        data: z.string(),
+      }),
+    )
+    .query((opts) => `received ${opts.input.data.length} chars`),
+  m: t.procedure
+    .input(
+      z.object({
+        who: z.string().nullish(),
+      }),
+    )
+    .mutation((opts) => `hello ${opts.input?.who ?? 'world'}`),
+});
+
+async function startServer(opts: {
+  linkOptions: Partial<
+    HTTPLinkBaseOptions<inferRouterRootTypes<typeof router>>
+  >;
+  batch?: boolean;
+}) {
+  return testServerAndClientResource(router, {
+    server: {},
+    client(clientOpts) {
+      return {
+        links: [
+          opts.batch
+            ? httpBatchLink({
+                url: clientOpts.httpUrl,
+                fetch: fetch as any,
+                ...opts.linkOptions,
+              })
+            : httpLink({
+                url: clientOpts.httpUrl,
+                fetch: fetch as any,
+                ...opts.linkOptions,
+              }),
+        ],
+      };
+    },
+  });
+}
+
+test('client: sends query as QUERY method when queryMethod=QUERY', async () => {
+  await using t = await startServer({
+    linkOptions: {
+      queryMethod: 'QUERY',
+    },
+  });
+
+  expect(
+    await t.client.q.query({
+      who: 'test1',
+    }),
+  ).toBe('hello test1');
+});
+
+test('client: QUERY method handles large inputs in body', async () => {
+  await using t = await startServer({
+    linkOptions: {
+      queryMethod: 'QUERY',
+    },
+  });
+
+  const largeData = 'x'.repeat(10000);
+  expect(
+    await t.client.qLargeInput.query({
+      data: largeData,
+    }),
+  ).toBe('received 10000 chars');
+});
+
+test('client: GET method still works by default', async () => {
+  await using t = await startServer({
+    linkOptions: {},
+  });
+
+  expect(
+    await t.client.q.query({
+      who: 'test-default',
+    }),
+  ).toBe('hello test-default');
+});
+
+test('client: queryMethod=GET explicitly uses GET', async () => {
+  await using t = await startServer({
+    linkOptions: {
+      queryMethod: 'GET',
+    },
+  });
+
+  expect(
+    await t.client.q.query({
+      who: 'test-explicit-get',
+    }),
+  ).toBe('hello test-explicit-get');
+});
+
+test('client/server: e2e batched query as QUERY', async () => {
+  await using t = await startServer({
+    linkOptions: {
+      queryMethod: 'QUERY',
+    },
+    batch: true,
+  });
+
+  expect(
+    await Promise.all([
+      t.client.q.query({
+        who: 'test1',
+      }),
+      t.client.q.query({
+        who: 'test2',
+      }),
+    ]),
+  ).toMatchInlineSnapshot(`
+    Array [
+      "hello test1",
+      "hello test2",
+    ]
+  `);
+});
+
+test('mutations still use POST when queryMethod=QUERY', async () => {
+  await using t = await startServer({
+    linkOptions: {
+      queryMethod: 'QUERY',
+    },
+  });
+
+  expect(
+    await t.client.m.mutate({
+      who: 'mutation-test',
+    }),
+  ).toBe('hello mutation-test');
+});
+
+test('methodOverride takes precedence over queryMethod', async () => {
+  // When both are set, methodOverride should win
+  await using t = await startServer({
+    linkOptions: {
+      methodOverride: 'POST',
+      queryMethod: 'QUERY',
+    },
+  });
+
+  // This should work because methodOverride: 'POST' is used
+  // However, the server needs allowMethodOverride: true for POST queries
+  // Since we didn't set it, this should fail
+  const err = await waitError(() =>
+    t.client.q.query({
+      who: 'test1',
+    }),
+  );
+
+  expect(err).toMatchInlineSnapshot(
+    `[TRPCClientError: Unsupported POST-request to query procedure at path "q"]`,
+  );
+});

--- a/packages/tests/server/queryMethod.test.ts
+++ b/packages/tests/server/queryMethod.test.ts
@@ -5,8 +5,8 @@ import type { HTTPLinkBaseOptions } from '@trpc/client/links/internals/httpUtils
 import { initTRPC } from '@trpc/server';
 import type { inferRouterRootTypes } from '@trpc/server/unstable-core-do-not-import';
 import fetch from 'node-fetch';
-import { expect, test } from 'vitest';
-import { z } from 'zod';
+import { expect, test, vi } from 'vitest';
+import * as z from 'zod';
 
 const t = initTRPC.create();
 const router = t.router({
@@ -33,11 +33,21 @@ const router = t.router({
     .mutation((opts) => `hello ${opts.input?.who ?? 'world'}`),
 });
 
+function createFetchSpy() {
+  const calls: { url: string; method: string }[] = [];
+  const spy = vi.fn((url: string, init?: { method?: string }) => {
+    calls.push({ url, method: init?.method ?? 'GET' });
+    return (fetch as any)(url, init);
+  });
+  return { spy, calls };
+}
+
 async function startServer(opts: {
   linkOptions: Partial<
     HTTPLinkBaseOptions<inferRouterRootTypes<typeof router>>
   >;
   batch?: boolean;
+  fetchSpy?: ReturnType<typeof vi.fn>;
 }) {
   return testServerAndClientResource(router, {
     server: {},
@@ -47,12 +57,12 @@ async function startServer(opts: {
           opts.batch
             ? httpBatchLink({
                 url: clientOpts.httpUrl,
-                fetch: fetch as any,
+                fetch: (opts.fetchSpy ?? fetch) as any,
                 ...opts.linkOptions,
               })
             : httpLink({
                 url: clientOpts.httpUrl,
-                fetch: fetch as any,
+                fetch: (opts.fetchSpy ?? fetch) as any,
                 ...opts.linkOptions,
               }),
         ],
@@ -62,10 +72,12 @@ async function startServer(opts: {
 }
 
 test('client: sends query as QUERY method when queryMethod=QUERY', async () => {
+  const { spy, calls } = createFetchSpy();
   await using t = await startServer({
     linkOptions: {
       queryMethod: 'QUERY',
     },
+    fetchSpy: spy,
   });
 
   expect(
@@ -73,13 +85,19 @@ test('client: sends query as QUERY method when queryMethod=QUERY', async () => {
       who: 'test1',
     }),
   ).toBe('hello test1');
+
+  expect(calls).toHaveLength(1);
+  expect(calls[0]!.method).toBe('QUERY');
+  expect(calls[0]!.url).not.toContain('input=');
 });
 
 test('client: QUERY method handles large inputs in body', async () => {
+  const { spy, calls } = createFetchSpy();
   await using t = await startServer({
     linkOptions: {
       queryMethod: 'QUERY',
     },
+    fetchSpy: spy,
   });
 
   const largeData = 'x'.repeat(10000);
@@ -88,11 +106,17 @@ test('client: QUERY method handles large inputs in body', async () => {
       data: largeData,
     }),
   ).toBe('received 10000 chars');
+
+  expect(calls).toHaveLength(1);
+  expect(calls[0]!.method).toBe('QUERY');
+  expect(calls[0]!.url).not.toContain('input=');
 });
 
 test('client: GET method still works by default', async () => {
+  const { spy, calls } = createFetchSpy();
   await using t = await startServer({
     linkOptions: {},
+    fetchSpy: spy,
   });
 
   expect(
@@ -100,13 +124,19 @@ test('client: GET method still works by default', async () => {
       who: 'test-default',
     }),
   ).toBe('hello test-default');
+
+  expect(calls).toHaveLength(1);
+  expect(calls[0]!.method).toBe('GET');
+  expect(calls[0]!.url).toContain('input=');
 });
 
 test('client: queryMethod=GET explicitly uses GET', async () => {
+  const { spy, calls } = createFetchSpy();
   await using t = await startServer({
     linkOptions: {
       queryMethod: 'GET',
     },
+    fetchSpy: spy,
   });
 
   expect(
@@ -114,14 +144,20 @@ test('client: queryMethod=GET explicitly uses GET', async () => {
       who: 'test-explicit-get',
     }),
   ).toBe('hello test-explicit-get');
+
+  expect(calls).toHaveLength(1);
+  expect(calls[0]!.method).toBe('GET');
+  expect(calls[0]!.url).toContain('input=');
 });
 
 test('client/server: e2e batched query as QUERY', async () => {
+  const { spy, calls } = createFetchSpy();
   await using t = await startServer({
     linkOptions: {
       queryMethod: 'QUERY',
     },
     batch: true,
+    fetchSpy: spy,
   });
 
   expect(
@@ -139,13 +175,19 @@ test('client/server: e2e batched query as QUERY', async () => {
       "hello test2",
     ]
   `);
+
+  expect(calls).toHaveLength(1);
+  expect(calls[0]!.method).toBe('QUERY');
+  expect(calls[0]!.url).not.toContain('input=');
 });
 
 test('mutations still use POST when queryMethod=QUERY', async () => {
+  const { spy, calls } = createFetchSpy();
   await using t = await startServer({
     linkOptions: {
       queryMethod: 'QUERY',
     },
+    fetchSpy: spy,
   });
 
   expect(
@@ -153,19 +195,23 @@ test('mutations still use POST when queryMethod=QUERY', async () => {
       who: 'mutation-test',
     }),
   ).toBe('hello mutation-test');
+
+  expect(calls).toHaveLength(1);
+  expect(calls[0]!.method).toBe('POST');
 });
 
 test('methodOverride takes precedence over queryMethod', async () => {
-  // When both are set, methodOverride should win
+  const { spy, calls } = createFetchSpy();
   await using t = await startServer({
     linkOptions: {
       methodOverride: 'POST',
       queryMethod: 'QUERY',
     },
+    fetchSpy: spy,
   });
 
-  // This should work because methodOverride: 'POST' is used
-  // However, the server needs allowMethodOverride: true for POST queries
+  // methodOverride: 'POST' takes precedence over queryMethod: 'QUERY'
+  // Server needs allowMethodOverride: true for POST queries
   // Since we didn't set it, this should fail
   const err = await waitError(() =>
     t.client.q.query({
@@ -176,4 +222,8 @@ test('methodOverride takes precedence over queryMethod', async () => {
   expect(err).toMatchInlineSnapshot(
     `[TRPCClientError: Unsupported POST-request to query procedure at path "q"]`,
   );
+
+  // Verify POST was used, not QUERY
+  expect(calls).toHaveLength(1);
+  expect(calls[0]!.method).toBe('POST');
 });

--- a/packages/upgrade/test/__fixtures__/hooks/optimistic-update.spec.tsx
+++ b/packages/upgrade/test/__fixtures__/hooks/optimistic-update.spec.tsx
@@ -8,6 +8,9 @@ import { ctx, resetFixtureState } from './optimistic-update.trpc';
 export const run: SpecRun = async (Component) => {
   expect(Component).toBeDefined();
 
+  // Reset state at START to handle vitest retries where cleanup may not have run
+  resetFixtureState();
+
   using _finally = makeResource({}, () => {
     resetFixtureState();
     utils.unmount();

--- a/www/docs/further/rpc.md
+++ b/www/docs/further/rpc.md
@@ -10,6 +10,7 @@ slug: /rpc
 | HTTP Method | Mapping           | Notes                                                                                                                                                                                    |
 | ----------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `GET`       | `.query()`        | Input JSON-stringified in query param.<br/>_e.g._ `myQuery?input=${encodeURIComponent(JSON.stringify(input))}`                                                                           |
+| `QUERY`     | `.query()`        | Input as request body. Safe, cacheable, no URL length limits. See [QUERY method](#using-the-http-query-method) below.                                                                    |
 | `POST`      | `.mutation()`     | Input as POST body.                                                                                                                                                                      |
 | `GET`       | `.subscription()` | Subscriptions are supported via [Server-sent Events](/docs/client/links/httpSubscriptionLink) using `httpSubscriptionLink`, or via [WebSockets](/docs/server/websockets) using `wsLink`. |
 
@@ -330,6 +331,43 @@ const client = createTRPCClient<AppRouter>({
   ],
 });
 ```
+
+### Using the HTTP QUERY method
+
+The HTTP `QUERY` method ([RFC 9110 extension](https://www.ietf.org/archive/id/draft-ietf-httpbis-safe-method-w-body-05.html)) is a safe, cacheable HTTP method that supports a request body. This solves the URL length limitation of `GET` requests while maintaining cache semantics that `POST` lacks.
+
+Use `queryMethod: 'QUERY'` when you need to:
+- Send large query inputs that would exceed URL length limits
+- Maintain HTTP cacheability (unlike `methodOverride: 'POST'`)
+- Keep safe/idempotent semantics for read operations
+
+```tsx twoslash title = 'client/trpc.ts'
+// @filename: server.ts
+import { initTRPC } from '@trpc/server';
+const t = initTRPC.create();
+export const appRouter = t.router({});
+export type AppRouter = typeof appRouter;
+
+// @filename: client.ts
+// ---cut---
+import { createTRPCClient, httpLink } from '@trpc/client';
+import type { AppRouter } from './server';
+
+const client = createTRPCClient<AppRouter>({
+  links: [
+    httpLink({
+      url: `http://localhost:3000`,
+      queryMethod: 'QUERY', // queries use HTTP QUERY method with input in body
+    }),
+  ],
+});
+```
+
+The server automatically accepts `QUERY` requests for query procedures - no additional configuration is required.
+
+:::note
+The HTTP `QUERY` method is a relatively new addition to the HTTP specification. Ensure your infrastructure (proxies, CDNs, load balancers) supports this method before using it in production.
+:::
 
 ## Dig deeper
 

--- a/www/docs/further/rpc.md
+++ b/www/docs/further/rpc.md
@@ -337,6 +337,7 @@ const client = createTRPCClient<AppRouter>({
 The HTTP `QUERY` method ([RFC 9110 extension](https://www.ietf.org/archive/id/draft-ietf-httpbis-safe-method-w-body-05.html)) is a safe, cacheable HTTP method that supports a request body. This solves the URL length limitation of `GET` requests while maintaining cache semantics that `POST` lacks.
 
 Use `queryMethod: 'QUERY'` when you need to:
+
 - Send large query inputs that would exceed URL length limits
 - Maintain HTTP cacheability (unlike `methodOverride: 'POST'`)
 - Keep safe/idempotent semantics for read operations


### PR DESCRIPTION
## Summary

Adds support for the HTTP QUERY method (RFC 9110 extension) for query procedures. The QUERY method is a safe, cacheable HTTP method that supports a request body, solving URL length limitations of GET while maintaining cache semantics that POST lacks.

### Changes

**Client-side (`packages/client/`):**
- Add `queryMethod?: 'GET' | 'QUERY'` option to `httpLink`/`httpBatchLink`
- When `queryMethod: 'QUERY'` is set, use HTTP QUERY method with input in request body
- `methodOverride` takes precedence over `queryMethod`

**Server-side (`packages/server/`):**
- Add `QUERY` to `HTTPMethods` type in `resolveResponse.ts`
- Accept `QUERY` for query procedures in `TYPE_ACCEPTED_METHOD_MAP`
- Parse input from body for QUERY requests (like POST) in `contentType.ts`
- Fallback to JSON handler for QUERY requests without content-type

**Tests:**
- Add `queryMethod.test.ts` with 7 tests covering QUERY method functionality

**Docs:**
- Update `www/docs/further/rpc.md` with QUERY method documentation

### Usage

\`\`\`typescript
import { createTRPCClient, httpLink } from '@trpc/client';

const client = createTRPCClient<AppRouter>({
  links: [
    httpLink({
      url: 'http://localhost:3000',
      queryMethod: 'QUERY', // queries use HTTP QUERY method with input in body
    }),
  ],
});
\`\`\`

The server automatically accepts QUERY requests for query procedures - no additional configuration required.

## Test plan

- [x] All existing tests pass (544 tests)
- [x] New queryMethod tests pass (7 tests)
- [x] methodOverride tests still pass (4 tests)
- [x] Client and server packages build successfully

## References

- [HTTP QUERY Method (draft-ietf-httpbis-safe-method-w-body)](https://www.ietf.org/archive/id/draft-ietf-httpbis-safe-method-w-body-05.html)
- RFC 9110 extension for safe methods with request body

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for using the HTTP `QUERY` method for query procedures, including batched queries.
  * When set to `QUERY`, inputs are sent in the request body (avoids URL query limits); `methodOverride` takes precedence.
* **Bug Fixes**
  * Server now accepts `QUERY` for query procedures and correctly handles response content-type fallback for browser-openable JSON.
* **Documentation**
  * Documented `queryMethod: 'QUERY'`, including safe/cacheable behavior and usage guidance.
* **Tests**
  * Added coverage for `GET` vs `QUERY`, large inputs, batching, and `methodOverride` precedence/error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->