### PR TITLE
fix(client): abort httpLink/httpBatchLink requests on unsubscribe

### DIFF
--- a/packages/client/src/links/httpBatchLink.ts
+++ b/packages/client/src/links/httpBatchLink.ts
@@ -3,7 +3,7 @@ import { observable } from '@trpc/server/observable';
 import { transformResult } from '@trpc/server/unstable-core-do-not-import';
 import type { BatchLoader } from '../internals/dataLoader';
 import { dataLoader } from '../internals/dataLoader';
-import { allAbortSignals } from '../internals/signals';
+import { allAbortSignals, raceAbortSignals } from '../internals/signals';
 import type { NonEmptyArray } from '../internals/types';
 import { TRPCClientError } from '../TRPCClientError';
 import type { HTTPBatchLinkOptions } from './HTTPBatchLinkOptions';
@@ -98,12 +98,18 @@ export function httpBatchLink<TRouter extends AnyRouter>(
             'Subscriptions are unsupported by `httpLink` - use `httpSubscriptionLink` or `wsLink`',
           );
         }
+        const ac = new AbortController();
         const loader = loaders[op.type];
-        const promise = loader.load(op);
+        const promise = loader.load({
+          ...op,
+          signal: raceAbortSignals(op.signal, ac.signal),
+        });
 
+        let isDone = false;
         let _res = undefined as HTTPResult | undefined;
         promise
           .then((res) => {
+            isDone = true;
             _res = res;
             const transformed = transformResult(
               res.json,
@@ -125,6 +131,7 @@ export function httpBatchLink<TRouter extends AnyRouter>(
             observer.complete();
           })
           .catch((err) => {
+            isDone = true;
             observer.error(
               TRPCClientError.from(err, {
                 meta: _res?.meta,
@@ -133,7 +140,9 @@ export function httpBatchLink<TRouter extends AnyRouter>(
           });
 
         return () => {
-          // noop
+          if (!isDone) {
+            ac.abort();
+          }
         };
       });
     };

--- a/packages/client/src/links/httpLink.ts
+++ b/packages/client/src/links/httpLink.ts
@@ -5,6 +5,7 @@ import type {
 } from '@trpc/server/unstable-core-do-not-import';
 import { transformResult } from '@trpc/server/unstable-core-do-not-import';
 import { TRPCClientError } from '../TRPCClientError';
+import { raceAbortSignals } from '../internals/signals';
 import type {
   HTTPLinkBaseOptions,
   HTTPResult,
@@ -88,12 +89,13 @@ export function httpLink<TRouter extends AnyRouter = AnyRouter>(
           );
         }
 
+        const ac = new AbortController();
         const request = universalRequester({
           ...resolvedOpts,
           type,
           path,
           input,
-          signal: op.signal,
+          signal: raceAbortSignals(op.signal, ac.signal),
           headers() {
             if (!opts.headers) {
               return {};
@@ -106,9 +108,11 @@ export function httpLink<TRouter extends AnyRouter = AnyRouter>(
             return opts.headers;
           },
         });
+        let isDone = false;
         let meta: HTTPResult['meta'] | undefined = undefined;
         request
           .then((res) => {
+            isDone = true;
             meta = res.meta;
             const transformed = transformResult(
               res.json,
@@ -130,11 +134,14 @@ export function httpLink<TRouter extends AnyRouter = AnyRouter>(
             observer.complete();
           })
           .catch((cause) => {
+            isDone = true;
             observer.error(TRPCClientError.from(cause, { meta }));
           });
 
         return () => {
-          // noop
+          if (!isDone) {
+            ac.abort();
+          }
         };
       });
     };

--- a/packages/client/src/links/httpLink.ts
+++ b/packages/client/src/links/httpLink.ts
@@ -4,8 +4,8 @@ import type {
   AnyRouter,
 } from '@trpc/server/unstable-core-do-not-import';
 import { transformResult } from '@trpc/server/unstable-core-do-not-import';
-import { TRPCClientError } from '../TRPCClientError';
 import { raceAbortSignals } from '../internals/signals';
+import { TRPCClientError } from '../TRPCClientError';
 import type {
   HTTPLinkBaseOptions,
   HTTPResult,

--- a/packages/tests/server/links.test.ts
+++ b/packages/tests/server/links.test.ts
@@ -1045,3 +1045,105 @@ test('httpBatchStreamLink - unsubscribe aborts fetch', async () => {
     vi.restoreAllMocks();
   }
 });
+
+test('httpLink - unsubscribe aborts fetch', async () => {
+  let fetchSignal: AbortSignal | undefined;
+  const fetchCalled = new Promise<void>((resolve) => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
+      fetchSignal = init?.signal ?? undefined;
+      resolve();
+      return new Response(
+        new ReadableStream({
+          start() {
+            // never enqueue or close - keeps the stream open
+          },
+        }),
+        { status: 200 },
+      );
+    });
+  });
+
+  try {
+    const links = [
+      httpLink({
+        url: 'http://localhost:9999',
+      })(mockRuntime),
+    ];
+
+    const chain = createChain({
+      links,
+      op: {
+        id: 1,
+        type: 'query',
+        path: 'hello',
+        input: null,
+        context: {},
+        signal: null,
+      },
+    });
+
+    const sub = chain.subscribe({});
+
+    await fetchCalled;
+
+    expect(fetchSignal!.aborted).toBe(false);
+
+    sub.unsubscribe();
+
+    expect(fetchSignal!.aborted).toBe(true);
+    expect(fetchSignal!.reason?.name).toBe('AbortError');
+  } finally {
+    vi.restoreAllMocks();
+  }
+});
+
+test('httpBatchLink - unsubscribe aborts fetch', async () => {
+  let fetchSignal: AbortSignal | undefined;
+  const fetchCalled = new Promise<void>((resolve) => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
+      fetchSignal = init?.signal ?? undefined;
+      resolve();
+      return new Response(
+        new ReadableStream({
+          start() {
+            // never enqueue or close - keeps the stream open
+          },
+        }),
+        { status: 200 },
+      );
+    });
+  });
+
+  try {
+    const links = [
+      httpBatchLink({
+        url: 'http://localhost:9999',
+      })(mockRuntime),
+    ];
+
+    const chain = createChain({
+      links,
+      op: {
+        id: 1,
+        type: 'query',
+        path: 'hello',
+        input: null,
+        context: {},
+        signal: null,
+      },
+    });
+
+    const sub = chain.subscribe({});
+
+    await fetchCalled;
+
+    expect(fetchSignal!.aborted).toBe(false);
+
+    sub.unsubscribe();
+
+    expect(fetchSignal!.aborted).toBe(true);
+    expect(fetchSignal!.reason?.name).toBe('AbortError');
+  } finally {
+    vi.restoreAllMocks();
+  }
+});


