### PR TITLE
docs: clarify abort signals for mutations and procedures

### DIFF
--- a/www/docs/client/nextjs/pages-router/aborting-procedures.md
+++ b/www/docs/client/nextjs/pages-router/aborting-procedures.md
@@ -7,6 +7,8 @@ slug: /client/nextjs/pages-router/aborting-procedure-calls
 
 By default, tRPC does not cancel requests on unmount. If you want to opt into this behavior, you can provide `abortOnUnmount` in your configuration callback.
 
+This option only applies to queries. `@trpc/react-query` mutation options do not accept an `AbortSignal`. To cancel a mutation request explicitly, use the [vanilla client API](/docs/client/vanilla/aborting-procedure-calls) and pass `signal` as the second argument to `.mutate()`.
+
 ### Globally
 
 ```ts twoslash title="client.ts"

--- a/www/docs/client/react/aborting-procedures.md
+++ b/www/docs/client/react/aborting-procedures.md
@@ -8,7 +8,7 @@ slug: /client/react/aborting-procedure-calls
 By default, tRPC does not cancel requests via React Query. If you want to opt into this behavior, you can provide `abortOnUnmount` in your configuration.
 
 :::note
-@tanstack/react-query only supports aborting queries.
+TanStack React Query only provides automatic request abortion for queries. `@trpc/react-query` mutation options do not accept an `AbortSignal`. To cancel a mutation request explicitly, use the [vanilla client API](/docs/client/vanilla/aborting-procedure-calls) and pass `signal` as the second argument to `.mutate()`.
 :::
 
 ```twoslash include router

--- a/www/docs/client/vanilla/aborting-procedures.md
+++ b/www/docs/client/vanilla/aborting-procedures.md
@@ -15,6 +15,9 @@ import { z } from 'zod';
 const t = initTRPC.create();
 const appRouter = t.router({
   userById: t.procedure.input(z.string()).query(({ input }) => ({ id: input, name: 'Bilbo' })),
+  updateUser: t.procedure
+    .input(z.object({ id: z.string(), name: z.string() }))
+    .mutation(({ input }) => input),
 });
 export type AppRouter = typeof appRouter;
 
@@ -31,12 +34,37 @@ const client = createTRPCClient<AppRouter>({
   ],
 });
 
-// 1. Create an AbortController instance - this is a standard javascript API
-const ac = new AbortController();
+// Pass a signal to a query
+const queryController = new AbortController();
+const query = client.userById.query('id_bilbo', {
+  signal: queryController.signal,
+});
+queryController.abort();
 
-// 2. Pass the signal to a query or mutation
-const query = client.userById.query('id_bilbo', { signal: ac.signal });
+// Mutation options accept a signal too
+const mutationController = new AbortController();
+const mutation = client.updateUser.mutate(
+  { id: 'id_bilbo', name: 'Bilbo' },
+  { signal: mutationController.signal },
+);
+mutationController.abort();
+```
 
-// 3. Cancel the request if needed
-ac.abort();
+## Cancelling work on the server
+
+Aborting a client request stops the client from waiting for the response and asks the transport to cancel the request. It does not interrupt JavaScript already running on the server or roll back side effects that a mutation has already committed.
+
+Procedure resolvers receive the request's `signal`. Pass it to APIs that support `AbortSignal`, or check `signal.aborted` in long-running work, to stop cooperatively when the server detects that the request was cancelled.
+
+```ts twoslash title="server.ts"
+import { initTRPC } from '@trpc/server';
+
+const t = initTRPC.create();
+
+const appRouter = t.router({
+  report: t.procedure.query(async ({ signal }) => {
+    const response = await fetch('https://example.com/report', { signal });
+    return response.json();
+  }),
+});
 ```


### PR DESCRIPTION
Closes #4317

## 🎯 Changes

- show how to pass an `AbortSignal` to both vanilla client queries and mutations
- explain that aborting a request does not interrupt already-running server JavaScript or roll back committed side effects
- show how resolvers can cooperatively cancel work by forwarding their request `signal`
- clarify that `abortOnUnmount` only applies to queries in the classic React Query and Next.js integrations, with a link to the vanilla mutation API

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made. (No runtime behavior changed; the updated Twoslash examples compile in the full website build.)

## Verification

- `pnpm exec prettier --check` on the three changed documentation files
- `TYPEDOC=0 pnpm --filter www build`
- generated-page assertions for all three updated routes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that automatic unmount cancellation applies only to queries, not mutations.
  * Documented how to explicitly cancel mutations using an `AbortSignal` through the vanilla client API.
  * Added guidance on server-side cancellation and explained that cancelling a client request does not roll back completed side effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->