### PR TITLE
fix(server): validate request ids of every invalid type

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/rpc/parseTRPCMessage.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/rpc/parseTRPCMessage.test.ts
@@ -1,0 +1,39 @@
+import { defaultTransformer } from '../transformer';
+import { parseTRPCMessage } from './parseTRPCMessage';
+
+function parse(id: unknown) {
+  return parseTRPCMessage(
+    {
+      id,
+      jsonrpc: '2.0',
+      method: 'query',
+      params: { path: 'greeting', input: undefined },
+    },
+    defaultTransformer,
+  );
+}
+
+describe('request id validation', () => {
+  test.each([['a string'], [1], [0], [-1], [1.5]])(
+    'accepts %p as a request id',
+    (id) => {
+      expect(parse(id).id).toBe(id);
+    },
+  );
+
+  test('accepts null, which `subscription.stop` messages rely on', () => {
+    expect(
+      parseTRPCMessage(
+        { id: null, jsonrpc: '2.0', method: 'subscription.stop' },
+        defaultTransformer,
+      ).id,
+    ).toBe(null);
+  });
+
+  test.each([[true], [false], [{}], [[]], [undefined], [NaN]])(
+    'rejects %p as a request id',
+    (id) => {
+      expect(() => parse(id)).toThrow('Invalid request id');
+    },
+  );
+});

--- a/packages/server/src/unstable-core-do-not-import/rpc/parseTRPCMessage.ts
+++ b/packages/server/src/unstable-core-do-not-import/rpc/parseTRPCMessage.ts
@@ -23,9 +23,8 @@ function assertIsRequestId(
 ): asserts obj is number | string | null {
   if (
     obj !== null &&
-    typeof obj === 'number' &&
-    isNaN(obj) &&
-    typeof obj !== 'string'
+    typeof obj !== 'string' &&
+    (typeof obj !== 'number' || isNaN(obj))
   ) {
     throw new Error('Invalid request id');
   }


### PR DESCRIPTION
Closes #7450

## 🎯 Changes

Bug fix. `assertIsRequestId` checked `typeof obj === 'number'` *before* `isNaN(obj)`, so the whole condition could only ever be true for `NaN`:

```ts
if (
  obj !== null &&
  typeof obj === 'number' &&   // booleans/objects/arrays/undefined stop here
  isNaN(obj) &&
  typeof obj !== 'string'      // unreachable: a number is never a string
) {
```

Anything that isn't a number short-circuits at the second clause, so `true`, `{}`, `[]` and `undefined` all passed through as valid request ids. Inverted so it throws for anything that is not a string, a non-NaN number, or `null`:

```ts
if (
  obj !== null &&
  typeof obj !== 'string' &&
  (typeof obj !== 'number' || isNaN(obj))
) {
```

### One deviation from the fix suggested in the issue

The issue proposes starting the condition with `id === null || …`, which would **reject `null`**. That would break subscriptions: `null` is a legitimate request id here.

- `envelopes.ts` declares `type RequestId = number | string | null`
- the `subscription.stop` envelope is typed `{ id: null }`
- `assertIsRequestId`'s own signature is `asserts obj is number | string | null`

So `null` is kept valid, and there's a test pinning that specifically.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made. <!-- internal guard, no docs surface -->
- [x] I have added or updated the tests related to the changes made.

## Verification

Added `parseTRPCMessage.test.ts`. Against `main` with only the test applied, it fails on exactly the types the issue describes, while everything that was already handled keeps passing:

| Case | Before | After |
| --- | --- | --- |
| `'a string'`, `1`, `0`, `-1`, `1.5` | ✅ accepted | ✅ accepted |
| `null` (`subscription.stop`) | ✅ accepted | ✅ accepted |
| `NaN` | ✅ rejected | ✅ rejected |
| `true`, `false`, `{}`, `[]`, `undefined` | ❌ **accepted** | ✅ rejected |

`5 failed | 7 passed` before the fix, `12 passed` after.

Also run locally:

- full `@trpc/server` project → **19 files, 122 tests passed**
- `websockets.test.ts`, `websockets.encoder.test.ts`, `websockets.memory.test.ts` → no change from this PR. `websockets.test.ts > keep alive on the server > no pong message should be received` fails, but it fails identically on a clean `main` checkout here (`1 failed | 42 passed` either way), so it looks like an unrelated timing flake on this machine.
- `pnpm lint` and `pnpm typecheck` in `packages/server` → clean

---

Disclosure: I used an AI assistant while investigating and preparing this change, including running the verification above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request ID validation to accept valid strings and numbers, while continuing to support `null` for subscription stop messages.
  * Rejects invalid request IDs, including booleans, objects, arrays, undefined values, and `NaN`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->