### PR TITLE
docs: add Authier to awesome tRPC projects

### DIFF
--- a/www/docs/community/awesome-trpc.mdx
+++ b/www/docs/community/awesome-trpc.mdx
@@ -131,3 +131,4 @@ A collection of resources on tRPC.
 | [Workplacify](https://workplacify.com/) - Desk scheduling software, for hybrid and in-office teams                                             | https://workplacify.com/                            |
 | [Dotfyle](https://dotfyle.com/) - Discover and share Neovim plugins                                                                            | https://dotfyle.com/                                |
 | [ConvoForm](https://www.convoform.com/?utm_source=github&utm_medium=social&utm_campaign=trpc) - Create your own AI-Powered conversational form | https://www.convoform.com/                          |
+| [Authier](https://www.authier.pm/) - Open-source password manager with browser autofill and TOTP                                               | https://github.com/authier-pm/authier               |


### PR DESCRIPTION
## 🎯 Changes

Adds Authier to the **Open-source projects using tRPC** table with its canonical homepage and public source repository.

Authier's published browser extension uses both `@trpc/client` and `@trpc/server`. I maintain Authier. An AI coding assistant helped verify the public usage evidence, contribution precedent, and rendered link behavior, and helped prepare this one-line documentation change. Authier is early-stage and has not undergone an independent security audit.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] This pull request is the documentation update.
- [x] Tests are not applicable to a one-row catalogue addition; `pnpm prettier www/docs/community/awesome-trpc.mdx --check`, `pnpm typecheck-www`, and `pnpm build-www` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Authier, an open-source password manager with browser autofill and TOTP support, to the list of projects using tRPC.
  * Added vscode-trpc to the library adapters list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->