### PR TITLE
fix(docs): fix 19 dead links in llms.txt — use permalink, absolute URLs, and H1 title

### DIFF
--- a/www/docusaurus.config.ts
+++ b/www/docusaurus.config.ts
@@ -398,8 +398,20 @@ export default {
                 return true;
               })
               .map((docItem) => {
-                let link = `${versionSpec.routePath}/${docItem.id}`;
-                link = link.replace(new RegExp('([^:])//', 'g'), '$1/');
+                // Prefer the doc's own permalink (which honours custom `slug`
+                // frontmatter) over the file-path-based id. Fall back to
+                // constructing from the id only when permalink is unavailable.
+                const docPath: string =
+                  (docItem.permalink as string | undefined) ??
+                  `${versionSpec.routePath}/${docItem.id}`;
+                // Make the URL absolute so llms.txt consumers don't need to
+                // know the site's base URL.
+                const link = docPath.startsWith('http')
+                  ? docPath
+                  : `${siteConfig.url}${docPath}`.replace(
+                      new RegExp('([^:])//', 'g'),
+                      '$1/',
+                    );
                 return `- [${docItem.title}](${link}): ${docItem.description ?? 'No description available'}`;
               });
 
@@ -473,7 +485,8 @@ export default {
                 otherVersionsLinksContent += '\n';
               }
 
-              const tocFileContent = `${tocTitle}\n\n${otherVersionsLinksContent}## Documentation Pages\n\n${tocRecords.join('\n')}`;
+              // llms.txt spec requires an H1 as the very first line.
+              const tocFileContent = `# ${tocTitle}\n\n${otherVersionsLinksContent}## Documentation Pages\n\n${tocRecords.join('\n')}`;
               const tocFilePath = path.join(outDir, tocOutputFilename);
               try {
                 fs.writeFileSync(tocFilePath, tocFileContent);


### PR DESCRIPTION
Fixes #7462.

Three issues in the `pluginLlmsTxt` plugin inside `www/docusaurus.config.ts` caused 19 of 89 links in `llms.txt` to 404.

---

### 1. Wrong path source (`docItem.id` vs `docItem.permalink`)

The plugin was constructing links from the file-path-based `docItem.id`:

```ts
// before
let link = `${versionSpec.routePath}/${docItem.id}`;
```

Several docs use custom `slug` frontmatter that changes their URL. For example:

| File | slug frontmatter | Generated (wrong) | Actual URL |
|---|---|---|---|
| `main/quickstart.mdx` | `/quickstart` | `/docs/main/quickstart` | `/docs/quickstart` |
| `further/faq.mdx` | `/faq` | `/docs/further/faq` | `/docs/faq` |
| `client/overview.md` | `/client` | `/docs/client/overview` | `/docs/client` |
| `client/nextjs/app-router/server-actions.mdx` | `/client/nextjs/server-actions` | `/docs/client/nextjs/app-router/server-actions` | `/docs/client/nextjs/server-actions` |

The fix: use `docItem.permalink` (which Docusaurus populates with the resolved route, respecting slug overrides), falling back to the constructed path only when unavailable.

### 2. Relative URLs

The generated links were relative (`/docs/quickstart`). The llms.txt spec and AI agent consumers expect absolute URLs so the file is self-contained. The fix prepends `siteConfig.url`.

### 3. Missing H1 title

The llms.txt spec requires the first line to be an H1. The plugin was writing the title as plain text. The fix adds a `#` prefix.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved generated documentation table-of-contents links for more reliable navigation.
  * Updated TOC files to include a top-level heading, improving compatibility with `llms.txt` readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->