### PR TITLE
fix(client): own AbortController in httpLink and httpBatchLink (#7468)

### DIFF
--- a/packages/client/src/links/httpBatchLink.ts
+++ b/packages/client/src/links/httpBatchLink.ts
@@ -3,7 +3,7 @@ import { observable } from '@trpc/server/observable';
 import { transformResult } from '@trpc/server/unstable-core-do-not-import';
 import type { BatchLoader } from '../internals/dataLoader';
 import { dataLoader } from '../internals/dataLoader';
-import { allAbortSignals } from '../internals/signals';
+import { allAbortSignals, raceAbortSignals } from '../internals/signals';
 import type { NonEmptyArray } from '../internals/types';
 import { TRPCClientError } from '../TRPCClientError';
 import type { HTTPBatchLinkOptions } from './HTTPBatchLinkOptions';
@@ -98,8 +98,12 @@ export function httpBatchLink<TRouter extends AnyRouter>(
             'Subscriptions are unsupported by `httpLink` - use `httpSubscriptionLink` or `wsLink`',
           );
         }
+        const ac = new AbortController();
         const loader = loaders[op.type];
-        const promise = loader.load(op);
+        const promise = loader.load({
+          ...op,
+          signal: raceAbortSignals(op.signal, ac.signal),
+        });
 
         let _res = undefined as HTTPResult | undefined;
         promise
@@ -133,7 +137,7 @@ export function httpBatchLink<TRouter extends AnyRouter>(
           });
 
         return () => {
-          // noop
+          ac.abort();
         };
       });
     };

--- a/packages/client/src/links/httpLink.ts
+++ b/packages/client/src/links/httpLink.ts
@@ -88,12 +88,13 @@ export function httpLink<TRouter extends AnyRouter = AnyRouter>(
           );
         }
 
+        const ac = new AbortController();
         const request = universalRequester({
           ...resolvedOpts,
           type,
           path,
           input,
-          signal: op.signal,
+          signal: ac.signal,
           headers() {
             if (!opts.headers) {
               return {};
@@ -134,7 +135,7 @@ export function httpLink<TRouter extends AnyRouter = AnyRouter>(
           });
 
         return () => {
-          // noop
+          ac.abort();
         };
       });
     };


### PR DESCRIPTION
## Bug

`httpLink` and `httpBatchLink` both pass `op.signal` directly to the underlying request without creating an internal `AbortController`, and their observable cleanup functions are `// noop`.

This means when a subscriber unsubscribes, the in-flight fetch request is not cancelled — the same class of bug that was fixed in `httpBatchStreamLink` by PR #7390.

Every other link in the package (`httpSubscriptionLink`, `httpBatchStreamLink`, `localLink`) already owns its own `AbortController` and calls `ac.abort()` in the observable cleanup.

## Fix

**httpLink** — create an `AbortController`, pass `ac.signal` to the requester, call `ac.abort()` in cleanup.

**httpBatchLink** — create an `AbortController`, combine it with `op.signal` via `raceAbortSignals` so the batch request is aborted when the individual observable unsubscribes, call `ac.abort()` in cleanup.

Pattern matches the existing correct implementations in `httpSubscriptionLink` and `httpBatchStreamLink`.

Closes #7468

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cancellation of in-flight HTTP requests when an operation is unsubscribed.
  - Added reliable cancellation for batched HTTP loads during teardown.
  - Ensured request cancellation signals correctly combine operation and subscription lifecycle events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->