### PR TITLE
fix(react-query): usable proxy type for createTRPCReact<AnyTRPCRouter>

### DIFF
--- a/packages/react-query/test/regression/issue-6721-anyrouter-intersection.test.tsx
+++ b/packages/react-query/test/regression/issue-6721-anyrouter-intersection.test.tsx
@@ -11,8 +11,8 @@ test('createTRPCReact<AnyTRPCRouter>() does not collide with itself', () => {
   // If it does, `trpc` collapses to a union of `IntersectionError<...>` string
   // literals and none of its built-in methods are accessible below - this
   // block fails to compile on the bug.
-  expectTypeOf(trpc.useContext).toBeFunction();
-  expectTypeOf(trpc.useUtils).toBeFunction();
+  expectTypeOf<typeof trpc.useContext>().toBeFunction();
+  expectTypeOf<typeof trpc.useUtils>().toBeFunction();
   expectTypeOf(trpc.Provider).not.toBeAny();
   expectTypeOf(trpc.createClient).toBeFunction();
   expectTypeOf(trpc.useQueries).toBeFunction();

--- a/packages/react-query/test/regression/issue-6721-anyrouter-intersection.test.tsx
+++ b/packages/react-query/test/regression/issue-6721-anyrouter-intersection.test.tsx
@@ -1,0 +1,20 @@
+import { createTRPCReact } from '@trpc/react-query';
+import type { AnyTRPCRouter } from '@trpc/server';
+
+test('createTRPCReact<AnyTRPCRouter>() does not collide with itself', () => {
+  const trpc = createTRPCReact<AnyTRPCRouter>();
+
+  // `AnyTRPCRouter` is `Router<any, any>`, whose `keyof` resolves to the bare
+  // `string` index signature. `ProtectedIntersection` must not treat that as
+  // colliding with every built-in method (`useContext`, `useUtils`, `Provider`,
+  // `createClient`, `useQueries`, `useSuspenseQueries`, ...) simultaneously.
+  // If it does, `trpc` collapses to a union of `IntersectionError<...>` string
+  // literals and none of its built-in methods are accessible below - this
+  // block fails to compile on the bug.
+  expectTypeOf(trpc.useContext).toBeFunction();
+  expectTypeOf(trpc.useUtils).toBeFunction();
+  expectTypeOf(trpc.Provider).not.toBeAny();
+  expectTypeOf(trpc.createClient).toBeFunction();
+  expectTypeOf(trpc.useQueries).toBeFunction();
+  expectTypeOf(trpc.useSuspenseQueries).toBeFunction();
+});

--- a/packages/server/src/unstable-core-do-not-import/types.ts
+++ b/packages/server/src/unstable-core-do-not-import/types.ts
@@ -156,10 +156,16 @@ export type IntersectionError<TKey extends string> =
 /**
  * @internal
  */
-export type ProtectedIntersection<TType, TWith> = keyof TType &
-  keyof TWith extends never
-  ? TType & TWith
-  : IntersectionError<string & keyof TType & keyof TWith>;
+export type ProtectedIntersection<TType, TWith> =
+  // When `keyof TWith` is (or includes) the bare `string` index signature -
+  // e.g. `TWith` originates from `AnyTRPCRouter` (`Router<any, any>`) - every
+  // key of `TType` trivially overlaps with it. Skip collision detection in
+  // that case instead of reporting a false-positive collision for every key.
+  string extends keyof TWith
+    ? TType & TWith
+    : keyof TType & keyof TWith extends never
+      ? TType & TWith
+      : IntersectionError<string & keyof TType & keyof TWith>;
 
 /**
  * @internal

--- a/packages/upgrade/test/__fixtures__/hooks/optimistic-update.spec.tsx
+++ b/packages/upgrade/test/__fixtures__/hooks/optimistic-update.spec.tsx
@@ -8,8 +8,15 @@ import { ctx, resetFixtureState } from './optimistic-update.trpc';
 export const run: SpecRun = async (Component) => {
   expect(Component).toBeDefined();
 
+  // The query client and server data are shared across every run in this file.
+  // Start each run from a clean slate so the initial-render assertion below
+  // can't observe stale data left behind by a previous run (which made the
+  // first `waitFor` flakily read "Posts: 2initialFoo").
+  await ctx.queryClient.cancelQueries();
+  ctx.queryClient.clear();
+  resetFixtureState();
+
   using _finally = makeResource({}, () => {
-    resetFixtureState();
     utils.unmount();
   });
 


### PR DESCRIPTION
`createTRPCReact<AnyTRPCRouter>()` produces a union of false `IntersectionError` strings ("collides with a built-in method") instead of a usable proxy type (#6721).

`ProtectedIntersection<TType, TWith>` reports a collision when `keyof TType & keyof TWith` is not `never`. For `AnyTRPCRouter`, `keyof TWith` collapses to the bare `string` index signature, so `string & 'useContext'` is not `never` and every built-in key is flagged as colliding.

This guards the type: when `keyof TWith` is (or includes) the bare `string` index signature, it returns the plain intersection instead of the error. A concrete key colliding with a wide index signature is not constructible in TypeScript (an index signature collapses `keyof` to `string`), so the guard is exhaustive.

Added a regression type test. It fails to typecheck without the fix and passes with it. All packages typecheck, full vitest green, the existing collision-regression test is unchanged and still passes.

Closes #6721


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved type-collision false positives when merging router types that include broad string index signatures, preventing incorrect intersection error types.
  * Ensured key React Query/TRPC members keep their correct built-in typings instead of degrading into unusable types.

* **Tests**
  * Added a regression test verifying core React Query/TRPC hook typings remain intact.
  * Improved an optimistic update test fixture by resetting shared state up front to avoid stale-data flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->