### PR TITLE
feat(client): WebSocket reconnect attempt sliding budget regulator

### DIFF
--- a/packages/client/src/links/wsReconnectBudget.ts
+++ b/packages/client/src/links/wsReconnectBudget.ts
@@ -1,0 +1,1 @@
+export class WSReconnectBudget { private attempts: number[] = []; constructor(public maxPerMinute = 10) {} canAttempt(): boolean { const now = Date.now(); this.attempts = this.attempts.filter(t => now - t < 60000); if (this.attempts.length >= this.maxPerMinute) return false; this.attempts.push(now); return true; } }


### PR DESCRIPTION
## Summary

feat(client): WebSocket reconnect attempt sliding budget regulator.

Tested and typed strictly with TypeScript.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added protection against excessive WebSocket reconnection attempts.
  * Reconnection attempts are now limited to 10 per rolling 60-second period by default.
  * Expired attempts are automatically cleared so reconnecting can resume normally over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->