### PR TITLE
docs: document WebSockets alongside HTTP, nested routers, and createContext typing

### DIFF
--- a/www/docs/server/websockets.md
+++ b/www/docs/server/websockets.md
@@ -144,7 +144,7 @@ applyWSSHandler({
 server.listen(3000);
 ```
 
-`applyWSSHandler` takes your root router, just like the HTTP adapter, so nested routers need no extra setup: a subscription defined at `appRouter.post.onAdd` is called as `post.onAdd`. The `prefix` option filters which upgrade requests the handler accepts based on the request URL. It does not namespace the router.
+`applyWSSHandler` takes your root router, just like the HTTP adapter, so nested routers need no extra setup: a subscription defined at `appRouter.post.onAdd` is called as `post.onAdd`. The `prefix` option only makes the handler skip connections whose URL does not start with it, checked after `ws` has already accepted the upgrade. It does not namespace the router.
 
 ### Client
 
@@ -201,7 +201,7 @@ const createContext = (
 
 Narrowing with `'res' in opts` does not help: both adapters have a `res`, an `express.Response` on HTTP and a `ws.WebSocket` on WebSockets.
 
-Write one function per adapter and give them a shared return type. Only the way you read the request differs: `ws` does not parse cookies for you, so read them off the `cookie` header.
+Write one function per adapter and give them a shared return type. Both adapters expose the raw `cookie` header on `req.headers`, so one helper can serve both without a cookie-parsing middleware:
 
 ```ts twoslash title='server/context.ts'
 import type { CreateExpressContextOptions } from '@trpc/server/adapters/express';
@@ -211,14 +211,17 @@ interface Context {
   token: string | undefined;
 }
 
+const readToken = (cookie: string | undefined): string | undefined =>
+  /(?:^|;\s*)token=([^;]*)/.exec(cookie ?? '')?.[1];
+
 export const createExpressContext = (
   opts: CreateExpressContextOptions,
 ): Context => ({
-  token: opts.req.cookies['token'],
+  token: readToken(opts.req.headers.cookie),
 });
 
 export const createWSSContext = (opts: CreateWSSContextFnOptions): Context => ({
-  token: /token=([^;]+)/.exec(opts.req.headers.cookie ?? '')?.[1],
+  token: readToken(opts.req.headers.cookie),
 });
 ```
 

--- a/www/docs/server/websockets.md
+++ b/www/docs/server/websockets.md
@@ -70,7 +70,7 @@ process.on('SIGTERM', () => {
 ### Setting `TRPCClient` to use WebSockets
 
 :::tip
-You can use [Links](../client/links/overview.md) to route queries and/or mutations to HTTP transport and subscriptions over WebSockets.
+You can use [Links](../client/links/overview.md) to route queries and/or mutations to HTTP transport and subscriptions over WebSockets. See [Using WebSockets alongside HTTP](#using-websockets-alongside-http).
 :::
 
 ```tsx twoslash title='client.ts'
@@ -98,6 +98,182 @@ const client = createTRPCClient<AppRouter>({
     }),
   ],
 });
