### PR TITLE
fix(server): correct assertIsRequestId boolean logic — non-NaN invalid types passed silently

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/rpc/parseTRPCMessage.ts
+++ b/packages/server/src/unstable-core-do-not-import/rpc/parseTRPCMessage.ts
@@ -23,9 +23,8 @@ function assertIsRequestId(
 ): asserts obj is number | string | null {
   if (
     obj !== null &&
-    typeof obj === 'number' &&
-    isNaN(obj) &&
-    typeof obj !== 'string'
+    typeof obj !== 'string' &&
+    (typeof obj !== 'number' || isNaN(obj))
   ) {
     throw new Error('Invalid request id');
   }

--- a/packages/tests/server/parseTRPCMessage.test.ts
+++ b/packages/tests/server/parseTRPCMessage.test.ts
@@ -1,0 +1,73 @@
+import { parseTRPCMessage } from '@trpc/server/rpc';
+import type { CombinedDataTransformer } from '@trpc/server/unstable-core-do-not-import';
+
+/**
+ * Regression tests for assertIsRequestId.
+ *
+ * The condition was previously inverted: it only threw for NaN and silently
+ * accepted booleans, objects, arrays, and undefined as valid request IDs.
+ * Fixed by correcting the boolean logic so anything that is not null, a string,
+ * or a finite number is rejected.
+ *
+ * Ref: https://github.com/trpc/trpc/issues/7430
+ * Ref: https://github.com/trpc/trpc/issues/7450
+ */
+
+const noopTransformer: CombinedDataTransformer = {
+  input: { serialize: (v) => v, deserialize: (v) => v },
+  output: { serialize: (v) => v, deserialize: (v) => v },
+};
+
+function makeMsg(id: unknown) {
+  return { id, method: 'subscription.stop' };
+}
+
+describe('parseTRPCMessage - assertIsRequestId', () => {
+  describe('valid ids - should not throw', () => {
+    test('number id', () => {
+      expect(() => parseTRPCMessage(makeMsg(1), noopTransformer)).not.toThrow();
+    });
+
+    test('string id', () => {
+      expect(() => parseTRPCMessage(makeMsg('abc'), noopTransformer)).not.toThrow();
+    });
+
+    test('null id', () => {
+      expect(() => parseTRPCMessage(makeMsg(null), noopTransformer)).not.toThrow();
+    });
+
+    test('zero id', () => {
+      expect(() => parseTRPCMessage(makeMsg(0), noopTransformer)).not.toThrow();
+    });
+
+    test('empty string id', () => {
+      expect(() => parseTRPCMessage(makeMsg(''), noopTransformer)).not.toThrow();
+    });
+  });
+
+  describe('invalid ids - should throw (regression: previously accepted silently)', () => {
+    test('NaN id throws', () => {
+      expect(() => parseTRPCMessage(makeMsg(NaN), noopTransformer)).toThrow('Invalid request id');
+    });
+
+    test('boolean true id throws', () => {
+      expect(() => parseTRPCMessage(makeMsg(true), noopTransformer)).toThrow('Invalid request id');
+    });
+
+    test('boolean false id throws', () => {
+      expect(() => parseTRPCMessage(makeMsg(false), noopTransformer)).toThrow('Invalid request id');
+    });
+
+    test('object id throws', () => {
+      expect(() => parseTRPCMessage(makeMsg({}), noopTransformer)).toThrow('Invalid request id');
+    });
+
+    test('array id throws', () => {
+      expect(() => parseTRPCMessage(makeMsg([]), noopTransformer)).toThrow('Invalid request id');
+    });
+
+    test('undefined id throws', () => {
+      expect(() => parseTRPCMessage(makeMsg(undefined), noopTransformer)).toThrow('Invalid request id');
+    });
+  });
+});

--- a/packages/tests/server/parseTRPCMessage.test.ts
+++ b/packages/tests/server/parseTRPCMessage.test.ts
@@ -29,11 +29,15 @@ describe('parseTRPCMessage - assertIsRequestId', () => {
     });
 
     test('string id', () => {
-      expect(() => parseTRPCMessage(makeMsg('abc'), noopTransformer)).not.toThrow();
+      expect(() =>
+        parseTRPCMessage(makeMsg('abc'), noopTransformer),
+      ).not.toThrow();
     });
 
     test('null id', () => {
-      expect(() => parseTRPCMessage(makeMsg(null), noopTransformer)).not.toThrow();
+      expect(() =>
+        parseTRPCMessage(makeMsg(null), noopTransformer),
+      ).not.toThrow();
     });
 
     test('zero id', () => {
@@ -41,33 +45,47 @@ describe('parseTRPCMessage - assertIsRequestId', () => {
     });
 
     test('empty string id', () => {
-      expect(() => parseTRPCMessage(makeMsg(''), noopTransformer)).not.toThrow();
+      expect(() =>
+        parseTRPCMessage(makeMsg(''), noopTransformer),
+      ).not.toThrow();
     });
   });
 
   describe('invalid ids - should throw (regression: previously accepted silently)', () => {
     test('NaN id throws', () => {
-      expect(() => parseTRPCMessage(makeMsg(NaN), noopTransformer)).toThrow('Invalid request id');
+      expect(() => parseTRPCMessage(makeMsg(NaN), noopTransformer)).toThrow(
+        'Invalid request id',
+      );
     });
 
     test('boolean true id throws', () => {
-      expect(() => parseTRPCMessage(makeMsg(true), noopTransformer)).toThrow('Invalid request id');
+      expect(() => parseTRPCMessage(makeMsg(true), noopTransformer)).toThrow(
+        'Invalid request id',
+      );
     });
 
     test('boolean false id throws', () => {
-      expect(() => parseTRPCMessage(makeMsg(false), noopTransformer)).toThrow('Invalid request id');
+      expect(() => parseTRPCMessage(makeMsg(false), noopTransformer)).toThrow(
+        'Invalid request id',
+      );
     });
 
     test('object id throws', () => {
-      expect(() => parseTRPCMessage(makeMsg({}), noopTransformer)).toThrow('Invalid request id');
+      expect(() => parseTRPCMessage(makeMsg({}), noopTransformer)).toThrow(
+        'Invalid request id',
+      );
     });
 
     test('array id throws', () => {
-      expect(() => parseTRPCMessage(makeMsg([]), noopTransformer)).toThrow('Invalid request id');
+      expect(() => parseTRPCMessage(makeMsg([]), noopTransformer)).toThrow(
+        'Invalid request id',
+      );
     });
 
     test('undefined id throws', () => {
-      expect(() => parseTRPCMessage(makeMsg(undefined), noopTransformer)).toThrow('Invalid request id');
+      expect(() =>
+        parseTRPCMessage(makeMsg(undefined), noopTransformer),
+      ).toThrow('Invalid request id');
     });
   });
 });


