### PR TITLE
docs: fix broken source links in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,13 +74,13 @@ This package contains the core and server-side functionality. If something is sh
 
 #### Building a Router
 
-This is where tRPC has the most interaction with users, so it should be treated with a great deal of importance. We care about offering a simple, intuitive API in which the HTTP layer disappears for the user. Here the user's entrypoint is [`initTRPC`](packages/server/src/core/initTRPC.ts) where root configuration such as a [data transformer](https://trpc.io/docs/data-transformers) is set and factory functions for router, procedure, middleware, etc. creation are returned.
+This is where tRPC has the most interaction with users, so it should be treated with a great deal of importance. We care about offering a simple, intuitive API in which the HTTP layer disappears for the user. Here the user's entrypoint is [`initTRPC`](packages/server/src/unstable-core-do-not-import/initTRPC.ts) where root configuration such as a [data transformer](https://trpc.io/docs/data-transformers) is set and factory functions for router, procedure, middleware, etc. creation are returned.
 
 The most complex types are also in this area because we must keep track of the context, meta, middleware, and each procedure and its inputs and outputs. If you are ever struggling to understand a type, feel free to ask for help on [Discord](https://trpc.io/discord).
 
 #### Handling a Request and Forming a Response
 
-The core implementation for HTTP handling is contained in [`resolveResponse`](packages/server/src/http/resolveHTTPResponse.ts) where [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request)s are handled and a [`Response`-object](https://developer.mozilla.org/en-US/docs/Web/API/Response) is created. This function deals with handling different methods (`query` and `mutation` have different specs), batching, streaming, etc. so it is an excellent place to get an overview of the complete process of handling a request and forming a response. If you want to learn more about the specification that we implement, read [this docs page](https://trpc.io/docs/rpc).
+The core implementation for HTTP handling is contained in [`resolveResponse`](packages/server/src/unstable-core-do-not-import/http/resolveResponse.ts) where [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request)s are handled and a [`Response`-object](https://developer.mozilla.org/en-US/docs/Web/API/Response) is created. This function deals with handling different methods (`query` and `mutation` have different specs), batching, streaming, etc. so it is an excellent place to get an overview of the complete process of handling a request and forming a response. If you want to learn more about the specification that we implement, read [this docs page](https://trpc.io/docs/rpc).
 
 #### Adapting Requests and Responses
 


### PR DESCRIPTION
The Contributing guide links two source files by paths that no longer exist, so both links currently 404 on GitHub.

- `initTRPC` points to `packages/server/src/core/initTRPC.ts`. The `src/core/` directory has since been consolidated and the file now lives at `packages/server/src/unstable-core-do-not-import/initTRPC.ts`.
- `resolveResponse` points to `packages/server/src/http/resolveHTTPResponse.ts`. That path no longer exists; the function's file is now `packages/server/src/unstable-core-do-not-import/http/resolveResponse.ts` (the link text already reads `resolveResponse`).

Repointed both links to their current locations. Documentation only, no prose changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the contributor guide’s project overview to reflect relocated source files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->