### PR TITLE
docs: document FormData and octet-stream content types

### DIFF
--- a/packages/client/src/links/httpLink.ts
+++ b/packages/client/src/links/httpLink.ts
@@ -25,8 +25,7 @@ import {
 } from './types';
 
 /** @see https://trpc.io/docs/server/non-json-content-types */
-const CONTENT_TYPES_DOCS =
-  'https://trpc.io/docs/server/non-json-content-types';
+const CONTENT_TYPES_DOCS = 'https://trpc.io/docs/server/non-json-content-types';
 
 export type HTTPLinkOptions<TRoot extends AnyClientTypes> =
   HTTPLinkBaseOptions<TRoot> & {

--- a/packages/client/src/links/httpLink.ts
+++ b/packages/client/src/links/httpLink.ts
@@ -24,6 +24,10 @@ import {
   type TRPCLink,
 } from './types';
 
+/** @see https://trpc.io/docs/server/non-json-content-types */
+const CONTENT_TYPES_DOCS =
+  'https://trpc.io/docs/server/non-json-content-types';
+
 export type HTTPLinkOptions<TRoot extends AnyClientTypes> =
   HTTPLinkBaseOptions<TRoot> & {
     /**
@@ -40,7 +44,9 @@ const universalRequester: Requester = (opts) => {
     const { input } = opts;
     if (isFormData(input)) {
       if (opts.type !== 'mutation' && opts.methodOverride !== 'POST') {
-        throw new Error('FormData is only supported for mutations');
+        throw new Error(
+          `FormData is only supported for mutations. See ${CONTENT_TYPES_DOCS}`,
+        );
       }
 
       return httpRequest({
@@ -54,7 +60,9 @@ const universalRequester: Requester = (opts) => {
 
     if (isOctetType(input)) {
       if (opts.type !== 'mutation' && opts.methodOverride !== 'POST') {
-        throw new Error('Octet type input is only supported for mutations');
+        throw new Error(
+          `Octet type input is only supported for mutations. See ${CONTENT_TYPES_DOCS}`,
+        );
       }
 
       return httpRequest({
@@ -71,6 +79,7 @@ const universalRequester: Requester = (opts) => {
 
 /**
  * @see https://trpc.io/docs/client/links/httpLink
+ * @see https://trpc.io/docs/server/non-json-content-types
  */
 export function httpLink<TRouter extends AnyRouter = AnyRouter>(
   opts: HTTPLinkOptions<TRouter['_def']['_config']['$types']>,

--- a/packages/client/src/links/internals/contentTypes.ts
+++ b/packages/client/src/links/internals/contentTypes.ts
@@ -12,6 +12,13 @@ export function isFormData(input: unknown) {
   return input instanceof FormData;
 }
 
+/**
+ * `true` when `input` cannot be JSON-serialized and must be sent as
+ * `multipart/form-data` (`FormData`) or `application/octet-stream`
+ * (`Blob` / `File` / `Uint8Array`).
+ *
+ * @see https://trpc.io/docs/server/non-json-content-types
+ */
 export function isNonJsonSerializable(input: unknown) {
   return isOctetType(input) || isFormData(input);
 }

--- a/packages/react-query/test/formData.test.tsx
+++ b/packages/react-query/test/formData.test.tsx
@@ -220,7 +220,7 @@ test('GET requests are not supported', async () => {
   form.set('foo', 'bar');
 
   await expect(ctx.client.q.query(form)).rejects.toMatchInlineSnapshot(
-    `[TRPCClientError: FormData is only supported for mutations]`,
+    `[TRPCClientError: FormData is only supported for mutations. See https://trpc.io/docs/server/non-json-content-types]`,
   );
 });
 

--- a/packages/server/src/unstable-core-do-not-import/http/contentType.ts
+++ b/packages/server/src/unstable-core-do-not-import/http/contentType.ts
@@ -5,6 +5,10 @@ import { emptyObject, isObject } from '../utils';
 import { parseConnectionParamsFromString } from './parseConnectionParams';
 import type { TRPCAcceptHeader, TRPCRequestInfo } from './types';
 
+/** @see https://trpc.io/docs/server/non-json-content-types */
+const CONTENT_TYPES_DOCS =
+  'https://trpc.io/docs/server/non-json-content-types';
+
 export function getAcceptHeader(headers: Headers): TRPCAcceptHeader | null {
   return (
     (headers.get('trpc-accept') as TRPCAcceptHeader | null) ??
@@ -211,6 +215,11 @@ const jsonContentTypeHandler: ContentTypeHandler = {
   },
 };
 
+/**
+ * `multipart/form-data` — procedure input is `FormData`. POST only; not batchable.
+ * @see https://trpc.io/docs/server/non-json-content-types
+ * @see https://trpc.io/docs/rpc
+ */
 const formDataContentTypeHandler: ContentTypeHandler = {
   isMatch(req) {
     return !!req.headers.get('content-type')?.startsWith('multipart/form-data');
@@ -221,7 +230,8 @@ const formDataContentTypeHandler: ContentTypeHandler = {
       throw new TRPCError({
         code: 'METHOD_NOT_SUPPORTED',
         message:
-          'Only POST requests are supported for multipart/form-data requests',
+          'Only POST requests are supported for multipart/form-data requests. See ' +
+          CONTENT_TYPES_DOCS,
       });
     }
     const getInputs = memo(async () => {
@@ -249,6 +259,11 @@ const formDataContentTypeHandler: ContentTypeHandler = {
   },
 };
 
+/**
+ * `application/octet-stream` — procedure input is the request body (`ReadableStream`). POST only; not batchable.
+ * @see https://trpc.io/docs/server/non-json-content-types
+ * @see https://trpc.io/docs/rpc
+ */
 const octetStreamContentTypeHandler: ContentTypeHandler = {
   isMatch(req) {
     return !!req.headers
@@ -261,7 +276,8 @@ const octetStreamContentTypeHandler: ContentTypeHandler = {
       throw new TRPCError({
         code: 'METHOD_NOT_SUPPORTED',
         message:
-          'Only POST requests are supported for application/octet-stream requests',
+          'Only POST requests are supported for application/octet-stream requests. See ' +
+          CONTENT_TYPES_DOCS,
       });
     }
     const getInputs = memo(async () => {
@@ -307,8 +323,8 @@ function getContentTypeHandler(req: Request): ContentTypeHandler {
   throw new TRPCError({
     code: 'UNSUPPORTED_MEDIA_TYPE',
     message: req.headers.has('content-type')
-      ? `Unsupported content-type "${req.headers.get('content-type')}`
-      : 'Missing content-type header',
+      ? `Unsupported content-type "${req.headers.get('content-type')}". See ${CONTENT_TYPES_DOCS}`
+      : `Missing content-type header. See ${CONTENT_TYPES_DOCS}`,
   });
 }
 

--- a/packages/server/src/unstable-core-do-not-import/http/contentType.ts
+++ b/packages/server/src/unstable-core-do-not-import/http/contentType.ts
@@ -6,8 +6,7 @@ import { parseConnectionParamsFromString } from './parseConnectionParams';
 import type { TRPCAcceptHeader, TRPCRequestInfo } from './types';
 
 /** @see https://trpc.io/docs/server/non-json-content-types */
-const CONTENT_TYPES_DOCS =
-  'https://trpc.io/docs/server/non-json-content-types';
+const CONTENT_TYPES_DOCS = 'https://trpc.io/docs/server/non-json-content-types';
 
 export function getAcceptHeader(headers: Headers): TRPCAcceptHeader | null {
   return (

--- a/packages/server/src/unstable-core-do-not-import/http/contentTypeParsers.ts
+++ b/packages/server/src/unstable-core-do-not-import/http/contentTypeParsers.ts
@@ -23,6 +23,12 @@ export interface FileLike extends Blob {
  */
 export type OctetInput = Blob | Uint8Array | FileLike;
 
+/**
+ * Input parser for `application/octet-stream` procedure inputs.
+ * The client may send a `Blob`, `File`, or `Uint8Array`; the procedure receives a `ReadableStream`.
+ *
+ * @see https://trpc.io/docs/server/non-json-content-types
+ */
 export const octetInputParser: UtilityParser<OctetInput, ReadableStream> = {
   _input: null as any as OctetInput,
   _output: null as any as ReadableStream,
@@ -32,7 +38,7 @@ export const octetInputParser: UtilityParser<OctetInput, ReadableStream> = {
     }
 
     throw new Error(
-      `Parsed input was expected to be a ReadableStream but was: ${typeof input}`,
+      `Parsed input was expected to be a ReadableStream but was: ${typeof input}. See https://trpc.io/docs/server/non-json-content-types`,
     );
   },
 };

--- a/packages/tests/server/adapters/standalone.test.ts
+++ b/packages/tests/server/adapters/standalone.test.ts
@@ -226,7 +226,7 @@ test('force content-type on mutations', async () => {
             "httpStatus": 415,
             "stack": "[redacted]",
           },
-          "message": "Missing content-type header",
+          "message": "Missing content-type header. See https://trpc.io/docs/server/non-json-content-types",
         },
       }
     `);

--- a/www/docs/client/links/httpLink.md
+++ b/www/docs/client/links/httpLink.md
@@ -7,7 +7,7 @@ slug: /client/links/httpLink
 
 `httpLink` is a [**terminating link**](./overview.md#the-terminating-link) that sends a tRPC operation to a tRPC procedure over HTTP.
 
-`httpLink` supports both POST and GET requests.
+`httpLink` supports both POST and GET requests. It is also the terminating link that can send non-JSON inputs (`FormData`, `Blob`, `File`, `Uint8Array`). Batch links cannot — see [Content Types](../../server/non-json-content-types.md).
 
 ## Usage
 

--- a/www/docs/further/rpc.md
+++ b/www/docs/further/rpc.md
@@ -13,6 +13,24 @@ slug: /rpc
 | `POST`      | `.mutation()`     | Input as POST body.                                                                                                                                                                      |
 | `GET`       | `.subscription()` | Subscriptions are supported via [Server-sent Events](/docs/client/links/httpSubscriptionLink) using `httpSubscriptionLink`, or via [WebSockets](/docs/server/websockets) using `wsLink`. |
 
+## Content types
+
+The handler is selected from the request `Content-Type` header (prefix match). **Responses** still use the JSON-RPC envelope in [HTTP Response Specification](#http-response-specification). Only the request body encoding changes.
+
+| `Content-Type` | Request body | Procedure type | Batching (`?batch=1`) |
+| -------------- | ------------ | -------------- | --------------------- |
+| `application/json` | JSON (transformed if configured) | query (`GET`) or mutation (`POST`) | yes |
+| omitted / other, on `GET` | JSON from `?input=` | query | yes |
+| `multipart/form-data` | `FormData` (`await request.formData()`) | mutation | no |
+| `application/octet-stream` | raw body (`request.body` as `ReadableStream`) | mutation | no |
+
+- FormData and octet-stream requests **must** use `POST`. Other methods return `METHOD_NOT_SUPPORTED` (`405`).
+- `POST` with a missing or unknown `Content-Type` returns `UNSUPPORTED_MEDIA_TYPE` (`415`).
+- JSON batching is unchanged: comma-separated procedure paths, `batch=1`, and `input` as `Record<number, unknown>` (query string on `GET`, JSON body on `POST`).
+- Non-JSON content types are a single call: one path, no `batch=1`, no comma-separated path list.
+
+Client helpers and adapter notes: [Content Types](/docs/server/non-json-content-types).
+
 ## Accessing nested procedures
 
 Nested procedures are separated by dots, so a request to `byId` below would end up being a request to `/api/trpc/post.byId`.
@@ -337,3 +355,4 @@ You can read more details by drilling into the TypeScript definitions in
 
 - [/packages/server/src/unstable-core-do-not-import/rpc/envelopes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/unstable-core-do-not-import/rpc/envelopes.ts)
 - [/packages/server/src/unstable-core-do-not-import/rpc/codes.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/unstable-core-do-not-import/rpc/codes.ts)
+- [/packages/server/src/unstable-core-do-not-import/http/contentType.ts](https://github.com/trpc/trpc/tree/main/packages/server/src/unstable-core-do-not-import/http/contentType.ts)

--- a/www/docs/further/rpc.md
+++ b/www/docs/further/rpc.md
@@ -17,12 +17,12 @@ slug: /rpc
 
 The handler is selected from the request `Content-Type` header (prefix match). **Responses** still use the JSON-RPC envelope in [HTTP Response Specification](#http-response-specification). Only the request body encoding changes.
 
-| `Content-Type`             | Request body                                  | Procedure type                                                                                      | Batching (`?batch=1`) |
-| -------------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------------- | --------------------- |
-| `application/json`         | JSON (transformed if configured)              | query (`GET`) or mutation (`POST`)                                                                  | yes                   |
-| omitted / other, on `GET`  | JSON from `?input=`                           | query                                                                                               | yes                   |
-| `multipart/form-data`      | `FormData` (`await request.formData()`)       | mutation (default); `.query()` with `methodOverride: 'POST'` when `allowMethodOverride: true`       | no                    |
-| `application/octet-stream` | raw body (`request.body` as `ReadableStream`) | mutation (default); `.query()` with `methodOverride: 'POST'` when `allowMethodOverride: true`       | no                    |
+| `Content-Type`             | Request body                                  | Procedure type                                                                                | Batching (`?batch=1`) |
+| -------------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------- | --------------------- |
+| `application/json`         | JSON (transformed if configured)              | query (`GET`) or mutation (`POST`)                                                            | yes                   |
+| omitted / other, on `GET`  | JSON from `?input=`                           | query                                                                                         | yes                   |
+| `multipart/form-data`      | `FormData` (`await request.formData()`)       | mutation (default); `.query()` with `methodOverride: 'POST'` when `allowMethodOverride: true` | no                    |
+| `application/octet-stream` | raw body (`request.body` as `ReadableStream`) | mutation (default); `.query()` with `methodOverride: 'POST'` when `allowMethodOverride: true` | no                    |
 
 - FormData and octet-stream requests **must** use `POST`. Other methods return `METHOD_NOT_SUPPORTED` (`405`).
 - `POST` with a missing or unknown `Content-Type` returns `UNSUPPORTED_MEDIA_TYPE` (`415`).

--- a/www/docs/further/rpc.md
+++ b/www/docs/further/rpc.md
@@ -17,12 +17,12 @@ slug: /rpc
 
 The handler is selected from the request `Content-Type` header (prefix match). **Responses** still use the JSON-RPC envelope in [HTTP Response Specification](#http-response-specification). Only the request body encoding changes.
 
-| `Content-Type`             | Request body                                  | Procedure type                     | Batching (`?batch=1`) |
-| -------------------------- | --------------------------------------------- | ---------------------------------- | --------------------- |
-| `application/json`         | JSON (transformed if configured)              | query (`GET`) or mutation (`POST`) | yes                   |
-| omitted / other, on `GET`  | JSON from `?input=`                           | query                              | yes                   |
-| `multipart/form-data`      | `FormData` (`await request.formData()`)       | mutation                           | no                    |
-| `application/octet-stream` | raw body (`request.body` as `ReadableStream`) | mutation                           | no                    |
+| `Content-Type`             | Request body                                  | Procedure type                                                                                      | Batching (`?batch=1`) |
+| -------------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------------- | --------------------- |
+| `application/json`         | JSON (transformed if configured)              | query (`GET`) or mutation (`POST`)                                                                  | yes                   |
+| omitted / other, on `GET`  | JSON from `?input=`                           | query                                                                                               | yes                   |
+| `multipart/form-data`      | `FormData` (`await request.formData()`)       | mutation (default); `.query()` with `methodOverride: 'POST'` when `allowMethodOverride: true`       | no                    |
+| `application/octet-stream` | raw body (`request.body` as `ReadableStream`) | mutation (default); `.query()` with `methodOverride: 'POST'` when `allowMethodOverride: true`       | no                    |
 
 - FormData and octet-stream requests **must** use `POST`. Other methods return `METHOD_NOT_SUPPORTED` (`405`).
 - `POST` with a missing or unknown `Content-Type` returns `UNSUPPORTED_MEDIA_TYPE` (`415`).

--- a/www/docs/further/rpc.md
+++ b/www/docs/further/rpc.md
@@ -17,12 +17,12 @@ slug: /rpc
 
 The handler is selected from the request `Content-Type` header (prefix match). **Responses** still use the JSON-RPC envelope in [HTTP Response Specification](#http-response-specification). Only the request body encoding changes.
 
-| `Content-Type` | Request body | Procedure type | Batching (`?batch=1`) |
-| -------------- | ------------ | -------------- | --------------------- |
-| `application/json` | JSON (transformed if configured) | query (`GET`) or mutation (`POST`) | yes |
-| omitted / other, on `GET` | JSON from `?input=` | query | yes |
-| `multipart/form-data` | `FormData` (`await request.formData()`) | mutation | no |
-| `application/octet-stream` | raw body (`request.body` as `ReadableStream`) | mutation | no |
+| `Content-Type`             | Request body                                  | Procedure type                     | Batching (`?batch=1`) |
+| -------------------------- | --------------------------------------------- | ---------------------------------- | --------------------- |
+| `application/json`         | JSON (transformed if configured)              | query (`GET`) or mutation (`POST`) | yes                   |
+| omitted / other, on `GET`  | JSON from `?input=`                           | query                              | yes                   |
+| `multipart/form-data`      | `FormData` (`await request.formData()`)       | mutation                           | no                    |
+| `application/octet-stream` | raw body (`request.body` as `ReadableStream`) | mutation                           | no                    |
 
 - FormData and octet-stream requests **must** use `POST`. Other methods return `METHOD_NOT_SUPPORTED` (`405`).
 - `POST` with a missing or unknown `Content-Type` returns `UNSUPPORTED_MEDIA_TYPE` (`415`).

--- a/www/docs/server/non-json-content-types.md
+++ b/www/docs/server/non-json-content-types.md
@@ -7,6 +7,29 @@ slug: /server/non-json-content-types
 
 tRPC supports multiple content types as procedure inputs: JSON-serializable data, FormData, File, Blob, and other binary types.
 
+The HTTP handler chooses a parser from the request `Content-Type` header. Procedure **responses** are still JSON-RPC envelopes — only the **request body** changes. See the [HTTP RPC Specification](/docs/rpc#content-types) for the wire format.
+
+## Request `Content-Type` mapping
+
+| `Content-Type` | Client input | Server input | HTTP method | Batching |
+| -------------- | ------------ | ------------ | ----------- | -------- |
+| `application/json` (default) | JSON-serializable values | deserialized JSON (after any [transformer](/docs/server/data-transformers)) | `GET` for queries, `POST` for mutations | yes |
+| `multipart/form-data` | `FormData` | `FormData` | `POST` only | no |
+| `application/octet-stream` | `Blob`, `File`, or `Uint8Array` | `ReadableStream` (via [`octetInputParser`](#file-and-other-binary-type-inputs)) | `POST` only | no |
+
+Matching is prefix-based (`content-type` `startsWith`), so values like `application/json; charset=utf-8` or `multipart/form-data; boundary=…` are accepted.
+
+- `GET` requests with no matching content type fall back to the JSON handler so query URLs can be opened in a browser.
+- `POST` requests with a missing or unsupported `Content-Type` throw `UNSUPPORTED_MEDIA_TYPE` (`415`).
+- FormData and octet-stream requests always map to a single `.mutation()` call. They cannot be combined with `?batch=1`.
+
+On the client, `httpLink` sends:
+
+- `FormData` as `multipart/form-data` (the runtime sets `Content-Type`, including the multipart boundary — do not set this header yourself)
+- `Blob` / `File` / `Uint8Array` as `application/octet-stream`
+
+Use [`isNonJsonSerializable()`](#client-setup) from `@trpc/client` to detect those inputs when splitting links.
+
 ## JSON (Default)
 
 By default, tRPC sends and receives JSON-serializable data. No extra configuration is needed — any input that can be serialized to JSON works out of the box with all links (`httpLink`, `httpBatchLink`, `httpBatchStreamLink`).
@@ -98,6 +121,8 @@ createTRPCClient<AppRouter>({
 });
 ```
 
+`isNonJsonSerializable(input)` is `true` when `input` is `FormData`, a `Uint8Array`, or a `Blob` (including `File`). Those values cannot go through `httpBatchLink` / `httpBatchStreamLink`.
+
 If you are using `transformer` in your tRPC server, TypeScript requires that your tRPC client link defines `transformer` as well.
 Use this example as a base:
 
@@ -144,6 +169,10 @@ createTRPCClient<AppRouter>({
   ],
 });
 ```
+
+The non-JSON `httpLink` must skip serializing the request body (`serialize: (data) => data`). FormData and binary bodies cannot be run through JSON transformers; the JSON response can still be deserialized.
+
+Passing `FormData` or a binary value to `.query()` throws (`FormData` / octet inputs are mutations / `POST` only), unless the link uses `methodOverride: 'POST'` and the server sets `allowMethodOverride: true`.
 
 ### Server Setup
 
@@ -208,7 +237,7 @@ For a more advanced code sample you can see our [example project here](https://g
 
 #### `File` and other Binary Type Inputs
 
-tRPC converts many octet content types to a `ReadableStream` which can be consumed in a procedure. Currently these are `Blob` `Uint8Array` and `File`.
+Import `octetInputParser` from `@trpc/server/http`. tRPC converts octet content types to a `ReadableStream` which can be consumed in a procedure. Currently these are `Blob`, `Uint8Array`, and `File`.
 
 ```ts twoslash
 // @target: esnext
@@ -230,3 +259,21 @@ export const appRouter = t.router({
   }),
 });
 ```
+
+A full server + client example lives in [`examples/minimal-content-types`](https://github.com/trpc/trpc/tree/main/examples/minimal-content-types).
+
+## Adapter compatibility
+
+HTTP adapters convert the host request into a Fetch [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) and then run the same content-type handlers. After that conversion, JSON, `multipart/form-data`, and `application/octet-stream` work the same way.
+
+| Adapter | JSON | `multipart/form-data` | `application/octet-stream` | Notes |
+| ------- | ---- | --------------------- | -------------------------- | ----- |
+| [Standalone](/docs/server/adapters/standalone) | Yes | Yes | Yes | Node HTTP server |
+| [Express](/docs/server/adapters/express) | Yes | Yes | Yes | Do not mount a global body parser (`express.json()`, `multer`, …) in front of tRPC |
+| [Fastify](/docs/server/adapters/fastify) | Yes | Yes | Yes | Do not pre-parse the tRPC route body (e.g. `@fastify/multipart`) before tRPC reads it |
+| [Next.js (Pages)](/docs/server/adapters/nextjs) | Yes | Yes | Yes | Same Node HTTP conversion as Express |
+| [Fetch](/docs/server/adapters/fetch) (edge, Next.js App Router, …) | Yes | Yes | Yes | Uses the platform `Request` directly |
+| [AWS Lambda](/docs/server/adapters/aws-lambda) | Yes | Yes | Yes | Adapter copies `event.body` (including base64) onto a Fetch `Request` |
+| [WebSockets](/docs/server/websockets) | Yes (JSON messages) | No | No | WS is not HTTP; there is no `Content-Type` body |
+
+Community adapters that wrap `resolveResponse` with a Fetch `Request` inherit the same content types. Adapters that still parse JSON themselves will not.

--- a/www/docs/server/non-json-content-types.md
+++ b/www/docs/server/non-json-content-types.md
@@ -11,11 +11,11 @@ The HTTP handler chooses a parser from the request `Content-Type` header. Proced
 
 ## Request `Content-Type` mapping
 
-| `Content-Type` | Client input | Server input | HTTP method | Batching |
-| -------------- | ------------ | ------------ | ----------- | -------- |
-| `application/json` (default) | JSON-serializable values | deserialized JSON (after any [transformer](/docs/server/data-transformers)) | `GET` for queries, `POST` for mutations | yes |
-| `multipart/form-data` | `FormData` | `FormData` | `POST` only | no |
-| `application/octet-stream` | `Blob`, `File`, or `Uint8Array` | `ReadableStream` (via [`octetInputParser`](#file-and-other-binary-type-inputs)) | `POST` only | no |
+| `Content-Type`               | Client input                    | Server input                                                                    | HTTP method                             | Batching |
+| ---------------------------- | ------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------- | -------- |
+| `application/json` (default) | JSON-serializable values        | deserialized JSON (after any [transformer](/docs/server/data-transformers))     | `GET` for queries, `POST` for mutations | yes      |
+| `multipart/form-data`        | `FormData`                      | `FormData`                                                                      | `POST` only                             | no       |
+| `application/octet-stream`   | `Blob`, `File`, or `Uint8Array` | `ReadableStream` (via [`octetInputParser`](#file-and-other-binary-type-inputs)) | `POST` only                             | no       |
 
 Matching is prefix-based (`content-type` `startsWith`), so values like `application/json; charset=utf-8` or `multipart/form-data; boundary=…` are accepted.
 
@@ -266,14 +266,14 @@ A full server + client example lives in [`examples/minimal-content-types`](https
 
 HTTP adapters convert the host request into a Fetch [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) and then run the same content-type handlers. After that conversion, JSON, `multipart/form-data`, and `application/octet-stream` work the same way.
 
-| Adapter | JSON | `multipart/form-data` | `application/octet-stream` | Notes |
-| ------- | ---- | --------------------- | -------------------------- | ----- |
-| [Standalone](/docs/server/adapters/standalone) | Yes | Yes | Yes | Node HTTP server |
-| [Express](/docs/server/adapters/express) | Yes | Yes | Yes | Do not mount a global body parser (`express.json()`, `multer`, …) in front of tRPC |
-| [Fastify](/docs/server/adapters/fastify) | Yes | Yes | Yes | Do not pre-parse the tRPC route body (e.g. `@fastify/multipart`) before tRPC reads it |
-| [Next.js (Pages)](/docs/server/adapters/nextjs) | Yes | Yes | Yes | Same Node HTTP conversion as Express |
-| [Fetch](/docs/server/adapters/fetch) (edge, Next.js App Router, …) | Yes | Yes | Yes | Uses the platform `Request` directly |
-| [AWS Lambda](/docs/server/adapters/aws-lambda) | Yes | Yes | Yes | Adapter copies `event.body` (including base64) onto a Fetch `Request` |
-| [WebSockets](/docs/server/websockets) | Yes (JSON messages) | No | No | WS is not HTTP; there is no `Content-Type` body |
+| Adapter                                                            | JSON                | `multipart/form-data` | `application/octet-stream` | Notes                                                                                 |
+| ------------------------------------------------------------------ | ------------------- | --------------------- | -------------------------- | ------------------------------------------------------------------------------------- |
+| [Standalone](/docs/server/adapters/standalone)                     | Yes                 | Yes                   | Yes                        | Node HTTP server                                                                      |
+| [Express](/docs/server/adapters/express)                           | Yes                 | Yes                   | Yes                        | Do not mount a global body parser (`express.json()`, `multer`, …) in front of tRPC    |
+| [Fastify](/docs/server/adapters/fastify)                           | Yes                 | Yes                   | Yes                        | Do not pre-parse the tRPC route body (e.g. `@fastify/multipart`) before tRPC reads it |
+| [Next.js (Pages)](/docs/server/adapters/nextjs)                    | Yes                 | Yes                   | Yes                        | Same Node HTTP conversion as Express                                                  |
+| [Fetch](/docs/server/adapters/fetch) (edge, Next.js App Router, …) | Yes                 | Yes                   | Yes                        | Uses the platform `Request` directly                                                  |
+| [AWS Lambda](/docs/server/adapters/aws-lambda)                     | Yes                 | Yes                   | Yes                        | Adapter copies `event.body` (including base64) onto a Fetch `Request`                 |
+| [WebSockets](/docs/server/websockets)                              | Yes (JSON messages) | No                    | No                         | WS is not HTTP; there is no `Content-Type` body                                       |
 
 Community adapters that wrap `resolveResponse` with a Fetch `Request` inherit the same content types. Adapters that still parse JSON themselves will not.

--- a/www/docs/server/non-json-content-types.md
+++ b/www/docs/server/non-json-content-types.md
@@ -21,7 +21,7 @@ Matching is prefix-based (`content-type` `startsWith`), so values like `applicat
 
 - `GET` requests with no matching content type fall back to the JSON handler so query URLs can be opened in a browser.
 - `POST` requests with a missing or unsupported `Content-Type` throw `UNSUPPORTED_MEDIA_TYPE` (`415`).
-- FormData and octet-stream requests always map to a single `.mutation()` call. They cannot be combined with `?batch=1`.
+- FormData and octet-stream requests map to a single `.mutation()` call by default. `.query()` is supported with `methodOverride: 'POST'` when `allowMethodOverride: true`. They cannot be combined with `?batch=1`.
 
 On the client, `httpLink` sends:
 


### PR DESCRIPTION
Closes #5643

## 🎯 Changes

FormData and octet-stream handlers shipped in v11 (https://github.com/trpc/trpc/pull/5613) with only a partial docs page. This fills in the remaining items from #5643:

- Document the request `Content-Type` mapping (`application/json`, `multipart/form-data`, `application/octet-stream`) and the public helpers (`isNonJsonSerializable`, `octetInputParser`) on the Content Types page
- Add an HTTP adapter compatibility table (and note that WebSockets are JSON-only)
- Point handler / client errors and related JSDoc at those docs
- Extend the [HTTP RPC Specification](https://trpc.io/docs/rpc) with the same content-type rules

APIs described here match current `main` (`contentType.ts`, `httpLink.ts`, `octetInputParser`). No new public APIs.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded guidance for JSON, `multipart/form-data`, and `application/octet-stream` requests.
  - Clarified supported inputs, HTTP methods, batching limitations, method overrides, and adapter compatibility.
  - Documented non-JSON support for HTTP links and octet-stream parsing.
  - Added content-type mapping details and guidance for binary and form-data inputs.

- **Bug Fixes**
  - Error messages for unsupported or missing content types now include direct links to relevant documentation.
  - Clarified restrictions for FormData and binary inputs in GET requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->