### PR DESCRIPTION
## Summary

`assertIsRequestId` in `parseTRPCMessage.ts` has an inverted boolean condition that only throws for `NaN`. Booleans, objects, arrays, and `undefined` all pass through silently as valid request IDs.

**Root cause**

```ts
// Before — broken: only throws when typeof obj === 'number' AND isNaN(obj)
if (
  obj !== null &&
  typeof obj === 'number' &&   // short-circuits for non-numbers
  isNaN(obj) &&
  typeof obj !== 'string'      // always true when typeof obj === 'number'
) {
  throw new Error('Invalid request id');
}
```

The original intent (PR #508) was `typeof id !== 'number' || isNaN(id)`. The condition got inverted when the type was widened to `number | string | null`.

**Fix**

```ts
// After — throws for anything that is not null, a finite number, or a string
if (
  obj !== null &&
  typeof obj !== 'string' &&
  (typeof obj !== 'number' || isNaN(obj))
) {
  throw new Error('Invalid request id');
}
```

## Previously broken (now fixed)

| Input | Before | After |
|---|---|---|
| `NaN` | throws | throws |
| `true` | passes silently | throws |
| `false` | passes silently | throws |
| `{}` | passes silently | throws |
| `[]` | passes silently | throws |
| `undefined` | passes silently | throws |

## Tests

Added 11 unit tests in `packages/tests/server/parseTRPCMessage.test.ts` covering all valid (`number`, `string`, `null`, `0`, `""`) and all previously-silent-invalid cases.

Fixes #7430, fixes #7450

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of request IDs in subscription messages.
  * Invalid values such as booleans, objects, arrays, `undefined`, and `NaN` are now rejected with an appropriate error.
  * Valid string, number, zero, empty-string, and `null` request IDs continue to be accepted.

* **Tests**
  * Added regression coverage for valid and invalid request ID values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->