### PR TITLE
feat(client): procedure execution timeout abort controller link

### DIFF
--- a/packages/client/src/links.ts
+++ b/packages/client/src/links.ts
@@ -10,6 +10,7 @@ export * from './links/wsLink/wsLink';
 export * from './links/httpSubscriptionLink';
 export * from './links/retryLink';
 export * from './links/localLink';
+export * from './links/timeoutLink';
 
 // These are not public (yet) as we get this functionality from tanstack query
 // export * from './links/internals/dedupeLink';

--- a/packages/client/src/links/timeoutLink.ts
+++ b/packages/client/src/links/timeoutLink.ts
@@ -1,0 +1,37 @@
+/**
+ * tRPC - Procedure Timeout Abort Link
+ */
+export interface TimeoutLinkOperation {
+  path: string;
+}
+
+export function createTimeoutLink(timeoutMs = 10000) {
+  return () =>
+    <TOperation extends TimeoutLinkOperation, TResult>({
+      op,
+      next,
+    }: {
+      op: TOperation;
+      next: (operation: TOperation) => Promise<TResult>;
+    }) => {
+      return new Promise<TResult>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          reject(
+            new Error(
+              `tRPC request timed out after ${timeoutMs}ms for path: ${op.path}`,
+            ),
+          );
+        }, timeoutMs);
+
+        next(op)
+          .then((res) => {
+            clearTimeout(timer);
+            resolve(res);
+          })
+          .catch((err) => {
+            clearTimeout(timer);
+            reject(err);
+          });
+      });
+    };
+}


### PR DESCRIPTION
### Timeout Abort Link

- Client-side timeout rejection guard for hanging RPC operations.

Ready for review! 🚀

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added request deduplication so identical in-flight requests share a single operation.
  - Added support for marking procedures as deprecated, including an optional reason and recommended alternative.
- **Bug Fixes**
  - Improved concurrent request handling by preventing duplicate operations.
  - Ensured request tracking is cleaned up after operations complete, whether they succeed or fail.
- **Maintenance**
  - Preserved existing request timeout behavior while improving its handling and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->