### PR TITLE
fix(tanstack-react-query): subscriptionOptions(skipToken).enabled incorrectly returns true

### DIFF
--- a/packages/tanstack-react-query/src/internals/createOptionsProxy.ts
+++ b/packages/tanstack-react-query/src/internals/createOptionsProxy.ts
@@ -485,6 +485,7 @@ export function createTRPCOptionsProxy<
         return trpcSubscriptionOptions({
           opts: arg2,
           path,
+          input: arg1,
           queryKey: getQueryKeyInternal({
             path,
             input: arg1,

--- a/packages/tanstack-react-query/src/internals/subscriptionOptions.ts
+++ b/packages/tanstack-react-query/src/internals/subscriptionOptions.ts
@@ -12,7 +12,7 @@ import type {
   TRPCQueryKey,
   TRPCQueryOptionsResult,
 } from './types';
-import { createTRPCOptionsResult, readQueryKey } from './utils';
+import { createTRPCOptionsResult } from './utils';
 
 interface BaseTRPCSubscriptionOptionsIn<TOutput, TError> {
   enabled?: boolean;
@@ -135,16 +135,24 @@ export const trpcSubscriptionOptions = <
   subscribe: typeof TRPCUntypedClient.prototype.subscription;
   path: string[];
   queryKey: TRPCQueryKey<TFeatureFlags['keyPrefix']>;
+  /**
+   * The raw input before queryKey serialization. Required to correctly detect
+   * `skipToken` because `getQueryKeyInternal` strips it from the queryKey args.
+   */
+  input: unknown;
   opts?: AnyTRPCSubscriptionOptionsIn;
 }): AnyTRPCSubscriptionOptionsOut<TFeatureFlags> => {
-  const { subscribe, path, queryKey, opts = {} } = args;
-  const input = readQueryKey(queryKey)?.args?.input;
+  const { subscribe, path, queryKey, input, opts = {} } = args;
   const enabled = 'enabled' in opts ? !!opts.enabled : input !== skipToken;
 
   const _subscribe: ReturnType<
     TRPCSubscriptionOptions<any, TFeatureFlags>
   >['subscribe'] = (innerOpts) => {
-    return subscribe(path.join('.'), input ?? undefined, innerOpts);
+    return subscribe(
+      path.join('.'),
+      input === skipToken ? undefined : (input as any),
+      innerOpts,
+    );
   };
 
   return {

--- a/packages/tanstack-react-query/test/skipToken.test.tsx
+++ b/packages/tanstack-react-query/test/skipToken.test.tsx
@@ -32,6 +32,12 @@ const testContext = () => {
         )
         .query(() => ['__result'] as const),
     }),
+    events: t.procedure
+      .input(z.number())
+      .subscription(async function* () {
+        // stub — never called in these tests
+        yield 0 as never;
+      }),
   });
 
   return {
@@ -57,6 +63,38 @@ describe('skipToken', () => {
         },
       });
       expect(options2.queryFn).toBe(skipToken);
+
+      return <pre>OK</pre>;
+    }
+
+    const utils = ctx.renderApp(<MyComponent />);
+    await vi.waitFor(() => {
+      expect(utils.container).toHaveTextContent(`OK`);
+    });
+  });
+
+  test('subscriptionOptions(skipToken).enabled is false; normal input is enabled', async () => {
+    // Regression test for https://github.com/trpc/trpc/issues/7373.
+    // getQueryKeyInternal strips skipToken from the serialized queryKey args,
+    // so reading `enabled` back from the queryKey was returning undefined (→ true).
+    // The fix passes the raw `input` directly to trpcSubscriptionOptions instead.
+    await using ctx = testContext();
+
+    const { useTRPC } = ctx;
+    function MyComponent() {
+      const trpc = useTRPC();
+
+      // skipToken case: must disable the subscription.
+      const skipped = trpc.events.subscriptionOptions(skipToken, {});
+      expect(skipped.enabled).toBe(false);
+
+      // normal input case: must remain enabled (no explicit `enabled` override).
+      const active = trpc.events.subscriptionOptions(42, {});
+      expect(active.enabled).toBe(true);
+
+      // explicit `enabled: false` override must still be respected.
+      const forcedOff = trpc.events.subscriptionOptions(42, { enabled: false });
+      expect(forcedOff.enabled).toBe(false);
 
       return <pre>OK</pre>;
     }

--- a/packages/tanstack-react-query/test/skipToken.test.tsx
+++ b/packages/tanstack-react-query/test/skipToken.test.tsx
@@ -32,12 +32,10 @@ const testContext = () => {
         )
         .query(() => ['__result'] as const),
     }),
-    events: t.procedure
-      .input(z.number())
-      .subscription(async function* () {
-        // stub — never called in these tests
-        yield 0 as never;
-      }),
+    events: t.procedure.input(z.number()).subscription(async function* () {
+      // stub — never called in these tests
+      yield 0 as never;
+    }),
   });
 
   return {


### PR DESCRIPTION
## Root cause

`getQueryKeyInternal` intentionally strips `skipToken` from the query key args (line 168 of `utils.ts`):

```ts
...(typeof input !== 'undefined' &&
  input !== skipToken && { input: input }),
```

This means when `trpcSubscriptionOptions` tries to recover the original input from the queryKey:

```ts
const input = readQueryKey(queryKey)?.args?.input;
const enabled = 'enabled' in opts ? !!opts.enabled : input !== skipToken;
```

…it gets `undefined` back (not `skipToken`). So `undefined !== skipToken` evaluates to `true`, making `enabled: true` even though `skipToken` was the caller's intent.

## Fix

Thread the raw `input` argument into `trpcSubscriptionOptions` alongside the `queryKey`. This lets the `enabled` check compare against the original value before queryKey serialization strips it. Also updated the internal `_subscribe` call to pass `undefined` rather than `skipToken` when the input is a skip token.

## Before

```ts
trpc.foo.bar.subscriptionOptions(skipToken).enabled // true ❌
```

## After

```ts
trpc.foo.bar.subscriptionOptions(skipToken).enabled // false ✅
```

Fixes #7373

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription handling to use the provided input consistently.
  * Preserved correct behavior when subscriptions are skipped, including proper handling of `skipToken`.
  * Ensured explicitly disabled subscriptions remain disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->