### PR TITLE
fix(server): register keepalive once per websocket connection

### DIFF
--- a/packages/server/src/adapters/fastify/fastifyTRPCPlugin.ts
+++ b/packages/server/src/adapters/fastify/fastifyTRPCPlugin.ts
@@ -14,11 +14,7 @@ import type { AnyRouter } from '../../@trpc/server';
 // @trpc/server/http
 import type { NodeHTTPCreateContextFnOptions } from '../node-http';
 // @trpc/server/ws
-import {
-  getWSConnectionHandler,
-  handleKeepAlive,
-  type WSSHandlerOptions,
-} from '../ws';
+import { getWSConnectionHandler, type WSSHandlerOptions } from '../ws';
 import type { FastifyHandlerOptions } from './fastifyRequestHandler';
 import { fastifyRequestHandler } from './fastifyRequestHandler';
 
@@ -77,11 +73,10 @@ export function fastifyTRPCPlugin<TRouter extends AnyRouter>(
     });
 
     fastify.get(prefix ?? '/', { websocket: true }, (socket, req) => {
+      // keepalive is registered by getWSConnectionHandler, which every
+      // adapter goes through — registering it here as well gave each socket
+      // two ping intervals and two pong-wait timers
       onConnection(socket, req.raw);
-      if (trpcOptions?.keepAlive?.enabled) {
-        const { pingMs, pongWaitMs } = trpcOptions.keepAlive;
-        handleKeepAlive(socket, pingMs, pongWaitMs);
-      }
     });
   }
 

--- a/packages/tests/server/adapters/fastify.test.ts
+++ b/packages/tests/server/adapters/fastify.test.ts
@@ -149,6 +149,7 @@ interface ServerOptions {
   appRouter: AppRouter;
   fastifyPluginWrapper?: boolean;
   withContentTypeParser?: boolean;
+  keepAlive?: { enabled: boolean; pingMs: number; pongWaitMs: number };
 }
 
 type PostPayload = { Body: { text: string; life: number } };
