### PR TITLE
fix(www): update star button link to repository root

### DIFF
--- a/www/src/components/GithubStarsButton.tsx
+++ b/www/src/components/GithubStarsButton.tsx
@@ -25,7 +25,7 @@ export const GithubStarsButton = ({ className }: Props) => {
   return (
     <Button
       variant="secondary"
-      href="https://github.com/trpc/trpc/stargazers"
+      href="https://github.com/trpc/trpc"
       target="_blank"
       className={className}
     >


### PR DESCRIPTION
## 🎯 Changes

Updated the destination link of the `GithubStarsButton` component on the landing page from `https://github.com/trpc/trpc/stargazers` to `https://github.com/trpc/trpc`.

Per GitHub's announcement on [upcoming access restrictions to public API endpoints and UI views](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/), visiting `/stargazers` directly or unauthenticated returns an HTTP 404. Linking directly to the repository root ensures visitors can view the repository and star it reliably.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the GitHub link to direct visitors to the repository homepage instead of the stargazers page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->