### PR TITLE
fix(client): compose AbortSignal on unsubscribe in http links

### DIFF
--- a/packages/client/src/links/httpBatchLink.ts
+++ b/packages/client/src/links/httpBatchLink.ts
@@ -3,7 +3,7 @@ import { observable } from '@trpc/server/observable';
 import { transformResult } from '@trpc/server/unstable-core-do-not-import';
 import type { BatchLoader } from '../internals/dataLoader';
 import { dataLoader } from '../internals/dataLoader';
-import { allAbortSignals } from '../internals/signals';
+import { allAbortSignals, raceAbortSignals } from '../internals/signals';
 import type { NonEmptyArray } from '../internals/types';
 import { TRPCClientError } from '../TRPCClientError';
 import type { HTTPBatchLinkOptions } from './HTTPBatchLinkOptions';
@@ -98,12 +98,18 @@ export function httpBatchLink<TRouter extends AnyRouter>(
             'Subscriptions are unsupported by `httpLink` - use `httpSubscriptionLink` or `wsLink`',
           );
         }
+        const ac = new AbortController();
         const loader = loaders[op.type];
-        const promise = loader.load(op);
+        const promise = loader.load({
+          ...op,
+          signal: raceAbortSignals(op.signal, ac.signal),
+        });
 
+        let isDone = false;
         let _res = undefined as HTTPResult | undefined;
         promise
           .then((res) => {
+            isDone = true;
             _res = res;
             const transformed = transformResult(
               res.json,
@@ -125,6 +131,7 @@ export function httpBatchLink<TRouter extends AnyRouter>(
             observer.complete();
           })
           .catch((err) => {
+            isDone = true;
             observer.error(
               TRPCClientError.from(err, {
                 meta: _res?.meta,
@@ -133,7 +140,9 @@ export function httpBatchLink<TRouter extends AnyRouter>(
           });
 
         return () => {
-          // noop
+          if (!isDone) {
+            ac.abort();
+          }
         };
       });
     };

--- a/packages/client/src/links/httpLink.test.ts
+++ b/packages/client/src/links/httpLink.test.ts
@@ -17,7 +17,7 @@ describe('HTTP link cancellation', () => {
   test('aborts an in-flight httpLink request when unsubscribed', async () => {
     const fetchMock = vi.fn(
       (_url: RequestInfo | URL, _init?: RequestInit) =>
-        new Promise<never>(() => {}),
+        new Promise<never>(() => undefined),
     );
     const link = httpLink<AnyRouter>({
       url: 'https://example.com',
@@ -45,7 +45,7 @@ describe('HTTP link cancellation', () => {
   test('aborts an in-flight httpBatchLink request when unsubscribed', async () => {
     const fetchMock = vi.fn(
       (_url: RequestInfo | URL, _init?: RequestInit) =>
-        new Promise<never>(() => {}),
+        new Promise<never>(() => undefined),
     );
     const link = httpBatchLink<AnyRouter>({
       url: 'https://example.com',

--- a/packages/client/src/links/httpLink.test.ts
+++ b/packages/client/src/links/httpLink.test.ts
@@ -1,0 +1,72 @@
+import type { AnyRouter } from '@trpc/server/unstable-core-do-not-import';
+import { describe, expect, test, vi } from 'vitest';
+import { httpBatchLink } from './httpBatchLink';
+import { httpLink } from './httpLink';
+import type { Operation } from './types';
+
+const operation: Operation = {
+  id: 1,
+  type: 'query',
+  input: undefined,
+  path: 'hello',
+  context: {},
+  signal: null,
+};
+
+describe('HTTP link cancellation', () => {
+  test('aborts an in-flight httpLink request when unsubscribed', async () => {
+    const fetchMock = vi.fn(
+      (_url: RequestInfo | URL, _init?: RequestInit) =>
+        new Promise<never>(() => {}),
+    );
+    const link = httpLink<AnyRouter>({
+      url: 'https://example.com',
+      fetch: fetchMock,
+    })({});
+
+    const subscription = link({
+      op: operation,
+      next: () => {
+        throw new Error('not reached');
+      },
+    }).subscribe({});
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    const signal = fetchMock.mock.calls[0]?.[1]?.signal;
+
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal?.aborted).toBe(false);
+
+    subscription.unsubscribe();
+
+    expect(signal?.aborted).toBe(true);
+  });
+
+  test('aborts an in-flight httpBatchLink request when unsubscribed', async () => {
+    const fetchMock = vi.fn(
+      (_url: RequestInfo | URL, _init?: RequestInit) =>
+        new Promise<never>(() => {}),
+    );
+    const link = httpBatchLink<AnyRouter>({
+      url: 'https://example.com',
+      fetch: fetchMock,
+    })({});
+
+    const subscription = link({
+      op: operation,
+      next: () => {
+        throw new Error('not reached');
+      },
+    }).subscribe({});
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    const signal = fetchMock.mock.calls[0]?.[1]?.signal;
+
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(signal?.aborted).toBe(false);
+
+    subscription.unsubscribe();
+
+    expect(signal?.aborted).toBe(true);
+  });
+});

--- a/packages/client/src/links/httpLink.ts
+++ b/packages/client/src/links/httpLink.ts
@@ -4,6 +4,7 @@ import type {
   AnyRouter,
 } from '@trpc/server/unstable-core-do-not-import';
 import { transformResult } from '@trpc/server/unstable-core-do-not-import';
+import { raceAbortSignals } from '../internals/signals';
 import { TRPCClientError } from '../TRPCClientError';
 import type {
   HTTPLinkBaseOptions,
@@ -88,12 +89,13 @@ export function httpLink<TRouter extends AnyRouter = AnyRouter>(
           );
         }
 
+        const ac = new AbortController();
         const request = universalRequester({
           ...resolvedOpts,
           type,
           path,
           input,
-          signal: op.signal,
+          signal: raceAbortSignals(op.signal, ac.signal),
           headers() {
             if (!opts.headers) {
               return {};
@@ -107,8 +109,10 @@ export function httpLink<TRouter extends AnyRouter = AnyRouter>(
           },
         });
         let meta: HTTPResult['meta'] | undefined = undefined;
+        let isDone = false;
         request
           .then((res) => {
+            isDone = true;
             meta = res.meta;
             const transformed = transformResult(
               res.json,
@@ -130,11 +134,14 @@ export function httpLink<TRouter extends AnyRouter = AnyRouter>(
             observer.complete();
           })
           .catch((cause) => {
+            isDone = true;
             observer.error(TRPCClientError.from(cause, { meta }));
           });
 
         return () => {
-          // noop
+          if (!isDone) {
+            ac.abort();
+          }
         };
       });
     };


### PR DESCRIPTION
## Summary
Resolves #7468 by managing an internal `AbortController` in `httpLink` and `httpBatchLink`, ensuring underlying HTTP requests are cancelled when subscribers unsubscribe before response completion.

### Motivation
Previously, `httpLink` and `httpBatchLink` only passed through caller-provided `op.signal` without creating their own `AbortController` bound to the observable lifecycle. When a subscriber unsubscribed, the cleanup handler was a `// noop`, leaving the in-flight network request active.

### Solution
- Created an internal `AbortController` in `httpLink` and `httpBatchLink`.
- Combined `op.signal` and `ac.signal` using `raceAbortSignals`.
- Called `ac.abort()` in the observable teardown/cleanup callback if the operation is not yet complete.
- Matches the pattern established in `httpBatchStreamLink` (#7390), `httpSubscriptionLink`, and `localLink`.

Closes #7468

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation of in-progress HTTP requests when subscriptions are cancelled.
  * Prevented unnecessary request cancellation after a request has completed or failed.
  * Applied consistent cancellation behavior to both standard and batched HTTP requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->