### PR TITLE
fix(server): avoid duplicate keepAlive handler registration in fastify adapter

### DIFF
--- a/packages/server/src/adapters/fastify/fastifyTRPCPlugin.ts
+++ b/packages/server/src/adapters/fastify/fastifyTRPCPlugin.ts
@@ -14,11 +14,7 @@ import type { AnyRouter } from '../../@trpc/server';
 // @trpc/server/http
 import type { NodeHTTPCreateContextFnOptions } from '../node-http';
 // @trpc/server/ws
-import {
-  getWSConnectionHandler,
-  handleKeepAlive,
-  type WSSHandlerOptions,
-} from '../ws';
+import { getWSConnectionHandler, type WSSHandlerOptions } from '../ws';
 import type { FastifyHandlerOptions } from './fastifyRequestHandler';
 import { fastifyRequestHandler } from './fastifyRequestHandler';
 
@@ -78,10 +74,6 @@ export function fastifyTRPCPlugin<TRouter extends AnyRouter>(
 
     fastify.get(prefix ?? '/', { websocket: true }, (socket, req) => {
       onConnection(socket, req.raw);
-      if (trpcOptions?.keepAlive?.enabled) {
-        const { pingMs, pongWaitMs } = trpcOptions.keepAlive;
-        handleKeepAlive(socket, pingMs, pongWaitMs);
-      }
     });
   }
 

--- a/packages/tests/server/adapters/fastify.test.ts
+++ b/packages/tests/server/adapters/fastify.test.ts
@@ -18,6 +18,7 @@ import type {
   FastifyTRPCPluginOptions,
 } from '@trpc/server/adapters/fastify';
 import { fastifyTRPCPlugin } from '@trpc/server/adapters/fastify';
+import * as wsAdapter from '@trpc/server/adapters/ws';
 import { observable } from '@trpc/server/observable';
 import fastify from 'fastify';
 import fp from 'fastify-plugin';
@@ -631,5 +632,56 @@ describe('issue #5530 - cannot receive new WebSocket messages after receiving 16
     for (let i = 0; i < 4; i++) {
       expect(await app.client.echo.query(data)).toBe(data);
     }
+  });
+});
+
+// https://github.com/trpc/trpc/issues/7502
+describe('regression #7502 - keepAlive does not attach duplicate ping handlers', () => {
+  let serverInstance: any;
+
+  afterEach(async () => {
+    await serverInstance?.close();
+  });
+
+  test('sends only one PING when keepAlive is enabled', async () => {
+    const t = initTRPC.create();
+    const appRouter = t.router({
+      ping: t.procedure.query(() => 'pong'),
+    });
+
+    const instance = fastify();
+    serverInstance = instance;
+    instance.register(ws);
+    instance.register(fastifyTRPCPlugin, {
+      useWSS: true,
+      prefix: '/trpc',
+      trpcOptions: {
+        router: appRouter,
+        keepAlive: {
+          enabled: true,
+          pingMs: 20,
+          pongWaitMs: 1000,
+        },
+      } as any,
+    });
+
+    await instance.listen({ port: 0, host: '127.0.0.1' });
+    const port = (instance.server.address() as any).port;
+
+    const pings: string[] = [];
+    const rawWs = new WebSocket(`ws://127.0.0.1:${port}/trpc`);
+    rawWs.on('message', (data) => {
+      const msg = typeof data === 'string' ? data : Buffer.from(data as any).toString();
+      if (msg === 'PING') {
+        pings.push('PING');
+      }
+    });
+
+    await new Promise((resolve) => rawWs.on('open', resolve));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(pings.length).toBe(1);
+
+    rawWs.close();
   });
 });

--- a/packages/tests/server/adapters/fastify.test.ts
+++ b/packages/tests/server/adapters/fastify.test.ts
@@ -671,7 +671,8 @@ describe('regression #7502 - keepAlive does not attach duplicate ping handlers',
     const pings: string[] = [];
     const rawWs = new WebSocket(`ws://127.0.0.1:${port}/trpc`);
     rawWs.on('message', (data) => {
-      const msg = typeof data === 'string' ? data : Buffer.from(data as any).toString();
+      const msg =
+        typeof data === 'string' ? data : Buffer.from(data as any).toString();
       if (msg === 'PING') {
         pings.push('PING');
       }


### PR DESCRIPTION
## Problem

When `keepAlive` is enabled in `fastifyTRPCPlugin`, clients receive duplicate `PING` messages on every heartbeat interval.

## Root Cause

`fastifyTRPCPlugin` invoked `handleKeepAlive(socket, pingMs, pongWaitMs)` inside the websocket route handler in addition to `getWSConnectionHandler`, which already registers `handleKeepAlive` internally when `keepAlive.enabled` is true.

## Fix

Removed the redundant `handleKeepAlive` invocation and unused import from `fastifyTRPCPlugin.ts`.

## Testing

- Added regression test in `packages/tests/server/adapters/fastify.test.ts` verifying that exactly one `PING` message is received per interval when `keepAlive.enabled` is true.
- Verified all 17 fastify adapter tests, typecheck, and eslint pass cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket connection handling for Fastify servers by eliminating duplicate keep-alive processing.
  * Prevented redundant `PING` messages during WebSocket connections, helping maintain reliable connection health checks.

* **Tests**
  * Added regression coverage to verify that keep-alive behavior sends exactly one expected `PING` message during a WebSocket connection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->