### PR TITLE
fix(client): wire AbortSignal event listener to cancel in-flight operations

### DIFF
--- a/packages/client/src/links/wsLink/wsClient/wsClient.ts
+++ b/packages/client/src/links/wsLink/wsClient/wsClient.ts
@@ -195,6 +195,23 @@ export class WsClient {
       OperationResultEnvelope<unknown, TRPCClientError<AnyTRPCRouter>>,
       TRPCClientError<AnyTRPCRouter>
     >((observer) => {
+      const abortError = () =>
+        TRPCClientError.from(
+          signal?.reason ??
+            new DOMException('This operation was aborted', 'AbortError'),
+        );
+
+      if (signal?.aborted) {
+        observer.error(abortError());
+        return;
+      }
+
+      const onAbort = () => {
+        observer.error(abortError());
+      };
+
+      signal?.addEventListener('abort', onAbort, { once: true });
+
       const abort = this.batchSend(
         {
           id,
@@ -232,7 +249,7 @@ export class WsClient {
           });
         }
 
-        signal?.removeEventListener('abort', abort);
+        signal?.removeEventListener('abort', onAbort);
       };
     });
   }

--- a/packages/tests/server/websockets.test.ts
+++ b/packages/tests/server/websockets.test.ts
@@ -613,6 +613,57 @@ test('requests get aborted if called before connection is established and reques
   });
 });
 
+test('pre-aborted signal rejects with AbortError', async () => {
+  await using ctx = factory();
+
+  await vi.waitFor(() => {
+    expect(ctx.wsClient.connection?.state === 'open').toBe(true);
+  });
+
+  const ac = new AbortController();
+  ac.abort();
+
+  await expect(
+    ctx.client.greeting.query('alexdotjs', { signal: ac.signal }),
+  ).rejects.toMatchObject({
+    cause: { name: 'AbortError' },
+  });
+});
+
+test('in-flight operation aborts with AbortError when signal fires', async () => {
+  await using ctx = factory();
+
+  const ac = new AbortController();
+  const onStarted = vi.fn();
+  const onError = vi.fn();
+
+  const unsub = ctx.client.onMessageObservable.subscribe(undefined, {
+    signal: ac.signal,
+    onStarted,
+    onError,
+  });
+
+  await vi.waitFor(() => {
+    expect(onStarted).toHaveBeenCalledTimes(1);
+  });
+
+  ac.abort();
+
+  await vi.waitFor(() => {
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  expect(onError.mock.calls[0]![0]).toMatchObject({
+    cause: { name: 'AbortError' },
+  });
+
+  await vi.waitFor(() => {
+    expect(ctx.ee.listenerCount('server:msg')).toBe(0);
+  });
+
+  unsub.unsubscribe();
+});
+
 test('subscriptions are automatically resumed upon explicit reconnect request', async () => {
   await using ctx = factory();
   ctx.ee.once('subscription:created', () => {


### PR DESCRIPTION
Wire AbortSignal event listener and early aborted check in `wsClient` to reject in-flight operations when signal is aborted.

Closes #7431

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket request cancellation with consistent abort errors.
  * Requests cancelled before starting now fail immediately.
  * Active subscriptions now stop cleanly when cancelled, preventing further server messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->