### PR TITLE
fix(upgrade): clear the query cache on every fixture render

### DIFF
--- a/packages/upgrade/test/__fixtures__/hooks/optimistic-update.spec.tsx
+++ b/packages/upgrade/test/__fixtures__/hooks/optimistic-update.spec.tsx
@@ -1,5 +1,5 @@
 import userEvent from '@testing-library/user-event';
-import { makeResource } from '@trpc/server/unstable-core-do-not-import';
+import { makeAsyncResource } from '@trpc/server/unstable-core-do-not-import';
 import * as React from 'react';
 import { expect, vi } from 'vitest';
 import type { SpecRun } from '../../specDef';
@@ -8,7 +8,11 @@ import { ctx, resetFixtureState } from './optimistic-update.trpc';
 export const run: SpecRun = async (Component) => {
   expect(Component).toBeDefined();
 
-  using _finally = makeResource({}, () => {
+  await using _finally = makeAsyncResource({}, async () => {
+    // a run can end (or fail) with the create mutation still in flight — wait
+    // for it to settle so it can't re-populate the server AFTER the reset
+    // below, which would poison the next run's (or CI retry's) initial fetch
+    await vi.waitFor(() => expect(ctx.queryClient.isMutating()).toBe(0));
     resetFixtureState();
     utils.unmount();
   });

--- a/packages/upgrade/test/__helpers.tsx
+++ b/packages/upgrade/test/__helpers.tsx
@@ -36,6 +36,9 @@ export function testReactResource<TRouter extends AnyTRPCRouter>(
   const trpcTrq = trq.createTRPCContext<TRouter>();
 
   function renderApp(ui: React.ReactNode) {
+    // each render is a fresh app: drop whatever a previous run (or a vitest
+    // retry of a failed one) left in the module-scoped queryClient
+    queryClient.clear();
     return render(
       <QueryClientProvider client={queryClient}>
         <baseProxy.Provider client={ctx.client} queryClient={queryClient}>


### PR DESCRIPTION
## 🎯 Changes

Fixes a CI-only failure of `transforms.test.ts > hooks optimistic-update.tsx`: `Expected "Posts: 1initial", Received "Posts: 2initialFoo"` **at the initial-render assertion** — reproducible on unrelated PRs (the docs-only #7445, and #7447), always with `retry x2` all failing the same way.

Two leaks between spec runs (the spec executes twice per test — input component and transformed snapshot — and again on CI retries), both via module-scoped state:

1. **In-flight mutation re-populates the server after reset.** The fixture's update is optimistic, so a spec run finishes (or fails) with the `create` mutation still in flight. `resetFixtureState()` truncates `posts`, then the late mutation settles and pushes `'Foo'` back — the next run's (or retry's) initial fetch returns `2initialFoo` for its whole `waitFor` window. Under CI load the settle reliably lands in that gap; on a fast local machine (where `retry` is 0 anyway) it practically never does, which is why this only ever failed in CI. The spec's disposer is now async (`makeAsyncResource` + `await using`) and waits for `queryClient.isMutating() === 0` before resetting.

2. **The shared `QueryClient` cache outlives a run.** `renderApp` now clears it before mounting, so a retry can't render the previous attempt's cached data. This covers all nine fixtures using the harness; no spec renders more than once per run, so nothing relied on cache persistence.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by resetting the app’s data cache before each render, preventing prior render or retry state from leaking into later tests.
  * Enhanced optimistic-update test cleanup by waiting for all in-flight mutations to fully complete before resetting fixture state and unmounting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->