### PR DESCRIPTION
## What

`httpLink` and `httpBatchLink` rely entirely on the caller-supplied `op.signal` to cancel their in-flight fetch. Their observable cleanup is a `// noop`, so when a subscriber unsubscribes and the caller's `op.signal` isn't wired to that specific subscription's teardown, the underlying `fetch` outlives the subscriber — the same dangling-request/wasted-bandwidth consequence fixed for `httpBatchStreamLink` in #7389 (via #7390).

Every other link in the package (`httpSubscriptionLink`, `localLink`, and `httpBatchStreamLink` after #7390) owns its own `AbortController` and aborts it in cleanup; these two are the remaining holdouts.

## Fix

Mirror #7390's exact pattern in both links:
- `httpLink.ts`: create an `AbortController`, race its signal with `op.signal` via `raceAbortSignals`, and `ac.abort()` in cleanup unless the request already settled.
- `httpBatchLink.ts`: same, with the raced signal fed into the batch loader so the batch fetch's `allAbortSignals` sees it.

Both track an `isDone` flag so a completed/errored request is not spuriously aborted.

## Test

Two regression tests in `packages/tests/server/links.test.ts` (`httpLink - unsubscribe aborts fetch`, `httpBatchLink - unsubscribe aborts fetch`) follow the existing `httpBatchStreamLink` test: they mock `globalThis.fetch`, assert the signal is not aborted before unsubscribe, then assert it is aborted (with an `AbortError` reason) after `sub.unsubscribe()`.

TDD: both tests fail on `main` (cleanup is `// noop`, so the fetch signal never aborts) and pass after the fix.

Fixes #7468

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Canceling an in-progress HTTP request now properly aborts the underlying network operation.
  * Applies to both individual and batched requests.
  * Completed or failed requests are no longer interrupted during cleanup.

* **Tests**
  * Added coverage to verify request cancellation behavior and expected abort errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->