### PR TITLE
fix(react-query): allow useQueries callback to return conditional empty array

### DIFF
--- a/packages/react-query/src/internals/useQueries.ts
+++ b/packages/react-query/src/internals/useQueries.ts
@@ -189,7 +189,7 @@ export type TRPCUseQueries<TRouter extends AnyRouter> = <
       TRouter['_def']['_config']['$types'],
       TRouter['_def']['record']
     >,
-  ) => readonly [...QueriesOptions<TQueryOptions>],
+  ) => readonly [...QueriesOptions<TQueryOptions>] | readonly [],
   options?: {
     combine?: (results: QueriesResults<TQueryOptions>) => TCombinedResult;
   },
@@ -211,5 +211,5 @@ export type TRPCUseSuspenseQueries<TRouter extends AnyRouter> = <
       TRouter['_def']['_config']['$types'],
       TRouter['_def']['record']
     >,
-  ) => readonly [...SuspenseQueriesOptions<TQueryOptions>],
+  ) => readonly [...SuspenseQueriesOptions<TQueryOptions>] | readonly [],
 ) => SuspenseQueriesResults<TQueryOptions>;


### PR DESCRIPTION
When a `useQueries` callback conditionally returns an empty array, TypeScript errors:

```ts
trpc.useQueries((t) =>
  condition ? [] : [t.greeting.query(input)]
  //          ^^ Type '[]' is not assignable to type 'readonly []'
)
```

**Root cause:** The callback return type is `readonly [...QueriesOptions<TQueryOptions>]`. When TypeScript tries to unify both branches it infers `TQueryOptions = []`, making the tuple type `readonly []` — which then rejects the non-empty branch. The type has no room to express "zero or more queries."

**Fix:** Union in `| readonly []` on both `TRPCUseQueries` (line 192) and `TRPCUseSuspenseQueries` (line 214). This is a type-only change with zero runtime impact and matches the idiomatic TypeScript pattern for "this tuple also accepts an empty case."

Fixes #6188