### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ npx @tanstack/intent@latest install
 
 ## Star History
 
-<a href="https://star-history.com/#trpc/trpc"><img src="https://api.star-history.com/svg?repos=trpc/trpc&type=Date" alt="Star History Chart" width="600" /></a>
+<a href="https://star-history.dera.page/#trpc/trpc&type=Date"><img src="https://star-history.dera.page/svg?repos=trpc/trpc&type=Date" alt="Star History Chart" width="600" /></a>
 
 ## Core Team
 


### PR DESCRIPTION
The star history chart in the README is broken. It relied on an upstream service that is no longer functional because of GitHub stargazer API restrictions, so the chart fails to render for everyone visiting the repository. This switches the chart to a working mirror that needs no API token, restoring the chart with no further maintenance. The link was also migrated to the newer hash-based URL format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History chart link and image source to the new hosting domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->