### PR TITLE
docs(www): add Sury to validator library integrations

### DIFF
--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -29,7 +29,7 @@
     "srvx": "0.12.5",
     "superstruct": "^2.0.0",
     "supertest": "^7.0.0",
-    "sury": "11.0.0-rc.1",
+    "sury": "11.0.0",
     "tsx": "^4.19.3",
     "tupleson": "0.23.1",
     "typescript": "^5.9.2",

--- a/packages/tests/package.json
+++ b/packages/tests/package.json
@@ -29,6 +29,7 @@
     "srvx": "0.12.5",
     "superstruct": "^2.0.0",
     "supertest": "^7.0.0",
+    "sury": "11.0.0-rc.1",
     "tsx": "^4.19.3",
     "tupleson": "0.23.1",
     "typescript": "^5.9.2",

--- a/packages/tests/server/outputParser.test.ts
+++ b/packages/tests/server/outputParser.test.ts
@@ -2,6 +2,7 @@ import { testServerAndClientResource } from '@trpc/client/__tests__/testClientRe
 import { initTRPC } from '@trpc/server';
 import myzod from 'myzod';
 import * as t from 'superstruct';
+import * as S from 'sury';
 import * as v from 'valibot';
 import * as yup from 'yup';
 import { z } from 'zod';
@@ -288,6 +289,32 @@ test('myzod', async () => {
           input: myzod.string(),
         }),
       )
