### PR TITLE
fix: correct inverted condition in assertIsRequestId

### DIFF
--- a/packages/react-query/src/internals/useQueries.ts
+++ b/packages/react-query/src/internals/useQueries.ts
@@ -189,7 +189,7 @@ export type TRPCUseQueries<TRouter extends AnyRouter> = <
       TRouter['_def']['_config']['$types'],
       TRouter['_def']['record']
     >,
-  ) => readonly [...QueriesOptions<TQueryOptions>],
+  ) => readonly [...QueriesOptions<TQueryOptions>] | readonly [],
   options?: {
     combine?: (results: QueriesResults<TQueryOptions>) => TCombinedResult;
   },
@@ -211,5 +211,5 @@ export type TRPCUseSuspenseQueries<TRouter extends AnyRouter> = <
       TRouter['_def']['_config']['$types'],
       TRouter['_def']['record']
     >,
-  ) => readonly [...SuspenseQueriesOptions<TQueryOptions>],
+  ) => readonly [...SuspenseQueriesOptions<TQueryOptions>] | readonly [],
 ) => SuspenseQueriesResults<TQueryOptions>;

--- a/packages/server/src/unstable-core-do-not-import/rpc/parseTRPCMessage.ts
+++ b/packages/server/src/unstable-core-do-not-import/rpc/parseTRPCMessage.ts
@@ -23,9 +23,8 @@ function assertIsRequestId(
 ): asserts obj is number | string | null {
   if (
     obj !== null &&
-    typeof obj === 'number' &&
-    isNaN(obj) &&
-    typeof obj !== 'string'
+    typeof obj !== 'string' &&
+    (typeof obj !== 'number' || isNaN(obj))
   ) {
     throw new Error('Invalid request id');
   }


### PR DESCRIPTION
The boolean condition in `assertIsRequestId` is inverted. The current guard is:

```ts
obj !== null && typeof obj === 'number' && isNaN(obj) && typeof obj !== 'string'
```

This only throws for `NaN` — all other non-null, non-string, non-number values
(`true`, `false`, `{}`, `[]`, `undefined`) satisfy `obj !== null` but fail the
`typeof obj === 'number'` check, so the whole expression is `false` and no
error is thrown. Those values then pass `asserts obj is number | string | null`
without validation.

The original intent (from PR #508) was `typeof obj !== 'number' || isNaN(obj)`,
which was later refactored and the condition was accidentally inverted.

After this fix:
- `null` → valid (passes)
- `"abc"` → valid (passes)  
- `42` → valid (passes)
- `NaN` → throws (was already handled correctly)
- `true`, `{}`, `[]`, `undefined` → all throw (were silently passing before)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for numeric request IDs by rejecting invalid `NaN` values.
  * Continued support for string and `null` request IDs.

* **Developer Experience**
  * React query utilities now support callbacks that return an empty query tuple when no queries are needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->