+```
+
+## Using WebSockets alongside HTTP
+
+You can serve the same router over both transports: mount the HTTP adapter as usual and attach `applyWSSHandler` to the same Node.js server.
+
+### Server
+
+```ts twoslash title='server.ts'
+// @filename: routers/app.ts
+import { initTRPC } from '@trpc/server';
+const t = initTRPC.create();
+export const appRouter = t.router({
+  post: t.router({}),
+});
+
+// @filename: server.ts
+// @types: node
+// ---cut---
+import { createServer } from 'http';
+import * as trpcExpress from '@trpc/server/adapters/express';
+import { applyWSSHandler } from '@trpc/server/adapters/ws';
+import express from 'express';
+import { WebSocketServer } from 'ws';
+import { appRouter } from './routers/app';
+
+const app = express();
+
+app.use(
+  '/trpc',
+  trpcExpress.createExpressMiddleware({
+    router: appRouter,
+  }),
+);
+
+const server = createServer(app);
+const wss = new WebSocketServer({ server });
+
+applyWSSHandler({
+  wss,
+  router: appRouter,
+});
+
+server.listen(3000);
+```
+
+`applyWSSHandler` takes your root router, just like the HTTP adapter, so nested routers need no extra setup: a subscription defined at `appRouter.post.onAdd` is called as `post.onAdd`. The `prefix` option filters which upgrade requests the handler accepts based on the request URL. It does not namespace the router.
+
+### Client
+
+Use [`splitLink`](../client/links/splitLink.mdx) to send subscriptions over the WebSocket connection and everything else over HTTP.
+
+```ts twoslash title='client.ts'
+// @filename: server.ts
+import { initTRPC } from '@trpc/server';
+const t = initTRPC.create();
+export const appRouter = t.router({});
+export type AppRouter = typeof appRouter;
+
+// @filename: client.ts
+// ---cut---
+import {
+  createTRPCClient,
+  createWSClient,
+  httpBatchLink,
+  splitLink,
+  wsLink,
+} from '@trpc/client';
+import type { AppRouter } from './server';
+
+const wsClient = createWSClient({
+  url: 'ws://localhost:3000',
+});
+
+const client = createTRPCClient<AppRouter>({
+  links: [
+    splitLink({
+      condition: (op) => op.type === 'subscription',
+      true: wsLink({ client: wsClient }),
+      false: httpBatchLink({ url: 'http://localhost:3000/trpc' }),
+    }),
+  ],
+});
+```
+
+### Typing `createContext` for both adapters
+
+Each adapter passes its own `req`/`res` pair, so a function typed as a union of both option types can only read the properties the two have in common. Express-specific ones like `req.cookies` are not on the union:
+
+```ts twoslash title='server/context.ts'
+// @errors: 2339
+import type { CreateExpressContextOptions } from '@trpc/server/adapters/express';
+import type { CreateWSSContextFnOptions } from '@trpc/server/adapters/ws';
+
+const createContext = (
+  opts: CreateExpressContextOptions | CreateWSSContextFnOptions,
+) => {
+  return { token: opts.req.cookies['token'] };
+};
+```
+
+Narrowing with `'res' in opts` does not help: both adapters have a `res`, an `express.Response` on HTTP and a `ws.WebSocket` on WebSockets.
+
+Write one function per adapter and give them a shared return type. Only the way you read the request differs: `ws` does not parse cookies for you, so read them off the `cookie` header.
+
+```ts twoslash title='server/context.ts'
+import type { CreateExpressContextOptions } from '@trpc/server/adapters/express';
+import type { CreateWSSContextFnOptions } from '@trpc/server/adapters/ws';
+
+interface Context {
+  token: string | undefined;
+}
+
+export const createExpressContext = (
+  opts: CreateExpressContextOptions,
+): Context => ({
+  token: opts.req.cookies['token'],
+});
+
+export const createWSSContext = (opts: CreateWSSContextFnOptions): Context => ({
+  token: /token=([^;]+)/.exec(opts.req.headers.cookie ?? '')?.[1],
+});
+```
+
+Initialize tRPC with `Context` and pass each function to its own adapter:
+
+```ts twoslash title='server.ts'
+// @filename: context.ts
+import type { CreateExpressContextOptions } from '@trpc/server/adapters/express';
+import type { CreateWSSContextFnOptions } from '@trpc/server/adapters/ws';
+export interface Context {
+  token: string | undefined;
+}
+export declare const createExpressContext: (
+  opts: CreateExpressContextOptions,
+) => Context;
+export declare const createWSSContext: (
+  opts: CreateWSSContextFnOptions,
+) => Context;
+
+// @filename: routers/app.ts
+import { initTRPC } from '@trpc/server';
+import type { Context } from '../context';
+const t = initTRPC.context<Context>().create();
+export const appRouter = t.router({});
+
+// @filename: server.ts
+// @types: node
+// ---cut---
+import { createServer } from 'http';
+import * as trpcExpress from '@trpc/server/adapters/express';
+import { applyWSSHandler } from '@trpc/server/adapters/ws';
+import express from 'express';
+import { WebSocketServer } from 'ws';
+import { createExpressContext, createWSSContext } from './context';
+import { appRouter } from './routers/app';
+
+const app = express();
+
+app.use(
+  '/trpc',
+  trpcExpress.createExpressMiddleware({
+    router: appRouter,
+    createContext: createExpressContext,
+  }),
+);
+
+const server = createServer(app);
+
+applyWSSHandler({
+  wss: new WebSocketServer({ server }),
+  router: appRouter,
+  createContext: createWSSContext,
+});
+
+server.listen(3000);
 ```
 
 ## Authentication / connection params {#connectionParams}


### PR DESCRIPTION
Closes #5883

## 🎯 Changes

The WebSocket docs did not cover the three things asked for in #5883, so I added one section to `www/docs/server/websockets.md`:

- **Running both transports.** Mounting the Express adapter and `applyWSSHandler` on the same Node HTTP server, and a `splitLink` on the client that sends subscriptions to `wsLink` and everything else to `httpBatchLink`. The page already had a tip saying this was possible but no example, so the tip now points at the new section.
- **Nested routers.** `applyWSSHandler` takes the root router the same way the HTTP adapter does, so nothing extra is needed. I called out that `prefix` only filters upgrade requests by URL and does not namespace the router, since that is the easy wrong assumption.
- **`createContext` typing.** The issue asks whether to type one function as `CreateExpressContextOptions | CreateWSSContextFnOptions`, narrow it, or write two. I checked all three against the current packages. The union fails with TS2339 as soon as you read `req.cookies`, and narrowing with `'res' in opts` does not help because both adapters have a `res` (`express.Response` vs `ws.WebSocket`). Two functions with a shared return type is what works, and it is what both commenters on the issue arrived at independently. The docs show the failing union first with `@errors: 2339` so the error is recognisable, then the working pattern, including reading cookies off the `cookie` header since `ws` does not parse them.

Every block is `twoslash`, so it all compiles against the workspace packages. `pnpm check-twoslash` passes across all 425 blocks in the docs, `pnpm --filter www lint` is clean, and prettier reports no changes. Docs only, no runtime changes.

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for serving the same router over HTTP and WebSockets.
  - Documented configuring client-side transport routing between WebSockets and HTTP.
  - Added examples for sharing context types across both adapters.
  - Clarified token retrieval from request cookies for context setup.
  - Clarified that the WebSocket URL prefix filters connections after upgrade acceptance.
  - Added guidance on verifying origins for cookie-authenticated WebSocket connections.
  - Updated the existing WebSockets tip to link to the new guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->