### PR TITLE
fix(tanstack-react-query): honour skipToken in subscriptionOptions

### DIFF
--- a/packages/tanstack-react-query/src/internals/createOptionsProxy.ts
+++ b/packages/tanstack-react-query/src/internals/createOptionsProxy.ts
@@ -483,6 +483,7 @@ export function createTRPCOptionsProxy<
 
       subscriptionOptions: () => {
         return trpcSubscriptionOptions({
+          input: arg1,
           opts: arg2,
           path,
           queryKey: getQueryKeyInternal({

--- a/packages/tanstack-react-query/src/internals/subscriptionOptions.ts
+++ b/packages/tanstack-react-query/src/internals/subscriptionOptions.ts
@@ -12,7 +12,7 @@ import type {
   TRPCQueryKey,
   TRPCQueryOptionsResult,
 } from './types';
-import { createTRPCOptionsResult, readQueryKey } from './utils';
+import { createTRPCOptionsResult } from './utils';
 
 interface BaseTRPCSubscriptionOptionsIn<TOutput, TError> {
   enabled?: boolean;
@@ -135,16 +135,24 @@ export const trpcSubscriptionOptions = <
   subscribe: typeof TRPCUntypedClient.prototype.subscription;
   path: string[];
   queryKey: TRPCQueryKey<TFeatureFlags['keyPrefix']>;
+  input: unknown;
   opts?: AnyTRPCSubscriptionOptionsIn;
 }): AnyTRPCSubscriptionOptionsOut<TFeatureFlags> => {
-  const { subscribe, path, queryKey, opts = {} } = args;
-  const input = readQueryKey(queryKey)?.args?.input;
-  const enabled = 'enabled' in opts ? !!opts.enabled : input !== skipToken;
+  const { subscribe, path, queryKey, input, opts = {} } = args;
+  const inputIsSkipToken = input === skipToken;
+  // skipToken always wins over `enabled`: with no input, firing could only send
+  // `undefined`. Matches queries, where `queryFn: skipToken` is a no-op.
+  const enabled =
+    !inputIsSkipToken && ('enabled' in opts ? !!opts.enabled : true);
 
   const _subscribe: ReturnType<
     TRPCSubscriptionOptions<any, TFeatureFlags>
   >['subscribe'] = (innerOpts) => {
-    return subscribe(path.join('.'), input ?? undefined, innerOpts);
+    return subscribe(
+      path.join('.'),
+      inputIsSkipToken ? undefined : (input ?? undefined),
+      innerOpts,
+    );
   };
 
   return {

--- a/packages/tanstack-react-query/test/skipToken.test.tsx
+++ b/packages/tanstack-react-query/test/skipToken.test.tsx
@@ -31,6 +31,11 @@ const testContext = () => {
           }),
         )
         .query(() => ['__result'] as const),
+      onUpdate: t.procedure
+        .input(z.string().optional())
+        .subscription(async function* () {
+          yield '__result' as const;
+        }),
     }),
   });
 
@@ -57,6 +62,24 @@ describe('skipToken', () => {
         },
       });
       expect(options2.queryFn).toBe(skipToken);
+
+      const options3 = trpc.post.onUpdate.subscriptionOptions(skipToken);
+      expect(options3.enabled).toBe(false);
+
+      const options4 = trpc.post.onUpdate.subscriptionOptions('hello');
+      expect(options4.enabled).toBe(true);
+
+      // an explicit `enabled: false` still disables a real-input subscription
+      const options5 = trpc.post.onUpdate.subscriptionOptions('hello', {
+        enabled: false,
+      });
+      expect(options5.enabled).toBe(false);
+
+      // skipToken always disables, even against an explicit `enabled: true`
+      const options6 = trpc.post.onUpdate.subscriptionOptions(skipToken, {
+        enabled: true,
+      });
+      expect(options6.enabled).toBe(false);
 
       return <pre>OK</pre>;
     }

--- a/packages/tanstack-react-query/test/useSubscription.test.tsx
+++ b/packages/tanstack-react-query/test/useSubscription.test.tsx
@@ -1,5 +1,6 @@
 import { EventEmitter, on } from 'node:events';
 import { testReactResource } from './__helpers';
+import { skipToken } from '@tanstack/react-query';
 import { fireEvent } from '@testing-library/react';
 import { httpSubscriptionLink, wsLink } from '@trpc/client';
 import { initTRPC } from '@trpc/server';
@@ -276,6 +277,59 @@ describe.each([
       // no event listeners
       expect(ctx.ee.listenerCount('data')).toBe(0);
     });
+  });
+
+  test('skipToken', async () => {
+    await using ctx = getCtx(protocol);
+
+    const { useTRPC } = ctx;
+
+    function MyComponent() {
+      const [input, setInput] = React.useState<number | typeof skipToken>(
+        skipToken,
+      );
+
+      const trpc = useTRPC();
+      const result = useSubscription(
+        trpc.onEventIterable.subscriptionOptions(input),
+      );
+
+      return (
+        <>
+          <button
+            onClick={() => {
+              setInput(10);
+            }}
+            data-testid="set-input"
+          >
+            set input
+          </button>
+          <div>status:{result.status}</div>
+          <div>data:{result.data ?? 'NO_DATA'}</div>
+        </>
+      );
+    }
+
+    const utils = ctx.renderApp(<MyComponent />);
+
+    await vi.waitFor(() => {
+      expect(utils.container).toHaveTextContent(`status:idle`);
+    });
+    // the subscription should not have started while the input is skipToken
+    expect(ctx.ee.listenerCount('data')).toBe(0);
+
+    fireEvent.click(utils.getByTestId('set-input'));
+
+    await vi.waitFor(() => {
+      expect(utils.container).toHaveTextContent(`status:pending`);
+    });
+    ctx.ee.emit('data', 20);
+
+    await vi.waitFor(() => {
+      expect(utils.container).toHaveTextContent(`data:30`);
+    });
+
+    utils.unmount();
   });
 });
 


### PR DESCRIPTION
Closes #7373

## 🎯 Changes

Bug fix. `subscriptionOptions(skipToken).enabled` returned `true` instead of `false`.

`enabled` was derived by reading the input back out of the query key, but `skipToken` is stripped when the key is built, so it read as `undefined` and `enabled` was always `true`. For a procedure with required input, the subscription then fired with `undefined` input and produced a bad request.

Now `enabled` comes from the raw input, and `skipToken` always disables the subscription:

- `skipToken` means there's no valid input, so enabling it could only send `undefined`. Forcing `enabled: false` makes that unrepresentable, and costs nothing since a procedure with no input wouldn't use `skipToken`.
- Matches queries: `queryOptions` sets `queryFn: skipToken`, which is a no-op even with `enabled: true`. Subscriptions are hand-rolled, so `skipToken` should win there too.

A real input keeps the default (enabled unless `enabled: false`). Also fixes falsy inputs (e.g. `0`) being sent as `undefined`.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription behavior when using `skipToken`, ensuring subscriptions remain disabled until a valid input is provided.
  * Subscription state and data updates now transition correctly when switching from `skipToken` to a real input.
  * `enabled` overrides are applied consistently, while `skipToken` still forces the subscription to stay disabled even if `enabled: true` is set.
* **Tests**
  * Added coverage for `skipToken` behavior in subscription options and `useSubscription`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->