### PR TITLE
feat(client): add `iterate()` method to subscriptions

### DIFF
--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import type { Unsubscribable } from '@trpc/server/observable';
 import type {
   AnyProcedure,
@@ -161,7 +160,10 @@ export function createTRPCClientProxy<TRouter extends AnyRouter>(
 ): TRPCClient<TRouter> {
   const proxy = createRecursiveProxy<TRPCClient<TRouter>>(({ path, args }) => {
     const pathCopy = [...path];
-    const clientCallType = pathCopy.pop()!;
+    const clientCallType = pathCopy.pop();
+    if (!clientCallType) {
+      throw new Error('Missing client call type');
+    }
 
     const fullPath = pathCopy.join('.');
 

--- a/packages/client/src/createTRPCClient.ts
+++ b/packages/client/src/createTRPCClient.ts
@@ -3,6 +3,7 @@ import type { Unsubscribable } from '@trpc/server/observable';
 import type {
   AnyProcedure,
   AnyRouter,
+  inferAsyncIterableYield,
   inferClientTypes,
   inferProcedureInput,
   InferrableClientTypes,
@@ -75,6 +76,12 @@ export type SubscriptionResolver<TDef extends TRPCResolverDef> = (
     TRPCProcedureOptions,
 ) => Unsubscribable;
 
+/** @internal */
+export type SubscriptionIterableResolver<TDef extends TRPCResolverDef> = (
+  input: TDef['input'],
+  opts?: TRPCProcedureOptions,
+) => AsyncIterable<inferAsyncIterableYield<TDef['output']>>;
+
 type DecorateProcedure<
   TType extends ProcedureType,
   TDef extends TRPCResolverDef,
@@ -89,6 +96,16 @@ type DecorateProcedure<
     : TType extends 'subscription'
       ? {
           subscribe: SubscriptionResolver<TDef>;
+          /**
+           * Get an `AsyncIterable` that yields the data of this subscription.
+           *
+           * The iterable is cold: every new iterator starts a new
+           * subscription, which is torn down when iteration stops early
+           * (e.g. `break`/`return`). Aborting `opts.signal` ends the
+           * iteration - values that are already buffered are still yielded
+           * before it finishes.
+           */
+          iterate: SubscriptionIterableResolver<TDef>;
         }
       : never;
 
@@ -126,6 +143,7 @@ const clientCallTypeMap: Record<
   query: 'query',
   mutate: 'mutation',
   subscribe: 'subscription',
+  iterate: 'subscription',
 };
 
 /** @internal */
@@ -143,9 +161,15 @@ export function createTRPCClientProxy<TRouter extends AnyRouter>(
 ): TRPCClient<TRouter> {
   const proxy = createRecursiveProxy<TRPCClient<TRouter>>(({ path, args }) => {
     const pathCopy = [...path];
-    const procedureType = clientCallTypeToProcedureType(pathCopy.pop()!);
+    const clientCallType = pathCopy.pop()!;
 
     const fullPath = pathCopy.join('.');
+
+    if (clientCallType === 'iterate') {
+      return (client.subscriptionAsIterable as any)(fullPath, ...(args as any));
+    }
+
+    const procedureType = clientCallTypeToProcedureType(clientCallType);
 
     return (client[procedureType] as any)(fullPath, ...(args as any));
   });

--- a/packages/client/src/internals/TRPCUntypedClient.ts
+++ b/packages/client/src/internals/TRPCUntypedClient.ts
@@ -2,7 +2,12 @@ import type {
   inferObservableValue,
   Unsubscribable,
 } from '@trpc/server/observable';
-import { observableToPromise, share } from '@trpc/server/observable';
+import {
+  observable,
+  observableToAsyncIterable,
+  observableToPromise,
+  share,
+} from '@trpc/server/observable';
 import type {
   AnyRouter,
   inferAsyncIterableYield,
@@ -158,5 +163,56 @@ export class TRPCUntypedClient<TInferrable extends InferrableClientTypes> {
         opts.onComplete?.();
       },
     });
+  }
+  public subscriptionAsIterable(
+    path: string,
+    input: unknown,
+    opts?: TRPCRequestOptions,
+  ): AsyncIterable<unknown> {
+    return {
+      [Symbol.asyncIterator]: () => {
+        const signal =
+          opts?.signal ??
+          // teardown is driven by the consumer stopping iteration, so a
+          // never-aborted signal is fine when none is provided
+          new AbortController().signal;
+
+        const observable$ = this.$request({
+          type: 'subscription',
+          path,
+          input,
+          context: opts?.context,
+          signal,
+        });
+        const iterable$ = observable<unknown, unknown>((observer) => {
+          return observable$.subscribe({
+            next(envelope) {
+              switch (envelope.result.type) {
+                case 'state':
+                case 'started':
+                case 'stopped': {
+                  // ignore connection state envelopes
+                  break;
+                }
+                case 'data':
+                case undefined: {
+                  observer.next?.(envelope.result.data);
+                  break;
+                }
+              }
+            },
+            error(err) {
+              observer.error?.(err);
+            },
+            complete() {
+              observer.complete?.();
+            },
+          });
+        });
+        return observableToAsyncIterable(iterable$, signal)[
+          Symbol.asyncIterator
+        ]();
+      },
+    };
   }
 }

--- a/packages/server/src/observable/observable.test.ts
+++ b/packages/server/src/observable/observable.test.ts
@@ -288,9 +288,9 @@ test('observableToAsyncIterable() - aborting the signal ends iteration', async (
   expect(ee.listenerCount('data')).toBe(0);
 });
 
-test('observableToAsyncIterable() - abort listener is removed once settled', async () => {
+test('observableToAsyncIterable() - synchronous settlement does not attach an abort listener', async () => {
   const ac = new AbortController();
-  const removeEventListenerSpy = vi.spyOn(ac.signal, 'removeEventListener');
+  const addEventListenerSpy = vi.spyOn(ac.signal, 'addEventListener');
 
   const obs = observable<number, Error>((observer) => {
     observer.next(1);
@@ -303,7 +303,10 @@ test('observableToAsyncIterable() - abort listener is removed once settled', asy
   }
 
   expect(aggregate).toEqual([1]);
-  expect(removeEventListenerSpy).toHaveBeenCalled();
+  expect(addEventListenerSpy).not.toHaveBeenCalled();
+
+  ac.abort();
+  expect(ac.signal.aborted).toBe(true);
 });
 
 test('observableToAsyncIterable() - pre-aborted signal does not subscribe', async () => {

--- a/packages/server/src/observable/observable.test.ts
+++ b/packages/server/src/observable/observable.test.ts
@@ -288,6 +288,25 @@ test('observableToAsyncIterable() - aborting the signal ends iteration', async (
   expect(ee.listenerCount('data')).toBe(0);
 });
 
+test('observableToAsyncIterable() - abort ignores source emissions during teardown', async () => {
+  const ac = new AbortController();
+  const obs = observable<number, Error>((observer) => {
+    observer.next(1);
+    return () => {
+      observer.next(2);
+      observer.error(new Error('teardown error'));
+    };
+  });
+
+  const aggregate: unknown[] = [];
+  for await (const value of observableToAsyncIterable(obs, ac.signal)) {
+    aggregate.push(value);
+    ac.abort();
+  }
+
+  expect(aggregate).toEqual([1]);
+});
+
 test('observableToAsyncIterable() - synchronous settlement does not attach an abort listener', async () => {
   const ac = new AbortController();
   const addEventListenerSpy = vi.spyOn(ac.signal, 'addEventListener');

--- a/packages/server/src/observable/observable.test.ts
+++ b/packages/server/src/observable/observable.test.ts
@@ -195,3 +195,132 @@ test('observableToAsyncIterable() - doesnt hang', async () => {
 
   expect(ee.listenerCount('data')).toBe(0);
 });
+
+test('observableToAsyncIterable() - source emits during teardown', async () => {
+  const ee = new EventEmitter();
+  const obs = observable<number, Error>((observer) => {
+    const onData = (data: number) => {
+      observer.next(data);
+    };
+    ee.on('data', onData);
+    return () => {
+      ee.off('data', onData);
+      // some sources emit a final `complete` when they are torn down,
+      // this should not throw after the stream has been cancelled
+      observer.complete();
+    };
+  });
+
+  setTimeout(() => {
+    ee.emit('data', 1);
+  }, 1);
+
+  const aggregate: unknown[] = [];
+  for await (const value of observableToAsyncIterable(
+    obs,
+    new AbortController().signal,
+  )) {
+    aggregate.push(value);
+    break;
+  }
+
+  expect(aggregate).toEqual([1]);
+  expect(ee.listenerCount('data')).toBe(0);
+});
+
+test('observableToAsyncIterable() - source errors during teardown', async () => {
+  const ee = new EventEmitter();
+  const obs = observable<number, Error>((observer) => {
+    const onData = (data: number) => {
+      observer.next(data);
+    };
+    ee.on('data', onData);
+    return () => {
+      ee.off('data', onData);
+      // some sources emit a final `error` when they are torn down,
+      // this should not throw after the stream has been cancelled
+      observer.error(new Error('teardown error'));
+    };
+  });
+
+  setTimeout(() => {
+    ee.emit('data', 1);
+  }, 1);
+
+  const aggregate: unknown[] = [];
+  for await (const value of observableToAsyncIterable(
+    obs,
+    new AbortController().signal,
+  )) {
+    aggregate.push(value);
+    break;
+  }
+
+  expect(aggregate).toEqual([1]);
+  expect(ee.listenerCount('data')).toBe(0);
+});
+
+test('observableToAsyncIterable() - aborting the signal ends iteration', async () => {
+  const ee = new EventEmitter();
+  const obs = observable<number, Error>((observer) => {
+    const onData = (data: number) => {
+      observer.next(data);
+    };
+    ee.on('data', onData);
+    return () => {
+      ee.off('data', onData);
+      // note: this source does not emit anything more once torn down
+    };
+  });
+
+  const ac = new AbortController();
+  setTimeout(() => {
+    ee.emit('data', 1);
+    ac.abort();
+  }, 1);
+
+  const aggregate: unknown[] = [];
+  for await (const value of observableToAsyncIterable(obs, ac.signal)) {
+    aggregate.push(value);
+  }
+
+  expect(aggregate).toEqual([1]);
+  expect(ee.listenerCount('data')).toBe(0);
+});
+
+test('observableToAsyncIterable() - abort listener is removed once settled', async () => {
+  const ac = new AbortController();
+  const removeEventListenerSpy = vi.spyOn(ac.signal, 'removeEventListener');
+
+  const obs = observable<number, Error>((observer) => {
+    observer.next(1);
+    observer.complete();
+  });
+
+  const aggregate: unknown[] = [];
+  for await (const value of observableToAsyncIterable(obs, ac.signal)) {
+    aggregate.push(value);
+  }
+
+  expect(aggregate).toEqual([1]);
+  expect(removeEventListenerSpy).toHaveBeenCalled();
+});
+
+test('observableToAsyncIterable() - pre-aborted signal does not subscribe', async () => {
+  const subscribe = vi.fn();
+  const obs = observable<number, Error>(() => {
+    subscribe();
+    return () => {
+      // noop
+    };
+  });
+
+  const ac = new AbortController();
+  ac.abort();
+
+  for await (const value of observableToAsyncIterable(obs, ac.signal)) {
+    void value;
+  }
+
+  expect(subscribe).not.toHaveBeenCalled();
+});

--- a/packages/server/src/observable/observable.test.ts
+++ b/packages/server/src/observable/observable.test.ts
@@ -324,3 +324,52 @@ test('observableToAsyncIterable() - pre-aborted signal does not subscribe', asyn
 
   expect(subscribe).not.toHaveBeenCalled();
 });
+
+test('observableToAsyncIterable() - break unsubscribes without an abort signal', async () => {
+  const teardown = vi.fn();
+  const obs = observable<number, Error>((observer) => {
+    observer.next(1);
+    return teardown;
+  });
+
+  // a signal that is never aborted, mirroring the
+  // `new AbortController().signal` fallback in `subscriptionAsIterable` -
+  // teardown must be driven by the consumer stopping iteration
+  const neverAbortedSignal = new AbortController().signal;
+
+  const aggregate: unknown[] = [];
+  for await (const value of observableToAsyncIterable(
+    obs,
+    neverAbortedSignal,
+  )) {
+    aggregate.push(value);
+    break;
+  }
+
+  expect(aggregate).toEqual([1]);
+  expect(teardown).toHaveBeenCalledTimes(1);
+});
+
+test('observableToAsyncIterable() - consumer cancel detaches the abort listener', async () => {
+  const ac = new AbortController();
+  const removeEventListenerSpy = vi.spyOn(ac.signal, 'removeEventListener');
+
+  const teardown = vi.fn();
+  const obs = observable<number, Error>((observer) => {
+    observer.next(1);
+    return teardown;
+  });
+
+  const aggregate: unknown[] = [];
+  for await (const value of observableToAsyncIterable(obs, ac.signal)) {
+    aggregate.push(value);
+    break;
+  }
+
+  expect(aggregate).toEqual([1]);
+  // the consumer cancelled iteration without aborting the signal, yet the
+  // abort listener is detached and the subscription is torn down
+  expect(removeEventListenerSpy).toHaveBeenCalled();
+  expect(teardown).toHaveBeenCalledTimes(1);
+  expect(ac.signal.aborted).toBe(false);
+});

--- a/packages/server/src/observable/observable.ts
+++ b/packages/server/src/observable/observable.ts
@@ -196,6 +196,8 @@ function observableToReadableStream<TValue>(
       }
     },
     cancel() {
+      // set `active` first so `onAbort` doesn't close an already-cancelled
+      // stream; `onAbort` also detaches the abort listener
       active = false;
       onAbort();
     },

--- a/packages/server/src/observable/observable.ts
+++ b/packages/server/src/observable/observable.ts
@@ -191,7 +191,7 @@ function observableToReadableStream<TValue>(
 
       if (signal.aborted) {
         onAbort();
-      } else {
+      } else if (active) {
         signal.addEventListener('abort', onAbort, { once: true });
       }
     },

--- a/packages/server/src/observable/observable.ts
+++ b/packages/server/src/observable/observable.ts
@@ -136,14 +136,14 @@ function observableToReadableStream<TValue>(
 
   const onAbort = () => {
     signal.removeEventListener('abort', onAbort);
-    unsub?.unsubscribe();
-    unsub = null;
     if (active) {
       active = false;
-      // the source might not emit anything more once it has been torn down,
-      // so we close the stream to avoid leaving a pending reader hanging
+      // close before teardown so synchronous teardown emissions are ignored
+      // and a pending reader cannot be left hanging
       controllerRef?.close();
     }
+    unsub?.unsubscribe();
+    unsub = null;
   };
 
   /** Detach the abort listener once the stream has settled */

--- a/packages/server/src/observable/observable.ts
+++ b/packages/server/src/observable/observable.ts
@@ -130,24 +130,61 @@ function observableToReadableStream<TValue>(
   signal: AbortSignal,
 ): ReadableStream<Result<TValue>> {
   let unsub: Unsubscribable | null = null;
+  let active = true;
+  let controllerRef: ReadableStreamDefaultController<Result<TValue>> | null =
+    null;
 
   const onAbort = () => {
+    signal.removeEventListener('abort', onAbort);
     unsub?.unsubscribe();
     unsub = null;
+    if (active) {
+      active = false;
+      // the source might not emit anything more once it has been torn down,
+      // so we close the stream to avoid leaving a pending reader hanging
+      controllerRef?.close();
+    }
+  };
+
+  /** Detach the abort listener once the stream has settled */
+  const onSettled = () => {
+    active = false;
     signal.removeEventListener('abort', onAbort);
   };
 
   return new ReadableStream<Result<TValue>>({
     start(controller) {
+      controllerRef = controller;
+
+      if (signal.aborted) {
+        // no point in subscribing if the signal is already aborted
+        onAbort();
+        return;
+      }
+
       unsub = observable.subscribe({
         next(data) {
+          if (!active) {
+            return;
+          }
           controller.enqueue({ ok: true, value: data });
         },
         error(error) {
+          if (!active) {
+            // the source emitted after the stream was settled - this can
+            // happen during teardown, in which case we drop it
+            return;
+          }
+          onSettled();
           controller.enqueue({ ok: false, error });
           controller.close();
         },
         complete() {
+          if (!active) {
+            // see comment in `error` above
+            return;
+          }
+          onSettled();
           controller.close();
         },
       });
@@ -159,6 +196,7 @@ function observableToReadableStream<TValue>(
       }
     },
     cancel() {
+      active = false;
       onAbort();
     },
   });

--- a/packages/tests/server/httpSubscriptionLink.test.ts
+++ b/packages/tests/server/httpSubscriptionLink.test.ts
@@ -204,6 +204,184 @@ test('iterable event', async () => {
   });
 });
 
+test('async iterable', async () => {
+  const { client } = ctx;
+
+  const iterable = client.sub.iterableEvent.iterate(undefined);
+
+  const results: number[] = [];
+  const done = (async () => {
+    for await (const value of iterable) {
+      expectTypeOf(value).toEqualTypeOf<number>();
+      results.push(value);
+    }
+  })();
+
+  // the subscription only starts once iteration begins
+  await vi.waitFor(() => {
+    expect(ctx.ee.listenerCount('data')).toBe(1);
+  });
+
+  ctx.ee.emit('data', 1);
+  ctx.ee.emit('data', 2);
+  ctx.ee.emit('data', returnSymbol);
+
+  await done;
+  expect(results).toEqual([1, 2]);
+
+  await vi.waitFor(() => {
+    expect(ctx.ee.listenerCount('data')).toBe(0);
+  });
+
+  expect(ctx.onErrorSpy).not.toHaveBeenCalled();
+});
+
+test('async iterable - abort signal', async () => {
+  const { client } = ctx;
+
+  const ac = new AbortController();
+  const iterable = client.sub.iterableEvent.iterate(undefined, {
+    signal: ac.signal,
+  });
+
+  const results: number[] = [];
+  const done = (async () => {
+    for await (const value of iterable) {
+      results.push(value);
+    }
+  })();
+
+  await vi.waitFor(() => {
+    expect(ctx.ee.listenerCount('data')).toBe(1);
+  });
+
+  ctx.ee.emit('data', 1);
+
+  await vi.waitFor(() => {
+    expect(results).toEqual([1]);
+  });
+
+  ac.abort();
+
+  // aborting ends the iteration instead of leaving it hanging
+  await done;
+
+  await vi.waitFor(() => {
+    expect(ctx.ee.listenerCount('data')).toBe(0);
+  });
+});
+
+test('async iterable - reconnects and continues', async () => {
+  const { client } = ctx;
+
+  const iterable = client.sub.iterableInfinite.iterate({});
+
+  const results: number[] = [];
+  const release = suppressLogs();
+  const done = (async () => {
+    for await (const value of iterable) {
+      results.push(value.data);
+      if (results.length === 3) {
+        // sever the connection mid-iteration
+        ctx.destroyConnections();
+      }
+      if (results.length >= 10) {
+        break;
+      }
+    }
+  })();
+
+  // iteration survives the reconnect since connection state envelopes
+  // are not exposed to the async iterable
+  await done;
+  release();
+
+  // initial subscription + one reconnect
+  expect(ctx.onIterableInfiniteSpy).toHaveBeenCalledTimes(2);
+  expect(
+    results.every(
+      (value, index) => index === 0 || value >= results[index - 1]!,
+    ),
+  ).toBe(true);
+  // values continue after the reconnect, replaying the last received id
+  expect(results.at(-1)).toBeGreaterThanOrEqual(8);
+});
+
+test('async iterable - pre-aborted signal does not start a subscription', async () => {
+  const { client } = ctx;
+
+  const ac = new AbortController();
+  ac.abort();
+
+  const iterable = client.sub.iterableInfinite.iterate(
+    {},
+    { signal: ac.signal },
+  );
+
+  for await (const value of iterable) {
+    void value;
+  }
+
+  // give the subscription a chance to start if it were going to
+  await sleep(100);
+  expect(ctx.onIterableInfiniteSpy).not.toHaveBeenCalled();
+});
+
+test('async iterable - each iterator starts a new subscription', async () => {
+  const { client } = ctx;
+
+  const iterable = client.sub.iterableEvent.iterate(undefined);
+
+  const iterateOnce = async () => {
+    const results: number[] = [];
+    const done = (async () => {
+      for await (const value of iterable) {
+        results.push(value);
+      }
+    })();
+
+    await vi.waitFor(() => {
+      expect(ctx.ee.listenerCount('data')).toBeGreaterThanOrEqual(1);
+    });
+
+    ctx.ee.emit('data', 1);
+    ctx.ee.emit('data', returnSymbol);
+
+    await done;
+    return results;
+  };
+
+  expect(await iterateOnce()).toEqual([1]);
+  expect(await iterateOnce()).toEqual([1]);
+});
+
+test('async iterable - stop iterating early', async () => {
+  const { client } = ctx;
+
+  const iterable = client.sub.iterableInfinite.iterate({
+    lastEventId: 5,
+  });
+
+  const results: number[] = [];
+  for await (const value of iterable) {
+    expectTypeOf(value).toEqualTypeOf<{
+      data: number;
+      id: string;
+    }>();
+    results.push(value.data);
+    if (results.length >= 3) {
+      break;
+    }
+  }
+  expect(results).toEqual([5, 6, 7]);
+
+  await vi.waitFor(() => {
+    expect(ctx.onReqAborted).toHaveBeenCalledTimes(1);
+  });
+
+  expect(ctx.onErrorSpy).not.toHaveBeenCalled();
+});
+
 test(
   'iterable event with error',
   {

--- a/packages/tests/server/websockets.test.ts
+++ b/packages/tests/server/websockets.test.ts
@@ -426,6 +426,101 @@ test('basic subscription test (iterator)', async () => {
   });
 });
 
+test('iterate() - basic subscription', async () => {
+  await using ctx = factory();
+  ctx.ee.once('subscription:created', () => {
+    setTimeout(() => {
+      ctx.ee.emit('server:msg', {
+        id: '1',
+      });
+      ctx.ee.emit('server:msg', {
+        id: '2',
+      });
+    });
+  });
+
+  const aggregate: Message[] = [];
+  for await (const value of ctx.client.onMessageIterable.iterate(undefined)) {
+    expectTypeOf(value).not.toBeAny();
+    expectTypeOf(value).toMatchTypeOf<Message>();
+    aggregate.push(value);
+    if (aggregate.length === 2) {
+      break;
+    }
+  }
+
+  expect(aggregate).toEqual([{ id: '1' }, { id: '2' }]);
+
+  await vi.waitFor(() => {
+    expect(ctx.ee.listenerCount('server:msg')).toBe(0);
+  });
+});
+
+test('iterate() - propagates errors', async () => {
+  await using ctx = factory();
+  ctx.ee.once('subscription:created', () => {
+    setTimeout(() => {
+      ctx.ee.emit('server:msg', {
+        id: '1',
+      });
+      ctx.ee.emit('observable:error', new Error('MyError'));
+    });
+  });
+
+  const aggregate: Message[] = [];
+  await expect(async () => {
+    for await (const value of ctx.client.onMessageObservable.iterate(
+      undefined,
+    )) {
+      expectTypeOf(value).not.toBeAny();
+      expectTypeOf(value).toMatchTypeOf<Message>();
+      aggregate.push(value);
+    }
+  }).rejects.toThrowError('MyError');
+
+  expect(aggregate).toEqual([{ id: '1' }]);
+
+  // the subscription is torn down after the error without needing `cancel`
+  await vi.waitFor(() => {
+    expect(ctx.ee.listenerCount('server:msg')).toBe(0);
+  });
+});
+
+test('iterate() - abort signal ends iteration', async () => {
+  await using ctx = factory();
+
+  const ac = new AbortController();
+  const aggregate: Message[] = [];
+  const done = (async () => {
+    for await (const value of ctx.client.onMessageIterable.iterate(undefined, {
+      signal: ac.signal,
+    })) {
+      aggregate.push(value);
+    }
+  })();
+
+  await vi.waitFor(() => {
+    expect(ctx.ee.listenerCount('server:msg')).toBe(1);
+  });
+
+  ctx.ee.emit('server:msg', {
+    id: '1',
+  });
+
+  await vi.waitFor(() => {
+    expect(aggregate).toEqual([{ id: '1' }]);
+  });
+
+  ac.abort();
+
+  // aborting ends the iteration instead of leaving it hanging
+  await done;
+
+  await vi.waitFor(() => {
+    expect(ctx.ee.listenerCount('server:msg')).toBe(0);
+  });
+});
+
 test('$subscription() - client resumes subscriptions after reconnecting', async () => {
   await using ctx = factory();
   ctx.ee.once('subscription:created', () => {

--- a/www/docs/client/vanilla/setup.mdx
+++ b/www/docs/client/vanilla/setup.mdx
@@ -94,4 +94,42 @@ const frodo = await client.createUser.mutate({ name: 'Frodo' });
 // => { id: 'id_frodo', name: 'Frodo' };
 ```
 
+### 5. Use subscriptions
+
+Given a [subscription procedure](../../server/subscriptions.md), you can subscribe with callbacks, or consume the subscription as an `AsyncIterable` - both require a link that supports subscriptions, e.g. [`wsLink`](../links/wsLink.md) or [`httpSubscriptionLink`](../links/httpSubscriptionLink.md):
+
+```ts twoslash title='client.ts'
+// @target: esnext
+// @filename: server.ts
+import { initTRPC } from '@trpc/server';
+const t = initTRPC.create();
+const appRouter = t.router({
+  onUserAdd: t.procedure.subscription(async function* () {
+    yield { name: 'Frodo' };
+  }),
+});
+export type AppRouter = typeof appRouter;
+
+// @filename: client.ts
+import { createTRPCClient, httpSubscriptionLink } from '@trpc/client';
+import type { AppRouter } from './server';
+const client = createTRPCClient<AppRouter>({
+  links: [httpSubscriptionLink({ url: 'http://localhost:3000/trpc' })],
+});
+// ---cut---
+// subscribe with callbacks:
+const sub = client.onUserAdd.subscribe(undefined, {
+  onData(user) {
+    console.log(user);
+  },
+});
+// stop listening:
+sub.unsubscribe();
+
+// or, as an AsyncIterable - the subscription ends once you stop iterating:
+for await (const user of client.onUserAdd.iterate(undefined)) {
+  console.log(user);
+}
+```
+
 You're all set!


### PR DESCRIPTION
Closes #6868

## What changed

Subscription procedures on the vanilla client can now be consumed as an `AsyncIterable`:

```ts
for await (const data of client.onPostAdd.iterate()) {
  // ...
}
```

`iterate(input, opts?)` uses the existing `observableToAsyncIterable` helper. It filters connection-state envelopes, yields subscription data with the same output typing as `onData`, and propagates link errors unchanged. The iterable is cold, so each iterator owns one subscription and tears it down on `break`, `return`, or abort.

The shared stream helper now also closes its lifecycle gaps: late emissions after cancellation are ignored, signal abort settles the stream before teardown, listeners are detached after settlement and never attached after synchronous settlement, and an already-aborted signal does not start a request.

The vanilla client docs show both callback subscriptions and `iterate()`.

## Verification

- Added 6 HTTP subscription tests, 3 WebSocket tests, and 6 observable lifecycle tests.
- The required GitHub Actions matrix is green on the final code, including build, typecheck, lint, unit/integration tests, and the E2E fanout.
- Local Node 24 checks: root lint and package typechecks pass; the observable suite passes 14/14; the three added WebSocket `iterate()` cases pass; Prettier and `git diff --check` are clean.

## Notes

- Slow consumers still buffer values; this is existing stream-helper behavior.
- Errors are intentionally not wrapped again because links already return `TRPCClientError`, matching `subscribe`.
- No changeset was added because this repository uses lerna and has no `.changeset` setup.

## Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.

Best Regards, Tarik
