### PR TITLE
fix(tanstack-react-query): transition subscription to idle when server stops or completes it

### DIFF
--- a/packages/tanstack-react-query/src/internals/subscriptionOptions.ts
+++ b/packages/tanstack-react-query/src/internals/subscriptionOptions.ts
@@ -26,6 +26,8 @@ interface UnusedSkipTokenTRPCSubscriptionOptionsIn<TOutput, TError> {
   onStarted?: () => void;
   onData?: (data: inferAsyncIterableYield<TOutput>) => void;
   onError?: (err: TError) => void;
+  onStopped?: () => void;
+  onComplete?: () => void;
   onConnectionStateChange?: (state: TRPCConnectionState<TError>) => void;
 }
 
@@ -207,6 +209,24 @@ export function useSubscription<TOutput, TError>(
           ...(prev as any),
           status: 'error',
           error,
+        }));
+      },
+      onStopped: () => {
+        optsRef.current.onStopped?.();
+        updateState((prev) => ({
+          ...(prev as any),
+          status: 'idle',
+          data: undefined,
+          error: null,
+        }));
+      },
+      onComplete: () => {
+        optsRef.current.onComplete?.();
+        updateState((prev) => ({
+          ...(prev as any),
+          status: 'idle',
+          data: undefined,
+          error: null,
         }));
       },
       onConnectionStateChange: (result) => {


### PR DESCRIPTION
Fixes #6962.

`useSubscription` subscribes with `onStarted`, `onData`, `onError`, and `onConnectionStateChange` but never wires `onStopped` or `onComplete`. When a server procedure closes a subscription via `return` (sends `type: "stopped"`) or exhausts an async generator (sends `type: "complete"`), `TRPCUntypedClient` calls `opts.onStopped?.()` / `opts.onComplete?.()` — but since neither is passed, the client-side status stays `"pending"` forever. The subscription only reaches `"idle"` when the entire WebSocket drops, via `onConnectionStateChange`.

Added `onStopped` and `onComplete` to `UnusedSkipTokenTRPCSubscriptionOptionsIn` and wired both handlers in `useSubscription`'s `reset()` to transition status to `"idle"` and forward the call to any user-provided callback, matching the pattern already used for `onConnectionStateChange`'s `"idle"` case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional callbacks for subscription stop and completion events.
  * Subscription state now resets to idle and clears existing data and errors when stopped or completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->