### PR TITLE
fix(server): reject non-number/string request ids in assertIsRequestId

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/rpc/parseTRPCMessage.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/rpc/parseTRPCMessage.test.ts
@@ -1,0 +1,30 @@
+import { defaultTransformer } from '../transformer';
+import { parseTRPCMessage } from './parseTRPCMessage';
+
+/**
+ * `parseTRPCMessage` validates the JSON-RPC `id` of an incoming WebSocket
+ * message. A valid request id is `number | string | null`; anything else must
+ * be rejected before it is used as a `clientSubscriptions` Map key.
+ */
+const parse = (id: unknown) =>
+  parseTRPCMessage(
+    { id, jsonrpc: '2.0', method: 'subscription.stop' },
+    defaultTransformer,
+  );
+
+describe('parseTRPCMessage - request id validation', () => {
+  test.each([1, 0, -1, 42, 'abc', '', 'my-id', null])(
+    'accepts valid request id: %p',
+    (id) => {
+      expect(() => parse(id)).not.toThrow();
+      expect(parse(id)).toMatchObject({ id, method: 'subscription.stop' });
+    },
+  );
+
+  test.each([true, false, {}, [], undefined, NaN])(
+    'rejects invalid request id: %p',
+    (id) => {
+      expect(() => parse(id)).toThrow('Invalid request id');
+    },
+  );
+});

--- a/packages/server/src/unstable-core-do-not-import/rpc/parseTRPCMessage.ts
+++ b/packages/server/src/unstable-core-do-not-import/rpc/parseTRPCMessage.ts
@@ -23,9 +23,8 @@ function assertIsRequestId(
 ): asserts obj is number | string | null {
   if (
     obj !== null &&
-    typeof obj === 'number' &&
-    isNaN(obj) &&
-    typeof obj !== 'string'
+    typeof obj !== 'string' &&
+    (typeof obj !== 'number' || isNaN(obj))
   ) {
     throw new Error('Invalid request id');
   }


### PR DESCRIPTION
### What & why

`assertIsRequestId` in `packages/server/src/unstable-core-do-not-import/rpc/parseTRPCMessage.ts` is meant to accept `number | string | null` and reject everything else, but the condition is a no-op for all invalid non-number types:

```js
obj !== null && typeof obj === 'number' && isNaN(obj) && typeof obj !== 'string'
```

Once `typeof obj === 'number'` holds, `typeof obj !== 'string'` is always true, so the `throw` only ever fires for `NaN`. Booleans, objects, arrays, and `undefined` all pass as "valid" request ids and flow downstream into `clientSubscriptions` Map keys and error responses (this is the incoming-message parser used by the WebSocket adapter).

**Regression:** the original check in PR #508 was correct (`if (typeof obj !== 'number' || isNaN(obj))`); the boolean was mangled when the id type was widened to `number | string | null` and the function was extracted into `parseTRPCMessage` in PR #4872.

### Fix

Restore the correct logic:

```js
obj !== null && typeof obj !== 'string' && (typeof obj !== 'number' || isNaN(obj))
```

### Tests

New colocated `parseTRPCMessage.test.ts` (matching the repo's colocated-test convention). Buggy source: 5 failing (`true`, `false`, `{}`, `[]`, `undefined` don't throw). Fixed: 14 passing. Adjacent WS suites unaffected (control frames never pass through `parseTRPCMessage`).

Closes #7430


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of request IDs in incoming WebSocket messages.
  * Valid numeric, string, and null IDs are now accepted reliably.
  * Invalid IDs—including booleans, objects, arrays, undefined values, and `NaN`—are rejected with a clear error before further processing.
* **Tests**
  * Added coverage for valid and invalid request ID formats to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->