### PR TITLE
fix(client): honor AbortSignal on in-flight websocket operations

### DIFF
--- a/packages/client/src/links/wsLink/wsClient/wsClient.ts
+++ b/packages/client/src/links/wsLink/wsClient/wsClient.ts
@@ -222,6 +222,16 @@ export class WsClient {
         },
       );
 
+      // Wire AbortSignal so callers can cancel in-flight WS ops (#7439).
+      // removeEventListener was already present in cleanup without a matching add.
+      if (signal) {
+        if (signal.aborted) {
+          abort();
+        } else {
+          signal.addEventListener('abort', abort, { once: true });
+        }
+      }
+
       return () => {
         abort();
 


### PR DESCRIPTION
Closes #7439

## 🎯 Changes

Bug fix for `wsLink` / `wsClient.request()`.

`AbortSignal` was plumbed into `request()` and teardown already called `signal?.removeEventListener('abort', abort)`, but there was **no** matching `addEventListener`. Aborting the caller's controller therefore never cancelled in-flight WS queries/mutations/subscriptions.

This PR:
- if `signal` is already aborted → call `abort()` immediately
- otherwise → `signal.addEventListener('abort', abort, { once: true })`
- keep existing removeEventListener + subscription.stop cleanup

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.

(Happy to add a focused unit/integration test for signal abort if maintainers want a preferred harness location.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket requests now properly stop when their associated cancellation signal is triggered.
  * Requests are canceled immediately when the signal has already been aborted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->