### PR TITLE
fix(server): stream the request body when express 5 body-parser leaves req.body undefined

### DIFF
--- a/packages/server/src/adapters/node-http/incomingMessageToRequest.test.ts
+++ b/packages/server/src/adapters/node-http/incomingMessageToRequest.test.ts
@@ -277,13 +277,14 @@ test('adapter with pre-parsed body - object', async () => {
   expect(body).toBe('{"hello":"world"}');
 });
 
-test('adapter with pre-parsed body - undefined', async () => {
+test('adapter with pre-parsed body - undefined after consuming the stream', async () => {
   const mockReq = createMockReq({
     headers: {},
     url: '/test',
     method: 'POST',
     // @ts-expect-error - test
     body: undefined,
+    readableEnded: true,
   });
 
   const request = incomingMessageToRequest(mockReq, createMockRes(), {

--- a/packages/server/src/adapters/node-http/incomingMessageToRequest.ts
+++ b/packages/server/src/adapters/node-http/incomingMessageToRequest.ts
@@ -14,20 +14,27 @@ function createBody(
 ): RequestInit['body'] {
   // Some adapters will pre-parse the body and add it to the request object
   if ('body' in req) {
-    if (req.body === undefined) {
-      // If body property exists but is undefined, return undefined
+    if (req.body !== undefined) {
+      // If the body is already a string, return it directly
+      if (typeof req.body === 'string') {
+        return req.body;
+      }
+      // formData use
+      if (req.body instanceof IncomingMessage) {
+        return req.body as any;
+      }
+      // If body exists but isn't a string, stringify it as JSON
+      return JSON.stringify(req.body);
+    }
+    if (req.readableEnded) {
+      // The stream was consumed without producing a parsed body — there is
+      // nothing left to read
       return undefined;
     }
-    // If the body is already a string, return it directly
-    if (typeof req.body === 'string') {
-      return req.body;
-    }
-    // formData use
-    if (req.body instanceof IncomingMessage) {
-      return req.body as any;
-    }
-    // If body exists but isn't a string, stringify it as JSON
-    return JSON.stringify(req.body);
+    // The property was defined without the stream being read — e.g. express
+    // 5's body-parser assigns `req.body = undefined` on content types it
+    // skips (such as multipart/form-data) — so stream it like an unparsed
+    // request
   }
   let size = 0;
   let hasClosed = false;

--- a/packages/tests/server/regression/issue-7446-express5-body-parser-formdata.test.ts
+++ b/packages/tests/server/regression/issue-7446-express5-body-parser-formdata.test.ts
@@ -12,10 +12,9 @@ const router = t.router({
   multipartForm: t.procedure
     .input(
       z.custom<FormData>((input) => {
-        // input instanceof FormData return false but is a FormData type
-        // maybe undici version
-
-        return input.toString() === '[object FormData]';
+        // instanceof FormData is unreliable across realms (the server-side
+        // instance comes from undici), so check the toString tag instead
+        return Object.prototype.toString.call(input) === '[object FormData]';
       }),
     )
     .mutation(({ input }) => {

--- a/packages/tests/server/regression/issue-7446-express5-body-parser-formdata.test.ts
+++ b/packages/tests/server/regression/issue-7446-express5-body-parser-formdata.test.ts
@@ -102,8 +102,9 @@ test('multipart/form-data body reaches the procedure', async () => {
   });
 
   expect(res.status).toBe(200);
-  const json: TRPCSuccessResponse<inferRouterOutputs<typeof router>['multipartForm']> =
-    await res.json();
+  const json: TRPCSuccessResponse<
+    inferRouterOutputs<typeof router>['multipartForm']
+  > = await res.json();
   expect(json.result.data).toEqual({ id: 'bar' });
 });
 

--- a/packages/tests/server/regression/issue-7446-express5-body-parser-formdata.test.ts
+++ b/packages/tests/server/regression/issue-7446-express5-body-parser-formdata.test.ts
@@ -14,12 +14,12 @@ const router = t.router({
       z.custom<FormData>((input) => {
         // input instanceof FormData return false but is a FormData type
         // maybe undici version
-         
+
         return input.toString() === '[object FormData]';
       }),
     )
     .mutation(({ input }) => {
-      return { id: (input).get('id') };
+      return { id: input.get('id') };
     }),
   helloMutation: t.procedure
     .input(z.string())

--- a/packages/tests/server/regression/issue-7446-express5-body-parser-formdata.test.ts
+++ b/packages/tests/server/regression/issue-7446-express5-body-parser-formdata.test.ts
@@ -1,0 +1,110 @@
+import type http from 'http';
+import { createTRPCClient, httpBatchLink } from '@trpc/client';
+import { initTRPC } from '@trpc/server';
+import * as trpcExpress from '@trpc/server/adapters/express';
+import express from 'express';
+import fetch from 'node-fetch';
+import { z } from 'zod';
+
+const t = initTRPC.create();
+
+const router = t.router({
+  multipartForm: t.procedure
+    .input(
+      z.custom<FormData>((input) => {
+        // input instanceof FormData return false but is a FormData type
+        // maybe undici version
+         
+        return input.toString() === '[object FormData]';
+      }),
+    )
+    .mutation(({ input }) => {
+      return { id: (input).get('id') };
+    }),
+  helloMutation: t.procedure
+    .input(z.string())
+    .mutation(({ input }) => `hello ${input}`),
+});
+
+async function startServer() {
+  const app = express();
+
+  // express 5's body-parser defines `req.body` (as `undefined`) even on
+  // content types it skips, e.g. multipart/form-data — the adapter must
+  // still stream those bodies instead of treating them as pre-parsed
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: true }));
+
+  app.use('/', trpcExpress.createExpressMiddleware({ router }));
+
+  const { server, port } = await new Promise<{
+    server: http.Server;
+    port: number;
+  }>((resolve) => {
+    const server = app.listen(0, () => {
+      resolve({
+        server,
+        port: (server.address() as any).port,
+      });
+    });
+  });
+
+  const url = `http://localhost:${port}`;
+  const client = createTRPCClient<typeof router>({
+    links: [
+      httpBatchLink({
+        url,
+        fetch: fetch as any,
+      }),
+    ],
+  });
+
+  return {
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => {
+          err ? reject(err) : resolve();
+        }),
+      ),
+    client,
+    url,
+  };
+}
+
+let $: Awaited<ReturnType<typeof startServer>>;
+beforeAll(async () => {
+  $ = await startServer();
+});
+afterAll(async () => {
+  await $.close();
+});
+
+test('multipart/form-data body reaches the procedure', async () => {
+  // the multipart body is built by hand so the test does not depend on the
+  // environment's FormData/fetch pairing
+  const boundary = 'trpc-issue-boundary';
+  const body = [
+    `--${boundary}`,
+    'Content-Disposition: form-data; name="id"',
+    '',
+    'bar',
+    `--${boundary}--`,
+    '',
+  ].join('\r\n');
+
+  const res = await fetch(`${$.url}/multipartForm`, {
+    method: 'POST',
+    headers: {
+      'content-type': `multipart/form-data; boundary=${boundary}`,
+    },
+    body,
+  });
+
+  expect(res.status).toBe(200);
+  const json: any = await res.json();
+  expect(json.result.data).toEqual({ id: 'bar' });
+});
+
+test('json bodies keep working through the pre-parsed path', async () => {
+  expect(await $.client.helloMutation.mutate('world')).toBe('hello world');
+});

--- a/packages/tests/server/regression/issue-7446-express5-body-parser-formdata.test.ts
+++ b/packages/tests/server/regression/issue-7446-express5-body-parser-formdata.test.ts
@@ -1,9 +1,9 @@
 import type http from 'http';
 import { createTRPCClient, httpBatchLink } from '@trpc/client';
-import { initTRPC } from '@trpc/server';
+import { initTRPC, type inferRouterOutputs } from '@trpc/server';
 import * as trpcExpress from '@trpc/server/adapters/express';
+import type { TRPCSuccessResponse } from '@trpc/server/rpc';
 import express from 'express';
-import fetch from 'node-fetch';
 import { z } from 'zod';
 
 const t = initTRPC.create();
@@ -39,21 +39,23 @@ async function startServer() {
   const { server, port } = await new Promise<{
     server: http.Server;
     port: number;
-  }>((resolve) => {
+  }>((resolve, reject) => {
     const server = app.listen(0, () => {
-      resolve({
-        server,
-        port: (server.address() as any).port,
-      });
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('expected the server to listen on a TCP address'));
+        return;
+      }
+      resolve({ server, port: address.port });
     });
   });
 
   const url = `http://localhost:${port}`;
   const client = createTRPCClient<typeof router>({
     links: [
+      // no fetch override: httpBatchLink defaults to the global fetch
       httpBatchLink({
         url,
-        fetch: fetch as any,
       }),
     ],
   });
@@ -100,7 +102,8 @@ test('multipart/form-data body reaches the procedure', async () => {
   });
 
   expect(res.status).toBe(200);
-  const json: any = await res.json();
+  const json: TRPCSuccessResponse<inferRouterOutputs<typeof router>['multipartForm']> =
+    await res.json();
   expect(json.result.data).toEqual({ id: 'bar' });
 });
 


### PR DESCRIPTION
Closes #7446

## 🎯 Changes

Bug fix. Express 5's body-parser defines `req.body` (as `undefined`) even on content types it skips, e.g. `multipart/form-data`. `createBody`'s `'body' in req` presence check then treated such requests as pre-parsed and built a body-less `Request`, so `request.formData()` failed with `Failed to parse body as FormData` for anyone running express 5 (including every NestJS app) with global body parsers registered.

`createBody` now only treats the request as pre-parsed when `req.body` holds a value. When the property exists but is `undefined`, it returns an empty body only if the stream was actually consumed (`req.readableEnded`) — preserving the existing tested behavior — and otherwise streams the untouched body exactly like a request no middleware saw. The pre-parsed string / `IncomingMessage` / object paths are unchanged.

Includes a regression test (express 5 + global body parsers + multipart mutation) that fails without the fix, plus a JSON mutation in the same app confirming the pre-parsed path still works. Full `@trpc/server` (110) and `@trpc/tests` (541) suites pass.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved request-body handling when the request stream has already been consumed, so `request.text()` safely resolves to an empty string.
  - Enhanced compatibility with Express 5 multipart/form-data scenarios where the body may be pre-parsed as `undefined`.
  - Preserved existing behavior for JSON and non-string body inputs.
- **Tests**
  - Updated the unit test to explicitly cover the `undefined` pre-parsed body case after the stream ends.
  - Added a regression test confirming multipart/form-data is still streamed correctly through the Express adapter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->