### PR TITLE
fix(server): correct inverted condition in assertIsRequestId (#7450)

### DIFF
--- a/packages/server/src/unstable-core-do-not-import/rpc/parseTRPCMessage.ts
+++ b/packages/server/src/unstable-core-do-not-import/rpc/parseTRPCMessage.ts
@@ -23,9 +23,8 @@ function assertIsRequestId(
 ): asserts obj is number | string | null {
   if (
     obj !== null &&
-    typeof obj === 'number' &&
-    isNaN(obj) &&
-    typeof obj !== 'string'
+    typeof obj !== 'string' &&
+    (typeof obj !== 'number' || isNaN(obj))
   ) {
     throw new Error('Invalid request id');
   }


### PR DESCRIPTION
## Bug

`assertIsRequestId` in `parseTRPCMessage.ts` had an inverted condition that only threw for `NaN`, silently accepting booleans, arrays, and objects as valid request IDs.

The broken condition:
```ts
if (obj !== null && typeof obj === 'number' && isNaN(obj) && typeof obj !== 'string')
```

Since `typeof obj === 'number'` is always true when `typeof obj !== 'string'` is evaluated, this simplifies to `isNaN(obj)` — it only throws for `NaN`.

## Fix

```ts
if (obj !== null && typeof obj !== 'string' && (typeof obj !== 'number' || isNaN(obj)))
```

This correctly throws when `id` is not `null`, not a `string`, and not a non-NaN `number`.

Closes #7450

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal request ID validation while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->