### PR TITLE
docs: mention disabling React Query default retry when using retryLink

### DIFF
--- a/www/docs/client/links/retryLink.md
+++ b/www/docs/client/links/retryLink.md
@@ -25,6 +25,7 @@ const queryClient = new QueryClient({
   },
 });
 ```
+
 :::
 
 ## Usage

--- a/www/docs/client/links/retryLink.md
+++ b/www/docs/client/links/retryLink.md
@@ -11,6 +11,22 @@ slug: /client/links/retryLink
 If you use `@trpc/react-query` you will generally **not** need this link as it's built into the `useQuery()` and the `useMutation()` hooks from `@tanstack/react-query`.
 :::
 
+:::note
+If you use `retryLink` alongside `@trpc/react-query`, you should disable React Query's default retry behavior on your `QueryClient` to avoid duplicate retries:
+
+```ts
+import { QueryClient } from '@tanstack/react-query';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+```
+:::
+
 ## Usage
 
 You can import and add the `retryLink` to the `links` array when creating your tRPC client. This link can be placed before or after other links in your setup, depending on your requirements.


### PR DESCRIPTION
Closes #6189\n\nAdds a note to the retryLink guide explaining that users should set `QueryClient` `defaultOptions.retry` to `false` when using `retryLink` alongside `@trpc/react-query` to avoid duplicate retries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance about potential duplicate retries when using `retryLink` with React Query.
  * Documented how to disable React Query’s default retry behavior through `QueryClient` configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->