+      .query(({ input }) => {
+        return { input: input as string };
+      }),
+  });
+
+  await using ctx = testServerAndClientResource(router);
+
+  const output = await ctx.client.q.query('foobar');
+  expectTypeOf(output.input).toBeString();
+  expect(output).toMatchInlineSnapshot(`
+    Object {
+      "input": "foobar",
+    }
+  `);
+
+  await expect(ctx.client.q.query(1234)).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: Output validation failed]`,
+  );
+});
+
+test('sury', async () => {
+  const trpc = initTRPC.create();
+  const router = trpc.router({
+    q: trpc.procedure
+      .input(S.union([S.string, S.number]))
+      .output(S.schema({ input: S.string }))
       .query(({ input }) => {
         return { input: input as string };
       }),

--- a/packages/tests/server/outputParser.test.ts
+++ b/packages/tests/server/outputParser.test.ts
@@ -335,6 +335,65 @@ test('sury', async () => {
   );
 });
 
+test('sury async', async () => {
+  const trpc = initTRPC.create();
+  const router = trpc.router({
+    q: trpc.procedure
+      .input(S.union([S.string, S.number]))
+      .output(
+        S.schema({
+          input: S.string.with(S.to, S.string, {
+            decode: { async: async (value) => value },
+            encode: 'auto',
+          }),
+        }),
+      )
+      .query(({ input }) => {
+        return { input: input as string };
+      }),
+  });
+
+  await using ctx = testServerAndClientResource(router);
+
+  const output = await ctx.client.q.query('foobar');
+  expectTypeOf(output.input).toBeString();
+  expect(output).toMatchInlineSnapshot(`
+    Object {
+      "input": "foobar",
+    }
+  `);
+
+  await expect(ctx.client.q.query(1234)).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: Output validation failed]`,
+  );
+});
+
+test('sury transform', async () => {
+  const trpc = initTRPC.create();
+  const router = trpc.router({
+    q: trpc.procedure
+      .input(S.union([S.string, S.number]))
+      .output(S.schema({ input: S.string.with(S.to, S.number) }))
+      .query(({ input }) => {
+        return { input: input as string };
+      }),
+  });
+
+  await using ctx = testServerAndClientResource(router);
+
+  const output = await ctx.client.q.query('1234');
+  expectTypeOf(output.input).toBeNumber();
+  expect(output).toMatchInlineSnapshot(`
+    Object {
+      "input": 1234,
+    }
+  `);
+
+  await expect(ctx.client.q.query(1234)).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: Output validation failed]`,
+  );
+});
+
 test('validator fn', async () => {
   const trpc = initTRPC.create();
   const router = trpc.router({

--- a/packages/tests/server/validators.test.ts
+++ b/packages/tests/server/validators.test.ts
@@ -15,6 +15,7 @@ import myzod from 'myzod';
 import * as T from 'runtypes';
 import * as $ from 'scale-codec';
 import * as st from 'superstruct';
+import * as S from 'sury';
 import * as v from 'valibot';
 import * as yup from 'yup';
 import { z as zod3 } from 'zod/v3';
@@ -554,6 +555,106 @@ test('runtypes', async () => {
   await expect(ctx.client.num.query('13')).rejects.toMatchInlineSnapshot(`
     [TRPCClientError: Expected { text: string; }, but was string]
   `);
+});
+
+test('sury', async () => {
+  const t = initTRPC.create();
+
+  const router = t.router({
+    num: t.procedure.input(S.schema({ text: S.string })).query((opts) => {
+      const { input } = opts;
+      expectTypeOf(input).toEqualTypeOf<{ text: string }>();
+      return {
+        input,
+      };
+    }),
+  });
+
+  await using ctx = testServerAndClientResource(router);
+  const res = await ctx.client.num.query({ text: '123' });
+  expect(res.input).toMatchObject({ text: '123' });
+
+  await expect(
+    // @ts-expect-error this only accepts {text: string}
+    ctx.client.num.query({ text: 123 }),
+  ).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: Expected string, received 123]`,
+  );
+});
+
+test('sury error type', async () => {
+  const t = initTRPC.create();
+
+  const router = t.router({
+    num: t.procedure.input(S.schema({ text: S.string })).query((opts) => {
+      const { input } = opts;
+      expectTypeOf(input).toEqualTypeOf<{ text: string }>();
+      return {
+        input,
+      };
+    }),
+  });
+
+  const caller = router.createCaller({});
+  const err = await waitError(
+    caller.num(
+      // @ts-expect-error this only accepts {text: string}
+      { text: 123 },
+    ),
+    TRPCError,
+  );
+  expect(err).toMatchInlineSnapshot(
+    `[TRPCError: Expected string, received 123]`,
+  );
+
+  assert(err.cause instanceof StandardSchemaV1Error);
+  expect(err.cause.issues).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "message": "Expected string, received 123",
+        "path": Array [
+          "text",
+        ],
+      },
+    ]
+  `);
+});
+
+test('sury transform mixed input/output', async () => {
+  const t = initTRPC.create();
+  // Sury derives the `string` -> `number` coercion from the pipeline, so the
+  // client sends a string and the resolver receives a number.
+  const input = S.schema({ length: S.string.with(S.to, S.number) });
+
+  const router = t.router({
+    num: t.procedure.input(input).query((opts) => {
+      const { input } = opts;
+      expectTypeOf(input.length).toBeNumber();
+      return {
+        input,
+      };
+    }),
+  });
+
+  await using ctx = testServerAndClientResource(router);
+
+  await expect(ctx.client.num.query({ length: '123' })).resolves
+    .toMatchInlineSnapshot(`
+    Object {
+      "input": Object {
+        "length": 123,
+      },
+    }
+  `);
+
+  await expect(
+    ctx.client.num.query({
+      // @ts-expect-error this should only accept a string
+      length: 123,
+    }),
+  ).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: Expected string, received 123]`,
+  );
 });
 
 test('validator fn', async () => {

--- a/packages/tests/server/validators.test.ts
+++ b/packages/tests/server/validators.test.ts
@@ -620,6 +620,43 @@ test('sury error type', async () => {
   `);
 });
 
+test('sury async', async () => {
+  const t = initTRPC.create();
+  const input = S.string.with(S.to, S.string, {
+    decode: {
+      async: async (value) => {
+        if (value !== 'foo') {
+          throw new Error(`Invalid input: Received "${value}"`);
+        }
+        return value;
+      },
+    },
+    encode: 'auto',
+  });
+
+  const router = t.router({
+    q: t.procedure.input(input).query((opts) => {
+      const { input } = opts;
+      expectTypeOf(input).toBeString();
+      return {
+        input,
+      };
+    }),
+  });
+
+  await using ctx = testServerAndClientResource(router);
+
+  await expect(ctx.client.q.query('bar')).rejects.toMatchInlineSnapshot(
+    `[TRPCClientError: Invalid input: Received "bar"]`,
+  );
+  const res = await ctx.client.q.query('foo');
+  expect(res).toMatchInlineSnapshot(`
+    Object {
+      "input": "foo",
+    }
+  `);
+});
+
 test('sury transform mixed input/output', async () => {
   const t = initTRPC.create();
   // Sury derives the `string` -> `number` coercion from the pipeline, so the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2270,6 +2270,9 @@ importers:
       supertest:
         specifier: ^7.0.0
         version: 7.0.0
+      sury:
+        specifier: 11.0.0-rc.1
+        version: 11.0.0-rc.1
       tsx:
         specifier: ^4.19.3
         version: 4.19.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2569,6 +2569,9 @@ importers:
       superstruct:
         specifier: ^2.0.0
         version: 2.0.0
+      sury:
+        specifier: 11.0.0-rc.1
+        version: 11.0.0-rc.1
       tailwindcss:
         specifier: ^3.4.6
         version: 3.4.6
@@ -18006,6 +18009,14 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  sury@11.0.0-rc.1:
+    resolution: {integrity: sha512-UzxKHMmL2iNdKmbckYDYgaQOnv1l6I+r6orv03P29oAEC9CpzljkpYeIcJ/oAoBc63VSFaCnmoL6gfuhPDTimA==}
+    peerDependencies:
+      rescript: 12.x
+    peerDependenciesMeta:
+      rescript:
+        optional: true
 
   svg-parser@2.0.4:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
@@ -39738,6 +39749,8 @@ snapshots:
   supports-color@9.4.0: {}
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  sury@11.0.0-rc.1: {}
 
   svg-parser@2.0.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2271,8 +2271,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
       sury:
-        specifier: 11.0.0-rc.1
-        version: 11.0.0-rc.1
+        specifier: 11.0.0
+        version: 11.0.0
       tsx:
         specifier: ^4.19.3
         version: 4.19.3
@@ -2573,8 +2573,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0
       sury:
-        specifier: 11.0.0-rc.1
-        version: 11.0.0-rc.1
+        specifier: 11.0.0
+        version: 11.0.0
       tailwindcss:
         specifier: ^3.4.6
         version: 3.4.6
@@ -18013,8 +18013,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  sury@11.0.0-rc.1:
-    resolution: {integrity: sha512-UzxKHMmL2iNdKmbckYDYgaQOnv1l6I+r6orv03P29oAEC9CpzljkpYeIcJ/oAoBc63VSFaCnmoL6gfuhPDTimA==}
+  sury@11.0.0:
+    resolution: {integrity: sha512-ixo9P04kr1VB15m+9OX1llkGYityBl5z79XBZqU4hIUjixbdoaoK92wO25DsPqVH8UjyB1rbotf8Gqj0K/uRwA==}
     peerDependencies:
       rescript: 12.x
     peerDependenciesMeta:
@@ -39753,7 +39753,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  sury@11.0.0-rc.1: {}
+  sury@11.0.0: {}
 
   svg-parser@2.0.4: {}
 

--- a/www/docs/server/validators.md
+++ b/www/docs/server/validators.md
@@ -415,6 +415,31 @@ export const appRouter = t.router({
 export type AppRouter = typeof appRouter;
 ```
 
+### With [Sury](https://github.com/DZakh/sury)
+
+```ts twoslash
+import { initTRPC } from '@trpc/server';
+import * as S from 'sury';
+
+export const t = initTRPC.create();
+
+const publicProcedure = t.procedure;
+
+export const appRouter = t.router({
+  hello: publicProcedure
+    .input(S.schema({ name: S.string }))
+    .output(S.schema({ greeting: S.string }))
+    .query(({ input }) => {
+      //      ^?
+      return {
+        greeting: `hello ${input.name}`,
+      };
+    }),
+});
+
+export type AppRouter = typeof appRouter;
+```
+
 ### With [@robolex/sure](https://github.com/robolex-app/public_ts)
 
 You're able to define your own Error types and error throwing function if necessary.

--- a/www/package.json
+++ b/www/package.json
@@ -112,6 +112,7 @@
     "runtypes": "^7.0.0",
     "scale-codec": "^0.13.0",
     "superstruct": "^2.0.0",
+    "sury": "11.0.0-rc.1",
     "tailwindcss": "^3.4.6",
     "tailwindcss-elevation": "^2.0.0",
     "tsx": "^4.19.3",

--- a/www/package.json
+++ b/www/package.json
@@ -112,7 +112,7 @@
     "runtypes": "^7.0.0",
     "scale-codec": "^0.13.0",
     "superstruct": "^2.0.0",
-    "sury": "11.0.0-rc.1",
+    "sury": "11.0.0",
     "tailwindcss": "^3.4.6",
     "tailwindcss-elevation": "^2.0.0",
     "tsx": "^4.19.3",


### PR DESCRIPTION
Sury implements Standard Schema, so it works with `.input()`/`.output()` out of the box.
https://github.com/DZakh/sury

As I understand it, trpc doesn't use it yet, but Sury also supports Standard JSON Schema.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added an example showing how to integrate Sury validation with tRPC procedures.
  - Demonstrates validating procedure inputs and outputs with Sury schemas and string validators.

- **Tests**
  - Added coverage for Sury input and output validation, including invalid values and validation errors.
  - Verified asynchronous validation and transformations between string and number values.
  - Confirmed successful and rejected requests behave as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->