### PR TITLE
fix(server): reject line breaks and null chars in tracked() SSE ids

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/stream/sse.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/sse.test.ts
@@ -344,3 +344,28 @@ test('sse()', () => {
     extras: {},
   });
 });
+
+describe('tracked() id validation', () => {
+  test('rejects empty string', () => {
+    expect(() => tracked('', 1)).toThrow('empty string');
+  });
+
+  test('rejects ids that would break the SSE wire format', () => {
+    // The id is written verbatim as `id: <value>\n`, so a newline/carriage
+    // return/null character could inject additional SSE lines into the stream.
+    expect(() => tracked('123\nevent: message', 1)).toThrow(
+      'Server-Sent Events',
+    );
+    expect(() => tracked('123\r\ndata: injected', 1)).toThrow(
+      'Server-Sent Events',
+    );
+    expect(() => tracked('123\rfoo', 1)).toThrow('Server-Sent Events');
+    expect(() => tracked('123\0foo', 1)).toThrow('Server-Sent Events');
+  });
+
+  test('allows ordinary ids', () => {
+    expect(isTrackedEnvelope(tracked('valid-id_123', 1))).toBe(true);
+    // spaces are valid inside an SSE field value
+    expect(isTrackedEnvelope(tracked('with space', 1))).toBe(true);
+  });
+});

--- a/packages/server/src/unstable-core-do-not-import/stream/tracked.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/tracked.ts
@@ -42,6 +42,15 @@ export function tracked<TData>(
       '`id` must not be an empty string as empty string is the same as not setting the id at all',
     );
   }
+  if (/[\n\r\0]/.test(id)) {
+    // The id is written verbatim into the SSE wire format (`id: <value>\n`).
+    // A line break (LF/CR) would terminate the field early and let the
+    // remainder be parsed as additional SSE lines, and U+0000 is disallowed
+    // for the id field by the SSE spec, so reject them up front.
+    throw new Error(
+      '`id` must not contain line breaks or null characters as they are not allowed in Server-Sent Events',
+    );
+  }
   return [id as TrackedId, data, trackedSymbol];
 }
 

--- a/packages/server/src/unstable-core-do-not-import/stream/tracked.ts
+++ b/packages/server/src/unstable-core-do-not-import/stream/tracked.ts
@@ -47,6 +47,10 @@ export function tracked<TData>(
     // A line break (LF/CR) would terminate the field early and let the
     // remainder be parsed as additional SSE lines, and U+0000 is disallowed
     // for the id field by the SSE spec, so reject them up front.
+    // Deliberate scope: only LF/CR/NUL are rejected because they are the
+    // characters that break the wire format or are spec-disallowed for the id
+    // field. Other control characters cannot inject new SSE lines, so they are
+    // passed through rather than silently altering user-provided ids.
     throw new Error(
       '`id` must not contain line breaks or null characters as they are not allowed in Server-Sent Events',
     );


### PR DESCRIPTION
## Summary

`tracked(id, data)` writes the `id` **verbatim** into the Server-Sent Events wire format as `id: <value>\n`. Unlike the `data` field (which is `JSON.stringify`-escaped) and `event` (a fixed enum), the `id` field is emitted unescaped:

https://github.com/trpc/trpc/blob/main/packages/server/src/unstable-core-do-not-import/stream/sse.ts#L189

```ts
if ('id' in chunk) {
  controller.enqueue(`id: ${chunk.id}\n`);
}
```

If an `id` contains a line break (`\n`/`\r`), the SSE field terminates early and the remainder of the value is parsed by the client's `EventSource` as **additional SSE lines** - allowing injection of extra `event:` / `data:` lines into the stream. `U+0000` is likewise disallowed for the `id` field by the [SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation).

This is reachable whenever an application derives a tracked id from a value it does not fully control (a cursor, external/message id, user-supplied string, etc.) - a common pattern for resumable subscriptions.

### Reproduction

```ts
// app code: yield tracked(untrustedId, { ok: true })
const untrustedId = '123\nevent: message\ndata: {"stolen":true}';
```

Wire output (one event becomes two):

```
data: {"ok":true}
id: 123
event: message
data: {"stolen":true}

```

## Fix

Validate the `id` at the `tracked()` boundary, right next to the existing empty-string guard, rejecting `\n`, `\r`, and `\0`. This fails fast with a clear error instead of silently corrupting the stream, and needs no changes to the wire serializer. Spaces remain allowed (valid inside an SSE field value).

## Tests

Added regression tests in `sse.test.ts` covering newline/CR/null rejection and that ordinary ids (including ids with spaces) still work. Full stream test suite passes (28/28).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for tracked event IDs.
  * IDs containing newlines, carriage returns, null characters, or no content are now rejected to prevent invalid event data.
  * IDs containing spaces and other ordinary characters continue to work as expected.
  * This helps ensure tracked events use valid Server-Sent Events field values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->