### PR TITLE
fix(server): match lazy router keys on a path boundary in getProcedureAtPath

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/router.test.ts
+++ b/packages/server/src/unstable-core-do-not-import/router.test.ts
@@ -37,6 +37,33 @@ describe('router', () => {
 });
 
 describe('lazy loading routers', () => {
+  // regression: sibling lazy routers where one key is a string prefix of another
+  test('prefix sibling routers do not load the wrong lazy router', async () => {
+    const t = initTRPC.create();
+
+    const postLoader = vi.fn(async () =>
+      t.router({
+        byId: t.procedure.query(() => 'post.byId'),
+      }),
+    );
+
+    const router = t.router({
+      // `post` is declared first, so it is enumerated before `posts`
+      post: lazy(postLoader),
+      posts: lazy(async () =>
+        t.router({
+          list: t.procedure.query(() => 'posts.list'),
+        }),
+      ),
+    });
+
+    const caller = router.createCaller({});
+
+    expect(await caller.posts.list()).toBe('posts.list');
+    // the unrelated `post` loader must never run for a `posts.*` path
+    expect(postLoader).not.toHaveBeenCalled();
+  });
+
   test('smoke test', async () => {
     const t = initTRPC.create();
 

--- a/packages/server/src/unstable-core-do-not-import/router.ts
+++ b/packages/server/src/unstable-core-do-not-import/router.ts
@@ -378,7 +378,9 @@ export async function getProcedureAtPath(
   let procedure = _def.procedures[path];
 
   while (!procedure) {
-    const key = Object.keys(_def.lazy).find((key) => path.startsWith(key));
+    const key = Object.keys(_def.lazy).find(
+      (key) => path === key || path.startsWith(key + '.'),
+    );
     // console.log(`found lazy: ${key ?? 'NOPE'} (fullPath: ${fullPath})`);
 
     if (!key) {


### PR DESCRIPTION
## Summary

Lazy router keys are dotted-path prefixes, and a procedure nested under a key resolves as `key + '.' + rest`. `getProcedureAtPath` picks the lazy router to load with a bare `path.startsWith(key)`, with no delimiter boundary:

```ts
const key = Object.keys(_def.lazy).find((key) => path.startsWith(key));
```

So a lazy key that is a string prefix of a sibling matches the sibling's paths. Object keys enumerate in insertion order, so with `post` declared before `posts`, a call to `posts.list` matches `post` first and loads the **wrong** router — running its dynamic import / side effects. The `while (!procedure)` loop self-heals the extra load, but if the wrong loader throws, a valid `posts.list()` rejects with the wrong router's error.

## Fix

Require a path boundary so a key only matches its own subtree:

```ts
const key = Object.keys(_def.lazy).find(
  (key) => path === key || path.startsWith(key + '.'),
);
```

## Test

Added a case with sibling lazy routers `post` (declared first) and `posts`, asserting `posts.list()` resolves correctly and the `post` loader is never called. It fails on `main` (the `post` loader runs) and passes with this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed routing for lazy-loaded endpoints whose names share a prefix.
  - Requests are now directed to the correct lazy router, preventing similarly named routes from being loaded accidentally.

- **Tests**
  - Added regression coverage for sibling lazy routers and overlapping route prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->