### PR TITLE
fix(react-query): forward falsy cursor values in infinite query fetches

### DIFF
--- a/packages/react-query/src/internals/getClientArgs.test.ts
+++ b/packages/react-query/src/internals/getClientArgs.test.ts
@@ -1,32 +1,55 @@
 import { getClientArgs } from './getClientArgs';
 import type { TRPCQueryKey } from './getQueryKey';
 
-const queryKey: TRPCQueryKey = [['posts'], { input: { limit: 10 }, type: 'infinite' }];
+const queryKey: TRPCQueryKey = [
+  ['posts'],
+  { input: { limit: 10 }, type: 'infinite' },
+];
 
 describe('getClientArgs', () => {
   describe('infiniteParams.pageParam', () => {
     it('includes cursor when pageParam is a positive number', () => {
-      const [, input] = getClientArgs(queryKey, {}, { pageParam: 5, direction: 'forward' });
+      const [, input] = getClientArgs(
+        queryKey,
+        {},
+        { pageParam: 5, direction: 'forward' },
+      );
       expect(input).toMatchObject({ cursor: 5 });
     });
 
     it('includes cursor when pageParam is 0 (offset-based pagination)', () => {
-      const [, input] = getClientArgs(queryKey, {}, { pageParam: 0, direction: 'forward' });
+      const [, input] = getClientArgs(
+        queryKey,
+        {},
+        { pageParam: 0, direction: 'forward' },
+      );
       expect(input).toMatchObject({ cursor: 0 });
     });
 
     it('includes cursor when pageParam is an empty string', () => {
-      const [, input] = getClientArgs(queryKey, {}, { pageParam: '', direction: 'forward' });
+      const [, input] = getClientArgs(
+        queryKey,
+        {},
+        { pageParam: '', direction: 'forward' },
+      );
       expect(input).toMatchObject({ cursor: '' });
     });
 
     it('omits cursor when pageParam is null (no cursor / initial page)', () => {
-      const [, input] = getClientArgs(queryKey, {}, { pageParam: null, direction: 'forward' });
+      const [, input] = getClientArgs(
+        queryKey,
+        {},
+        { pageParam: null, direction: 'forward' },
+      );
       expect(input).not.toHaveProperty('cursor');
     });
 
     it('omits cursor when pageParam is undefined', () => {
-      const [, input] = getClientArgs(queryKey, {}, { pageParam: undefined, direction: 'forward' });
+      const [, input] = getClientArgs(
+        queryKey,
+        {},
+        { pageParam: undefined, direction: 'forward' },
+      );
       expect(input).not.toHaveProperty('cursor');
     });
   });

--- a/packages/react-query/src/internals/getClientArgs.test.ts
+++ b/packages/react-query/src/internals/getClientArgs.test.ts
@@ -1,0 +1,33 @@
+import { getClientArgs } from './getClientArgs';
+import type { TRPCQueryKey } from './getQueryKey';
+
+const queryKey: TRPCQueryKey = [['posts'], { input: { limit: 10 }, type: 'infinite' }];
+
+describe('getClientArgs', () => {
+  describe('infiniteParams.pageParam', () => {
+    it('includes cursor when pageParam is a positive number', () => {
+      const [, input] = getClientArgs(queryKey, {}, { pageParam: 5, direction: 'forward' });
+      expect(input).toMatchObject({ cursor: 5 });
+    });
+
+    it('includes cursor when pageParam is 0 (offset-based pagination)', () => {
+      const [, input] = getClientArgs(queryKey, {}, { pageParam: 0, direction: 'forward' });
+      expect(input).toMatchObject({ cursor: 0 });
+    });
+
+    it('includes cursor when pageParam is an empty string', () => {
+      const [, input] = getClientArgs(queryKey, {}, { pageParam: '', direction: 'forward' });
+      expect(input).toMatchObject({ cursor: '' });
+    });
+
+    it('omits cursor when pageParam is null (no cursor / initial page)', () => {
+      const [, input] = getClientArgs(queryKey, {}, { pageParam: null, direction: 'forward' });
+      expect(input).not.toHaveProperty('cursor');
+    });
+
+    it('omits cursor when pageParam is undefined', () => {
+      const [, input] = getClientArgs(queryKey, {}, { pageParam: undefined, direction: 'forward' });
+      expect(input).not.toHaveProperty('cursor');
+    });
+  });
+});

--- a/packages/react-query/src/internals/getClientArgs.ts
+++ b/packages/react-query/src/internals/getClientArgs.ts
@@ -16,7 +16,9 @@ export function getClientArgs<TOptions>(
   if (infiniteParams) {
     input = {
       ...(input ?? {}),
-      ...(infiniteParams.pageParam ? { cursor: infiniteParams.pageParam } : {}),
+      ...(infiniteParams.pageParam != null
+        ? { cursor: infiniteParams.pageParam }
+        : {}),
       direction: infiniteParams.direction,
     };
   }


### PR DESCRIPTION
getClientArgs was using a truthy check (`infiniteParams.pageParam ?`) to decide whether to include the cursor key in the request input. This silently drops valid falsy cursor values — most notably `0`, which is common in offset-based infinite queries.

**Reproduction**

```ts
useInfiniteQuery(['posts'], fetchPosts, {
  initialCursor: 0,        // falsy → cursor was never sent to the server
  getNextPageParam: (last) => last.nextOffset,
})
```

On the first fetch, `pageParam` is `0` (from `initialPageParam: opts.initialCursor ?? null`). The truthy check evaluates `0 ? { cursor: 0 } : {}` and produces `{}`, so the server receives no cursor at all. Subsequent pages with non-zero cursors work fine.

**Fix**

Replace the truthy guard with an explicit `!= null` check:

```ts
// before
...(infiniteParams.pageParam ? { cursor: infiniteParams.pageParam } : {}),

// after
...(infiniteParams.pageParam != null
  ? { cursor: infiniteParams.pageParam }
  : {}),
```

`null` and `undefined` (the "no cursor / initial page" sentinels) are still omitted. Any other value — including `0`, `false`, or `''` — is now correctly forwarded.

A unit test for `getClientArgs` is included to cover:

- positive number cursor → included ✓
- 0 cursor → included ✓
- empty string cursor → included ✓
- null → omitted ✓
- undefined → omitted ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed infinite query handling so valid cursor values like `0` and empty strings are preserved instead of being dropped.
  * Continued to omit the cursor when no page value is provided, keeping initial page requests unchanged.
* **Tests**
  * Added coverage for cursor conversion across positive, zero, empty, null, and undefined page values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->