### PR TITLE
fix(server): keep middleware factory declarations portable

### DIFF
--- a/examples/.test/internal-types-export/package.json
+++ b/examples/.test/internal-types-export/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "rm -rf build && tsc && tsdown"
+    "build": "rm -rf build && tsc && tsc -p tsconfig.server-only.json && tsdown"
   },
   "devDependencies": {
     "@tsconfig/esm": "^1.0.3",

--- a/examples/.test/internal-types-export/src/middleware-factory.ts
+++ b/examples/.test/internal-types-export/src/middleware-factory.ts
@@ -1,0 +1,20 @@
+import { initTRPC, TRPCError } from '@trpc/server';
+
+interface AuthNContext {
+  user?: { id: string };
+}
+
+export function createAuthenticationMiddleware<
+  TContext extends AuthNContext = AuthNContext,
+>() {
+  return initTRPC
+    .context<TContext>()
+    .create()
+    .procedure.use(({ ctx, next }) => {
+      if (!ctx.user) {
+        throw new TRPCError({ code: 'UNAUTHORIZED' });
+      }
+
+      return next({ ctx: { user: ctx.user } });
+    });
+}

--- a/examples/.test/internal-types-export/tsconfig.server-only.json
+++ b/examples/.test/internal-types-export/tsconfig.server-only.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "build/server-only"
+  },
+  "include": ["src/middleware-factory.ts"]
+}

--- a/packages/server/src/@trpc/server/index.ts
+++ b/packages/server/src/@trpc/server/index.ts
@@ -79,6 +79,10 @@ export {
    * @internal
    */
   type UnsetMarker as TRPCUnsetMarker,
+  /**
+   * @internal
+   */
+  type Unwrap as TRPCUnwrap,
 } from '../../unstable-core-do-not-import';
 
 export type {


### PR DESCRIPTION
Closes #6889

## 🎯 Changes

Export a stable `TRPCUnwrap` alias from `@trpc/server` so declaration emit can name the return type of generic middleware factories.

Without the alias, TypeScript falls back to a hashed internal declaration chunk and reports TS2742. The existing declaration fixture did not catch this because importing `@trpc/client` or `@trpc/next` in the same program makes the internal type reachable. The added server-only config keeps that masking import out of the regression test.

## ✅ Checklist

- [x] I have followed the steps listed in the Contributing guide.
- [x] I have added or updated tests related to the changes.
- [ ] If necessary, I have added documentation related to the changes made.

## Test plan

- `pnpm --filter @trpc/server lint`
- `pnpm --filter @trpc/server typecheck`
- `pnpm --dir examples/.test/internal-types-export build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a reusable authentication middleware example that rejects unauthenticated requests and makes the signed-in user available to subsequent procedures.
  - Added an exported utility type to improve type handling for server-side integrations.

- **Build Improvements**
  - Updated the example project’s build process to include a dedicated server-only TypeScript compilation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->