### PR TITLE
fix(client): wire the operation AbortSignal in the WebSocket link

### DIFF
--- a/packages/client/src/links/wsLink/wsClient/wsClient.ts
+++ b/packages/client/src/links/wsLink/wsClient/wsClient.ts
@@ -222,6 +222,16 @@ export class WsClient {
         },
       );
 
+      // Wire the operation's AbortSignal: aborting must tear the request down
+      // (and send `subscription.stop` for subscriptions). Completing the
+      // observer runs the teardown below, which does exactly that.
+      const onAbort = () => observer.complete();
+      if (signal?.aborted) {
+        onAbort();
+      } else {
+        signal?.addEventListener('abort', onAbort, { once: true });
+      }
+
       return () => {
         abort();
 
@@ -232,7 +242,7 @@ export class WsClient {
           });
         }
 
-        signal?.removeEventListener('abort', abort);
+        signal?.removeEventListener('abort', onAbort);
       };
     });
   }

--- a/packages/client/src/links/wsLink/wsClient/wsClient.ts
+++ b/packages/client/src/links/wsLink/wsClient/wsClient.ts
@@ -222,9 +222,6 @@ export class WsClient {
         },
       );
 
-      // Wire the operation's AbortSignal: aborting must tear the request down
-      // (and send `subscription.stop` for subscriptions). Completing the
-      // observer runs the teardown below, which does exactly that.
       const onAbort = () => observer.complete();
       if (signal?.aborted) {
         onAbort();

--- a/packages/tests/server/websockets.test.ts
+++ b/packages/tests/server/websockets.test.ts
@@ -290,6 +290,33 @@ test('basic subscription test (observable)', async () => {
   expect(stateCalls).toContain('pending');
 });
 
+test('subscription is aborted when its signal aborts', async () => {
+  await using ctx = factory();
+
+  const ac = new AbortController();
+  const onStartedMock = vi.fn();
+
+  ctx.client.onMessageObservable.subscribe(undefined, {
+    signal: ac.signal,
+    onStarted() {
+      onStartedMock();
+    },
+  });
+
+  await vi.waitFor(() => {
+    expect(onStartedMock).toHaveBeenCalledTimes(1);
+    expect(ctx.ee.listenerCount('server:msg')).toBe(1);
+  });
+
+  ac.abort();
+
+  // Aborting the signal must tear the subscription down, sending
+  // `subscription.stop` so the server cleans up its listener.
+  await vi.waitFor(() => {
+    expect(ctx.ee.listenerCount('server:msg')).toBe(0);
+  });
+});
+
 test('subscription observable with error', async () => {
   await using ctx = factory();
   ctx.ee.once('subscription:created', () => {

--- a/packages/tests/server/websockets.test.ts
+++ b/packages/tests/server/websockets.test.ts
@@ -294,13 +294,11 @@ test('subscription is aborted when its signal aborts', async () => {
   await using ctx = factory();
 
   const ac = new AbortController();
-  const onStartedMock = vi.fn();
+  const onStartedMock = vi.fn<() => void>();
 
   ctx.client.onMessageObservable.subscribe(undefined, {
     signal: ac.signal,
-    onStarted() {
-      onStartedMock();
-    },
+    onStarted: onStartedMock,
   });
 
   await vi.waitFor(() => {


### PR DESCRIPTION
Closes #7431

## 🎯 Changes

The WebSocket link's `request` observable never listened to the operation's `AbortSignal`. Its teardown called `signal?.removeEventListener('abort', abort)`, but nothing ever registered that listener — `abort` was the function returned by `batchSend`, not a listener. Aborting an operation's signal did nothing: the request was never torn down, the subscription kept running, and its server-side listener leaked.

Register an `abort` listener that completes the observer. Completing runs the existing teardown, which sends `subscription.stop` for subscriptions, so an aborted operation now ends cleanly. The matching listener is removed on teardown, and an already-aborted signal is handled synchronously.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket request handling when an abort signal is triggered, including signals that were already aborted.
  * Ensured active subscriptions stop promptly and clean up their event listeners after cancellation, preventing further message delivery.

* **Tests**
  * Added coverage confirming that aborting a WebSocket message subscription removes its server-side listener and stops subsequent processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->