### PR TITLE
feat(react-query): add mutation onError override

### DIFF
--- a/packages/react-query/src/shared/hooks/createHooksInternal.tsx
+++ b/packages/react-query/src/shared/hooks/createHooksInternal.tsx
@@ -88,6 +88,10 @@ export function createRootHooks<
     config?.overrides?.useMutation?.onSuccess ??
     ((options) => options.originalFn());
 
+  const mutationErrorOverride: UseMutationOverride['onError'] =
+    config?.overrides?.useMutation?.onError ??
+    ((options) => options.originalFn());
+
   type TError = TRPCClientErrorLike<TRouter>;
 
   type ProviderContext = TRPCContextState<TRouter, TSSRContext>;
@@ -341,6 +345,18 @@ export function createRootHooks<
             opts?.onSuccess?.(...args) ?? defaultOpts?.onSuccess?.(...args);
 
           return mutationSuccessOverride({
+            originalFn,
+            queryClient,
+            meta: opts?.meta ?? defaultOpts?.meta ?? {},
+          });
+        },
+        onError(...args) {
+          const originalFn = () => {
+            const fn = opts?.onError ?? defaultOpts?.onError;
+            return fn?.(...args);
+          };
+
+          return mutationErrorOverride({
             originalFn,
             queryClient,
             meta: opts?.meta ?? defaultOpts?.meta ?? {},

--- a/packages/react-query/src/shared/types.ts
+++ b/packages/react-query/src/shared/types.ts
@@ -244,6 +244,17 @@ export interface UseMutationOverride {
      */
     meta: Record<string, unknown>;
   }) => MaybePromise<void>;
+  onError: (opts: {
+    /**
+     * Calls the original function that was defined in the query's `onError` option
+     */
+    originalFn: () => MaybePromise<void>;
+    queryClient: QueryClient;
+    /**
+     * Meta data passed in from the `useMutation()` hook
+     */
+    meta: Record<string, unknown>;
+  }) => MaybePromise<void>;
 }
 
 /**

--- a/packages/react-query/test/overrides.test.tsx
+++ b/packages/react-query/test/overrides.test.tsx
@@ -18,6 +18,8 @@ describe('mutation override', () => {
         title: string;
       }
       const onSuccessSpy = vi.fn();
+      const onErrorSpy = vi.fn();
+      const defaultOnErrorSpy = vi.fn();
 
       const posts: Post[] = [];
 
@@ -27,6 +29,9 @@ describe('mutation override', () => {
           posts.push({
             title: input,
           });
+        }),
+        fail: t.procedure.input(z.string()).mutation(({ input }) => {
+          throw new Error(input);
         }),
       });
       const opts = testServerAndClientResource(appRouter);
@@ -40,11 +45,21 @@ describe('mutation override', () => {
               }
               onSuccessSpy(opts);
             },
+            async onError(opts) {
+              await opts.originalFn();
+              onErrorSpy(opts);
+            },
           },
         },
       });
 
-      const queryClient = new QueryClient();
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          mutations: {
+            onError: defaultOnErrorSpy,
+          },
+        },
+      });
 
       function App(props: { children: ReactNode }) {
         return (
@@ -62,6 +77,8 @@ describe('mutation override', () => {
         App,
         trpc,
         onSuccessSpy,
+        onErrorSpy,
+        defaultOnErrorSpy,
       };
     })
     .afterEach(async (opts) => {
@@ -151,5 +168,118 @@ describe('mutation override', () => {
     await vi.waitFor(() => {
       expect($.container).not.toHaveTextContent(nonce);
     });
+  });
+
+  test('local onError runs before the tRPC onError override', async () => {
+    const { trpc } = ctx;
+    const localOnErrorSpy = vi.fn();
+
+    function MyComp() {
+      const mutation = trpc.fail.useMutation({
+        onError: (error) => {
+          localOnErrorSpy(error);
+        },
+      });
+
+      return (
+        <button
+          onClick={() => {
+            mutation.mutate('boom');
+          }}
+          data-testid="fail"
+        >
+          fail
+        </button>
+      );
+    }
+
+    const $ = render(
+      <ctx.App>
+        <MyComp />
+      </ctx.App>,
+    );
+
+    await userEvent.click($.getByTestId('fail'));
+
+    await vi.waitFor(() => {
+      expect(ctx.onErrorSpy).toHaveBeenCalledTimes(1);
+    });
+
+    expect(localOnErrorSpy).toHaveBeenCalledTimes(1);
+    expect(localOnErrorSpy).toHaveBeenCalledBefore(ctx.onErrorSpy);
+  });
+
+  test('local onError takes precedence over QueryClient default onError', async () => {
+    const { trpc } = ctx;
+    const localOnErrorSpy = vi.fn();
+
+    function MyComp() {
+      const mutation = trpc.fail.useMutation({
+        onError: (error) => {
+          localOnErrorSpy(error);
+        },
+      });
+
+      return (
+        <button
+          onClick={() => {
+            mutation.mutate('boom');
+          }}
+          data-testid="fail"
+        >
+          fail
+        </button>
+      );
+    }
+
+    const $ = render(
+      <ctx.App>
+        <MyComp />
+      </ctx.App>,
+    );
+
+    await userEvent.click($.getByTestId('fail'));
+
+    await vi.waitFor(() => {
+      expect(ctx.onErrorSpy).toHaveBeenCalledTimes(1);
+    });
+
+    expect(localOnErrorSpy).toHaveBeenCalledTimes(1);
+    expect(ctx.defaultOnErrorSpy).not.toHaveBeenCalled();
+    expect(localOnErrorSpy).toHaveBeenCalledBefore(ctx.onErrorSpy);
+  });
+
+  test('QueryClient default onError runs when no local onError is provided', async () => {
+    const { trpc } = ctx;
+
+    function MyComp() {
+      const mutation = trpc.fail.useMutation();
+
+      return (
+        <button
+          onClick={() => {
+            mutation.mutate('boom');
+          }}
+          data-testid="fail"
+        >
+          fail
+        </button>
+      );
+    }
+
+    const $ = render(
+      <ctx.App>
+        <MyComp />
+      </ctx.App>,
+    );
+
+    await userEvent.click($.getByTestId('fail'));
+
+    await vi.waitFor(() => {
+      expect(ctx.onErrorSpy).toHaveBeenCalledTimes(1);
+    });
+
+    expect(ctx.defaultOnErrorSpy).toHaveBeenCalledTimes(1);
+    expect(ctx.defaultOnErrorSpy).toHaveBeenCalledBefore(ctx.onErrorSpy);
   });
 });


### PR DESCRIPTION
Fixes #4924

## Summary
Adds tRPC-level mutation onError override support. The override receives originalFn, queryClient, and meta. The selected original callback (hook-level onError if provided, otherwise the QueryClient default mutation onError) runs before the tRPC override onError. A hook-level callback takes precedence over the QueryClient default callback.

## Root cause
The public override type and createRootHooks wiring only supported onSuccess. A callback-return-value fallback would also be incorrect because normal onError callbacks return void, so callback selection must happen before invocation.

## Tests
- `npx vitest run packages/react-query/test/overrides.test.tsx --project @trpc/react-query --maxWorkers=1 --no-file-parallelism`
- `npm exec --offline -- tsc --noEmit --preserveWatchOutput --pretty`
- `npm exec --offline -- eslint --no-cache src`
- `npm exec --offline -- prettier --check packages/react-query/src/shared/types.ts packages/react-query/src/shared/hooks/createHooksInternal.tsx packages/react-query/test/overrides.test.tsx`

AI assistance: this change was produced with AI assistance and submitted by an automated contribution workflow. The workflow replayed the focused RED test against the base revision, reran the listed GREEN checks offline, and applied the recorded review gates before submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable error handling for mutations.
  * Mutation error overrides can now access the original error callback, query client, and mutation metadata.
  * Preserved existing local and query-client default error-handling behavior.

* **Bug Fixes**
  * Ensured local mutation error handlers take precedence while still allowing fallback handlers to run when no local handler exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->