### PR TITLE
fix(server): return 400 for malformed url-encoding in the request path

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/http/resolveResponse.ts
+++ b/packages/server/src/unstable-core-do-not-import/http/resolveResponse.ts
@@ -29,6 +29,23 @@ import type {
   TRPCRequestInfo,
 } from './types';
 
+/**
+ * `decodeURIComponent` throws a plain `URIError` on malformed escape sequences,
+ * which would otherwise surface as an `INTERNAL_SERVER_ERROR` even though the
+ * request itself is at fault
+ */
+function decodePath(path: string) {
+  try {
+    return decodeURIComponent(path);
+  } catch (cause) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `Invalid URL-encoding in path "${path}"`,
+      cause,
+    });
+  }
+}
+
 function errorToAsyncIterable(err: TRPCError): AsyncIterable<never> {
   return run(async function* () {
     throw err;
@@ -243,7 +260,7 @@ export async function resolveResponse<TRouter extends AnyRouter>(
         undefined,
         await getRequestInfo({
           req,
-          path: decodeURIComponent(opts.path),
+          path: decodePath(opts.path),
           router,
           searchParams: url.searchParams,
           headers: opts.req.headers,

--- a/packages/tests/server/errors.test.ts
+++ b/packages/tests/server/errors.test.ts
@@ -128,6 +128,28 @@ test('unauthorized()', async () => {
   expect(serverError).toBeInstanceOf(TRPCError);
 });
 
+test('malformed url-encoding in the path', async () => {
+  const onError = vi.fn();
+  const t = initTRPC.create();
+
+  const router = t.router({
+    hello: t.procedure.query(() => 'world'),
+  });
+  await using ctx = testServerAndClientResource(router, {
+    server: {
+      onError,
+    },
+  });
+  const res = await fetch(`${ctx.httpUrl}/%`);
+
+  expect(res.status).toBe(400);
+  expect(onError).toHaveBeenCalledTimes(1);
+  const serverError = onError.mock.calls[0]![0]!.error;
+
+  expect(serverError).toBeInstanceOf(TRPCError);
+  expect(serverError.code).toBe('BAD_REQUEST');
+});
+
 test('getMessageFromUnknownError()', () => {
   expect(getMessageFromUnknownError('test', 'nope')).toBe('test');
   expect(getMessageFromUnknownError(1, 'test')).toBe('test');


### PR DESCRIPTION
## 🎯 Changes

Bug fix.

`resolveResponse` decodes the request path with `decodeURIComponent`, which throws a plain `URIError: URI malformed` on an invalid escape sequence. That error is not a `TRPCError`, so `getTRPCErrorFromUnknown` turns it into `INTERNAL_SERVER_ERROR` → HTTP 500.

The request is malformed, not the server, so this both returns the wrong status and reports a fake internal error to `onError` (and leaks a stack trace in dev). It is trivially reachable — any crawler hitting `/trpc/%` triggers it.

Before, on `main` (`GET ${httpUrl}/%` against a standalone adapter):

```
STATUS: 500
BODY: {"error":{"message":"URI malformed","code":-32603,"data":{"code":"INTERNAL_SERVER_ERROR","httpStatus":500,"stack":"URIError: URI malformed\n    at decodeURIComponent (<anonymous>)\n    at .../http/resolveResponse.ts:246:17\n ..."}}}
onError code: INTERNAL_SERVER_ERROR
onError message: URI malformed
```

After:

```
STATUS: 400
BODY: {"error":{"message":"Invalid URL-encoding in path \"%\"","code":-32600,"data":{"code":"BAD_REQUEST","httpStatus":400, ...}}}
onError code: BAD_REQUEST
onError message: Invalid URL-encoding in path "%"
```

The decode is wrapped in a small helper that rethrows as `BAD_REQUEST`, consistent with how the other client-input failures on this path are already normalised (malformed JSON input → `BAD_REQUEST` in `contentType.ts`, bad `connectionParams` → `PARSE_ERROR`).

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.

### Verification

- Added `malformed url-encoding in the path` to `packages/tests/server/errors.test.ts`. It fails on `main` (`expected 500 to be 400`) and passes with the fix.
- `pnpm vitest run packages/tests/server packages/server` — 647 passed, 2 failed. Both failures are pre-existing on a clean checkout of `main` on the same machine (Windows): `errors.test.ts > retain stack trace` (compares `__filename` backslashes against a forward-slash stack) and `adapters/standalone.test.ts > custom host` (timeout binding to a local address). Same 2 failures before and after the diff, 646 → 647 passing.
- `pnpm typecheck-packages` — all 7 packages clean.
- `eslint` on `@trpc/server` and `@trpc/tests` — clean. Prettier `--check` on both changed files — clean.

<sub>Written with the help of an AI coding assistant; every claim above was run locally before opening this PR.</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Malformed URL-encoded request paths now return a clear `400 Bad Request` response instead of causing an unhandled error.
  * Server error handling now consistently reports these invalid requests as `BAD_REQUEST` errors with a descriptive message.
  * Invalid path encoding no longer prevents the request from being processed through standard error handling.

* **Tests**
  * Added coverage to verify the response status and error reporting behavior for malformed request paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->