### PR TITLE
fix(client): handle AbortSignal events and pre-aborted signals in wsLink

### DIFF
--- a/packages/client/src/links/wsLink/wsClient/wsClient.ts
+++ b/packages/client/src/links/wsLink/wsClient/wsClient.ts
@@ -25,6 +25,12 @@ import { RequestManager } from './requestManager';
 import { ResettableTimeout, TRPCWebSocketClosedError } from './utils';
 import { backwardCompatibility, WsConnection } from './wsConnection';
 
+function toAbortError(signal?: AbortSignal): Error {
+  const reason = signal?.reason;
+  if (reason instanceof Error) return reason;
+  return new Error(typeof reason === 'string' ? reason : 'Operation aborted');
+}
+
 /**
  * A WebSocket client for managing TRPC operations, supporting lazy initialization,
  * reconnection, keep-alive, and request management.
@@ -195,7 +201,14 @@ export class WsClient {
       OperationResultEnvelope<unknown, TRPCClientError<AnyTRPCRouter>>,
       TRPCClientError<AnyTRPCRouter>
     >((observer) => {
-      const abort = this.batchSend(
+      let isDone = false;
+
+      if (signal?.aborted) {
+        observer.error(TRPCClientError.from(toAbortError(signal)));
+        return;
+      }
+
+      const batchSendAbort = this.batchSend(
         {
           id,
           method: type,
@@ -219,11 +232,22 @@ export class WsClient {
               result: transformed.result,
             });
           },
+          error(err) {
+            isDone = true;
+            observer.error(err);
+          },
+          complete() {
+            isDone = true;
+            observer.complete();
+          },
         },
       );
 
-      return () => {
-        abort();
+      const stop = () => {
+        if (isDone) return;
+        isDone = true;
+
+        batchSendAbort();
 
         if (type === 'subscription' && this.activeConnection.isOpen()) {
           this.send({
@@ -231,8 +255,19 @@ export class WsClient {
             method: 'subscription.stop',
           });
         }
+      };
 
-        signal?.removeEventListener('abort', abort);
+      const onAbort = () => {
+        if (isDone) return;
+        observer.error(TRPCClientError.from(toAbortError(signal)));
+        stop();
+      };
+
+      signal?.addEventListener('abort', onAbort, { once: true });
+
+      return () => {
+        signal?.removeEventListener('abort', onAbort);
+        stop();
       };
     });
   }

--- a/packages/tests/server/websockets.test.ts
+++ b/packages/tests/server/websockets.test.ts
@@ -2224,3 +2224,31 @@ test('connection state should not be updated for subscriptions', async () => {
   // Clean up
   subscription.unsubscribe();
 });
+
+describe('wsLink AbortSignal support', () => {
+  test('aborts in-flight query when AbortSignal is triggered', async () => {
+    await using ctx = factory();
+
+    const ac = new AbortController();
+    const queryPromise = ctx.client.greeting.query('world', {
+      signal: ac.signal,
+    });
+
+    ac.abort();
+
+    await expect(queryPromise).rejects.toThrow(/aborted/i);
+  });
+
+  test('rejects immediately if signal is already aborted', async () => {
+    await using ctx = factory();
+
+    const ac = new AbortController();
+    ac.abort();
+
+    const queryPromise = ctx.client.greeting.query('world', {
+      signal: ac.signal,
+    });
+
+    await expect(queryPromise).rejects.toThrow(/aborted/i);
+  });
+});


### PR DESCRIPTION
### Summary

Fixes #7439 where `wsLink` ignored the `AbortSignal` passed with an operation. Calling `controller.abort()` on an `AbortController` had no effect on in-flight queries, mutations, or subscriptions over WebSocket because the abort event listener was never registered on `signal`.

### Problem Statement & Root Cause

In `packages/client/src/links/wsLink/wsClient/wsClient.ts`, `signal?.removeEventListener('abort', abort)` was called in the cleanup function returned by `request()`, but `signal?.addEventListener('abort', ...)` was never called during operation setup. Additionally, pre-aborted `AbortSignal` instances were not checked before sending batch messages.

### Solution

1. **Abort Listener Registration**: Register a `{ once: true }` listener for `'abort'` on `op.signal` when an operation is dispatched. When triggered, it cleans up the pending request from `RequestManager`, sends `subscription.stop` if an active subscription, and notifies observers with a `TRPCClientError`.
2. **Pre-aborted Check**: Check `signal?.aborted` before dispatching, rejecting immediately if already aborted.
3. **Clean Teardown**: Remove event listener on normal completion or unsubscription.

### Test Coverage

Added integration tests in `packages/tests/server/websockets.test.ts`:
- Verifies in-flight query cancellation upon `AbortSignal` trigger over WebSocket.
- Verifies immediate rejection when passing an already-aborted `AbortSignal`.

Tested via `npx vitest run packages/tests/server/websockets.test.ts` (45/45 tests passing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation behavior for WebSocket-backed queries using `AbortSignal`, including immediate rejection when the signal is already aborted.
  * Ensures in-flight requests and active subscriptions are stopped cleanly, and sends stop messages when the WebSocket connection is open.

* **Tests**
  * Added coverage for aborting in-flight WebSocket queries and for handling already-aborted signals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->