### PR TITLE
fix(server): preserve `this` when chaining to a pre-existing dispose method

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/stream/utils/disposable.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/utils/disposable.test.ts
@@ -1,0 +1,72 @@
+import { makeAsyncResource, makeResource } from './disposable';
+
+test('makeAsyncResource preserves `this` when chaining to a pre-existing Symbol.asyncDispose', async () => {
+  // Simulates a value that already implements AsyncDisposable via a method
+  // that relies on `this` (as native AsyncGenerator/AsyncIterator objects do
+  // under the Explicit Resource Management proposal, supported natively by
+  // Bun and Node 24+).
+  let disposedWith: unknown;
+  const thing = {
+    // eslint-disable-next-line no-restricted-syntax
+    [Symbol.asyncDispose]: async function () {
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      disposedWith = this;
+    },
+  };
+
+  const calls: string[] = [];
+  const wrapped = makeAsyncResource(thing, async () => {
+    calls.push('outer');
+  });
+
+  // eslint-disable-next-line no-restricted-syntax
+  await wrapped[Symbol.asyncDispose]();
+
+  expect(calls).toEqual(['outer']);
+  expect(disposedWith).toBe(thing);
+});
+
+test('makeResource preserves `this` when chaining to a pre-existing Symbol.dispose', () => {
+  let disposedWith: unknown;
+  const thing = {
+    // eslint-disable-next-line no-restricted-syntax
+    [Symbol.dispose]: function () {
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      disposedWith = this;
+    },
+  };
+
+  const calls: string[] = [];
+  const wrapped = makeResource(thing, () => {
+    calls.push('outer');
+  });
+
+  // eslint-disable-next-line no-restricted-syntax
+  wrapped[Symbol.dispose]();
+
+  expect(calls).toEqual(['outer']);
+  expect(disposedWith).toBe(thing);
+});
+
+test('makeAsyncResource disposal does not throw for an async generator with a native Symbol.asyncDispose', async () => {
+  const finallyRan = { value: false };
+
+  async function* gen() {
+    try {
+      yield 1;
+    } finally {
+      finallyRan.value = true;
+    }
+  }
+
+  const generator = gen();
+  await generator.next();
+
+  const wrapped = makeAsyncResource(generator, async () => {
+    // outer cleanup, e.g. aborting an AbortController
+  });
+
+  // eslint-disable-next-line no-restricted-syntax
+  await expect(wrapped[Symbol.asyncDispose]()).resolves.toBeUndefined();
+  expect(finallyRan.value).toBe(true);
+});

--- a/packages/server/src/unstable-core-do-not-import/stream/utils/disposable.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/utils/disposable.ts
@@ -22,7 +22,7 @@ export function makeResource<T>(thing: T, dispose: () => void): T & Disposable {
   // eslint-disable-next-line no-restricted-syntax
   it[Symbol.dispose] = () => {
     dispose();
-    existing?.();
+    existing?.call(it);
   };
 
   return it as T & Disposable;
@@ -47,7 +47,7 @@ export function makeAsyncResource<T>(
   // eslint-disable-next-line no-restricted-syntax
   it[Symbol.asyncDispose] = async () => {
     await dispose();
-    await existing?.();
+    await existing?.call(it);
   };
 
   return it as T & AsyncDisposable;


### PR DESCRIPTION
## Problem

`makeResource`/`makeAsyncResource` in `disposable.ts` capture a pre-existing native `Symbol.dispose`/`Symbol.asyncDispose` method off the wrapped object and later invoke it **detached** from its receiver:

```ts
const existing = it[Symbol.asyncDispose];
it[Symbol.asyncDispose] = async () => {
  await dispose();
  await existing?.();
};
```

On runtimes that natively implement the TC39 Explicit Resource Management proposal on generators/async generators — Bun (JSC) and Node 24+/25 (V8) — the native `Symbol.asyncDispose`/`Symbol.dispose` method relies on `this` internally. Calling it detached throws:

- Bun: `TypeError: undefined is not an object` at `[Symbol.asyncDispose] (native:1:11)`
- Node 24+/25: `TypeError: Cannot read properties of undefined (reading 'return')`

This surfaces in practice whenever a tRPC subscription implemented as an async generator (e.g. one built with `for await` over `events.on(emitter, key, { signal })`) is torn down — for example on client disconnect/logout — since the subscription handler's async generator already has a native `Symbol.asyncDispose`, and `makeAsyncResource` wraps it to also abort the underlying stream.

Confirmed via `npm pack @trpc/server@11.18.0` that this is still present in the latest published version.

## Fix

Call the existing method bound to `it` instead of detached:

```ts
await existing?.call(it);
```

This preserves the original receiver so the native implementation can use `this` as it expects, while still chaining to the outer `dispose()` cleanup.

## Testing

Added `disposable.test.ts` with 3 regression tests:
- `makeAsyncResource` preserves `this` when chaining to a pre-existing `Symbol.asyncDispose`
- `makeResource` preserves `this` when chaining to a pre-existing `Symbol.dispose`
- `makeAsyncResource` disposal does not throw for a real async generator with a native `Symbol.asyncDispose`, and its `finally` block still runs

Verified the tests fail (reproducing the exact reported error) with the fix reverted, and pass with it applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of synchronous and asynchronous resources by preserving the resource context during disposal.
  * Ensured asynchronous generator cleanup completes reliably without errors.
* **Tests**
  * Added coverage for disposal chaining and generator cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->