@@ -179,6 +180,7 @@ function createServer(opts: ServerOptions) {
     trpcOptions: {
       router,
       createContext,
+      keepAlive: opts.keepAlive,
       onError(data) {
         // report to error monitoring
         data;
@@ -631,5 +633,48 @@ describe('issue #5530 - cannot receive new WebSocket messages after receiving 16
     for (let i = 0; i < 4; i++) {
       expect(await app.client.echo.query(data)).toBe(data);
     }
+  });
+});
+
+describe('issue #7502 - keepAlive must register a single ping interval', () => {
+  const pingMs = 250;
+
+  beforeEach(async () => {
+    app = await createApp({
+      serverOptions: {
+        keepAlive: { enabled: true, pingMs, pongWaitMs: 10_000 },
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await app.stop();
+  });
+
+  test('sends one ping per interval', async () => {
+    const socket = new WebSocket(
+      `ws://localhost:${app.url.port}${config.prefix}`,
+    );
+
+    // keepalive is sent as a "PING" text message, not a protocol ping frame
+    let pings = 0;
+    socket.on('message', (data) => {
+      if (data.toString() === 'PING') {
+        pings++;
+      }
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      socket.on('open', () => resolve());
+      socket.on('error', reject);
+    });
+
+    // a duplicate registration schedules its interval at essentially the same
+    // moment as the first, so the extra ping lands well inside one period
+    await new Promise((resolve) => setTimeout(resolve, pingMs * 1.5));
+
+    expect(pings).toBe(1);
+
+    socket.close();
   });
 });

--- a/packages/tests/server/adapters/fastify.test.ts
+++ b/packages/tests/server/adapters/fastify.test.ts
@@ -173,20 +173,27 @@ function createServer(opts: ServerOptions) {
 
   const router = opts.appRouter;
 
+  const trpcOptions = {
+    router,
+    createContext,
+    onError(data) {
+      // report to error monitoring
+      data;
+      // ^?
+    },
+  } satisfies FastifyTRPCPluginOptions<AppRouter>['trpcOptions'];
+
   instance.register(ws);
   instance.register(plugin, {
     useWSS: true,
     prefix: config.prefix,
+    // the plugin casts trpcOptions to WSSHandlerOptions internally, so
+    // keepAlive reaches the websocket handler at runtime even though the
+    // public type for trpcOptions does not declare it
     trpcOptions: {
-      router,
-      createContext,
-      keepAlive: opts.keepAlive,
-      onError(data) {
-        // report to error monitoring
-        data;
-        // ^?
-      },
-    } satisfies FastifyTRPCPluginOptions<AppRouter>['trpcOptions'],
+      ...trpcOptions,
+      ...(opts.keepAlive ? { keepAlive: opts.keepAlive } : {}),
+    } as FastifyTRPCPluginOptions<AppRouter>['trpcOptions'],
   });
 
   instance.register(async function (fastify) {
@@ -659,7 +666,7 @@ describe('issue #7502 - keepAlive must register a single ping interval', () => {
     // keepalive is sent as a "PING" text message, not a protocol ping frame
     let pings = 0;
     socket.on('message', (data) => {
-      if (data.toString() === 'PING') {
+      if (Buffer.isBuffer(data) && data.toString('utf8') === 'PING') {
         pings++;
       }
     });


### PR DESCRIPTION
## Summary

`fastifyTRPCPlugin` registered keepalive twice for every WebSocket connection.

It calls `getWSConnectionHandler` to build its `onConnection` handler, and that handler [already registers keepalive](https://github.com/trpc/trpc/blob/main/packages/server/src/adapters/ws.ts#L124-L126) when `opts.keepAlive?.enabled` is set. The plugin then called `handleKeepAlive(socket, …)` again straight after invoking it, so each socket ended up with two ping intervals and two pong-wait timers.

## Why it matters beyond the doubled PING

@01101101 reported the duplicate PING traffic in #7502. There is a second consequence worth noting: each `handleKeepAlive` closure clears only *its own* `ping`/`timeout` handles on an incoming message. With two registrations, a client's message resets one pair while the other pong-wait timer keeps running, so a healthy connection can be terminated by the timer belonging to the registration that did not see the reset.

## The fix

Removed the plugin-level call rather than the one in `getWSConnectionHandler`. Every adapter goes through that shared handler, so keepalive belongs there, and `grep` confirms no other adapter registers it separately — the fastify plugin was the only place doing it twice.

## Test

`packages/tests/server/adapters/fastify.test.ts` gains a regression test that starts the plugin with `keepAlive` enabled, opens a raw `ws` connection and counts the `PING` messages over one and a half intervals.

I checked that it actually catches the bug rather than merely passing: with the fix reverted it fails with `expected 2 to be 1`, and passes with the fix. The whole file is 17/17 green.

One implementation note for reviewers: keepalive is sent as a `'PING'` **text message**, not a protocol-level ping frame, so the test listens on `message` rather than the `ping` event.

The test harness needed a small addition — `ServerOptions` now accepts `keepAlive`, forwarded into `trpcOptions` — since there was no existing way to enable it for the fastify adapter.

## Checklist

- [x] The fix is covered by a test that fails without it
- [x] `vitest run packages/tests/server/adapters/fastify.test.ts` passes (17/17)
- [x] `prettier` clean
- [x] Links the issue with a closing keyword: Closes #7502


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate WebSocket keepalive timers that could send repeated ping messages.
  * Improved connection stability by ensuring each WebSocket receives only one keepalive ping per interval.
  * Added support for configuring keepalive and pong-wait intervals when enabling WebSocket connections.

* **Tests**
  * Added coverage for configurable keepalive and pong-wait intervals.
  * Added regression testing to verify a single ping is sent per interval and correctly detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->