### PR TITLE
docs: fix tRPC handler path in websockets example readme

### DIFF
--- a/examples/next-prisma-websockets-starter/README.md
+++ b/examples/next-prisma-websockets-starter/README.md
@@ -39,7 +39,7 @@ pnpm dx
       <td>Prisma schema</td>
     </tr>
     <tr>
-      <td><a href="./src/api/trpc/[trpc].tsx"><code>./src/api/trpc/[trpc].tsx</code></a></td>
+      <td><a href="./src/pages/api/trpc/[trpc].ts"><code>./src/pages/api/trpc/[trpc].ts</code></a></td>
       <td>tRPC response handler</td>
     </tr>
     <tr>


### PR DESCRIPTION
The "What's inside" table in this example's README links the tRPC response handler as `./src/api/trpc/[trpc].tsx`, but no such file exists. The handler is a Next.js Pages Router API route, so it lives under `src/pages/api/` and is a `.ts` file, not `.tsx`.

The actual path is `./src/pages/api/trpc/[trpc].ts`. Updated both the link target and the displayed code text so the entry resolves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the documented tRPC response-handler path in the Next.js Prisma WebSockets starter guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->